### PR TITLE
Auth backend productionization completion

### DIFF
--- a/api/_runtime/route-registry.js
+++ b/api/_runtime/route-registry.js
@@ -11,9 +11,11 @@ export const LEGACY_EXCLUDED_ENDPOINTS = [
 const RAG_AI_RATE_LIMIT_POLICY_ID = 'rag_ai_default_v1';
 const COMMUNITY_WRITE_RATE_LIMIT_POLICY_ID = 'community_write_v1';
 const ERROR_BOOK_WRITE_RATE_LIMIT_POLICY_ID = 'error_book_write_v1';
+const AUTH_PUBLIC_RATE_LIMIT_POLICY_ID = 'auth_public_v1';
 const RAG_AI_RATE_LIMIT = getRateLimitPolicy(RAG_AI_RATE_LIMIT_POLICY_ID);
 const COMMUNITY_WRITE_RATE_LIMIT = getRateLimitPolicy(COMMUNITY_WRITE_RATE_LIMIT_POLICY_ID);
 const ERROR_BOOK_WRITE_RATE_LIMIT = getRateLimitPolicy(ERROR_BOOK_WRITE_RATE_LIMIT_POLICY_ID);
+const AUTH_PUBLIC_RATE_LIMIT = getRateLimitPolicy(AUTH_PUBLIC_RATE_LIMIT_POLICY_ID);
 
 const ROUTES = [
   {
@@ -171,6 +173,8 @@ const ROUTES = [
     authMode: 'public',
     methods: ['*'],
     moduleOwnsMethodRouting: true,
+    rateLimitPolicyId: AUTH_PUBLIC_RATE_LIMIT_POLICY_ID,
+    rateLimit: AUTH_PUBLIC_RATE_LIMIT,
   },
 ];
 

--- a/api/auth/__tests__/productionization.test.js
+++ b/api/auth/__tests__/productionization.test.js
@@ -1,0 +1,470 @@
+import bcrypt from 'bcryptjs';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const clientState = {
+  authGetUser: async () => ({ data: { user: null }, error: null }),
+  resolveQuery: () => ({ data: null, error: null }),
+  calls: [],
+};
+
+class QueryBuilder {
+  constructor(table) {
+    this.table = table;
+    this.operation = 'select';
+    this.payload = null;
+    this.filters = [];
+    this.options = {};
+  }
+
+  select(columns, options = {}) {
+    if (this.operation === 'select') {
+      this.operation = 'select';
+    }
+    this.options.columns = columns;
+    this.options.select = options;
+    return this;
+  }
+
+  insert(payload) {
+    this.operation = 'insert';
+    this.payload = payload;
+    return this;
+  }
+
+  update(payload) {
+    this.operation = 'update';
+    this.payload = payload;
+    return this;
+  }
+
+  delete() {
+    this.operation = 'delete';
+    return this;
+  }
+
+  eq(field, value) {
+    this.filters.push({ operator: 'eq', field, value });
+    return this;
+  }
+
+  gte(field, value) {
+    this.filters.push({ operator: 'gte', field, value });
+    return this;
+  }
+
+  order(field, options = {}) {
+    this.options.order = { field, options };
+    return this;
+  }
+
+  maybeSingle() {
+    return this.#resolve({ maybeSingle: true });
+  }
+
+  single() {
+    return this.#resolve({ single: true });
+  }
+
+  then(resolve, reject) {
+    return this.#resolve({}).then(resolve, reject);
+  }
+
+  #resolve(extra = {}) {
+    const query = {
+      table: this.table,
+      operation: this.operation,
+      payload: this.payload,
+      filters: [...this.filters],
+      options: {
+        ...this.options,
+        ...extra,
+      },
+    };
+    clientState.calls.push(query);
+    return Promise.resolve(clientState.resolveQuery(query));
+  }
+}
+
+const mockGetServiceClient = jest.fn(() => ({
+  auth: {
+    getUser: (...args) => clientState.authGetUser(...args),
+  },
+  from(table) {
+    return new QueryBuilder(table);
+  },
+}));
+
+jest.unstable_mockModule('../../lib/supabase/client.js', () => ({
+  getServiceClient: mockGetServiceClient,
+}));
+
+const { default: authHandler } = await import('../index.js');
+const { resolveTrustedAuthContext } = await import('../../lib/security/auth-context.js');
+const { generateToken, hashToken } = await import('../../middleware/auth.js');
+const { listRoutes } = await import('../../_runtime/route-registry.js');
+
+function createReq({
+  method = 'GET',
+  headers = {},
+  query = {},
+  body = {},
+  url,
+} = {}) {
+  return {
+    method,
+    headers,
+    query,
+    body,
+    url: url || `/api/auth?action=${query.action || ''}`,
+    request_id: 'req-auth-prod-1',
+    connection: {
+      remoteAddress: '127.0.0.1',
+    },
+  };
+}
+
+function createRes() {
+  const headers = {};
+  return {
+    statusCode: 200,
+    headers,
+    body: null,
+    writableEnded: false,
+    setHeader(name, value) {
+      headers[String(name).toLowerCase()] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      this.writableEnded = true;
+      return this;
+    },
+    end(payload) {
+      this.body = payload;
+      this.writableEnded = true;
+      return this;
+    },
+  };
+}
+
+function matchFilter(query, field, value) {
+  return query.filters.some((filter) => filter.field === field && filter.value === value);
+}
+
+function buildActiveUser(overrides = {}) {
+  return {
+    id: 'user-1',
+    email: 'user@example.com',
+    username: 'auth-user',
+    name: 'Auth User',
+    role: 'student',
+    status: 'active',
+    reputation: 8,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  process.env.ALLOWED_ORIGINS = 'http://localhost:3000';
+  process.env.JWT_SECRET = 'test-secret';
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+  process.env.AUTH_LOCAL_TEST_MODE = 'false';
+  process.env.AUTH_EMAIL_MODE = 'log';
+  process.env.AUTH_PUBLIC_BASE_URL = 'https://app.example.com';
+  delete process.env.AUTH_ENFORCE_SESSIONS;
+  delete process.env.RESEND_API_KEY;
+  delete process.env.AUTH_EMAIL_FROM;
+  clientState.calls = [];
+  clientState.authGetUser = async () => ({
+    data: { user: null },
+    error: { message: 'Invalid token' },
+  });
+  clientState.resolveQuery = () => ({ data: null, error: null });
+  jest.clearAllMocks();
+});
+
+describe('auth backend productionization', () => {
+  it('adds a verify action for login-issued access tokens', async () => {
+    const user = buildActiveUser();
+    clientState.resolveQuery = (query) => {
+      if (query.table === 'user_profiles' && query.operation === 'select' && matchFilter(query, 'id', user.id)) {
+        return { data: user, error: null };
+      }
+      if (query.table === 'user_permissions') {
+        return { data: [], error: null };
+      }
+      throw new Error(`Unhandled query ${query.table}:${query.operation}`);
+    };
+
+    const token = generateToken({ userId: user.id, email: user.email, role: user.role }, '24h');
+    const req = createReq({
+      method: 'GET',
+      headers: {
+        origin: 'http://localhost:3000',
+        authorization: `Bearer ${token}`,
+      },
+      query: { action: 'verify' },
+      url: '/api/auth?action=verify',
+    });
+    const res = createRes();
+
+    await authHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.code).toBe('AUTH_TOKEN_VALID');
+    expect(res.body.user).toMatchObject({
+      id: user.id,
+      email: user.email,
+      role: user.role,
+    });
+  });
+
+  it('lets gateway auth-context accept custom JWTs even when Supabase auth.getUser rejects them', async () => {
+    const user = buildActiveUser();
+    clientState.resolveQuery = (query) => {
+      if (query.table === 'user_profiles' && query.operation === 'select' && matchFilter(query, 'id', user.id)) {
+        return { data: user, error: null };
+      }
+      if (query.table === 'user_permissions') {
+        return { data: [], error: null };
+      }
+      throw new Error(`Unhandled query ${query.table}:${query.operation}`);
+    };
+
+    const token = generateToken({ userId: user.id, email: user.email, role: user.role }, '24h');
+    const req = createReq({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+      url: '/api/community/questions',
+    });
+
+    const result = await resolveTrustedAuthContext(req);
+
+    expect(result.ok).toBe(true);
+    expect(result.context.userId).toBe(user.id);
+    expect(result.context.role).toBe(user.role);
+    expect(result.context.source).toBe('custom_jwt');
+  });
+
+  it('logs a verification delivery artifact with a real verify-email link in local mail mode', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    clientState.resolveQuery = (query) => {
+      if (query.table === 'user_profiles' && query.operation === 'select' && matchFilter(query, 'email', 'user@example.com')) {
+        return { data: null, error: null };
+      }
+      if (query.table === 'user_profiles' && query.operation === 'insert') {
+        return {
+          data: {
+            id: 'user-1',
+            email: 'user@example.com',
+            name: 'Auth User',
+            role: 'student',
+            status: 'pending_verification',
+          },
+          error: null,
+        };
+      }
+      if (query.table === 'user_community_profiles' || query.table === 'user_learning_profiles') {
+        return { data: null, error: null };
+      }
+      if (query.table === 'security_events') {
+        return { data: null, error: null };
+      }
+      throw new Error(`Unhandled query ${query.table}:${query.operation}`);
+    };
+
+    const req = createReq({
+      method: 'POST',
+      headers: {
+        origin: 'http://localhost:3000',
+      },
+      query: { action: 'register' },
+      body: {
+        email: 'user@example.com',
+        password: 'abc12345',
+        name: 'Auth User',
+      },
+      url: '/api/auth?action=register',
+    });
+    const res = createRes();
+
+    await authHandler(req, res);
+
+    expect(res.statusCode).toBe(201);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('action=verify-email&code='),
+      expect.any(Object),
+    );
+  });
+
+  it('logs a password-reset delivery artifact with a real reset-password link in local mail mode', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    clientState.resolveQuery = (query) => {
+      if (query.table === 'user_profiles' && query.operation === 'select' && matchFilter(query, 'email', 'user@example.com')) {
+        return {
+          data: {
+            id: 'user-1',
+            email: 'user@example.com',
+            status: 'active',
+          },
+          error: null,
+        };
+      }
+      if (query.table === 'user_profiles' && query.operation === 'update') {
+        return { data: null, error: null };
+      }
+      if (query.table === 'security_events') {
+        return { data: null, error: null };
+      }
+      throw new Error(`Unhandled query ${query.table}:${query.operation}`);
+    };
+
+    const req = createReq({
+      method: 'POST',
+      headers: {
+        origin: 'http://localhost:3000',
+      },
+      query: { action: 'request-reset' },
+      body: {
+        email: 'user@example.com',
+      },
+      url: '/api/auth?action=request-reset',
+    });
+    const res = createRes();
+
+    await authHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('action=reset-password&token='),
+      expect.any(Object),
+    );
+  });
+
+  it('rotates tracked refresh sessions using user_sessions.refresh_token_hash', async () => {
+    const user = buildActiveUser();
+    const refreshToken = generateToken(
+      { userId: user.id, email: user.email, role: user.role, type: 'refresh' },
+      '7d',
+    );
+
+    clientState.resolveQuery = (query) => {
+      if (query.table === 'user_sessions' && query.operation === 'select') {
+        return {
+          data: {
+            id: 'session-1',
+            user_id: user.id,
+            refresh_token_hash: hashToken(refreshToken),
+            expires_at: '2099-01-01T00:00:00.000Z',
+          },
+          error: null,
+        };
+      }
+      if (query.table === 'user_profiles' && query.operation === 'select' && matchFilter(query, 'id', user.id)) {
+        return { data: user, error: null };
+      }
+      if (query.table === 'user_sessions' && query.operation === 'update') {
+        return { data: null, error: null };
+      }
+      if (query.table === 'security_events') {
+        return { data: null, error: null };
+      }
+      throw new Error(`Unhandled query ${query.table}:${query.operation}`);
+    };
+
+    const req = createReq({
+      method: 'POST',
+      headers: {
+        origin: 'http://localhost:3000',
+      },
+      query: { action: 'refresh' },
+      body: {
+        refreshToken,
+      },
+      url: '/api/auth?action=refresh',
+    });
+    const res = createRes();
+
+    await authHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.refreshToken).toEqual(expect.any(String));
+    expect(res.body.refreshToken).not.toBe(refreshToken);
+
+    const sessionLookup = clientState.calls.find(
+      (query) => query.table === 'user_sessions' && query.operation === 'select',
+    );
+    expect(sessionLookup).toBeTruthy();
+    expect(matchFilter(sessionLookup, 'refresh_token_hash', hashToken(refreshToken))).toBe(true);
+
+    const sessionUpdate = clientState.calls.find(
+      (query) => query.table === 'user_sessions' && query.operation === 'update',
+    );
+    expect(sessionUpdate).toBeTruthy();
+    expect(sessionUpdate.payload.refresh_token_hash).toBe(hashToken(res.body.refreshToken));
+  });
+
+  it('keeps login working when user_sessions is unavailable and session persistence degrades', async () => {
+    const user = buildActiveUser({
+      password_hash: await bcrypt.hash('abc12345', 4),
+    });
+
+    clientState.resolveQuery = (query) => {
+      if (query.table === 'user_login_attempts' && query.operation === 'select') {
+        return { data: [], error: null };
+      }
+      if (query.table === 'user_profiles' && query.operation === 'select' && matchFilter(query, 'email', 'user@example.com')) {
+        return { data: user, error: null };
+      }
+      if (query.table === 'user_sessions' && query.operation === 'insert') {
+        return { data: null, error: { code: '42P01', message: 'relation "user_sessions" does not exist' } };
+      }
+      if (query.table === 'user_profiles' && query.operation === 'update') {
+        return { data: null, error: null };
+      }
+      if (query.table === 'user_login_attempts' && query.operation === 'insert') {
+        return { data: null, error: null };
+      }
+      if (query.table === 'security_events') {
+        return { data: null, error: null };
+      }
+      throw new Error(`Unhandled query ${query.table}:${query.operation}`);
+    };
+
+    const req = createReq({
+      method: 'POST',
+      headers: {
+        origin: 'http://localhost:3000',
+      },
+      query: { action: 'login' },
+      body: {
+        email: 'user@example.com',
+        password: 'abc12345',
+      },
+      url: '/api/auth?action=login',
+    });
+    const res = createRes();
+
+    await authHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.code).toBe('AUTH_LOGIN_SUCCESS');
+    expect(res.body.tokens.accessToken).toEqual(expect.any(String));
+    expect(res.body.tokens.refreshToken).toEqual(expect.any(String));
+  });
+
+  it('registers a dedicated gateway rate-limit policy for /api/auth', () => {
+    const authRoute = listRoutes().find((route) => route.module === 'auth');
+
+    expect(authRoute).toBeTruthy();
+    expect(authRoute.hasRateLimit).toBe(true);
+    expect(authRoute.rateLimitPolicyId).toBe('auth_public_v1');
+  });
+});

