### PR TITLE
PR-4: Restore migrations replay in CI required gate

### DIFF
--- a/.github/workflows/syllabus-boundary-tests.yml
+++ b/.github/workflows/syllabus-boundary-tests.yml
@@ -96,19 +96,25 @@ jobs:
           PGPASSWORD: postgres
           PGDATABASE: cie_copilot_test
         run: |
-          # Create roles
+          # Step 1: Create roles (required by Supabase RLS policies)
           psql -c "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN CREATE ROLE anon NOLOGIN; END IF; END \$\$;"
           psql -c "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated NOLOGIN; END IF; END \$\$;"
           psql -c "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN CREATE ROLE service_role NOLOGIN; END IF; END \$\$;"
           
-          # Apply shims (creates auth schema stubs)
-          psql -f test/fixtures/supabase-shims.sql
+          # Step 2: Apply baseline schema (simulates old production state)
+          # Creates chunks table WITHOUT syllabus boundary columns
+          psql -v ON_ERROR_STOP=1 -f test/fixtures/baseline-schema.sql
           
-          # Initialize test database with full schema
-          # (creates chunks, curriculum_nodes tables and hybrid_search_v2 RPC)
-          psql -v ON_ERROR_STOP=1 -f test/fixtures/init-test-db.sql
+          # Step 3: Apply Supabase shims (required before migration 3 for RLS)
+          psql -v ON_ERROR_STOP=1 -f test/fixtures/supabase-shims.sql
           
-          # Apply seed data
+          # Step 4: Replay migrations in order (CRITICAL - validates migration correctness)
+          psql -v ON_ERROR_STOP=1 -f supabase/migrations/20251223000100_enable_ltree.sql
+          psql -v ON_ERROR_STOP=1 -f supabase/migrations/20251223000200_chunks_add_topic_path_fts.sql
+          psql -v ON_ERROR_STOP=1 -f supabase/migrations/20251223000300_create_curriculum_nodes.sql
+          psql -v ON_ERROR_STOP=1 -f supabase/migrations/20251223000400_rpc_hybrid_search_v2.sql
+          
+          # Step 5: Apply deterministic seed data
           psql -v ON_ERROR_STOP=1 -f test/fixtures/syllabus_boundary_seed.sql
       
       - name: Run leakage tests

--- a/test/fixtures/baseline-schema.sql
+++ b/test/fixtures/baseline-schema.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- Baseline Schema for CI Migration Replay
+-- 
+-- Purpose: Simulate "old production state" before syllabus boundary migrations
+-- This file creates the MINIMAL chunks table that migration 2 expects to ALTER.
+-- 
+-- IMPORTANT:
+-- - DO NOT include: topic_path, fts, syllabus_code, node_id, curriculum_nodes
+-- - These should be created by migrations 2, 3, 4
+-- - DO NOT create ltree extension (migration 1 does this)
+-- =============================================================================
+
+BEGIN;
+
+-- pgvector extension (required for embedding column)
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Drop existing tables to ensure clean state
+DROP TABLE IF EXISTS public.chunks CASCADE;
+DROP TABLE IF EXISTS public.curriculum_nodes CASCADE;
+
+-- Create baseline chunks table (pre-syllabus-boundary state)
+-- This matches the production schema BEFORE PR-1 migrations
+CREATE TABLE public.chunks (
+  id bigserial PRIMARY KEY,
+  content text NOT NULL,
+  metadata jsonb DEFAULT '{}'::jsonb,
+  embedding vector(1536),
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL
+);
+
+-- Basic embedding index (existed before syllabus boundary)
+CREATE INDEX IF NOT EXISTS chunks_embedding_idx ON public.chunks 
+  USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+
+COMMIT;


### PR DESCRIPTION
## Summary

This PR restores migrations replay as the CI required gate, ensuring that migration correctness is validated on every PR.

## Changes

1. **New file: \	est/fixtures/baseline-schema.sql\**
   - Simulates old production state (chunks table WITHOUT syllabus boundary columns)
   - Creates minimal schema that migration 2 expects to ALTER

2. **Modified: \.github/workflows/syllabus-boundary-tests.yml\**
   - Changed DB setup from \init-test-db.sql\ (bypasses migrations) to:
     - \aseline-schema.sql\  \supabase-shims.sql\  migrations(1..4)  seed
   - This validates that migrations can be replayed on production-like baseline

3. **Updated: \	est/fixtures/README.md\**
   - Documented two paths: CI (migrations replay) vs Local (quick start)
   - Added warnings about not using \init-test-db.sql\ in CI required gate

## Why This Matters

- **Before**: CI used \init-test-db.sql\ which creates final schema directly, bypassing migration validation
- **After**: CI replays migrations on baseline, catching migration bugs before merge

## Required Gate

Job name: \syllabus-boundary-leakage-gate\ (unchanged, branch protection compatible)