### PR TITLE
Harden community backend security and contracts

### DIFF
--- a/api/community/__tests__/content-counter-consistency.test.js
+++ b/api/community/__tests__/content-counter-consistency.test.js
@@ -1,0 +1,215 @@
+import { jest } from '@jest/globals';
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://example.supabase.co';
+process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || 'anon-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'service-key';
+process.env.ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS || 'http://localhost:3000';
+
+let authResponse = { data: { user: { id: 'moderator-1' } }, error: null };
+let queryResolver = () => {
+  throw new Error('Unhandled Supabase query');
+};
+const calls = [];
+
+function createSupabaseStub() {
+  class QueryBuilder {
+    constructor(table) {
+      this.table = table;
+      this.operation = 'select';
+      this.payload = null;
+      this.filters = [];
+      this.options = {};
+    }
+
+    select(columns) {
+      this.options.columns = columns;
+      return this;
+    }
+
+    update(payload) {
+      this.operation = 'update';
+      this.payload = payload;
+      return this;
+    }
+
+    delete() {
+      this.operation = 'delete';
+      return this;
+    }
+
+    upsert(payload, options = {}) {
+      this.operation = 'upsert';
+      this.payload = payload;
+      this.options.upsert = options;
+      return this;
+    }
+
+    eq(field, value) {
+      this.filters.push({ operator: 'eq', field, value });
+      return this;
+    }
+
+    single() {
+      const snapshot = this.snapshot({ single: true });
+      calls.push(snapshot);
+      return Promise.resolve(queryResolver(snapshot));
+    }
+
+    maybeSingle() {
+      const snapshot = this.snapshot({ maybeSingle: true });
+      calls.push(snapshot);
+      return Promise.resolve(queryResolver(snapshot));
+    }
+
+    then(resolve, reject) {
+      const snapshot = this.snapshot();
+      calls.push(snapshot);
+      return Promise.resolve(queryResolver(snapshot)).then(resolve, reject);
+    }
+
+    snapshot(extra = {}) {
+      return {
+        table: this.table,
+        operation: this.operation,
+        payload: this.payload,
+        filters: [...this.filters],
+        options: {
+          ...this.options,
+          ...extra,
+        },
+      };
+    }
+  }
+
+  return {
+    auth: {
+      getUser: jest.fn(async () => authResponse),
+    },
+    sql(strings, ...values) {
+      return { text: String.raw({ raw: strings }, ...values) };
+    },
+    from(table) {
+      return new QueryBuilder(table);
+    },
+  };
+}
+
+const supabaseStub = createSupabaseStub();
+const mockGetServiceClient = jest.fn(() => supabaseStub);
+
+jest.unstable_mockModule('../../lib/supabase/client.js', () => ({
+  getServiceClient: mockGetServiceClient,
+}));
+
+const { default: questionsHandler } = await import('../questions.js');
+const { default: answersHandler } = await import('../answers.js');
+
+function createReq({ method = 'DELETE', query = {}, headers = {} } = {}) {
+  return {
+    method,
+    query,
+    headers,
+    body: {},
+  };
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    headers: {},
+    setHeader(name, value) {
+      this.headers[String(name).toLowerCase()] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    end(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+beforeEach(() => {
+  authResponse = { data: { user: { id: 'moderator-1' } }, error: null };
+  queryResolver = () => {
+    throw new Error('Unhandled Supabase query');
+  };
+  calls.length = 0;
+  jest.clearAllMocks();
+});
+
+describe('community content counter consistency', () => {
+  it('decrements the deleted question author counter instead of the acting moderator', async () => {
+    queryResolver = (query) => {
+      if (query.table === 'community_questions' && query.operation === 'select') {
+        return { data: { id: 'question-1', author_id: 'author-1' }, error: null };
+      }
+      if (query.table === 'user_community_profiles' && query.operation === 'select') {
+        return { data: { user_id: 'moderator-1', role: 'moderator', reputation_score: 100 }, error: null };
+      }
+      if (query.table === 'community_questions' && query.operation === 'update') {
+        return { data: null, error: null };
+      }
+      if (query.table === 'user_community_profiles' && query.operation === 'upsert') {
+        return { data: null, error: null };
+      }
+      throw new Error(`Unhandled query: ${query.table} ${query.operation}`);
+    };
+
+    const req = createReq({
+      query: { question_id: 'question-1' },
+      headers: { origin: 'http://localhost:3000', authorization: 'Bearer token' },
+    });
+    const res = createRes();
+
+    await questionsHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const counterUpdate = calls.find((call) => call.table === 'user_community_profiles' && call.operation === 'upsert');
+    expect(counterUpdate.payload.user_id).toBe('author-1');
+  });
+
+  it('decrements the deleted answer author counter instead of the acting moderator', async () => {
+    queryResolver = (query) => {
+      if (query.table === 'community_answers' && query.operation === 'select') {
+        return {
+          data: { id: 'answer-1', author_id: 'answerer-1', question_id: 'question-1', is_best_answer: false },
+          error: null,
+        };
+      }
+      if (query.table === 'user_community_profiles' && query.operation === 'select') {
+        return { data: { user_id: 'moderator-1', role: 'moderator', reputation_score: 100 }, error: null };
+      }
+      if (query.table === 'community_answers' && query.operation === 'delete') {
+        return { data: null, error: null };
+      }
+      if (query.table === 'community_questions' && query.operation === 'update') {
+        return { data: null, error: null };
+      }
+      if (query.table === 'user_community_profiles' && query.operation === 'upsert') {
+        return { data: null, error: null };
+      }
+      throw new Error(`Unhandled query: ${query.table} ${query.operation}`);
+    };
+
+    const req = createReq({
+      query: { answer_id: 'answer-1' },
+      headers: { origin: 'http://localhost:3000', authorization: 'Bearer token' },
+    });
+    const res = createRes();
+
+    await answersHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const counterUpdate = calls.find((call) => call.table === 'user_community_profiles' && call.operation === 'upsert');
+    expect(counterUpdate.payload.user_id).toBe('answerer-1');
+  });
+});

--- a/api/community/__tests__/interactions-contract.test.js
+++ b/api/community/__tests__/interactions-contract.test.js
@@ -1,0 +1,232 @@
+import { jest } from '@jest/globals';
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://example.supabase.co';
+process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || 'anon-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'service-key';
+process.env.ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS || 'http://localhost:3000';
+
+let authResponse = { data: { user: { id: 'user-1' } }, error: null };
+let queryResolver = () => {
+  throw new Error('Unhandled Supabase query');
+};
+const calls = [];
+
+function createSupabaseStub() {
+  class QueryBuilder {
+    constructor(table) {
+      this.table = table;
+      this.operation = 'select';
+      this.payload = null;
+      this.filters = [];
+      this.options = {};
+    }
+
+    select(columns) {
+      this.options.columns = columns;
+      return this;
+    }
+
+    insert(payload) {
+      this.operation = 'insert';
+      this.payload = payload;
+      return this;
+    }
+
+    eq(field, value) {
+      this.filters.push({ operator: 'eq', field, value });
+      return this;
+    }
+
+    in(field, value) {
+      this.filters.push({ operator: 'in', field, value });
+      return this;
+    }
+
+    limit(value) {
+      this.options.limit = value;
+      return this;
+    }
+
+    single() {
+      const snapshot = this.snapshot({ single: true });
+      calls.push(snapshot);
+      return Promise.resolve(queryResolver(snapshot));
+    }
+
+    maybeSingle() {
+      const snapshot = this.snapshot({ maybeSingle: true });
+      calls.push(snapshot);
+      return Promise.resolve(queryResolver(snapshot));
+    }
+
+    snapshot(extra = {}) {
+      return {
+        table: this.table,
+        operation: this.operation,
+        payload: this.payload,
+        filters: [...this.filters],
+        options: {
+          ...this.options,
+          ...extra,
+        },
+      };
+    }
+  }
+
+  return {
+    auth: {
+      getUser: jest.fn(async () => authResponse),
+    },
+    from(table) {
+      return new QueryBuilder(table);
+    },
+  };
+}
+
+const supabaseStub = createSupabaseStub();
+const mockGetServiceClient = jest.fn(() => supabaseStub);
+
+jest.unstable_mockModule('../../lib/supabase/client.js', () => ({
+  getServiceClient: mockGetServiceClient,
+}));
+
+jest.unstable_mockModule('../badges.js', () => ({
+  checkAndAwardBadges: jest.fn(async () => []),
+}));
+
+jest.unstable_mockModule('../reputation.js', () => ({
+  updateUserReputation: jest.fn(async () => ({})),
+  REPUTATION_CONFIG: {},
+}));
+
+const { default: interactionsHandler } = await import('../interactions.js');
+
+function createReq({
+  method = 'POST',
+  query = {},
+  headers = {},
+  body = {},
+} = {}) {
+  return {
+    method,
+    query,
+    headers,
+    body,
+  };
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    headers: {},
+    setHeader(name, value) {
+      this.headers[String(name).toLowerCase()] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    end(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+beforeEach(() => {
+  authResponse = { data: { user: { id: 'user-1' } }, error: null };
+  queryResolver = () => {
+    throw new Error('Unhandled Supabase query');
+  };
+  calls.length = 0;
+  jest.clearAllMocks();
+});
+
+describe('community interactions contract', () => {
+  it('rejects duplicate bookmark creation without inserting a second row', async () => {
+    queryResolver = (query) => {
+      if (query.table === 'community_questions' && query.operation === 'select') {
+        return { data: { id: 'question-1' }, error: null };
+      }
+
+      if (query.table === 'user_community_profiles' && query.operation === 'select') {
+        return {
+          data: {
+            user_id: 'user-1',
+            role: 'student',
+            reputation_score: 100,
+          },
+          error: null,
+        };
+      }
+
+      if (query.table === 'community_interactions' && query.operation === 'select') {
+        const typeFilter = query.filters.find((filter) => filter.field === 'interaction_type');
+        if (typeFilter?.operator === 'eq' && typeFilter.value === 'bookmark') {
+          return {
+            data: {
+              id: 'bookmark-1',
+              interaction_type: 'bookmark',
+              content_type: 'question',
+              content_id: 'question-1',
+            },
+            error: null,
+          };
+        }
+
+        return { data: null, error: null };
+      }
+
+      if (query.table === 'community_interactions' && query.operation === 'insert') {
+        return {
+          data: {
+            id: 'new-bookmark',
+          },
+          error: null,
+        };
+      }
+
+      throw new Error(`Unhandled query: ${query.table} ${query.operation}`);
+    };
+
+    const req = createReq({
+      method: 'POST',
+      headers: {
+        origin: 'http://localhost:3000',
+        authorization: 'Bearer trusted-token',
+      },
+      body: {
+        content_type: 'question',
+        content_id: 'question-1',
+        interaction_type: 'bookmark',
+      },
+    });
+    const res = createRes();
+
+    await interactionsHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.code).toBe('INTERACTION_EXISTS');
+
+    const duplicateCheck = calls.find(
+      (call) =>
+        call.table === 'community_interactions' &&
+        call.operation === 'select' &&
+        call.filters.some(
+          (filter) => filter.operator === 'eq' && filter.field === 'interaction_type' && filter.value === 'bookmark'
+        )
+    );
+    expect(duplicateCheck).toBeDefined();
+
+    const inserts = calls.filter(
+      (call) => call.table === 'community_interactions' && call.operation === 'insert'
+    );
+    expect(inserts).toHaveLength(0);
+  });
+});

--- a/api/community/__tests__/notifications-contract.test.js
+++ b/api/community/__tests__/notifications-contract.test.js
@@ -1,0 +1,236 @@
+import { jest } from '@jest/globals';
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://example.supabase.co';
+process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || 'anon-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'service-key';
+process.env.ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS || 'http://localhost:3000';
+
+let authResponse = { data: { user: { id: 'trusted-user' } }, error: null };
+let queryResolver = () => {
+  throw new Error('Unhandled Supabase query');
+};
+const calls = [];
+
+function createSupabaseStub() {
+  class QueryBuilder {
+    constructor(table) {
+      this.table = table;
+      this.operation = 'select';
+      this.payload = null;
+      this.filters = [];
+      this.options = {};
+    }
+
+    select(columns) {
+      this.options.columns = columns;
+      return this;
+    }
+
+    update(payload) {
+      this.operation = 'update';
+      this.payload = payload;
+      return this;
+    }
+
+    delete() {
+      this.operation = 'delete';
+      return this;
+    }
+
+    eq(field, value) {
+      this.filters.push({ operator: 'eq', field, value });
+      return this;
+    }
+
+    single() {
+      const snapshot = this.snapshot({ single: true });
+      calls.push(snapshot);
+      return Promise.resolve(queryResolver(snapshot));
+    }
+
+    maybeSingle() {
+      const snapshot = this.snapshot({ maybeSingle: true });
+      calls.push(snapshot);
+      return Promise.resolve(queryResolver(snapshot));
+    }
+
+    then(resolve, reject) {
+      const snapshot = this.snapshot();
+      calls.push(snapshot);
+      return Promise.resolve(queryResolver(snapshot)).then(resolve, reject);
+    }
+
+    snapshot(extra = {}) {
+      return {
+        table: this.table,
+        operation: this.operation,
+        payload: this.payload,
+        filters: [...this.filters],
+        options: {
+          ...this.options,
+          ...extra,
+        },
+      };
+    }
+  }
+
+  return {
+    auth: {
+      getUser: jest.fn(async () => authResponse),
+    },
+    from(table) {
+      return new QueryBuilder(table);
+    },
+  };
+}
+
+const supabaseStub = createSupabaseStub();
+const mockGetServiceClient = jest.fn(() => supabaseStub);
+
+jest.unstable_mockModule('../../lib/supabase/client.js', () => ({
+  getServiceClient: mockGetServiceClient,
+}));
+
+const { default: deleteNotificationHandler } = await import('../notifications/[id].js');
+const { default: markNotificationReadHandler } = await import('../notifications/[id]/read.js');
+
+function createReq({ method = 'GET', query = {}, headers = {}, body = {} } = {}) {
+  return {
+    method,
+    query,
+    headers,
+    body,
+  };
+}
+
+function createRes() {
+  const headers = {};
+  return {
+    statusCode: 200,
+    headers,
+    body: null,
+    writableEnded: false,
+    setHeader(name, value) {
+      headers[String(name).toLowerCase()] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      this.writableEnded = true;
+      return this;
+    },
+    end(payload) {
+      this.body = payload;
+      this.writableEnded = true;
+      return this;
+    },
+  };
+}
+
+beforeEach(() => {
+  process.env.ALLOWED_ORIGINS = 'http://localhost:3000';
+  authResponse = { data: { user: { id: 'trusted-user' } }, error: null };
+  queryResolver = () => {
+    throw new Error('Unhandled Supabase query');
+  };
+  calls.length = 0;
+  jest.clearAllMocks();
+});
+
+describe('community notification contract hardening', () => {
+  it('returns 404 when single-notification read does not match the caller', async () => {
+    queryResolver = (query) => {
+      if (query.table === 'community_notifications') {
+        return { data: null, error: null };
+      }
+      throw new Error(`Unhandled query: ${query.table} ${query.operation}`);
+    };
+
+    const req = createReq({
+      method: 'POST',
+      headers: {
+        origin: 'http://localhost:3000',
+        authorization: 'Bearer trusted-token',
+      },
+      query: { id: 'notif-missing' },
+    });
+    const res = createRes();
+
+    await markNotificationReadHandler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body.code).toBe('NOTIFICATION_NOT_FOUND');
+  });
+
+  it('preserves first-read semantics by not rewriting an already-read notification', async () => {
+    queryResolver = (query) => {
+      if (query.table === 'community_notifications' && query.operation === 'select') {
+        return {
+          data: {
+            id: 'notif-read',
+            user_id: 'trusted-user',
+            is_read: true,
+            read_at: '2026-03-01T00:00:00.000Z',
+          },
+          error: null,
+        };
+      }
+      if (query.table === 'community_notifications' && query.operation === 'update') {
+        return {
+          data: {
+            id: 'notif-read',
+            is_read: true,
+            read_at: query.payload.read_at,
+          },
+          error: null,
+        };
+      }
+      throw new Error(`Unhandled query: ${query.table} ${query.operation}`);
+    };
+
+    const req = createReq({
+      method: 'POST',
+      headers: {
+        origin: 'http://localhost:3000',
+        authorization: 'Bearer trusted-token',
+      },
+      query: { id: 'notif-read' },
+    });
+    const res = createRes();
+
+    await markNotificationReadHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    const updateCalls = calls.filter((call) => call.operation === 'update');
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it('returns 404 when single-notification delete does not match the caller', async () => {
+    queryResolver = (query) => {
+      if (query.table === 'community_notifications') {
+        return { data: null, error: null };
+      }
+      throw new Error(`Unhandled query: ${query.table} ${query.operation}`);
+    };
+
+    const req = createReq({
+      method: 'DELETE',
+      headers: {
+        origin: 'http://localhost:3000',
+        authorization: 'Bearer trusted-token',
+      },
+      query: { id: 'notif-missing' },
+    });
+    const res = createRes();
+
+    await deleteNotificationHandler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body.code).toBe('NOTIFICATION_NOT_FOUND');
+  });
+});

--- a/api/community/__tests__/profiles-reputation-hardening.test.js
+++ b/api/community/__tests__/profiles-reputation-hardening.test.js
@@ -1,0 +1,309 @@
+import { jest } from '@jest/globals';
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'https://example.supabase.co';
+process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || 'anon-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'service-key';
+process.env.ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS || 'http://localhost:3000';
+
+let authResponse = { data: { user: { id: 'viewer-user' } }, error: null };
+let queryResolver = () => {
+  throw new Error('Unhandled Supabase query');
+};
+const calls = [];
+
+function createSupabaseStub() {
+  class QueryBuilder {
+    constructor(table) {
+      this.table = table;
+      this.operation = 'select';
+      this.payload = null;
+      this.filters = [];
+      this.options = {};
+    }
+
+    select(columns) {
+      this.options.columns = columns;
+      return this;
+    }
+
+    insert(payload) {
+      this.operation = 'insert';
+      this.payload = payload;
+      return this;
+    }
+
+    update(payload) {
+      this.operation = 'update';
+      this.payload = payload;
+      return this;
+    }
+
+    eq(field, value) {
+      this.filters.push({ operator: 'eq', field, value });
+      return this;
+    }
+
+    gte(field, value) {
+      this.filters.push({ operator: 'gte', field, value });
+      return this;
+    }
+
+    order(field, options = {}) {
+      this.options.order = { field, options };
+      return this;
+    }
+
+    limit(value) {
+      this.options.limit = value;
+      return this;
+    }
+
+    single() {
+      const snapshot = this.snapshot({ single: true });
+      calls.push(snapshot);
+      return Promise.resolve(queryResolver(snapshot));
+    }
+
+    maybeSingle() {
+      const snapshot = this.snapshot({ maybeSingle: true });
+      calls.push(snapshot);
+      return Promise.resolve(queryResolver(snapshot));
+    }
+
+    then(resolve, reject) {
+      const snapshot = this.snapshot();
+      calls.push(snapshot);
+      return Promise.resolve(queryResolver(snapshot)).then(resolve, reject);
+    }
+
+    snapshot(extra = {}) {
+      return {
+        table: this.table,
+        operation: this.operation,
+        payload: this.payload,
+        filters: [...this.filters],
+        options: {
+          ...this.options,
+          ...extra,
+        },
+      };
+    }
+  }
+
+  return {
+    auth: {
+      getUser: jest.fn(async () => authResponse),
+    },
+    from(table) {
+      return new QueryBuilder(table);
+    },
+  };
+}
+
+const supabaseStub = createSupabaseStub();
+const mockGetServiceClient = jest.fn(() => supabaseStub);
+
+jest.unstable_mockModule('../../lib/supabase/client.js', () => ({
+  getServiceClient: mockGetServiceClient,
+}));
+
+const { default: profilesHandler } = await import('../profiles.js');
+const { default: reputationHandler } = await import('../reputation.js');
+
+function createReq({ method = 'GET', query = {}, headers = {}, body = {} } = {}) {
+  return {
+    method,
+    query,
+    headers,
+    body,
+  };
+}
+
+function createRes() {
+  const headers = {};
+  return {
+    statusCode: 200,
+    headers,
+    body: null,
+    writableEnded: false,
+    setHeader(name, value) {
+      headers[String(name).toLowerCase()] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      this.writableEnded = true;
+      return this;
+    },
+    end(payload) {
+      this.body = payload;
+      this.writableEnded = true;
+      return this;
+    },
+  };
+}
+
+beforeEach(() => {
+  process.env.ALLOWED_ORIGINS = 'http://localhost:3000';
+  authResponse = { data: { user: { id: 'viewer-user' } }, error: null };
+  queryResolver = () => {
+    throw new Error('Unhandled Supabase query');
+  };
+  calls.length = 0;
+  jest.clearAllMocks();
+});
+
+describe('community profiles and reputation hardening', () => {
+  it('does not create a missing third-party profile during a read', async () => {
+    queryResolver = (query) => {
+      if (
+        query.table === 'user_community_profiles' &&
+        query.operation === 'select' &&
+        query.options.columns === 'visibility'
+      ) {
+        return { data: null, error: { code: 'PGRST116' } };
+      }
+      if (query.table === 'user_community_profiles' && query.operation === 'select') {
+        return { data: null, error: { code: 'PGRST116' } };
+      }
+      if (query.table === 'user_community_profiles' && query.operation === 'insert') {
+        return {
+          data: {
+            user_id: query.payload.user_id,
+            visibility: 'public',
+          },
+          error: null,
+        };
+      }
+      throw new Error(`Unhandled query: ${query.table} ${query.operation}`);
+    };
+
+    const req = createReq({
+      method: 'GET',
+      headers: {
+        origin: 'http://localhost:3000',
+        authorization: 'Bearer trusted-token',
+      },
+      query: { user_id: 'target-user' },
+    });
+    const res = createRes();
+
+    await profilesHandler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body.code).toBe('PROFILE_NOT_FOUND');
+    const insertCalls = calls.filter((call) => call.table === 'user_community_profiles' && call.operation === 'insert');
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('does not treat friends_only profiles as public', async () => {
+    queryResolver = (query) => {
+      if (
+        query.table === 'user_community_profiles' &&
+        query.operation === 'select' &&
+        query.options.columns === 'visibility'
+      ) {
+        return { data: { visibility: 'friends_only' }, error: null };
+      }
+      if (query.table === 'user_community_profiles' && query.operation === 'select') {
+        return {
+          data: {
+            user_id: 'target-user',
+            visibility: 'friends_only',
+            preferred_subjects: [],
+            learning_goals: [],
+            expertise_areas: [],
+            user_profiles: {
+              id: 'target-user',
+              username: 'target',
+              display_name: 'Target User',
+              avatar_url: null,
+              bio: null,
+              created_at: '2026-03-01T00:00:00.000Z',
+              updated_at: '2026-03-01T00:00:00.000Z',
+            },
+          },
+          error: null,
+        };
+      }
+      if (['community_questions', 'community_answers', 'community_interactions', 'user_badges', 'reputation_history'].includes(query.table)) {
+        if (query.options.columns === '*' || query.options.columns?.includes('count')) {
+          return { count: 0, error: null };
+        }
+        return { data: [], error: null };
+      }
+      throw new Error(`Unhandled query: ${query.table} ${query.operation}`);
+    };
+
+    const req = createReq({
+      method: 'GET',
+      headers: {
+        origin: 'http://localhost:3000',
+        authorization: 'Bearer trusted-token',
+      },
+      query: { user_id: 'target-user' },
+    });
+    const res = createRes();
+
+    await profilesHandler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.code).toBe('PROFILE_ACCESS_DENIED');
+  });
+
+  it('blocks non-owners from requesting another user history detail', async () => {
+    queryResolver = (query) => {
+      if (query.table === 'user_community_profiles' && query.operation === 'select') {
+        const userFilter = query.filters.find((filter) => filter.field === 'user_id')?.value;
+        if (userFilter === 'target-user') {
+          return {
+            data: {
+              user_id: 'target-user',
+              reputation_score: 42,
+              level: 'NEWCOMER',
+              role: 'student',
+            },
+            error: null,
+          };
+        }
+        return {
+          data: {
+            user_id: 'viewer-user',
+            reputation_score: 10,
+            level: 'NEWCOMER',
+            role: 'student',
+          },
+          error: null,
+        };
+      }
+      if (query.table === 'reputation_history') {
+        return { data: [], error: null };
+      }
+      throw new Error(`Unhandled query: ${query.table} ${query.operation}`);
+    };
+
+    const req = createReq({
+      method: 'GET',
+      headers: {
+        origin: 'http://localhost:3000',
+        authorization: 'Bearer trusted-token',
+      },
+      query: {
+        user_id: 'target-user',
+        include_history: 'true',
+      },
+    });
+    const res = createRes();
+
+    await reputationHandler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.code).toBe('REPUTATION_HISTORY_ACCESS_DENIED');
+    const historyCalls = calls.filter((call) => call.table === 'reputation_history');
+    expect(historyCalls).toHaveLength(0);
+  });
+});

--- a/api/community/__tests__/router-contract.test.js
+++ b/api/community/__tests__/router-contract.test.js
@@ -1,0 +1,148 @@
+import express from 'express';
+import request from 'supertest';
+import { jest } from '@jest/globals';
+
+const questionsHandler = jest.fn((req, res) => {
+  res.status(200).json({ module: 'questions', query: req.query, method: req.method });
+});
+const answersHandler = jest.fn((req, res) => {
+  res.status(200).json({ module: 'answers', query: req.query, method: req.method });
+});
+const interactionsHandler = jest.fn((req, res) => {
+  res.status(200).json({ module: 'interactions', query: req.query, method: req.method });
+});
+const profilesHandler = jest.fn((req, res) => {
+  res.status(200).json({ module: 'profiles', query: req.query, method: req.method });
+});
+const reputationHandler = jest.fn((req, res) => {
+  res.status(200).json({ module: 'reputation', query: req.query, method: req.method });
+});
+const badgesHandler = jest.fn((req, res) => {
+  res.status(200).json({ module: 'badges', query: req.query, method: req.method });
+});
+const notificationsHandler = jest.fn((req, res) => {
+  res.status(200).json({ module: 'notifications', query: req.query, method: req.method });
+});
+const notificationsReadAllHandler = jest.fn((req, res) => {
+  res.status(200).json({ module: 'notifications-read-all', query: req.query, method: req.method });
+});
+const notificationsUnreadCountHandler = jest.fn((req, res) => {
+  res.status(200).json({ module: 'notifications-unread-count', query: req.query, method: req.method });
+});
+const notificationItemHandler = jest.fn((req, res) => {
+  res.status(200).json({ module: 'notification-item', query: req.query, method: req.method });
+});
+const notificationReadHandler = jest.fn((req, res) => {
+  res.status(200).json({ module: 'notification-read', query: req.query, method: req.method });
+});
+
+jest.unstable_mockModule('../questions.js', () => ({ default: questionsHandler }));
+jest.unstable_mockModule('../answers.js', () => ({ default: answersHandler }));
+jest.unstable_mockModule('../interactions.js', () => ({ default: interactionsHandler }));
+jest.unstable_mockModule('../profiles.js', () => ({ default: profilesHandler }));
+jest.unstable_mockModule('../reputation.js', () => ({ default: reputationHandler }));
+jest.unstable_mockModule('../badges.js', () => ({ default: badgesHandler }));
+jest.unstable_mockModule('../notifications.js', () => ({ default: notificationsHandler }));
+jest.unstable_mockModule('../notifications/read-all.js', () => ({ default: notificationsReadAllHandler }));
+jest.unstable_mockModule('../notifications/unread-count.js', () => ({ default: notificationsUnreadCountHandler }));
+jest.unstable_mockModule('../notifications/[id].js', () => ({ default: notificationItemHandler }));
+jest.unstable_mockModule('../notifications/[id]/read.js', () => ({ default: notificationReadHandler }));
+
+jest.unstable_mockModule('../../middleware/auth.js', () => ({
+  authenticateToken: (req, _res, next) => {
+    req.user = { id: 'trusted-user', role: 'admin', permissions: ['manage_roles'] };
+    next();
+  },
+  requirePermission: () => (_req, _res, next) => next(),
+}));
+
+const { default: router } = await import('../index.js');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/community', router);
+  return app;
+}
+
+describe('community router contract', () => {
+  beforeEach(() => {
+    process.env.FRONTEND_URL = 'http://localhost:3000';
+    jest.clearAllMocks();
+  });
+
+  it('loads and maps REST-style params into the query contract used by the handlers', async () => {
+    const app = createApp();
+
+    const question = await request(app)
+      .get('/api/community/questions/question-123')
+      .set('Origin', 'http://localhost:3000');
+    expect(question.status).toBe(200);
+    expect(question.body.module).toBe('questions');
+    expect(question.body.query.question_id).toBe('question-123');
+
+    const badge = await request(app)
+      .get('/api/community/badges/user-456')
+      .set('Origin', 'http://localhost:3000');
+    expect(badge.status).toBe(200);
+    expect(badge.body.module).toBe('badges');
+    expect(badge.body.query.user_id).toBe('user-456');
+
+    const profile = await request(app)
+      .get('/api/community/users/user-789/profile')
+      .set('Origin', 'http://localhost:3000');
+    expect(profile.status).toBe(200);
+    expect(profile.body.module).toBe('profiles');
+    expect(profile.body.query.user_id).toBe('user-789');
+
+    const reputation = await request(app)
+      .get('/api/community/reputation/user-321')
+      .set('Origin', 'http://localhost:3000');
+    expect(reputation.status).toBe(200);
+    expect(reputation.body.module).toBe('reputation');
+    expect(reputation.body.query.user_id).toBe('user-321');
+
+    const adjust = await request(app)
+      .post('/api/community/reputation/adjust')
+      .set('Origin', 'http://localhost:3000');
+    expect(adjust.status).toBe(200);
+    expect(adjust.body.module).toBe('reputation');
+    expect(adjust.body.method).toBe('PUT');
+  });
+
+  it('dispatches notification subroutes to the correct dedicated handlers', async () => {
+    const app = createApp();
+
+    const list = await request(app)
+      .get('/api/community/notifications')
+      .set('Origin', 'http://localhost:3000');
+    expect(list.status).toBe(200);
+    expect(list.body.module).toBe('notifications');
+
+    const readAll = await request(app)
+      .post('/api/community/notifications/read-all')
+      .set('Origin', 'http://localhost:3000');
+    expect(readAll.status).toBe(200);
+    expect(readAll.body.module).toBe('notifications-read-all');
+
+    const unreadCount = await request(app)
+      .get('/api/community/notifications/unread-count')
+      .set('Origin', 'http://localhost:3000');
+    expect(unreadCount.status).toBe(200);
+    expect(unreadCount.body.module).toBe('notifications-unread-count');
+
+    const markRead = await request(app)
+      .post('/api/community/notifications/notif-1/read')
+      .set('Origin', 'http://localhost:3000');
+    expect(markRead.status).toBe(200);
+    expect(markRead.body.module).toBe('notification-read');
+    expect(markRead.body.query.id).toBe('notif-1');
+
+    const remove = await request(app)
+      .delete('/api/community/notifications/notif-2')
+      .set('Origin', 'http://localhost:3000');
+    expect(remove.status).toBe(200);
+    expect(remove.body.module).toBe('notification-item');
+    expect(remove.body.query.id).toBe('notif-2');
+  });
+});

--- a/api/community/__tests__/security-hardening.test.js
+++ b/api/community/__tests__/security-hardening.test.js
@@ -1,9 +1,101 @@
 import fs from 'fs';
 import path from 'path';
+import { pathToFileURL } from 'url';
+import { jest } from '@jest/globals';
 
 function readSource(relPath) {
   return fs.readFileSync(path.join(process.cwd(), relPath), 'utf8');
 }
+
+async function importFresh(relPath) {
+  const href = pathToFileURL(path.join(process.cwd(), relPath)).href;
+  return import(`${href}?t=${Date.now()}_${Math.random()}`);
+}
+
+function withSupabaseEnv() {
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+}
+
+function createMockResponse() {
+  return {
+    headers: {},
+    statusCode: null,
+    body: null,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    end() {
+      return this;
+    }
+  };
+}
+
+async function loadNotificationHandler(
+  relPath,
+  {
+    initialResult = { data: null, error: null },
+    mutationOperation = 'delete',
+    mutationResult = { data: null, error: null }
+  } = {}
+) {
+  jest.resetModules();
+  withSupabaseEnv();
+
+  const authGetUser = jest.fn().mockResolvedValue({
+    data: { user: { id: 'user-1' } },
+    error: null
+  });
+
+  await jest.unstable_mockModule('../../lib/supabase/client.js', () => ({
+    getServiceClient: () => ({
+      auth: { getUser: authGetUser },
+      from: jest.fn(() => {
+        let currentOperation = 'select';
+
+        const builder = {
+          select: jest.fn(() => builder),
+          update: jest.fn(() => {
+            currentOperation = 'update';
+            return builder;
+          }),
+          delete: jest.fn(() => {
+            currentOperation = 'delete';
+            return builder;
+          }),
+          eq: jest.fn(() => builder),
+          maybeSingle: jest.fn(() => Promise.resolve(
+            currentOperation === 'select' ? initialResult : mutationResult
+          ))
+        };
+
+        if (mutationOperation === 'update') {
+          builder[mutationOperation] = builder.update;
+        } else {
+          builder[mutationOperation] = builder.delete;
+        }
+
+        return builder;
+      })
+    })
+  }));
+
+  const module = await importFresh(relPath);
+  return module.default;
+}
+
+afterEach(() => {
+  jest.resetModules();
+});
 
 describe('community security hardening (T14)', () => {
   const corsFiles = [
@@ -55,5 +147,74 @@ describe('community security hardening (T14)', () => {
     expect(markRead).not.toContain('req.url.split');
     expect(deleteById).toContain('req.query?.id');
     expect(markRead).toContain('req.query?.id');
+  });
+
+  it('loads the aggregate community router without missing handler exports', async () => {
+    withSupabaseEnv();
+
+    await expect(importFresh('api/community/index.js')).resolves.toHaveProperty('default');
+  });
+
+  it('returns not found when marking a missing notification as read', async () => {
+    const handler = await loadNotificationHandler(
+      'api/community/notifications/[id]/read.js',
+      {
+        initialResult: { data: null, error: null },
+        mutationOperation: 'update',
+        mutationResult: { data: null, error: null }
+      }
+    );
+
+    const req = {
+      method: 'POST',
+      query: { id: 'missing-notification' },
+      headers: { authorization: 'Bearer test-token' }
+    };
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toMatchObject({
+      code: 'NOTIFICATION_NOT_FOUND'
+    });
+  });
+
+  it('returns not found when deleting a missing notification', async () => {
+    const handler = await loadNotificationHandler(
+      'api/community/notifications/[id].js',
+      {
+        mutationOperation: 'delete',
+        mutationResult: { data: null, error: null }
+      }
+    );
+
+    const req = {
+      method: 'DELETE',
+      query: { id: 'missing-notification' },
+      headers: { authorization: 'Bearer test-token' }
+    };
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toMatchObject({
+      code: 'NOTIFICATION_NOT_FOUND'
+    });
+  });
+
+  it('prevents duplicate non-vote interactions instead of checking only vote conflicts', () => {
+    const interactions = readSource('api/community/interactions.js');
+
+    expect(interactions).not.toContain(".in('interaction_type', ['upvote', 'downvote']) // 只检查投票类型的冲突");
+    expect(interactions).toContain(".eq('interaction_type', interactionType)");
+  });
+
+  it('keeps voter reputation updates symmetric when switching vote types', () => {
+    const interactions = readSource('api/community/interactions.js');
+    const voterUpdates = interactions.match(/updateUserReputationLocal\(user\.id,/g) || [];
+
+    expect(voterUpdates).toHaveLength(3);
   });
 });

--- a/api/community/answers.js
+++ b/api/community/answers.js
@@ -545,7 +545,7 @@ async function handleDeleteAnswer(req, res, user) {
     await updateQuestionAnswerCount(existingAnswer.question_id, -1);
 
     // 更新用户统计
-    await updateUserAnswerCount(user.id, -1);
+    await updateUserAnswerCount(existingAnswer.author_id, -1);
 
     // 如果删除的是最佳答案，扣除声誉分
     if (existingAnswer.is_best_answer) {
@@ -747,3 +747,4 @@ async function updateUserReputation(userId, increment) {
 
 // 导出配置供其他模块使用
 export { ANSWER_CONFIG };
+

--- a/api/community/index.js
+++ b/api/community/index.js
@@ -1,26 +1,27 @@
-// 社区系统主路由
 import express from 'express';
 import cors from 'cors';
 import { authenticateToken, requirePermission } from '../middleware/auth.js';
 import { getRequestId, sendApiError } from './lib/security.js';
 
-// 导入各个模块的处理函数
-import { handleGetQuestions, handleCreateQuestion, handleGetQuestionById, handleUpdateQuestion, handleDeleteQuestion } from './questions.js';
-import { handleGetAnswers, handleCreateAnswer, handleGetAnswerById, handleUpdateAnswer, handleDeleteAnswer } from './answers.js';
-import { handleGetInteractions, handleCreateInteraction, handleDeleteInteraction } from './interactions.js';
-import { handleGetBadges, handleAwardBadge } from './badges.js';
-import { handleGetReputation, handleUpdateReputation, handleAdjustReputation } from './reputation.js';
-import { handleGetProfile, handleUpdateProfile, handleCreateProfile } from './profiles.js';
+import questionsHandler from './questions.js';
+import answersHandler from './answers.js';
+import interactionsHandler from './interactions.js';
+import badgesHandler from './badges.js';
+import reputationHandler from './reputation.js';
+import profilesHandler from './profiles.js';
+import notificationsHandler from './notifications.js';
+import notificationsReadAllHandler from './notifications/read-all.js';
+import notificationsUnreadCountHandler from './notifications/unread-count.js';
+import notificationItemHandler from './notifications/[id].js';
+import notificationReadHandler from './notifications/[id]/read.js';
 
 const router = express.Router();
 
-// CORS配置
 router.use(cors({
   origin: process.env.FRONTEND_URL || 'http://localhost:3000',
-  credentials: true
+  credentials: true,
 }));
 
-// JSON解析中间件
 router.use(express.json());
 router.use((req, res, next) => {
   const requestId = getRequestId(req);
@@ -29,255 +30,105 @@ router.use((req, res, next) => {
   next();
 });
 
-// ==================== 问题相关路由 ====================
+function delegate(handler, { query, body, method } = {}) {
+  return async (req, res, next) => {
+    const originalQuery = req.query;
+    const originalBody = req.body;
+    const originalMethod = req.method;
 
-// 获取问题列表
-router.get('/questions', async (req, res) => {
-  try {
-    await handleGetQuestions(req, res);
-  } catch (error) {
-    console.error('Get questions error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
+    if (typeof query === 'function') {
+      req.query = {
+        ...(req.query || {}),
+        ...query(req),
+      };
+    }
 
-// 创建问题
-router.post('/questions', authenticateToken, async (req, res) => {
-  try {
-    await handleCreateQuestion(req, res);
-  } catch (error) {
-    console.error('Create question error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
+    if (typeof body === 'function') {
+      req.body = {
+        ...(req.body || {}),
+        ...body(req),
+      };
+    }
 
-// 获取单个问题
-router.get('/questions/:id', async (req, res) => {
-  try {
-    await handleGetQuestionById(req, res);
-  } catch (error) {
-    console.error('Get question by id error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
+    if (typeof method === 'string' && method) {
+      req.method = method;
+    }
 
-// 更新问题
-router.put('/questions/:id', authenticateToken, async (req, res) => {
-  try {
-    await handleUpdateQuestion(req, res);
-  } catch (error) {
-    console.error('Update question error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 删除问题
-router.delete('/questions/:id', authenticateToken, async (req, res) => {
-  try {
-    await handleDeleteQuestion(req, res);
-  } catch (error) {
-    console.error('Delete question error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// ==================== 回答相关路由 ====================
-
-// 获取回答列表
-router.get('/answers', async (req, res) => {
-  try {
-    await handleGetAnswers(req, res);
-  } catch (error) {
-    console.error('Get answers error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 创建回答
-router.post('/answers', authenticateToken, async (req, res) => {
-  try {
-    await handleCreateAnswer(req, res);
-  } catch (error) {
-    console.error('Create answer error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 获取单个回答
-router.get('/answers/:id', async (req, res) => {
-  try {
-    await handleGetAnswerById(req, res);
-  } catch (error) {
-    console.error('Get answer by id error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 更新回答
-router.put('/answers/:id', authenticateToken, async (req, res) => {
-  try {
-    await handleUpdateAnswer(req, res);
-  } catch (error) {
-    console.error('Update answer error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 删除回答
-router.delete('/answers/:id', authenticateToken, async (req, res) => {
-  try {
-    await handleDeleteAnswer(req, res);
-  } catch (error) {
-    console.error('Delete answer error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// ==================== 互动相关路由 ====================
-
-// 获取互动记录
-router.get('/interactions', authenticateToken, async (req, res) => {
-  try {
-    await handleGetInteractions(req, res);
-  } catch (error) {
-    console.error('Get interactions error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 创建互动
-router.post('/interactions', authenticateToken, async (req, res) => {
-  try {
-    await handleCreateInteraction(req, res);
-  } catch (error) {
-    console.error('Create interaction error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 删除互动
-router.delete('/interactions/:id', authenticateToken, async (req, res) => {
-  try {
-    await handleDeleteInteraction(req, res);
-  } catch (error) {
-    console.error('Delete interaction error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 通用互动端点（兼容性）
-router.post('/:type/:id/interact', authenticateToken, async (req, res) => {
-  try {
-    // 将参数转换为interactions格式
-    req.body.contentType = req.params.type;
-    req.body.contentId = req.params.id;
-    await handleCreateInteraction(req, res);
-  } catch (error) {
-    console.error('Interact error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// ==================== 徽章相关路由 ====================
-
-// 获取用户徽章
-router.get('/badges/:userId?', async (req, res) => {
-  try {
-    await handleGetBadges(req, res);
-  } catch (error) {
-    console.error('Get badges error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 颁发徽章（系统调用）
-router.post('/badges/award', authenticateToken, requirePermission('manage_roles'), async (req, res) => {
-  try {
-    await handleAwardBadge(req, res);
-  } catch (error) {
-    console.error('Award badge error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// ==================== 声誉相关路由 ====================
-
-// 获取用户声誉信息
-router.get('/reputation/:userId?', async (req, res) => {
-  try {
-    await handleGetReputation(req, res);
-  } catch (error) {
-    console.error('Get reputation error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 更新用户声誉（系统调用）
-router.post('/reputation/update', authenticateToken, requirePermission('manage_roles'), async (req, res) => {
-  try {
-    await handleUpdateReputation(req, res);
-  } catch (error) {
-    console.error('Update reputation error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 调整用户声誉（管理员功能）
-router.post('/reputation/adjust', authenticateToken, requirePermission('manage_roles'), async (req, res) => {
-  try {
-    await handleAdjustReputation(req, res);
-  } catch (error) {
-    console.error('Adjust reputation error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// ==================== 用户档案相关路由 ====================
-
-// 获取用户档案
-router.get('/users/:userId/profile', async (req, res) => {
-  try {
-    await handleGetProfile(req, res);
-  } catch (error) {
-    console.error('Get profile error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 更新用户档案
-router.put('/users/:userId/profile', authenticateToken, async (req, res) => {
-  try {
-    await handleUpdateProfile(req, res);
-  } catch (error) {
-    console.error('Update profile error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// 创建用户档案
-router.post('/users/:userId/profile', authenticateToken, async (req, res) => {
-  try {
-    await handleCreateProfile(req, res);
-  } catch (error) {
-    console.error('Create profile error:', error);
-    sendApiError(res, { status: 500, error: 'internal_server_error', code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error', requestId: req.requestId });
-  }
-});
-
-// ==================== 健康检查 ====================
+    try {
+      await handler(req, res);
+    } catch (error) {
+      next(error);
+    } finally {
+      req.query = originalQuery;
+      req.body = originalBody;
+      req.method = originalMethod;
+    }
+  };
+}
 
 router.get('/health', (req, res) => {
-  res.json({ 
-    status: 'ok', 
+  res.json({
+    status: 'ok',
     service: 'community-api',
     timestamp: new Date().toISOString(),
-    version: '1.0.0'
+    version: '1.0.0',
   });
 });
 
-// ==================== 错误处理 ====================
+router.all('/questions', delegate(questionsHandler));
+router.all('/questions/:id', delegate(questionsHandler, {
+  query: (req) => ({ question_id: req.params.id }),
+}));
 
-// 404处理
+router.all('/answers', delegate(answersHandler));
+router.all('/answers/:id', delegate(answersHandler, {
+  query: (req) => ({ answer_id: req.params.id }),
+}));
+
+router.all('/interactions', delegate(interactionsHandler));
+router.delete('/interactions/:id', delegate(interactionsHandler, {
+  query: (req) => ({ interaction_id: req.params.id }),
+}));
+router.post('/:type/:id/interact', authenticateToken, delegate(interactionsHandler, {
+  body: (req) => ({
+    content_type: req.params.type,
+    content_id: req.params.id,
+  }),
+}));
+
+router.post('/badges/award', authenticateToken, requirePermission('manage_roles'), delegate(badgesHandler));
+router.all('/badges', delegate(badgesHandler));
+router.all('/badges/:userId', delegate(badgesHandler, {
+  query: (req) => ({ user_id: req.params.userId }),
+}));
+
+router.post('/reputation/update', authenticateToken, requirePermission('manage_roles'), delegate(reputationHandler));
+router.post('/reputation/adjust', authenticateToken, requirePermission('manage_roles'), delegate(reputationHandler, {
+  method: 'PUT',
+}));
+router.all('/reputation', delegate(reputationHandler));
+router.all('/reputation/:userId', delegate(reputationHandler, {
+  query: (req) => ({ user_id: req.params.userId }),
+}));
+
+router.all('/profiles', delegate(profilesHandler));
+router.all('/profiles/:userId', delegate(profilesHandler, {
+  query: (req) => ({ user_id: req.params.userId }),
+}));
+router.all('/users/:userId/profile', delegate(profilesHandler, {
+  query: (req) => ({ user_id: req.params.userId }),
+}));
+
+router.post('/notifications/read-all', delegate(notificationsReadAllHandler));
+router.get('/notifications/unread-count', delegate(notificationsUnreadCountHandler));
+router.all('/notifications', delegate(notificationsHandler));
+router.all('/notifications/:id/read', delegate(notificationReadHandler, {
+  query: (req) => ({ id: req.params.id }),
+}));
+router.all('/notifications/:id', delegate(notificationItemHandler, {
+  query: (req) => ({ id: req.params.id }),
+}));
+
 router.use('*', (req, res) => {
   sendApiError(res, {
     status: 404,
@@ -287,15 +138,15 @@ router.use('*', (req, res) => {
     requestId: req.requestId,
     details: {
       path: req.originalUrl,
-      method: req.method
-    }
+      method: req.method,
+    },
   });
 });
 
-// 全局错误处理
 router.use((error, req, res, next) => {
+  void next;
   console.error('Community API Error:', { request_id: req.requestId, error });
-  
+
   if (error.name === 'ValidationError') {
     return sendApiError(res, {
       status: 400,
@@ -303,28 +154,27 @@ router.use((error, req, res, next) => {
       code: 'VALIDATION_ERROR',
       message: 'Validation failed',
       requestId: req.requestId,
-      details: error.message
+      details: error.message,
     });
   }
-  
+
   if (error.name === 'UnauthorizedError') {
     return sendApiError(res, {
       status: 401,
       error: 'unauthorized',
       code: 'UNAUTHORIZED',
       message: 'Unauthorized access',
-      requestId: req.requestId
+      requestId: req.requestId,
     });
   }
-  
-  sendApiError(res, {
+
+  return sendApiError(res, {
     status: 500,
     error: 'internal_server_error',
     code: 'INTERNAL_SERVER_ERROR',
     message: process.env.NODE_ENV === 'development' ? error.message : 'Something went wrong',
-    requestId: req.requestId
+    requestId: req.requestId,
   });
 });
 
 export default router;
-

--- a/api/community/interactions.js
+++ b/api/community/interactions.js
@@ -424,11 +424,15 @@ async function handleCreateInteraction(req, res, user) {
 // 删除互动
 async function handleDeleteInteraction(req, res, user) {
   try {
-    const { content_type, content_id, interaction_type } = req.query;
+    const { interaction_id, content_type, content_id, interaction_type } = req.query;
+
+    if (interaction_id) {
+      return await handleDeleteInteractionById(interaction_id, user, res);
+    }
 
     if (!content_type || !content_id || !interaction_type) {
       return res.status(400).json({
-        error: 'content_type, content_id, and interaction_type are required',
+        error: 'interaction_id or content_type, content_id, and interaction_type are required',
         code: 'MISSING_REQUIRED_FIELDS'
       });
     }
@@ -570,6 +574,14 @@ async function updateInteractionType(interactionId, newType, user, res) {
       await updateUserReputationLocal(contentAuthorId, oldReputationChange + newReputationChange);
     }
 
+    const oldVoterReputationChange = oldInteraction.interaction_type === 'upvote'
+      ? -INTERACTION_CONFIG.REPUTATION_REWARDS.UPVOTE_GIVEN
+      : -INTERACTION_CONFIG.REPUTATION_REWARDS.DOWNVOTE_GIVEN;
+    const newVoterReputationChange = newType === 'upvote'
+      ? INTERACTION_CONFIG.REPUTATION_REWARDS.UPVOTE_GIVEN
+      : INTERACTION_CONFIG.REPUTATION_REWARDS.DOWNVOTE_GIVEN;
+    await updateUserReputationLocal(user.id, oldVoterReputationChange + newVoterReputationChange);
+
     return res.status(200).json({
       success: true,
       data: updatedInteraction,
@@ -627,14 +639,22 @@ async function checkIfUserIsContentAuthor(userId, contentType, contentId) {
 // 获取现有互动
 async function getExistingInteraction(userId, contentType, contentId, interactionType) {
   try {
-    const { data, error } = await supabase
+    let query = supabase
       .from('community_interactions')
       .select('*')
       .eq('user_id', userId)
       .eq('content_type', contentType)
-      .eq('content_id', contentId)
-      .in('interaction_type', ['upvote', 'downvote']) // 只检查投票类型的冲突
-      .single();
+      .eq('content_id', contentId);
+
+    if (['upvote', 'downvote'].includes(interactionType)) {
+      query = query.in('interaction_type', ['upvote', 'downvote']);
+    } else {
+      query = query.eq('interaction_type', interactionType);
+    }
+
+    const { data, error } = await query
+      .limit(1)
+      .maybeSingle();
 
     if (error && error.code !== 'PGRST116') {
       throw error;

--- a/api/community/notifications/[id].js
+++ b/api/community/notifications/[id].js
@@ -60,14 +60,26 @@ export default async function handler(req, res) {
 				requestId
 			});
 		}
-		const { error } = await supabase
+		const { data, error } = await supabase
 			.from('community_notifications')
 			.delete()
 			.eq('id', id)
-			.eq('user_id', user.id);
+			.eq('user_id', user.id)
+			.select('id')
+			.maybeSingle();
 
 		if (error) {
 			throw error;
+		}
+
+		if (!data?.id) {
+			return sendApiError(res, {
+				status: 404,
+				error: 'notification_not_found',
+				code: 'NOTIFICATION_NOT_FOUND',
+				message: 'Notification not found',
+				requestId
+			});
 		}
 
 		return res.status(200).json({ success: true });
@@ -82,4 +94,5 @@ export default async function handler(req, res) {
 		});
 	}
 }
+
 

--- a/api/community/notifications/[id]/read.js
+++ b/api/community/notifications/[id]/read.js
@@ -61,17 +61,57 @@ export default async function handler(req, res) {
 			});
 		}
 
-		const { error } = await supabase
+		const { data: existingNotification, error: existingError } = await supabase
+			.from('community_notifications')
+			.select('id, is_read, read_at')
+			.eq('id', id)
+			.eq('user_id', user.id)
+			.maybeSingle();
+
+		if (existingError) {
+			throw existingError;
+		}
+
+		if (!existingNotification?.id) {
+			return sendApiError(res, {
+				status: 404,
+				error: 'notification_not_found',
+				code: 'NOTIFICATION_NOT_FOUND',
+				message: 'Notification not found',
+				requestId
+			});
+		}
+
+		if (existingNotification.is_read) {
+			return res.status(200).json({
+				success: true,
+				already_read: true,
+				read_at: existingNotification.read_at || null
+			});
+		}
+
+		const { data, error } = await supabase
 			.from('community_notifications')
 			.update({ is_read: true, read_at: new Date().toISOString() })
 			.eq('id', id)
-			.eq('user_id', user.id);
+			.eq('user_id', user.id)
+			.eq('is_read', false)
+			.select('id, read_at')
+			.maybeSingle();
 
 		if (error) {
 			throw error;
 		}
 
-		return res.status(200).json({ success: true });
+		if (!data?.id) {
+			return res.status(200).json({
+				success: true,
+				already_read: true,
+				read_at: existingNotification.read_at || null
+			});
+		}
+
+		return res.status(200).json({ success: true, read_at: data.read_at || null });
 	} catch (error) {
 		console.error('Mark as read error:', { request_id: requestId, error });
 		return sendApiError(res, {
@@ -83,3 +123,4 @@ export default async function handler(req, res) {
 		});
 	}
 }
+

--- a/api/community/profiles.js
+++ b/api/community/profiles.js
@@ -128,14 +128,7 @@ async function handleGetProfile(req, res, user) {
       activity_limit = 20
     } = req.query;
 
-    // 检查是否有权限查看该档案
-    const canView = await checkProfileViewPermission(user.id, user_id);
-    if (!canView) {
-      return res.status(403).json({
-        error: 'No permission to view this profile',
-        code: 'PROFILE_ACCESS_DENIED'
-      });
-    }
+    const isOwnProfile = user.id === user_id;
 
     // 获取基础档案信息
     const { data: profile, error: profileError } = await supabase
@@ -154,16 +147,43 @@ async function handleGetProfile(req, res, user) {
       throw profileError;
     }
 
-    // 如果档案不存在，创建默认档案
+    if (!profile && !isOwnProfile) {
+      return res.status(404).json({
+        error: 'Profile not found',
+        code: 'PROFILE_NOT_FOUND'
+      });
+    }
+
+    // 检查是否有权限查看该档案
+    const canView = await checkProfileViewPermission(user.id, user_id, profile?.visibility);
+    if (!canView) {
+      return res.status(403).json({
+        error: 'No permission to view this profile',
+        code: 'PROFILE_ACCESS_DENIED'
+      });
+    }
+
+    // 如果档案不存在，返回瞬时默认档案，但不在GET路径中写库
     if (!profile) {
-      const defaultProfile = await createDefaultProfile(user_id);
+      const defaultProfile = {
+        user_id,
+        role: 'student',
+        reputation_score: 0,
+        level: 'NEWCOMER',
+        visibility: 'public',
+        email_notifications: true,
+        push_notifications: true,
+        user_profiles: null
+      };
       return res.status(200).json({
         success: true,
         data: {
           ...defaultProfile,
           statistics: {},
           badges: [],
-          recent_activity: []
+          recent_activity: [],
+          profile_completeness: calculateProfileCompleteness(defaultProfile),
+          is_own_profile: isOwnProfile
         },
         response_time: Date.now() - startTime
       });
@@ -215,7 +235,7 @@ async function handleGetProfile(req, res, user) {
         badges,
         recent_activity: recentActivity,
         profile_completeness: completeness,
-        is_own_profile: user.id === user_id
+        is_own_profile: isOwnProfile
       },
       response_time: Date.now() - startTime
     });
@@ -582,25 +602,31 @@ async function getUserRecentActivity(userId, limit = 20) {
 }
 
 // 检查档案查看权限
-async function checkProfileViewPermission(viewerId, targetUserId) {
+async function checkProfileViewPermission(viewerId, targetUserId, resolvedVisibility) {
   try {
     // 自己的档案总是可以查看
     if (viewerId === targetUserId) {
       return true;
     }
 
-    // 获取目标用户的隐私设置
-    const { data: targetProfile, error } = await supabase
-      .from('user_community_profiles')
-      .select('visibility')
-      .eq('user_id', targetUserId)
-      .single();
+    let visibility = typeof resolvedVisibility === 'string' ? resolvedVisibility : null;
+    if (!visibility) {
+      const { data: targetProfile, error } = await supabase
+        .from('user_community_profiles')
+        .select('visibility')
+        .eq('user_id', targetUserId)
+        .single();
 
-    if (error && error.code !== 'PGRST116') {
-      throw error;
+      if (error && error.code !== 'PGRST116') {
+        throw error;
+      }
+
+      if (!targetProfile?.visibility) {
+        return false;
+      }
+
+      visibility = targetProfile.visibility;
     }
-
-    const visibility = targetProfile?.visibility || 'public';
 
     // 公开档案总是可以查看
     if (visibility === 'public') {
@@ -613,9 +639,10 @@ async function checkProfileViewPermission(viewerId, targetUserId) {
       return ['admin', 'moderator'].includes(viewerProfile.role);
     }
 
-    // 朋友可见档案（暂时按公开处理，后续可扩展好友系统）
+    // 在好友系统落地前，friends_only 按受限资源处理，避免被公开读取
     if (visibility === 'friends_only') {
-      return true; // 暂时允许查看
+      const viewerProfile = await getUserCommunityProfile(viewerId);
+      return ['admin', 'moderator'].includes(viewerProfile.role);
     }
 
     return false;
@@ -860,3 +887,4 @@ function isValidUrl(string) {
 
 // 导出配置供其他模块使用
 export { PROFILE_CONFIG };
+

--- a/api/community/questions.js
+++ b/api/community/questions.js
@@ -36,6 +36,41 @@ const COMMUNITY_CONFIG = {
   MIN_REPUTATION_TO_VOTE: 10
 };
 
+function isPrivilegedCommunityRole(role) {
+  return role === 'admin' || role === 'moderator';
+}
+
+function applyQuestionListFilters(
+  query,
+  { subjectCode, authorId, status, searchTerm, allowedQuestionIds, isPrivilegedViewer }
+) {
+  if (subjectCode) {
+    query = query.eq('subject_code', subjectCode);
+  }
+
+  if (authorId) {
+    query = query.eq('author_id', authorId);
+  }
+
+  if (Array.isArray(allowedQuestionIds)) {
+    query = query.in('id', allowedQuestionIds);
+  }
+
+  if (searchTerm) {
+    query = query.or('title.ilike.%' + searchTerm + '%,content.ilike.%' + searchTerm + '%');
+  }
+
+  if (!isPrivilegedViewer) {
+    query = query.neq('status', 'deleted');
+  }
+
+  if (status && status !== 'all') {
+    query = query.eq('status', status);
+  }
+
+  return query;
+}
+
 // 主要的社区问答API处理函数
 export default async function handler(req, res) {
   if (!applyCors(req, res, ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'])) {
@@ -99,9 +134,9 @@ export default async function handler(req, res) {
 // 获取问题列表
 async function handleGetQuestions(req, res, user) {
   const startTime = Date.now();
-  
+
   try {
-    const { 
+    const {
       question_id,
       subject_code,
       page = 1,
@@ -109,21 +144,31 @@ async function handleGetQuestions(req, res, user) {
       sort = 'latest',
       search,
       tags,
-      status = 'all',
+      status,
       author_id
     } = req.query;
 
-    // 如果指定了问题ID，获取单个问题详情
+    const userProfile = await getUserCommunityProfile(user.id);
+    const isPrivilegedViewer = isPrivilegedCommunityRole(userProfile.role);
+    const normalizedStatus = sanitizePlainText(status, 32).toLowerCase();
+
+    if (!isPrivilegedViewer && normalizedStatus === 'deleted') {
+      return res.status(403).json({
+        error: 'Permission denied',
+        code: 'PERMISSION_DENIED'
+      });
+    }
+
     if (question_id) {
-      const question = await getQuestionById(question_id, user.id);
-      
+      const question = await getQuestionById(question_id, user.id, { viewerRole: userProfile.role });
+
       if (!question) {
         return res.status(404).json({
           error: 'Question not found',
           code: 'QUESTION_NOT_FOUND'
         });
       }
-      
+
       return res.status(200).json({
         success: true,
         data: question,
@@ -131,43 +176,13 @@ async function handleGetQuestions(req, res, user) {
       });
     }
 
-    // 验证分页参数
     const pageNum = toPositiveInt(page, 1, 1, Number.MAX_SAFE_INTEGER);
     const limitNum = toPositiveInt(limit, COMMUNITY_CONFIG.DEFAULT_PAGE_SIZE, 1, COMMUNITY_CONFIG.MAX_PAGE_SIZE);
     const offset = (pageNum - 1) * limitNum;
     const searchTerm = sanitizeSearchTerm(search);
+    const statusFilter = normalizedStatus || 'all';
 
-    // 构建查询
-    let query = supabase
-      .from('community_questions')
-      .select(`
-        id, title, content, subject_code, author_id, status,
-        view_count, answer_count, vote_score, is_featured,
-        created_at, updated_at,
-        author:user_community_profiles!author_id(
-          display_name, avatar_url, reputation_score
-        )
-      `);
-
-    // 应用过滤条件
-    if (subject_code) {
-      query = query.eq('subject_code', subject_code);
-    }
-
-    if (author_id) {
-      query = query.eq('author_id', author_id);
-    }
-
-    if (status !== 'all') {
-      query = query.eq('status', status);
-    }
-
-    // 搜索功能
-    if (searchTerm) {
-      query = query.or(`title.ilike.%${searchTerm}%,content.ilike.%${searchTerm}%`);
-    }
-
-    // 标签过滤
+    let allowedQuestionIds = null;
     if (tags) {
       const rawTags = typeof tags === 'string' ? tags.split(',') : [];
       const tagArray = sanitizeTagList(rawTags, COMMUNITY_CONFIG.MAX_TAGS, 40);
@@ -177,18 +192,16 @@ async function handleGetQuestions(req, res, user) {
           code: 'INVALID_TAGS'
         });
       }
-      // 这里需要通过content_tags表进行关联查询
+
       const { data: taggedQuestionIds } = await supabase
         .from('content_tags')
         .select('content_id')
         .eq('content_type', 'question')
         .in('tag_name', tagArray);
-      
+
       if (taggedQuestionIds && taggedQuestionIds.length > 0) {
-        const questionIds = taggedQuestionIds.map(item => item.content_id);
-        query = query.in('id', questionIds);
+        allowedQuestionIds = taggedQuestionIds.map((item) => item.content_id);
       } else {
-        // 如果没有找到匹配的标签，返回空结果
         return res.status(200).json({
           success: true,
           data: {
@@ -205,7 +218,39 @@ async function handleGetQuestions(req, res, user) {
       }
     }
 
-    // 排序
+    let query = supabase
+      .from('community_questions')
+      .select(`
+        id, title, content, subject_code, author_id, status,
+        view_count, answer_count, vote_score, is_featured,
+        created_at, updated_at,
+        author:user_community_profiles!author_id(
+          display_name, avatar_url, reputation_score
+        )
+      `);
+
+    let countQuery = supabase
+      .from('community_questions')
+      .select('*', { count: 'exact', head: true });
+
+    query = applyQuestionListFilters(query, {
+      subjectCode: subject_code,
+      authorId: author_id,
+      status: statusFilter,
+      searchTerm,
+      allowedQuestionIds,
+      isPrivilegedViewer
+    });
+
+    countQuery = applyQuestionListFilters(countQuery, {
+      subjectCode: subject_code,
+      authorId: author_id,
+      status: statusFilter,
+      searchTerm,
+      allowedQuestionIds,
+      isPrivilegedViewer
+    });
+
     switch (sort) {
       case 'latest':
         query = query.order('created_at', { ascending: false });
@@ -229,37 +274,27 @@ async function handleGetQuestions(req, res, user) {
         query = query.order('created_at', { ascending: false });
     }
 
-    // 获取总数（用于分页）
-    const { count: totalCount, error: countError } = await supabase
-      .from('community_questions')
-      .select('*', { count: 'exact', head: true })
-      .eq('subject_code', subject_code || '');
+    query = query.range(offset, offset + limitNum - 1);
 
-    if (countError && subject_code) {
+    const { count: totalCount, error: countError } = await countQuery;
+    if (countError) {
       throw countError;
     }
 
-    // 应用分页
-    query = query.range(offset, offset + limitNum - 1);
-
-    // 执行查询
     const { data: questions, error: questionsError } = await query;
-
     if (questionsError) {
       throw questionsError;
     }
 
-    // 获取问题的标签
-    const questionIds = questions.map(q => q.id);
+    const questionIds = questions.map((question) => question.id);
     const questionTags = await getQuestionsTags(questionIds);
-
-    // 合并标签信息
-    const questionsWithTags = questions.map(question => ({
+    const questionsWithTags = questions.map((question) => ({
       ...question,
       tags: questionTags[question.id] || []
     }));
 
-    const totalPages = Math.ceil((totalCount || questions.length) / limitNum);
+    const safeTotal = totalCount || 0;
+    const totalPages = safeTotal > 0 ? Math.ceil(safeTotal / limitNum) : 0;
 
     return res.status(200).json({
       success: true,
@@ -268,7 +303,7 @@ async function handleGetQuestions(req, res, user) {
         pagination: {
           page: pageNum,
           limit: limitNum,
-          total: totalCount || questions.length,
+          total: safeTotal,
           total_pages: totalPages
         }
       },
@@ -390,6 +425,9 @@ async function handleUpdateQuestion(req, res, user) {
     const sanitizedTags = tags === undefined
       ? undefined
       : sanitizeTagList(tags, COMMUNITY_CONFIG.MAX_TAGS, 40);
+    const normalizedStatus = status === undefined
+      ? undefined
+      : sanitizePlainText(status, 32).toLowerCase();
 
     if (!question_id) {
       return res.status(400).json({
@@ -398,7 +436,6 @@ async function handleUpdateQuestion(req, res, user) {
       });
     }
 
-    // 检查问题是否存在且用户有权限修改
     const { data: existingQuestion, error: checkError } = await supabase
       .from('community_questions')
       .select('id, author_id, title, content')
@@ -412,10 +449,9 @@ async function handleUpdateQuestion(req, res, user) {
       });
     }
 
-    // 检查权限（只有作者或管理员可以修改）
     const userProfile = await getUserCommunityProfile(user.id);
     const isAuthor = existingQuestion.author_id === user.id;
-    const isAdmin = userProfile.role === 'admin' || userProfile.role === 'moderator';
+    const isAdmin = isPrivilegedCommunityRole(userProfile.role);
 
     if (!isAuthor && !isAdmin) {
       return res.status(403).json({
@@ -424,7 +460,6 @@ async function handleUpdateQuestion(req, res, user) {
       });
     }
 
-    // 准备更新数据
     const updateData = {
       updated_at: new Date().toISOString()
     };
@@ -461,19 +496,33 @@ async function handleUpdateQuestion(req, res, user) {
       updateData.content = sanitizedContent;
     }
 
-    if (status !== undefined && isAdmin) {
-      const validStatuses = ['open', 'closed', 'resolved', 'deleted'];
-      if (!validStatuses.includes(status)) {
+    if (normalizedStatus !== undefined) {
+      if (!isAdmin) {
+        return res.status(403).json({
+          error: 'Permission denied to update status',
+          code: 'PERMISSION_DENIED'
+        });
+      }
+
+      if (normalizedStatus === 'deleted') {
+        return res.status(400).json({
+          error: 'Use the delete endpoint for deleted status transitions',
+          code: 'USE_DELETE_ENDPOINT'
+        });
+      }
+
+      const validStatuses = ['open', 'closed', 'resolved'];
+      if (!validStatuses.includes(normalizedStatus)) {
         return res.status(400).json({
           error: 'Invalid status',
           code: 'INVALID_STATUS',
           valid_statuses: validStatuses
         });
       }
-      updateData.status = status;
+
+      updateData.status = normalizedStatus;
     }
 
-    // 更新问题
     const { data: updatedQuestion, error: updateError } = await supabase
       .from('community_questions')
       .update(updateData)
@@ -485,7 +534,6 @@ async function handleUpdateQuestion(req, res, user) {
       throw updateError;
     }
 
-    // 更新标签
     if (sanitizedTags !== undefined) {
       if (sanitizedTags.length > COMMUNITY_CONFIG.MAX_TAGS) {
         return res.status(400).json({
@@ -496,8 +544,7 @@ async function handleUpdateQuestion(req, res, user) {
       await updateQuestionTags(question_id, sanitizedTags);
     }
 
-    // 获取完整的问题信息
-    const fullQuestion = await getQuestionById(question_id, user.id);
+    const fullQuestion = await getQuestionById(question_id, user.id, { viewerRole: userProfile.role });
 
     return res.status(200).json({
       success: true,
@@ -567,7 +614,7 @@ async function handleDeleteQuestion(req, res, user) {
     }
 
     // 更新用户统计
-    await updateUserQuestionCount(user.id, -1);
+    await updateUserQuestionCount(existingQuestion.author_id, -1);
 
     return res.status(200).json({
       success: true,
@@ -585,9 +632,8 @@ async function handleDeleteQuestion(req, res, user) {
 }
 
 // 获取单个问题详情
-async function getQuestionById(questionId, currentUserId) {
+async function getQuestionById(questionId, currentUserId, options = {}) {
   try {
-    // 获取问题基本信息
     const { data: question, error: questionError } = await supabase
       .from('community_questions')
       .select(`
@@ -609,17 +655,22 @@ async function getQuestionById(questionId, currentUserId) {
       return null;
     }
 
-    // 获取标签
+    const viewerRole = options.viewerRole || (await getUserCommunityProfile(currentUserId)).role;
+    const canViewDeleted = question.author_id === currentUserId || isPrivilegedCommunityRole(viewerRole);
+
+    if (question.status === 'deleted' && !canViewDeleted) {
+      return null;
+    }
+
     const tags = await getQuestionsTags([questionId]);
     question.tags = tags[questionId] || [];
 
-    // 增加浏览次数（如果不是作者本人）
-    if (question.author_id !== currentUserId) {
+    if (question.status !== 'deleted' && question.author_id !== currentUserId) {
       await supabase
         .from('community_questions')
         .update({ view_count: supabase.sql`view_count + 1` })
         .eq('id', questionId);
-      
+
       question.view_count += 1;
     }
 
@@ -837,3 +888,6 @@ async function updateUserQuestionCount(userId, increment) {
 
 // 导出配置供其他模块使用
 export { COMMUNITY_CONFIG };
+
+
+

--- a/api/community/reputation.js
+++ b/api/community/reputation.js
@@ -138,12 +138,24 @@ async function handleGetReputation(req, res, user) {
   const startTime = Date.now();
   
   try {
-    const { 
+    const {
       user_id = user.id,
       include_history = 'false',
       include_breakdown = 'false',
       days = 30
     } = req.query;
+    const normalizedDays = Math.min(Math.max(parseInt(days, 10) || 30, 1), 365);
+
+    const requestingSensitiveDetails = include_history === 'true' || include_breakdown === 'true';
+    if (user_id !== user.id && requestingSensitiveDetails) {
+      const canViewSensitiveDetails = await isCommunityRoleAllowed(supabase, user.id, ['admin', 'moderator']);
+      if (!canViewSensitiveDetails) {
+        return res.status(403).json({
+          error: 'Insufficient permissions to view reputation history',
+          code: 'REPUTATION_HISTORY_ACCESS_DENIED'
+        });
+      }
+    }
 
     // 获取用户声誉档案
     const { data: profile, error: profileError } = await supabase
@@ -167,9 +179,9 @@ async function handleGetReputation(req, res, user) {
     if (include_history === 'true') {
       const { data: history, error: historyError } = await supabase
         .from('reputation_history')
-        .select('*')
+        .select('points_change, action_type, reason, previous_reputation, new_reputation, related_content_id, related_content_type, created_at')
         .eq('user_id', user_id)
-        .gte('created_at', new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString())
+        .gte('created_at', new Date(Date.now() - normalizedDays * 24 * 60 * 60 * 1000).toISOString())
         .order('created_at', { ascending: false })
         .limit(100);
 
@@ -182,7 +194,7 @@ async function handleGetReputation(req, res, user) {
     
     // 获取声誉来源分析
     if (include_breakdown === 'true') {
-      reputationBreakdown = await getReputationBreakdown(user_id, days);
+      reputationBreakdown = await getReputationBreakdown(user_id, normalizedDays);
     }
 
     // 计算今日声誉变化
@@ -677,3 +689,4 @@ export async function batchUpdateReputation(updates) {
 
 // 导出配置供其他模块使用
 export { REPUTATION_CONFIG };
+


### PR DESCRIPTION
## Summary
- harden community router dispatch so aggregate routes map correctly onto backend handlers
- fix notification read/delete semantics, interaction deduplication, and author counter consistency
- tighten profile and reputation trust boundaries and add focused backend regression coverage

## Scope
- backend community API only
- no supabase/migrations/*.sql changes
- no frontend or RAG changes

## Verification
- node --experimental-vm-modules C:\\Users\\Samsen\\cie-copilot\\node_modules\\jest\\bin\\jest.js --runInBand --runTestsByPath api/community/__tests__/router-contract.test.js api/community/__tests__/notifications-contract.test.js api/community/__tests__/profiles-reputation-hardening.test.js api/community/__tests__/content-counter-consistency.test.js api/community/__tests__/interactions-contract.test.js api/community/__tests__/security-hardening.test.js
- node --experimental-vm-modules C:\\Users\\Samsen\\cie-copilot\\node_modules\\jest\\bin\\jest.js --runInBand --runTestsByPath api/__tests__/api-route-integration.test.js