--- a/api/auth/index.js
+++ b/api/auth/index.js
@@ -1,7 +1,17 @@
+import crypto from 'node:crypto';
 import bcrypt from 'bcryptjs';
 import { applyApiCors } from '../lib/http/cors.js';
 import { getServiceClient } from '../lib/supabase/client.js';
-import { generateToken, verifyToken, USER_ROLES } from '../middleware/auth.js';
+import {
+  authenticateRequest,
+  generateToken,
+  verifyToken,
+  hashToken,
+  persistRefreshSession,
+  recordSecurityEvent,
+  rotateRefreshSession,
+} from '../middleware/auth.js';
+import { getBaseUrl, sendPasswordResetEmail, sendVerificationEmail } from './lib/auth-mailer.js';
 
 let _supabase = null;
 
@@ -35,11 +45,72 @@ const AUTH_CONFIG = {
   PASSWORD_MAX_LENGTH: 128,
   TOKEN_EXPIRES_IN: '24h',
   REFRESH_TOKEN_EXPIRES_IN: '7d',
+  REFRESH_TOKEN_EXPIRES_MS: 7 * 24 * 60 * 60 * 1000,
   MAX_LOGIN_ATTEMPTS: 5,
   LOCKOUT_DURATION: 15 * 60 * 1000, // 15分钟
   EMAIL_VERIFICATION_EXPIRES: 24 * 60 * 60 * 1000, // 24小时
   PASSWORD_RESET_EXPIRES: 60 * 60 * 1000 // 1小时
 };
+
+function normalizeEmail(email) {
+  return String(email || '').trim().toLowerCase();
+}
+
+function getRequestId(req) {
+  return req?.request_id || null;
+}
+
+function getClientIp(req) {
+  return req?.headers?.['x-forwarded-for'] || req?.connection?.remoteAddress || null;
+}
+
+function getUserAgent(req) {
+  return req?.headers?.['user-agent'] || req?.headers?.['User-Agent'] || null;
+}
+
+function sendError(req, res, status, code, error, message, extras = {}) {
+  return res.status(status).json({
+    success: false,
+    code,
+    error,
+    message,
+    request_id: getRequestId(req),
+    ...extras,
+  });
+}
+
+function sendSuccess(req, res, status, code, message, payload = {}) {
+  return res.status(status).json({
+    success: true,
+    code,
+    message,
+    request_id: getRequestId(req),
+    ...payload,
+  });
+}
+
+function createOpaqueToken() {
+  return crypto.randomBytes(24).toString('base64url');
+}
+
+function buildPublicBaseUrl(req) {
+  return getBaseUrl(req?.headers?.origin || null);
+}
+
+async function findUserByTokenField(field, rawToken) {
+  const candidates = [hashToken(rawToken), rawToken];
+  for (const value of candidates) {
+    const { data, error } = await supabase
+      .from('user_profiles')
+      .select('*')
+      .eq(field, value)
+      .single();
+    if (!error && data) {
+      return data;
+    }
+  }
+  return null;
+}
 
 /**
  * 验证请求方法
@@ -50,10 +121,7 @@ function validateMethod(req, res, allowedMethods) {
   }
 
   if (!allowedMethods.includes(req.method)) {
-    res.status(405).json({
-      error: 'Method not allowed',
-      message: '不支持的请求方法'
-    });
+    sendError(req, res, 405, 'AUTH_METHOD_NOT_ALLOWED', 'Method not allowed', '不支持的请求方法');
     return false;
   }
 
@@ -92,10 +160,10 @@ function validatePassword(password) {
 }
 
 /**
- * 生成随机验证码
+ * 生成安全随机令牌
  */
 function generateVerificationCode() {
-  return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+  return createOpaqueToken();
 }
 
 /**
@@ -143,29 +211,21 @@ async function recordLoginAttempt(email, success, ip) {
  */
 async function registerUser(req, res) {
   try {
-    const { email, password, name, role = 'student' } = req.body;
+    const { password, name, role = 'student' } = req.body;
+    const email = normalizeEmail(req.body?.email);
     
     // 验证输入
     if (!email || !password || !name) {
-      return res.status(400).json({
-        error: 'Missing required fields',
-        message: '缺少必填字段'
-      });
+      return sendError(req, res, 400, 'AUTH_VALIDATION_ERROR', 'Missing required fields', '缺少必填字段');
     }
     
     if (!validateEmail(email)) {
-      return res.status(400).json({
-        error: 'Invalid email',
-        message: '邮箱格式无效'
-      });
+      return sendError(req, res, 400, 'AUTH_INVALID_EMAIL', 'Invalid email', '邮箱格式无效');
     }
     
     const passwordValidation = validatePassword(password);
     if (!passwordValidation.valid) {
-      return res.status(400).json({
-        error: 'Invalid password',
-        message: passwordValidation.message
-      });
+      return sendError(req, res, 400, 'AUTH_INVALID_PASSWORD', 'Invalid password', passwordValidation.message);
     }
     
     // 检查邮箱是否已存在
@@ -176,10 +236,7 @@ async function registerUser(req, res) {
       .single();
     
     if (existingUser) {
-      return res.status(409).json({
-        error: 'Email already exists',
-        message: '邮箱已被注册'
-      });
+      return sendError(req, res, 409, 'AUTH_EMAIL_EXISTS', 'Email already exists', '邮箱已被注册');
     }
     
     // 加密密码
@@ -199,7 +256,7 @@ async function registerUser(req, res) {
         name,
         role: role.toLowerCase(),
         status: 'pending_verification',
-        email_verification_code: verificationCode,
+        email_verification_code: hashToken(verificationCode),
         email_verification_expires: verificationExpires.toISOString(),
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString()
@@ -209,10 +266,7 @@ async function registerUser(req, res) {
     
     if (createError) {
       console.error('Error creating user:', createError);
-      return res.status(500).json({
-        error: 'Registration failed',
-        message: '注册失败，请稍后重试'
-      });
+      return sendError(req, res, 500, 'AUTH_REGISTRATION_FAILED', 'Registration failed', '注册失败，请稍后重试');
     }
     
     // 创建用户社区档案
@@ -239,25 +293,35 @@ async function registerUser(req, res) {
         updated_at: new Date().toISOString()
       });
     
-    // TODO: 发送验证邮件
-    console.log(`Verification artifact generated for ${email}`);
+    const delivery = await sendVerificationEmail({
+      to: user.email,
+      name: user.name,
+      verificationToken: verificationCode,
+      baseUrl: buildPublicBaseUrl(req),
+    });
+
+    await recordSecurityEvent(user.id, 'register_pending_verification', {
+      ip_address: getClientIp(req),
+      user_agent: getUserAgent(req),
+      delivery_mode: delivery.mode,
+    });
     
-    res.status(201).json({
-      message: '注册成功，请检查邮箱验证链接',
+    return sendSuccess(req, res, 201, 'AUTH_REGISTERED', '注册成功，请检查邮箱验证链接', {
       user: {
         id: user.id,
         email: user.email,
         name: user.name,
         role: user.role,
         status: user.status
-      }
+      },
+      delivery: {
+        mode: delivery.mode,
+        degraded: Boolean(delivery.degraded),
+      },
     });
   } catch (error) {
     console.error('Registration error:', error);
-    res.status(500).json({
-      error: 'Internal server error',
-      message: '服务器内部错误'
-    });
+    return sendError(req, res, 500, 'AUTH_INTERNAL_ERROR', 'Internal server error', '服务器内部错误');
   }
 }
 
@@ -266,25 +330,28 @@ async function registerUser(req, res) {
  */
 async function loginUser(req, res) {
   try {
-    const { email, password } = req.body;
-    const clientIP = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+    const email = normalizeEmail(req.body?.email);
+    const { password } = req.body;
+    const clientIP = getClientIp(req);
+    const userAgent = getUserAgent(req);
     
     // 验证输入
     if (!email || !password) {
-      return res.status(400).json({
-        error: 'Missing credentials',
-        message: '缺少登录凭据'
-      });
+      return sendError(req, res, 400, 'AUTH_MISSING_CREDENTIALS', 'Missing credentials', '缺少登录凭据');
     }
     
     // 检查登录尝试次数
     const { locked, attempts } = await checkLoginAttempts(email);
     if (locked) {
       await recordLoginAttempt(email, false, clientIP);
-      return res.status(429).json({
-        error: 'Account locked',
-        message: `账户已锁定，请${AUTH_CONFIG.LOCKOUT_DURATION / 60000}分钟后重试`,
-        lockoutMinutes: AUTH_CONFIG.LOCKOUT_DURATION / 60000
+      await recordSecurityEvent(null, 'login_locked', {
+        ip_address: clientIP,
+        user_agent: userAgent,
+        email,
+        attempts,
+      });
+      return sendError(req, res, 429, 'AUTH_ACCOUNT_LOCKED', 'Account locked', `账户已锁定，请${AUTH_CONFIG.LOCKOUT_DURATION / 60000}分钟后重试`, {
+        lockoutMinutes: AUTH_CONFIG.LOCKOUT_DURATION / 60000,
       });
     }
     
@@ -297,37 +364,46 @@ async function loginUser(req, res) {
     
     if (userError || !user) {
       await recordLoginAttempt(email, false, clientIP);
-      return res.status(401).json({
-        error: 'Invalid credentials',
-        message: '邮箱或密码错误'
+      await recordSecurityEvent(null, 'login_failed', {
+        ip_address: clientIP,
+        user_agent: userAgent,
+        email,
+        reason: 'user_not_found',
       });
+      return sendError(req, res, 401, 'AUTH_INVALID_CREDENTIALS', 'Invalid credentials', '邮箱或密码错误');
     }
     
     // 验证密码
     const passwordValid = await bcrypt.compare(password, user.password_hash);
     if (!passwordValid) {
       await recordLoginAttempt(email, false, clientIP);
-      return res.status(401).json({
-        error: 'Invalid credentials',
-        message: '邮箱或密码错误'
+      await recordSecurityEvent(user.id, 'login_failed', {
+        ip_address: clientIP,
+        user_agent: userAgent,
+        reason: 'password_mismatch',
       });
+      return sendError(req, res, 401, 'AUTH_INVALID_CREDENTIALS', 'Invalid credentials', '邮箱或密码错误');
     }
     
     // 检查账户状态
     if (user.status === 'suspended') {
       await recordLoginAttempt(email, false, clientIP);
-      return res.status(403).json({
-        error: 'Account suspended',
-        message: '账户已被暂停'
+      await recordSecurityEvent(user.id, 'login_blocked', {
+        ip_address: clientIP,
+        user_agent: userAgent,
+        reason: 'account_suspended',
       });
+      return sendError(req, res, 403, 'AUTH_ACCOUNT_SUSPENDED', 'Account suspended', '账户已被暂停');
     }
     
     if (user.status === 'pending_verification') {
       await recordLoginAttempt(email, false, clientIP);
-      return res.status(403).json({
-        error: 'Email not verified',
-        message: '邮箱尚未验证，请检查验证邮件'
+      await recordSecurityEvent(user.id, 'login_blocked', {
+        ip_address: clientIP,
+        user_agent: userAgent,
+        reason: 'email_not_verified',
       });
+      return sendError(req, res, 403, 'AUTH_EMAIL_NOT_VERIFIED', 'Email not verified', '邮箱尚未验证，请检查验证邮件');
     }
     
     // 生成tokens
@@ -339,9 +415,22 @@ async function loginUser(req, res) {
     
     const accessToken = generateToken(tokenPayload, AUTH_CONFIG.TOKEN_EXPIRES_IN);
     const refreshToken = generateToken(
-      { ...tokenPayload, type: 'refresh' },
+      { ...tokenPayload, type: 'refresh', jti: createOpaqueToken() },
       AUTH_CONFIG.REFRESH_TOKEN_EXPIRES_IN
     );
+    const refreshExpiresAt = new Date(Date.now() + AUTH_CONFIG.REFRESH_TOKEN_EXPIRES_MS).toISOString();
+
+    const sessionPersistence = await persistRefreshSession({
+      userId: user.id,
+      refreshToken,
+      expiresAt: refreshExpiresAt,
+      ipAddress: clientIP,
+      userAgent,
+    });
+
+    if (sessionPersistence.checked && !sessionPersistence.persisted) {
+      return sendError(req, res, 500, 'AUTH_SESSION_PERSIST_FAILED', 'Session persistence failed', '会话初始化失败，请稍后重试');
+    }
     
     // 更新最后登录时间
     await supabase
@@ -354,9 +443,13 @@ async function loginUser(req, res) {
     
     // 记录成功登录
     await recordLoginAttempt(email, true, clientIP);
+    await recordSecurityEvent(user.id, 'login_success', {
+      ip_address: clientIP,
+      user_agent: userAgent,
+      session_persisted: Boolean(sessionPersistence.persisted),
+    });
     
-    res.status(200).json({
-      message: '登录成功',
+    return sendSuccess(req, res, 200, 'AUTH_LOGIN_SUCCESS', '登录成功', {
       user: {
         id: user.id,
         email: user.email,
@@ -367,15 +460,13 @@ async function loginUser(req, res) {
       tokens: {
         accessToken,
         refreshToken,
-        expiresIn: AUTH_CONFIG.TOKEN_EXPIRES_IN
-      }
+        expiresIn: AUTH_CONFIG.TOKEN_EXPIRES_IN,
+        refreshExpiresIn: AUTH_CONFIG.REFRESH_TOKEN_EXPIRES_IN,
+      },
     });
   } catch (error) {
     console.error('Login error:', error);
-    res.status(500).json({
-      error: 'Internal server error',
-      message: '服务器内部错误'
-    });
+    return sendError(req, res, 500, 'AUTH_INTERNAL_ERROR', 'Internal server error', '服务器内部错误');
   }
 }
 
@@ -385,22 +476,18 @@ async function loginUser(req, res) {
 async function refreshToken(req, res) {
   try {
     const { refreshToken } = req.body;
+    const clientIP = getClientIp(req);
+    const userAgent = getUserAgent(req);
     
     if (!refreshToken) {
-      return res.status(400).json({
-        error: 'Refresh token required',
-        message: '缺少刷新令牌'
-      });
+      return sendError(req, res, 400, 'AUTH_REFRESH_TOKEN_REQUIRED', 'Refresh token required', '缺少刷新令牌');
     }
     
     // 验证刷新令牌
     const decoded = verifyToken(refreshToken);
     
     if (decoded.type !== 'refresh') {
-      return res.status(401).json({
-        error: 'Invalid refresh token',
-        message: '无效的刷新令牌'
-      });
+      return sendError(req, res, 401, 'AUTH_INVALID_REFRESH_TOKEN', 'Invalid refresh token', '无效的刷新令牌');
     }
     
     // 检查用户状态
@@ -411,10 +498,7 @@ async function refreshToken(req, res) {
       .single();
     
     if (error || !user || user.status !== 'active') {
-      return res.status(401).json({
-        error: 'Invalid refresh token',
-        message: '无效的刷新令牌'
-      });
+      return sendError(req, res, 401, 'AUTH_INVALID_REFRESH_TOKEN', 'Invalid refresh token', '无效的刷新令牌');
     }
     
     // 生成新的访问令牌
@@ -425,26 +509,63 @@ async function refreshToken(req, res) {
     };
     
     const newAccessToken = generateToken(tokenPayload, AUTH_CONFIG.TOKEN_EXPIRES_IN);
+    const newRefreshToken = generateToken(
+      { ...tokenPayload, type: 'refresh', jti: createOpaqueToken() },
+      AUTH_CONFIG.REFRESH_TOKEN_EXPIRES_IN
+    );
+    const refreshExpiresAt = new Date(Date.now() + AUTH_CONFIG.REFRESH_TOKEN_EXPIRES_MS).toISOString();
+
+    const sessionRotation = await rotateRefreshSession({
+      userId: user.id,
+      currentRefreshToken: refreshToken,
+      nextRefreshToken: newRefreshToken,
+      expiresAt: refreshExpiresAt,
+      ipAddress: clientIP,
+      userAgent,
+    });
+
+    if (sessionRotation.checked && !sessionRotation.valid) {
+      return sendError(req, res, 401, 'AUTH_INVALID_REFRESH_TOKEN', 'Invalid refresh token', '无效的刷新令牌');
+    }
+
+    await recordSecurityEvent(user.id, 'refresh_success', {
+      ip_address: clientIP,
+      user_agent: userAgent,
+      session_checked: sessionRotation.checked,
+    });
     
-    res.status(200).json({
+    return sendSuccess(req, res, 200, 'AUTH_REFRESH_SUCCESS', '访问令牌刷新成功', {
       accessToken: newAccessToken,
-      expiresIn: AUTH_CONFIG.TOKEN_EXPIRES_IN
+      refreshToken: newRefreshToken,
+      expiresIn: AUTH_CONFIG.TOKEN_EXPIRES_IN,
+      refreshExpiresIn: AUTH_CONFIG.REFRESH_TOKEN_EXPIRES_IN,
     });
   } catch (error) {
     console.error('Token refresh error:', error);
     
     if (error.name === 'JsonWebTokenError' || error.name === 'TokenExpiredError') {
-      return res.status(401).json({
-        error: 'Invalid refresh token',
-        message: '无效的刷新令牌'
-      });
+      return sendError(req, res, 401, 'AUTH_INVALID_REFRESH_TOKEN', 'Invalid refresh token', '无效的刷新令牌');
     }
     
-    res.status(500).json({
-      error: 'Internal server error',
-      message: '服务器内部错误'
-    });
+    return sendError(req, res, 500, 'AUTH_INTERNAL_ERROR', 'Internal server error', '服务器内部错误');
   }
+}
+
+async function verifyAccessToken(req, res) {
+  const authResult = await authenticateRequest(req, { optional: false });
+  if (!authResult.success) {
+    return sendError(req, res, authResult.status, authResult.code, authResult.error, authResult.message);
+  }
+
+  return sendSuccess(req, res, 200, 'AUTH_TOKEN_VALID', '访问令牌有效', {
+    authenticated: true,
+    user: {
+      id: authResult.user.id,
+      email: authResult.user.email,
+      role: authResult.user.role,
+      status: authResult.user.status,
+    },
+  });
 }
 
 /**
@@ -455,32 +576,19 @@ async function verifyEmail(req, res) {
     const { code } = req.query;
     
     if (!code) {
-      return res.status(400).json({
-        error: 'Verification code required',
-        message: '缺少验证码'
-      });
+      return sendError(req, res, 400, 'AUTH_VERIFICATION_CODE_REQUIRED', 'Verification code required', '缺少验证码');
     }
     
     // 查找用户
-    const { data: user, error } = await supabase
-      .from('user_profiles')
-      .select('*')
-      .eq('email_verification_code', code)
-      .single();
+    const user = await findUserByTokenField('email_verification_code', code);
     
-    if (error || !user) {
-      return res.status(400).json({
-        error: 'Invalid verification code',
-        message: '无效的验证码'
-      });
+    if (!user) {
+      return sendError(req, res, 400, 'AUTH_INVALID_VERIFICATION_CODE', 'Invalid verification code', '无效的验证码');
     }
     
     // 检查验证码是否过期
     if (new Date() > new Date(user.email_verification_expires)) {
-      return res.status(400).json({
-        error: 'Verification code expired',
-        message: '验证码已过期'
-      });
+      return sendError(req, res, 400, 'AUTH_VERIFICATION_CODE_EXPIRED', 'Verification code expired', '验证码已过期');
     }
     
     // 激活用户
@@ -495,15 +603,15 @@ async function verifyEmail(req, res) {
       })
       .eq('id', user.id);
     
-    res.status(200).json({
-      message: '邮箱验证成功，账户已激活'
+    await recordSecurityEvent(user.id, 'email_verified', {
+      ip_address: getClientIp(req),
+      user_agent: getUserAgent(req),
     });
+
+    return sendSuccess(req, res, 200, 'AUTH_EMAIL_VERIFIED', '邮箱验证成功，账户已激活');
   } catch (error) {
     console.error('Email verification error:', error);
-    res.status(500).json({
-      error: 'Internal server error',
-      message: '服务器内部错误'
-    });
+    return sendError(req, res, 500, 'AUTH_INTERNAL_ERROR', 'Internal server error', '服务器内部错误');
   }
 }
 
@@ -512,13 +620,10 @@ async function verifyEmail(req, res) {
  */
 async function requestPasswordReset(req, res) {
   try {
-    const { email } = req.body;
+    const email = normalizeEmail(req.body?.email);
     
     if (!email || !validateEmail(email)) {
-      return res.status(400).json({
-        error: 'Valid email required',
-        message: '请提供有效的邮箱地址'
-      });
+      return sendError(req, res, 400, 'AUTH_INVALID_EMAIL', 'Valid email required', '请提供有效的邮箱地址');
     }
     
     // 查找用户
@@ -530,15 +635,11 @@ async function requestPasswordReset(req, res) {
     
     // 无论用户是否存在都返回成功，避免邮箱枚举攻击
     if (error || !user) {
-      return res.status(200).json({
-        message: '如果邮箱存在，重置链接已发送'
-      });
+      return sendSuccess(req, res, 200, 'AUTH_PASSWORD_RESET_REQUEST_ACCEPTED', '如果邮箱存在，重置链接已发送');
     }
     
     if (user.status !== 'active') {
-      return res.status(200).json({
-        message: '如果邮箱存在，重置链接已发送'
-      });
+      return sendSuccess(req, res, 200, 'AUTH_PASSWORD_RESET_REQUEST_ACCEPTED', '如果邮箱存在，重置链接已发送');
     }
     
     // 生成重置令牌
@@ -549,24 +650,28 @@ async function requestPasswordReset(req, res) {
     await supabase
       .from('user_profiles')
       .update({
-        password_reset_token: resetToken,
+        password_reset_token: hashToken(resetToken),
         password_reset_expires: resetExpires.toISOString(),
         updated_at: new Date().toISOString()
       })
       .eq('id', user.id);
     
-    // TODO: 发送重置邮件
-    console.log(`Account reset artifact generated for ${email}`);
-    
-    res.status(200).json({
-      message: '如果邮箱存在，重置链接已发送'
+    const delivery = await sendPasswordResetEmail({
+      to: user.email,
+      name: user.name,
+      resetToken,
+      baseUrl: buildPublicBaseUrl(req),
     });
+    await recordSecurityEvent(user.id, 'password_reset_requested', {
+      ip_address: getClientIp(req),
+      user_agent: getUserAgent(req),
+      delivery_mode: delivery.mode,
+    });
+
+    return sendSuccess(req, res, 200, 'AUTH_PASSWORD_RESET_REQUEST_ACCEPTED', '如果邮箱存在，重置链接已发送');
   } catch (error) {
     console.error('Password reset request error:', error);
-    res.status(500).json({
-      error: 'Internal server error',
-      message: '服务器内部错误'
-    });
+    return sendError(req, res, 500, 'AUTH_INTERNAL_ERROR', 'Internal server error', '服务器内部错误');
   }
 }
 
@@ -578,40 +683,24 @@ async function resetPassword(req, res) {
     const { token, newPassword } = req.body;
     
     if (!token || !newPassword) {
-      return res.status(400).json({
-        error: 'Token and new password required',
-        message: '缺少重置令牌或新密码'
-      });
+      return sendError(req, res, 400, 'AUTH_RESET_TOKEN_REQUIRED', 'Token and new password required', '缺少重置令牌或新密码');
     }
     
     const passwordValidation = validatePassword(newPassword);
     if (!passwordValidation.valid) {
-      return res.status(400).json({
-        error: 'Invalid password',
-        message: passwordValidation.message
-      });
+      return sendError(req, res, 400, 'AUTH_INVALID_PASSWORD', 'Invalid password', passwordValidation.message);
     }
     
     // 查找用户
-    const { data: user, error } = await supabase
-      .from('user_profiles')
-      .select('*')
-      .eq('password_reset_token', token)
-      .single();
+    const user = await findUserByTokenField('password_reset_token', token);
     
-    if (error || !user) {
-      return res.status(400).json({
-        error: 'Invalid reset token',
-        message: '无效的重置令牌'
-      });
+    if (!user) {
+      return sendError(req, res, 400, 'AUTH_INVALID_RESET_TOKEN', 'Invalid reset token', '无效的重置令牌');
     }
     
     // 检查令牌是否过期
     if (new Date() > new Date(user.password_reset_expires)) {
-      return res.status(400).json({
-        error: 'Reset token expired',
-        message: '重置令牌已过期'
-      });
+      return sendError(req, res, 400, 'AUTH_RESET_TOKEN_EXPIRED', 'Reset token expired', '重置令牌已过期');
     }
     
     // 加密新密码
@@ -629,15 +718,15 @@ async function resetPassword(req, res) {
       })
       .eq('id', user.id);
     
-    res.status(200).json({
-      message: '密码重置成功'
+    await recordSecurityEvent(user.id, 'password_reset_completed', {
+      ip_address: getClientIp(req),
+      user_agent: getUserAgent(req),
     });
+
+    return sendSuccess(req, res, 200, 'AUTH_PASSWORD_RESET_COMPLETED', '密码重置成功');
   } catch (error) {
     console.error('Password reset error:', error);
-    res.status(500).json({
-      error: 'Internal server error',
-      message: '服务器内部错误'
-    });
+    return sendError(req, res, 500, 'AUTH_INTERNAL_ERROR', 'Internal server error', '服务器内部错误');
   }
 }
 
@@ -666,40 +755,41 @@ export default async function handler(req, res) {
       
       case 'refresh':
         if (req.method !== 'POST') {
-          return res.status(405).json({ error: 'Method not allowed' });
+          return sendError(req, res, 405, 'AUTH_METHOD_NOT_ALLOWED', 'Method not allowed', '不支持的请求方法');
         }
         return await refreshToken(req, res);
+
+      case 'verify':
+        if (req.method !== 'GET') {
+          return sendError(req, res, 405, 'AUTH_METHOD_NOT_ALLOWED', 'Method not allowed', '不支持的请求方法');
+        }
+        return await verifyAccessToken(req, res);
       
       case 'verify-email':
         if (req.method !== 'GET') {
-          return res.status(405).json({ error: 'Method not allowed' });
+          return sendError(req, res, 405, 'AUTH_METHOD_NOT_ALLOWED', 'Method not allowed', '不支持的请求方法');
         }
         return await verifyEmail(req, res);
       
       case 'request-reset':
         if (req.method !== 'POST') {
-          return res.status(405).json({ error: 'Method not allowed' });
+          return sendError(req, res, 405, 'AUTH_METHOD_NOT_ALLOWED', 'Method not allowed', '不支持的请求方法');
         }
         return await requestPasswordReset(req, res);
       
       case 'reset-password':
         if (req.method !== 'POST') {
-          return res.status(405).json({ error: 'Method not allowed' });
+          return sendError(req, res, 405, 'AUTH_METHOD_NOT_ALLOWED', 'Method not allowed', '不支持的请求方法');
         }
         return await resetPassword(req, res);
       
       default:
-        return res.status(400).json({
-          error: 'Invalid action',
-          message: '无效的操作',
-          availableActions: ['register', 'login', 'refresh', 'verify-email', 'request-reset', 'reset-password']
+        return sendError(req, res, 400, 'AUTH_INVALID_ACTION', 'Invalid action', '无效的操作', {
+          availableActions: ['register', 'login', 'refresh', 'verify', 'verify-email', 'request-reset', 'reset-password']
         });
     }
   } catch (error) {
     console.error('Auth handler error:', error);
-    res.status(500).json({
-      error: 'Internal server error',
-      message: '服务器内部错误'
-    });
+    return sendError(req, res, 500, 'AUTH_INTERNAL_ERROR', 'Internal server error', '服务器内部错误');
   }
 }

--- a/api/auth/lib/auth-mailer.js
+++ b/api/auth/lib/auth-mailer.js
@@ -1,0 +1,111 @@
+function normalizeBaseUrl(rawBaseUrl) {
+  const fallback = 'http://localhost:3000';
+  const candidate = String(rawBaseUrl || fallback).trim() || fallback;
+  return candidate.endsWith('/') ? candidate.slice(0, -1) : candidate;
+}
+
+function getBaseUrl(explicitBaseUrl) {
+  return normalizeBaseUrl(explicitBaseUrl || process.env.AUTH_PUBLIC_BASE_URL || process.env.APP_BASE_URL);
+}
+
+function getMailerMode() {
+  const explicit = String(process.env.AUTH_EMAIL_MODE || '').trim().toLowerCase();
+  if (explicit) {
+    return explicit;
+  }
+  if (process.env.RESEND_API_KEY && process.env.AUTH_EMAIL_FROM) {
+    return 'resend';
+  }
+  return 'log';
+}
+
+function buildActionUrl(baseUrl, action, paramName, paramValue) {
+  const url = new URL('/api/auth', getBaseUrl(baseUrl));
+  url.searchParams.set('action', action);
+  url.searchParams.set(paramName, paramValue);
+  return url.toString();
+}
+
+async function sendWithResend({ to, subject, html }) {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.AUTH_EMAIL_FROM;
+  if (!apiKey || !from) {
+    return { delivered: false, mode: 'log', degraded: true, reason: 'resend_config_missing' };
+  }
+
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from,
+      to,
+      subject,
+      html,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Resend delivery failed: ${response.status} ${body}`);
+  }
+
+  return { delivered: true, mode: 'resend', degraded: false };
+}
+
+function logDelivery(kind, payload) {
+  console.info(payload.link, {
+    kind,
+    to: payload.to,
+    mode: payload.mode,
+    subject: payload.subject,
+  });
+}
+
+async function sendAuthMail(kind, { to, subject, html, link }) {
+  const mode = getMailerMode();
+  if (mode === 'disabled') {
+    logDelivery(kind, { to, subject, link, mode: 'disabled' });
+    return { delivered: false, mode: 'disabled', degraded: true };
+  }
+
+  if (mode === 'resend') {
+    try {
+      return await sendWithResend({ to, subject, html });
+    } catch (error) {
+      console.warn('Auth email provider delivery failed, falling back to log mode:', error.message || error);
+    }
+  }
+
+  logDelivery(kind, { to, subject, link, mode: 'log' });
+  return {
+    delivered: false,
+    mode: 'log',
+    degraded: true,
+    preview_url: link,
+  };
+}
+
+export async function sendVerificationEmail({ to, name, verificationToken, baseUrl }) {
+  const link = buildActionUrl(baseUrl, 'verify-email', 'code', verificationToken);
+  return sendAuthMail('verification', {
+    to,
+    subject: 'Verify your CIE Copilot account',
+    link,
+    html: `<p>Hello ${name || 'there'},</p><p>Verify your email by opening <a href="${link}">${link}</a>.</p>`,
+  });
+}
+
+export async function sendPasswordResetEmail({ to, name, resetToken, baseUrl }) {
+  const link = buildActionUrl(baseUrl, 'reset-password', 'token', resetToken);
+  return sendAuthMail('password_reset', {
+    to,
+    subject: 'Reset your CIE Copilot password',
+    link,
+    html: `<p>Hello ${name || 'there'},</p><p>Reset your password by opening <a href="${link}">${link}</a>.</p>`,
+  });
+}
+
+export { buildActionUrl, getBaseUrl, getMailerMode };

--- a/api/lib/security/auth-context.js
+++ b/api/lib/security/auth-context.js
@@ -1,4 +1,5 @@
 import { getServiceClient } from '../supabase/client.js';
+import { authenticateRequest } from '../../middleware/auth.js';
 
 export function parseBearerToken(req) {
   const raw = req?.headers?.authorization || req?.headers?.Authorization;
@@ -24,6 +25,17 @@ function buildAuthContext(user, token, source = 'supabase') {
     user,
     token,
     source,
+  };
+}
+
+function buildCustomJwtContext(authResult, token) {
+  return {
+    userId: authResult.user.id,
+    role: authResult.user.role,
+    user: authResult.user.profile || authResult.user,
+    token,
+    source: 'custom_jwt',
+    permissions: authResult.user.permissions || [],
   };
 }
 
@@ -67,32 +79,39 @@ export async function resolveTrustedAuthContext(req) {
     };
   }
 
-  let client;
   try {
-    client = getServiceClient();
+    const client = getServiceClient();
+    const { data, error } = await client.auth.getUser(token);
+    if (!error && data?.user) {
+      return {
+        ok: true,
+        token,
+        context: buildAuthContext(data.user, token, 'supabase'),
+      };
+    }
   } catch (error) {
-    return {
-      ok: false,
-      status: 500,
-      code: 'auth_config_missing',
-      message: error?.message || 'Supabase auth config missing.',
-    };
+    // Fall through to custom JWT validation.
   }
 
-  const { data, error } = await client.auth.getUser(token);
-  if (error || !data?.user) {
+  const authResult = await authenticateRequest(req, { optional: false });
+  if (authResult.success) {
     return {
-      ok: false,
-      status: 401,
-      code: 'auth_invalid',
-      message: error?.message || 'Invalid token.',
+      ok: true,
+      token,
+      context: buildCustomJwtContext(authResult, token),
     };
   }
 
   return {
-    ok: true,
-    token,
-    context: buildAuthContext(data.user, token, 'supabase'),
+    ok: false,
+    status: authResult.status || 401,
+    code:
+      authResult.error === 'access_token_required'
+        ? 'auth_required'
+        : authResult.status >= 500 || authResult.error === 'auth_config_missing'
+          ? 'auth_config_missing'
+          : 'auth_invalid',
+    message: authResult.message || 'Invalid token.',
   };
 }
 

--- a/api/lib/security/rate-limit-policy.js
+++ b/api/lib/security/rate-limit-policy.js
@@ -14,6 +14,11 @@ export const RATE_LIMIT_POLICIES = Object.freeze({
     user: { limit: 12, windowMs: 60_000, burstLimit: 12, keyMode: 'user' },
     ip: { limit: 6, windowMs: 60_000, burstLimit: 6, keyMode: 'ip' },
   },
+  auth_public_v1: {
+    policyId: 'auth_public_v1',
+    user: { limit: 20, windowMs: 60_000, burstLimit: 20, keyMode: 'user' },
+    ip: { limit: 8, windowMs: 60_000, burstLimit: 8, keyMode: 'ip' },
+  },
 });
 
 export function getRateLimitPolicy(id) {

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -12,16 +12,18 @@ function getRequiredJwtSecret() {
   return secret;
 }
 
-const SUPABASE_URL = process.env.SUPABASE_URL;
-const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
-const ENFORCE_SESSIONS = process.env.AUTH_ENFORCE_SESSIONS === 'true';
+function isSessionEnforcementEnabled() {
+  return process.env.AUTH_ENFORCE_SESSIONS === 'true';
+}
 
 let supabaseClient = null;
 function getSupabaseClient() {
   if (supabaseClient) {
     return supabaseClient;
   }
-  if (!SUPABASE_URL || !SUPABASE_KEY) {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseKey) {
     const error = new Error('Missing Supabase auth configuration: SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY');
     error.code = 'SUPABASE_AUTH_CONFIG_MISSING';
     throw error;
@@ -145,6 +147,14 @@ function isMissingRelationError(error) {
   return error.code === '42P01' || message.includes('does not exist') || message.includes('relation');
 }
 
+function isMissingColumnError(error, columnName) {
+  if (!error) {
+    return false;
+  }
+  const message = `${error.message || ''} ${error.details || ''}`.toLowerCase();
+  return error.code === '42703' && (!columnName || message.includes(String(columnName).toLowerCase()));
+}
+
 function buildFailure(status, error, message, code, extras = {}) {
   return {
     success: false,
@@ -254,65 +264,185 @@ async function getUserPermissions(userId, role) {
   return Array.from(permissionSet);
 }
 
-async function validateActiveSession(userId, token) {
+async function validateRefreshSession(userId, refreshToken) {
   const supabase = getSupabaseClient();
+  const refreshTokenHash = hashToken(refreshToken);
   try {
-    const { data, error } = await supabase
+    let query = await supabase
       .from('user_sessions')
-      .select('id')
+      .select('id, user_id, expires_at')
       .eq('user_id', userId)
-      .eq('token_hash', hashToken(token))
-      .eq('is_active', true)
+      .eq('refresh_token_hash', refreshTokenHash)
       .gte('expires_at', new Date().toISOString())
       .maybeSingle();
 
-    if (error) {
-      if (isMissingRelationError(error)) {
-        return { checked: false, valid: !ENFORCE_SESSIONS, reason: 'session_table_missing' };
-      }
-      console.warn('Session validation query failed:', error.message || error);
-      return { checked: false, valid: !ENFORCE_SESSIONS, reason: 'session_query_error' };
+    if (query.error && isMissingColumnError(query.error, 'refresh_token_hash')) {
+      query = await supabase
+        .from('user_sessions')
+        .select('id, user_id, expires_at')
+        .eq('user_id', userId)
+        .eq('token_hash', refreshTokenHash)
+        .gte('expires_at', new Date().toISOString())
+        .maybeSingle();
     }
 
-    if (!data) {
+    if (query.error) {
+      if (isMissingRelationError(query.error)) {
+        return { checked: false, valid: !isSessionEnforcementEnabled(), reason: 'session_table_missing' };
+      }
+      console.warn('Refresh session validation query failed:', query.error.message || query.error);
+      return { checked: false, valid: !isSessionEnforcementEnabled(), reason: 'session_query_error' };
+    }
+
+    if (!query.data) {
       return { checked: true, valid: false, reason: 'session_not_found' };
     }
 
-    return { checked: true, valid: true, sessionId: data.id };
+    return { checked: true, valid: true, sessionId: query.data.id };
   } catch (error) {
-    console.warn('Session validation failed:', error.message || error);
-    return { checked: false, valid: !ENFORCE_SESSIONS, reason: 'session_validation_exception' };
+    console.warn('Refresh session validation failed:', error.message || error);
+    return { checked: false, valid: !isSessionEnforcementEnabled(), reason: 'session_validation_exception' };
   }
 }
 
-async function touchSession(sessionId) {
-  if (!sessionId) {
-    return;
-  }
+async function persistRefreshSession({ userId, refreshToken, expiresAt, ipAddress = null, userAgent = null }) {
   const supabase = getSupabaseClient();
   try {
-    await supabase
+    let result = await supabase
       .from('user_sessions')
-      .update({ last_activity: new Date().toISOString() })
-      .eq('id', sessionId);
+      .insert({
+        user_id: userId,
+        refresh_token_hash: hashToken(refreshToken),
+        ip_address: ipAddress,
+        user_agent: userAgent,
+        expires_at: expiresAt,
+      });
+
+    if (result?.error && isMissingColumnError(result.error, 'refresh_token_hash')) {
+      result = await supabase
+        .from('user_sessions')
+        .insert({
+          user_id: userId,
+          token_hash: hashToken(refreshToken),
+          ip_address: ipAddress,
+          user_agent: userAgent,
+          expires_at: expiresAt,
+        });
+    }
+
+    if (result?.error) {
+      if (isMissingRelationError(result.error)) {
+        return { persisted: false, checked: false, reason: 'session_table_missing' };
+      }
+      console.warn('Failed to persist refresh session:', result.error.message || result.error);
+      return { persisted: false, checked: true, reason: 'session_insert_failed' };
+    }
+
+    return { persisted: true, checked: true, reason: null };
   } catch (error) {
-    console.warn('Failed to update session activity:', error.message || error);
+    console.warn('Failed to persist refresh session:', error.message || error);
+    return { persisted: false, checked: false, reason: 'session_insert_exception' };
+  }
+}
+
+async function rotateRefreshSession({
+  userId,
+  currentRefreshToken,
+  nextRefreshToken,
+  expiresAt,
+  ipAddress = null,
+  userAgent = null,
+}) {
+  const validation = await validateRefreshSession(userId, currentRefreshToken);
+  if (!validation.valid) {
+    return validation;
+  }
+
+  if (!validation.checked || !validation.sessionId) {
+    const persisted = await persistRefreshSession({
+      userId,
+      refreshToken: nextRefreshToken,
+      expiresAt,
+      ipAddress,
+      userAgent,
+    });
+    return {
+      checked: persisted.checked,
+      valid: persisted.persisted || !persisted.checked,
+      sessionId: null,
+      reason: persisted.reason,
+    };
+  }
+
+  const supabase = getSupabaseClient();
+  try {
+    let result = await supabase
+      .from('user_sessions')
+      .update({
+        refresh_token_hash: hashToken(nextRefreshToken),
+        ip_address: ipAddress,
+        user_agent: userAgent,
+        expires_at: expiresAt,
+      })
+      .eq('id', validation.sessionId);
+
+    if (result?.error && isMissingColumnError(result.error, 'refresh_token_hash')) {
+      result = await supabase
+        .from('user_sessions')
+        .update({
+          token_hash: hashToken(nextRefreshToken),
+          ip_address: ipAddress,
+          user_agent: userAgent,
+          expires_at: expiresAt,
+        })
+        .eq('id', validation.sessionId);
+    }
+
+    if (result?.error) {
+      console.warn('Failed to rotate refresh session:', result.error.message || result.error);
+      return { checked: true, valid: false, reason: 'session_rotate_failed' };
+    }
+
+    return { checked: true, valid: true, sessionId: validation.sessionId };
+  } catch (error) {
+    console.warn('Failed to rotate refresh session:', error.message || error);
+    return { checked: true, valid: false, reason: 'session_rotate_exception' };
   }
 }
 
 async function recordSecurityEvent(userId, eventType, metadata = {}) {
   const supabase = getSupabaseClient();
+  const payload = {
+    user_id: userId || null,
+    event_type: eventType,
+    severity: metadata.severity || 'info',
+    details: metadata,
+    ip_address: metadata.ip_address || null,
+    user_agent: metadata.user_agent || null,
+    created_at: new Date().toISOString()
+  };
   try {
-    await supabase
+    let result = await supabase
       .from('security_events')
-      .insert({
-        user_id: userId || null,
-        event_type: eventType,
-        metadata,
-        ip_address: metadata.ip_address || null,
-        user_agent: metadata.user_agent || null,
-        created_at: new Date().toISOString()
-      });
+      .insert(payload);
+
+    if (result?.error && isMissingColumnError(result.error, 'details')) {
+      result = await supabase
+        .from('security_events')
+        .insert({
+          user_id: userId || null,
+          event_type: eventType,
+          severity: metadata.severity || 'info',
+          metadata,
+          ip_address: metadata.ip_address || null,
+          user_agent: metadata.user_agent || null,
+          created_at: new Date().toISOString()
+        });
+    }
+
+    if (result?.error && !isMissingRelationError(result.error)) {
+      console.warn('Failed to record security event:', result.error.message || result.error);
+    }
   } catch (error) {
     if (!isMissingRelationError(error)) {
       console.warn('Failed to record security event:', error.message || error);
@@ -354,6 +484,10 @@ async function authenticateRequest(req, { optional = false } = {}) {
       return buildFailure(401, 'invalid_token_payload', '访问令牌载荷无效', 'AUTH_001');
     }
 
+    if (decoded?.type === 'refresh') {
+      return buildFailure(401, 'invalid_token_type', '访问令牌类型无效', 'AUTH_001');
+    }
+
     const userProfile = await fetchActiveUserProfile(userId);
     if (!userProfile) {
       return buildFailure(401, 'invalid_token', '无效的访问令牌', 'AUTH_002');
@@ -362,27 +496,13 @@ async function authenticateRequest(req, { optional = false } = {}) {
     const permissions = await getUserPermissions(userProfile.id, userProfile.role);
     const user = buildUserContext(userProfile, permissions);
 
-    const sessionResult = await validateActiveSession(user.id, token);
-    if (!sessionResult.valid) {
-      await recordSecurityEvent(user.id, 'invalid_session', {
-        reason: sessionResult.reason,
-        endpoint: req?.url || req?.path || null,
-        method: req?.method || null
-      });
-      return buildFailure(401, 'session_invalid', '会话已过期或无效', 'AUTH_002');
-    }
-
-    if (sessionResult.sessionId) {
-      await touchSession(sessionResult.sessionId);
-    }
-
     return {
       success: true,
       user,
       auth: {
-        session_checked: sessionResult.checked,
-        session_validated: sessionResult.valid,
-        session_id: sessionResult.sessionId || null
+        session_checked: false,
+        session_validated: null,
+        session_id: null
       }
     };
   } catch (error) {
@@ -688,6 +808,9 @@ export {
   generateToken,
   verifyToken,
   hashToken,
+  persistRefreshSession,
+  validateRefreshSession,
+  rotateRefreshSession,
   getUserPermissions,
   recordSecurityEvent,
   USER_ROLES,

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -18,13 +18,15 @@ Authorization: Bearer <access_token>
 
 ## 错误响应格式
 
-所有错误响应都遵循以下格式：
+当前 API 网关与 auth backend 使用带机器可读 `code` 的 envelope。auth 请求会额外携带 `request_id`。
 
 ```json
 {
   "success": false,
-  "message": "错误描述",
-  "errors": ["详细错误信息"]
+  "code": "AUTH_INVALID_CREDENTIALS",
+  "error": "Invalid credentials",
+  "message": "邮箱或密码错误",
+  "request_id": "req_123"
 }
 ```
 
@@ -43,18 +45,22 @@ Authorization: Bearer <access_token>
 
 用户认证、注册、登录相关接口
 
+### Active Auth Route Note
+
+当前运行时 auth 使用单一路由 `/api/auth` 加 `action` 分发，不再使用旧的 path-split 形式 `/api/auth/login`。
+
 ### 1. 用户注册
 
-**POST** `/api/auth/register`
+**POST** `/api/auth?action=register`
 
 **请求体:**
 
 ```json
 {
   "email": "user@example.com",
-  "password": "SecurePassword123!",
-  "username": "username",
-  "full_name": "Full Name"
+  "password": "abc12345",
+  "name": "Full Name",
+  "role": "student"
 }
 ```
 
@@ -64,13 +70,14 @@ Authorization: Bearer <access_token>
 ```json
 {
   "success": true,
-  "message": "用户注册成功",
-  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "code": "AUTH_REGISTERED",
+  "message": "注册成功，请检查邮箱验证链接",
   "user": {
     "id": "uuid",
     "email": "user@example.com",
-    "username": "username",
-    "role": "student"
+    "name": "Full Name",
+    "role": "student",
+    "status": "pending_verification"
   }
 }
 ```
@@ -79,7 +86,7 @@ Authorization: Bearer <access_token>
 
 ### 2. 用户登录
 
-**POST** `/api/auth/login`
+**POST** `/api/auth?action=login`
 
 **请求体:**
 
@@ -95,13 +102,19 @@ Authorization: Bearer <access_token>
 ```json
 {
   "success": true,
+  "code": "AUTH_LOGIN_SUCCESS",
   "message": "登录成功",
-  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
   "user": {
     "id": "uuid",
     "email": "user@example.com",
-    "username": "username",
-    "role": "student"
+    "role": "student",
+    "status": "active"
+  },
+  "tokens": {
+    "accessToken": "jwt-access-token",
+    "refreshToken": "jwt-refresh-token",
+    "expiresIn": "24h",
+    "refreshExpiresIn": "7d"
   }
 }
 ```
@@ -110,16 +123,21 @@ Authorization: Bearer <access_token>
 
 ### 3. 刷新访问令牌
 
-**POST** `/api/auth/refresh`
+**POST** `/api/auth?action=refresh`
 
-**请求头:**
-- `Authorization`: Bearer <refresh_token>
+**请求体:**
+
+```json
+{
+  "refreshToken": "jwt-refresh-token"
+}
+```
 
 ---
 
 ### 4. 验证访问令牌
 
-**GET** `/api/auth/verify`
+**GET** `/api/auth?action=verify`
 
 **请求头:**
 - `Authorization`: Bearer <access_token>
@@ -128,7 +146,7 @@ Authorization: Bearer <access_token>
 
 ### 5. 请求密码重置
 
-**POST** `/api/auth/forgot-password`
+**POST** `/api/auth?action=request-reset`
 
 **请求体:**
 
@@ -142,16 +160,18 @@ Authorization: Bearer <access_token>
 
 ### 6. 重置密码
 
-**POST** `/api/auth/reset-password`
+**POST** `/api/auth?action=reset-password`
 
 **请求体:**
 
 ```json
 {
   "token": "reset_token",
-  "password": "NewSecurePassword123!"
+  "newPassword": "abc12345"
 }
 ```
+
+更多本地运行说明见 [docs/setup/README_AUTH.md](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/docs/setup/README_AUTH.md)。
 
 ---
 

--- a/docs/setup/README_AUTH.md
+++ b/docs/setup/README_AUTH.md
@@ -1,0 +1,88 @@
+# Auth Backend Runtime Notes
+
+## Active Route Shape
+
+Auth does not use path-split endpoints like `/api/auth/login`.
+
+The active runtime route is:
+
+- `POST /api/auth?action=register`
+- `POST /api/auth?action=login`
+- `POST /api/auth?action=refresh`
+- `GET /api/auth?action=verify`
+- `GET /api/auth?action=verify-email&code=<token>`
+- `POST /api/auth?action=request-reset`
+- `POST /api/auth?action=reset-password`
+
+The route is registered in [api/_runtime/route-registry.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/_runtime/route-registry.js#L187).
+
+## Local/Test Environment
+
+Minimum server env for local auth backend work:
+
+```powershell
+$env:SUPABASE_URL="https://<project>.supabase.co"
+$env:SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
+$env:JWT_SECRET="replace-with-a-long-random-secret"
+$env:ALLOWED_ORIGINS="http://localhost:3000"
+```
+
+Optional mail/env settings:
+
+```powershell
+$env:AUTH_PUBLIC_BASE_URL="http://localhost:3000"
+$env:AUTH_EMAIL_MODE="log"
+```
+
+## Mail Delivery Modes
+
+Auth mail delivery is implemented through `api/auth/lib/auth-mailer.js`.
+
+Supported behavior:
+
+- `AUTH_EMAIL_MODE=log`
+  Local/test-safe default. Verification and reset links are written to server logs through `console.info(...)`.
+- `AUTH_EMAIL_MODE=disabled`
+  No provider call is attempted. The API still completes and logs a disabled delivery artifact.
+- `AUTH_EMAIL_MODE=resend`
+  Uses `RESEND_API_KEY` and `AUTH_EMAIL_FROM`. If provider delivery fails, the backend falls back to `log`.
+
+If no provider is configured, auth does **not** block local development. It degrades to logged delivery artifacts.
+
+## How to Use Logged Mail Artifacts
+
+### Email verification
+
+When `AUTH_EMAIL_MODE=log`, registration writes a verification link containing:
+
+```text
+/api/auth?action=verify-email&code=<token>
+```
+
+Open that URL to activate the account.
+
+### Password reset
+
+When `AUTH_EMAIL_MODE=log`, password-reset requests write a reset artifact containing:
+
+```text
+/api/auth?action=reset-password&token=<token>
+```
+
+Use the token value from that logged link in:
+
+```json
+POST /api/auth?action=reset-password
+{
+  "token": "<token>",
+  "newPassword": "abc12345"
+}
+```
+
+## Verification Commands
+
+Focused auth regression suite:
+
+```powershell
+npm run api:test -- --runInBand api/auth/__tests__/productionization.test.js api/middleware/__tests__/auth-unification.test.js api/_runtime/__tests__/adapter.test.js api/__tests__/security-baseline.test.js api/__tests__/security-depth.test.js api/__tests__/shared-rate-limit.test.js api/__tests__/api-route-integration.test.js
+```

--- a/docs/superpowers/plans/2026-03-14-auth-backend-productionization.md
+++ b/docs/superpowers/plans/2026-03-14-auth-backend-productionization.md
@@ -1,0 +1,183 @@
+# Auth Backend Productionization Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the existing auth backend's productionization gaps without redesigning auth, touching frontend/RAG, or modifying `supabase/migrations/*.sql`.
+
+**Architecture:** Keep the current `/api/auth?action=...` module and JWT middleware, then tighten the missing edges around token validation, session lifecycle, mail delivery, abuse controls, and API contract consistency. New behavior must degrade safely when optional infra like `user_sessions`, `security_events`, or an external mail provider is unavailable.
+
+**Tech Stack:** Node.js, Jest, custom API gateway/runtime, Supabase service client, JWT, bcryptjs
+
+---
+
+## Chunk 1: Lock Missing Auth Behaviors with Tests
+
+### Task 1: Add failing tests for token verification, auth-context alignment, and mail fallback
+
+**Files:**
+- Create: `api/auth/__tests__/productionization.test.js`
+- Modify: `api/lib/security/auth-context.js` (later implementation target)
+- Modify: `api/auth/index.js` (later implementation target)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests for:
+- `verify` action returns token validity and user context for a login-issued JWT.
+- gateway auth-context can resolve the same custom JWT format used by auth backend login.
+- registration/reset mail delivery falls back to local/test logging instead of crashing when no provider is configured.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run api:test -- --runInBand api/auth/__tests__/productionization.test.js`
+Expected: FAIL because verify action, auth-context fallback, or mail fallback behavior is incomplete.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implement only enough code to satisfy the failing tests.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run api:test -- --runInBand api/auth/__tests__/productionization.test.js`
+Expected: PASS
+
+### Task 2: Add failing tests for session persistence/rotation and auth route rate limiting
+
+**Files:**
+- Modify: `api/auth/__tests__/productionization.test.js`
+- Modify: `api/_runtime/route-registry.js` (later implementation target)
+- Modify: `api/lib/security/rate-limit-policy.js` (later implementation target)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests for:
+- login persists a session record when `user_sessions` exists and degrades safely when it does not.
+- refresh validates and rotates the stored refresh session.
+- `/api/auth` resolves a dedicated rate-limit policy from route registry.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run api:test -- --runInBand api/auth/__tests__/productionization.test.js`
+Expected: FAIL on missing session persistence/rotation or missing rate-limit policy.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implement only the behavior needed for the tests to pass.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run api:test -- --runInBand api/auth/__tests__/productionization.test.js`
+Expected: PASS
+
+## Chunk 2: Implement Auth Productionization Fixes
+
+### Task 3: Complete auth mail delivery and token/session helpers
+
+**Files:**
+- Modify: `api/auth/index.js`
+- Modify: `api/middleware/auth.js`
+- Create: `api/auth/lib/auth-mailer.js`
+
+- [ ] **Step 1: Implement the auth mailer adapter**
+
+Support:
+- local/test log fallback
+- provider-by-env dispatch
+- no-provider graceful degradation
+
+- [ ] **Step 2: Harden verification/reset token generation**
+
+Replace weak random-code handling with production-safe token generation and storage/lookup helpers that do not require schema changes.
+
+- [ ] **Step 3: Add session lifecycle support**
+
+Persist login sessions when possible and rotate/invalidate refresh sessions safely when `user_sessions` is available.
+
+- [ ] **Step 4: Re-run focused tests**
+
+Run: `npm run api:test -- --runInBand api/auth/__tests__/productionization.test.js`
+Expected: PASS
+
+### Task 4: Align gateway auth semantics with auth backend tokens
+
+**Files:**
+- Modify: `api/lib/security/auth-context.js`
+- Modify: `api/middleware/auth.js`
+
+- [ ] **Step 1: Implement custom-JWT auth-context fallback**
+
+Let protected-route auth recognize the same auth backend JWTs while preserving local test mode and safe failure semantics.
+
+- [ ] **Step 2: Normalize returned auth context**
+
+Ensure `req.auth_user_id`, `req.auth_user`, and related fields remain compatible with existing protected-route consumers.
+
+- [ ] **Step 3: Re-run auth/gateway security tests**
+
+Run: `npm run api:test -- --runInBand api/auth/__tests__/productionization.test.js api/__tests__/security-baseline.test.js api/__tests__/security-depth.test.js`
+Expected: PASS
+
+### Task 5: Add auth route abuse protection, audit events, and response consistency
+
+**Files:**
+- Modify: `api/_runtime/route-registry.js`
+- Modify: `api/lib/security/rate-limit-policy.js`
+- Modify: `api/auth/index.js`
+
+- [ ] **Step 1: Add a dedicated auth rate-limit policy**
+
+Attach a gateway-level auth rate-limit policy to `/api/auth`.
+
+- [ ] **Step 2: Emit auth audit events**
+
+Use the existing security event path for the main auth lifecycle events.
+
+- [ ] **Step 3: Normalize auth API envelopes**
+
+Add stable `code` and `success` semantics while preserving current user-facing data.
+
+- [ ] **Step 4: Re-run focused tests**
+
+Run: `npm run api:test -- --runInBand api/auth/__tests__/productionization.test.js api/__tests__/shared-rate-limit.test.js`
+Expected: PASS
+
+## Chunk 3: Docs, Verification, and Review
+
+### Task 6: Add minimal auth runtime documentation
+
+**Files:**
+- Create or Modify: `docs/setup/README_AUTH.md`
+- Modify: `docs/API_DOCUMENTATION.md`
+
+- [ ] **Step 1: Document the active auth route shape**
+
+State the real runtime contract: `/api/auth?action=...`
+
+- [ ] **Step 2: Document local/test mail behavior**
+
+Cover:
+- how to run locally
+- how mail falls back when no provider is configured
+- which env vars enable provider-backed sending
+
+- [ ] **Step 3: Run documentation-sensitive verification**
+
+Run a search command to verify outdated auth path examples are corrected or clearly superseded.
+
+### Task 7: Final verification and code review
+
+**Files:**
+- Verify the whole auth productionization change set
+
+- [ ] **Step 1: Run the focused auth verification suite**
+
+Run: `npm run api:test -- --runInBand api/auth/__tests__/productionization.test.js api/middleware/__tests__/auth-unification.test.js api/_runtime/__tests__/adapter.test.js api/__tests__/security-baseline.test.js api/__tests__/security-depth.test.js api/__tests__/shared-rate-limit.test.js`
+Expected: PASS
+
+- [ ] **Step 2: Run a route-registry contract check**
+
+Run: `npm run api:test -- --runInBand api/__tests__/api-route-integration.test.js`
+Expected: PASS
+
+- [ ] **Step 3: Request code review**
+
+Dispatch a reviewer against the auth productionization diff and address any important findings before completion.

--- a/docs/superpowers/specs/2026-03-14-auth-backend-productionization-design.md
+++ b/docs/superpowers/specs/2026-03-14-auth-backend-productionization-design.md
@@ -1,0 +1,101 @@
+# Auth Backend Productionization Design
+
+**Date:** 2026-03-14
+**Scope owner:** Codex auth backend productionization line
+**Worktree:** `C:\Users\Samsen\cie-copilot\.worktrees\codex-auth-prod`
+
+## Goal
+
+Take the existing auth backend closer to production readiness without redesigning the identity system, touching frontend integration, modifying `supabase/migrations/*.sql`, or changing any RAG behavior.
+
+## Locked Facts
+
+1. Auth backend primitives already exist in [api/auth/index.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/auth/index.js), including register, login, refresh, verify-email, request-reset, and reset-password handlers.
+2. Email verification and password-reset delivery are still TODOs in [api/auth/index.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/auth/index.js#L242) and [api/auth/index.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/auth/index.js#L558).
+3. Auth middleware already has JWT validation, permission checks, security event recording, and session validation hooks in [api/middleware/auth.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/middleware/auth.js).
+4. The gateway currently exposes auth publicly via [api/_runtime/route-registry.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/_runtime/route-registry.js#L185).
+5. The gateway's protected-route auth path currently resolves through [api/lib/security/auth-context.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/lib/security/auth-context.js#L42), which does not currently align with the login-issued JWTs in [api/auth/index.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/auth/index.js#L340).
+
+## Production Gaps
+
+### 1. Mail delivery gap
+
+- Registration and password-reset flows generate verification/reset artifacts, but do not dispatch mail.
+- Local/test behavior is not formalized, so there is no production-safe fallback when no provider is configured.
+
+### 2. Token semantics gap
+
+- Login emits custom JWTs, but protected-route auth is resolved elsewhere.
+- Refresh tokens are not backed by a persisted session lifecycle in the existing login flow.
+- There is no explicit auth API token verification endpoint even though token verification is part of the target flow.
+
+### 3. Abuse protection gap
+
+- Login-attempt counting exists per email, but `/api/auth` does not have a gateway-level rate-limit policy.
+- Critical auth actions do not consistently emit auth audit events.
+
+### 4. Consistency gap
+
+- Auth responses use mixed shapes and missing machine-readable codes.
+- Existing docs still describe outdated auth endpoints in [docs/API_DOCUMENTATION.md](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/docs/API_DOCUMENTATION.md#L48).
+
+## Non-Goals
+
+- No frontend integration.
+- No RAG changes.
+- No unrelated refactors.
+- No `supabase/migrations/*.sql` changes.
+- No replacement of the overall identity model with a different auth provider.
+
+## Minimal Complete Scope
+
+### A. Close the auth token loop
+
+- Add one explicit auth token verification action under `/api/auth?action=verify`.
+- Make gateway/protected-route auth accept the same login-issued JWT semantics as the auth backend.
+- Persist and validate session lifecycle when `user_sessions` exists, while degrading safely when the session table is absent or disabled.
+
+### B. Complete email-driven flows
+
+- Replace TODO mail gaps with a small auth mailer adapter.
+- Support provider-backed sending only through env vars.
+- Support local/test fallback with logged delivery artifacts so local development is not blocked.
+
+### C. Harden abuse handling and auditability
+
+- Add a minimal gateway rate-limit policy for `/api/auth`.
+- Record auth audit/security events for registration, login success/failure, verification, password-reset request, and password reset completion.
+- Keep responses generic where needed to avoid account enumeration.
+
+### D. Normalize API contract and docs
+
+- Standardize auth success/error envelopes enough to include stable machine-readable codes without breaking the current flow shape.
+- Add focused auth tests.
+- Add a minimal auth runtime document that explains local/test mode and no-provider mail fallback.
+
+## Implementation Shape
+
+### Files expected to change
+
+- [api/auth/index.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/auth/index.js)
+- [api/middleware/auth.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/middleware/auth.js)
+- [api/lib/security/auth-context.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/lib/security/auth-context.js)
+- [api/_runtime/route-registry.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/_runtime/route-registry.js)
+- [api/lib/security/rate-limit-policy.js](/C:/Users/Samsen/cie-copilot/.worktrees/codex-auth-prod/api/lib/security/rate-limit-policy.js)
+- New focused auth tests under `api/auth/__tests__/`
+- Minimal doc update/addition under `docs/`
+
+### Risks to contain
+
+- Avoid breaking existing protected routes while aligning token semantics.
+- Keep mail delivery optional in local/test environments.
+- Do not require schema changes for session or mail behavior.
+
+## Deliverables
+
+1. Auth productionization scope with fixed-path evidence.
+2. Issue list tied to concrete files and lines.
+3. Minimal code fixes for auth backend productionization.
+4. Focused auth tests and verification commands.
+5. Clear local/test mail-flow instructions with no-provider fallback.
+6. A final split between completed items, deferred items, and follow-up recommendations.


### PR DESCRIPTION
## Summary
- complete the existing auth backend productionization line without changing `supabase/migrations/*.sql`
- implement verification-mail and password-reset mail delivery with provider plus local fallback modes
- unify auth response envelopes, add `/api/auth?action=verify`, and align refresh-session persistence with the existing auth schema
- add gateway-level rate limiting for `/api/auth`, custom JWT fallback for trusted auth context, and focused auth productionization regression coverage
- add minimal auth backend runbook and update API documentation for the current `/api/auth?action=...` routes

## Scope
This PR is intentionally limited to auth backend completion and closeout:
- register / login / token verify / refresh
- email verification
- password reset
- rate limiting / audit logging consistency
- tests and minimal docs

Out of scope:
- frontend integration
- RAG changes
- unrelated refactors
- migration edits
- logout / revoke-session / resend-verification endpoints

## Verification
```powershell
node --experimental-vm-modules C:\Users\Samsen\cie-copilot\node_modules\jest\bin\jest.js api/auth/__tests__/productionization.test.js api/middleware/__tests__/auth-unification.test.js api/_runtime/__tests__/adapter.test.js api/__tests__/security-baseline.test.js api/__tests__/security-depth.test.js api/__tests__/shared-rate-limit.test.js api/__tests__/api-route-integration.test.js
git diff --check
```

## Notes
- `AUTH_EMAIL_MODE=log` remains local/test-safe and does not require an external provider.
- `AUTH_EMAIL_MODE=resend` uses `RESEND_API_KEY` plus `AUTH_EMAIL_FROM` and falls back to `log` on provider failure.
- staging should still run one real provider smoke test before release.
