### PR TITLE
feat(learning): add runtime repositories

### DIFF
--- a/api/learning/__tests__/question-registry-repository.test.js
+++ b/api/learning/__tests__/question-registry-repository.test.js
@@ -1,0 +1,153 @@
+import { insertImportedQuestion } from '../lib/repositories/question-registry-repository.js';
+
+function createQuestionRegistryDb() {
+  const inserts = [];
+  const updates = [];
+
+  return {
+    inserts,
+    updates,
+    from(table) {
+      return {
+        insert(payload) {
+          return {
+            select() {
+              return this;
+            },
+            async single() {
+              inserts.push({ table, payload });
+
+              if (table === 'question_bank') {
+                return {
+                  data: {
+                    question_id: 'question-1',
+                    ...payload,
+                  },
+                  error: null,
+                };
+              }
+
+              if (table === 'learning_question_analysis_snapshots') {
+                return {
+                  data: {
+                    classification_snapshot_id: 'snapshot-1',
+                    ...payload,
+                  },
+                  error: null,
+                };
+              }
+
+              throw new Error(`Unexpected insert table: ${table}`);
+            },
+          };
+        },
+        update(payload) {
+          return {
+            async eq(column, value) {
+              updates.push({ table, payload, filters: [{ column, value }] });
+              return { data: null, error: null };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('question-registry-repository', () => {
+  test('insertImportedQuestion stores a durable question without storage_key/q_number requirements and persists a typed snapshot ref', async () => {
+    const db = createQuestionRegistryDb();
+
+    const importedInput = {
+      subject_code: '9709',
+      prompt_representation: {
+        type: 'text',
+        value: 'Solve 2sin(x)=1 for 0<=x<=360.',
+      },
+      provenance_summary: {
+        import_source: 'manual_paste',
+      },
+      release_scope_status: 'non_released_fallback',
+      classification: {
+        primary_topic_id: 'topic-1',
+        secondary_topic_ids: ['topic-2'],
+        family_id: '9709.trigonometry_manipulation_equations',
+        primary_question_type_id: '9709.trigonometry.equations',
+        secondary_question_type_ids: ['9709.trigonometry.identities'],
+        variant_tags: ['paper:p1', 'answer_form:interval'],
+        classification_source: 'manual_import',
+        classification_confidence: 0.82,
+        candidate_rubric_refs: [
+          {
+            kind: 'rubric_release',
+            rubric_set_id: '9709.trig.eq',
+            rubric_version_id: 'v1',
+            scope_level: 'question_type',
+            release_state: 'released',
+          },
+        ],
+      },
+    };
+
+    const result = await insertImportedQuestion(db, importedInput);
+
+    expect(db.inserts).toHaveLength(2);
+    expect(db.inserts[0]).toMatchObject({
+      table: 'question_bank',
+      payload: {
+        source_kind: 'imported_question',
+        subject_code: '9709',
+        prompt_representation: importedInput.prompt_representation,
+        provenance_summary: importedInput.provenance_summary,
+        primary_topic_id: 'topic-1',
+        secondary_topic_ids: ['topic-2'],
+        family_id: '9709.trigonometry_manipulation_equations',
+        primary_question_type_id: '9709.trigonometry.equations',
+        secondary_question_type_ids: ['9709.trigonometry.identities'],
+        variant_tags: ['paper:p1', 'answer_form:interval'],
+        release_scope_status: 'non_released_fallback',
+      },
+    });
+    expect(db.inserts[0].payload).not.toHaveProperty('storage_key');
+    expect(db.inserts[0].payload).not.toHaveProperty('q_number');
+
+    expect(db.inserts[1]).toMatchObject({
+      table: 'learning_question_analysis_snapshots',
+      payload: {
+        question_id: 'question-1',
+        primary_topic_id: 'topic-1',
+        secondary_topic_ids: ['topic-2'],
+        family_id: '9709.trigonometry_manipulation_equations',
+        primary_question_type_id: '9709.trigonometry.equations',
+        secondary_question_type_ids: ['9709.trigonometry.identities'],
+        variant_tags: ['paper:p1', 'answer_form:interval'],
+        classification_source: 'manual_import',
+        classification_confidence: 0.82,
+        candidate_rubric_refs: importedInput.classification.candidate_rubric_refs,
+      },
+    });
+
+    expect(db.updates).toEqual([
+      {
+        table: 'question_bank',
+        payload: {
+          classification_snapshot_ref: {
+            kind: 'classification_snapshot',
+            classification_snapshot_id: 'snapshot-1',
+          },
+        },
+        filters: [{ column: 'question_id', value: 'question-1' }],
+      },
+    ]);
+
+    expect(result).toMatchObject({
+      question_id: 'question-1',
+      source_kind: 'imported_question',
+      primary_question_type_id: '9709.trigonometry.equations',
+      classification_snapshot_ref: {
+        kind: 'classification_snapshot',
+        classification_snapshot_id: 'snapshot-1',
+      },
+    });
+  });
+});

--- a/api/learning/__tests__/session-repository.test.js
+++ b/api/learning/__tests__/session-repository.test.js
@@ -1,0 +1,216 @@
+import { getSession, insertSession } from '../lib/repositories/session-repository.js';
+
+function createSessionDb() {
+  const inserts = [];
+  const selects = [];
+
+  const resumeProjectionRow = {
+    session_id: 'session-1',
+    user_id: 'user-1',
+    subject_code: '9709',
+    session_goal: 'Practice trig identities',
+    mode: 'guided_solve',
+    state: 'active',
+    active_scope_bundle: {
+      primary_topic_id: 'topic-1',
+      primary_topic_path: '9709/trigonometry/identities',
+      secondary_topics_in_scope: [],
+      allowed_prerequisites: [],
+      paper_context: null,
+      mode: 'guided_solve',
+      session_goal: 'Practice trig identities',
+      current_anchor_kind: 'question',
+      current_anchor_ref: { kind: 'question', question_id: 'question-1' },
+      current_question_ref: { kind: 'question', question_id: 'question-1' },
+      current_question_type_ref: {
+        kind: 'question_type',
+        question_type_id: '9709.trigonometry.identities',
+      },
+    },
+    current_anchor_kind: 'question',
+    current_anchor_ref: { kind: 'question', question_id: 'question-1' },
+    current_question_id: 'question-1',
+    current_question_type_id: '9709.trigonometry.identities',
+    summary_state: { progress: 'started' },
+    open_questions: [],
+    key_artifact_refs: [],
+    misconceptions_in_focus: [],
+    lineage_ref: { parent_session_id: null, handoff_kind: null },
+    created_at: '2026-03-21T10:00:00.000Z',
+    updated_at: '2026-03-21T10:00:00.000Z',
+    parent_session_id: null,
+    handoff_kind: null,
+    summary_snapshot: { progress: 'started' },
+  };
+
+  return {
+    inserts,
+    selects,
+    from(table) {
+      return {
+        insert(payload) {
+          return {
+            select() {
+              return this;
+            },
+            async single() {
+              inserts.push({ table, payload });
+
+              if (table === 'learning_sessions') {
+                return {
+                  data: {
+                    session_id: 'session-1',
+                    created_at: '2026-03-21T10:00:00.000Z',
+                    updated_at: '2026-03-21T10:00:00.000Z',
+                    ...payload,
+                  },
+                  error: null,
+                };
+              }
+
+              if (table === 'learning_session_lineage') {
+                return {
+                  data: {
+                    lineage_id: 'lineage-1',
+                    created_at: '2026-03-21T10:00:00.000Z',
+                    ...payload,
+                  },
+                  error: null,
+                };
+              }
+
+              throw new Error(`Unexpected insert table: ${table}`);
+            },
+          };
+        },
+        select(selection) {
+          const filters = [];
+
+          return {
+            eq(column, value) {
+              filters.push({ column, value });
+              return this;
+            },
+            async maybeSingle() {
+              selects.push({ table, selection, filters });
+
+              if (table !== 'learning_session_resume_projection') {
+                throw new Error(`Unexpected select table: ${table}`);
+              }
+
+              return {
+                data: resumeProjectionRow,
+                error: null,
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('session-repository', () => {
+  test('insertSession records a lineage stub with parent_session_id = null on create', async () => {
+    const db = createSessionDb();
+
+    const payload = {
+      user_id: 'user-1',
+      subject_code: '9709',
+      session_goal: 'Practice trig identities',
+      mode: 'guided_solve',
+      active_scope_bundle: {
+        primary_topic_id: 'topic-1',
+        primary_topic_path: '9709/trigonometry/identities',
+        secondary_topics_in_scope: [],
+        allowed_prerequisites: [],
+        paper_context: null,
+        mode: 'guided_solve',
+        session_goal: 'Practice trig identities',
+        current_anchor_kind: 'question',
+        current_anchor_ref: { kind: 'question', question_id: 'question-1' },
+        current_question_ref: { kind: 'question', question_id: 'question-1' },
+        current_question_type_ref: {
+          kind: 'question_type',
+          question_type_id: '9709.trigonometry.identities',
+        },
+      },
+      current_anchor_kind: 'question',
+      current_anchor_ref: { kind: 'question', question_id: 'question-1' },
+      current_question_id: 'question-1',
+      current_question_type_id: '9709.trigonometry.identities',
+      summary_state: { progress: 'started' },
+      open_questions: [],
+      key_artifact_refs: [],
+      misconceptions_in_focus: [],
+    };
+
+    const session = await insertSession(db, payload);
+
+    expect(db.inserts).toEqual([
+      {
+        table: 'learning_sessions',
+        payload: {
+          ...payload,
+          state: 'active',
+          lineage_ref: {
+            parent_session_id: null,
+            handoff_kind: null,
+          },
+        },
+      },
+      {
+        table: 'learning_session_lineage',
+        payload: {
+          parent_session_id: null,
+          child_session_id: 'session-1',
+          handoff_kind: null,
+          summary_snapshot: { progress: 'started' },
+        },
+      },
+    ]);
+
+    expect(session.lineage).toEqual({
+      parent_session_id: null,
+      handoff_kind: null,
+      summary_snapshot: { progress: 'started' },
+    });
+    expect(session.lineage_ref).toEqual({
+      parent_session_id: null,
+      handoff_kind: null,
+    });
+  });
+
+  test('getSession reads the resume projection and preserves lineage stub data', async () => {
+    const db = createSessionDb();
+
+    const session = await getSession(db, {
+      sessionId: 'session-1',
+      userId: 'user-1',
+    });
+
+    expect(db.selects).toEqual([
+      {
+        table: 'learning_session_resume_projection',
+        selection: '*',
+        filters: [
+          { column: 'session_id', value: 'session-1' },
+          { column: 'user_id', value: 'user-1' },
+        ],
+      },
+    ]);
+
+    expect(session).toMatchObject({
+      session_id: 'session-1',
+      lineage_ref: {
+        parent_session_id: null,
+        handoff_kind: null,
+      },
+      lineage: {
+        parent_session_id: null,
+        handoff_kind: null,
+        summary_snapshot: { progress: 'started' },
+      },
+    });
+  });
+});

--- a/api/learning/__tests__/workspace-repository.test.js
+++ b/api/learning/__tests__/workspace-repository.test.js
@@ -1,0 +1,133 @@
+import { fetchWorkspaceProjection } from '../lib/repositories/workspace-repository.js';
+
+function createWorkspaceDb() {
+  const selects = [];
+
+  return {
+    selects,
+    from(table) {
+      return {
+        select(selection) {
+          const filters = [];
+
+          return {
+            eq(column, value) {
+              filters.push({ column, value });
+              return this;
+            },
+            async maybeSingle() {
+              selects.push({ table, selection, filters });
+
+              if (table !== 'learning_workspace_projection') {
+                throw new Error(`Unexpected select table: ${table}`);
+              }
+
+              return {
+                data: {
+                  workspace_id: 'workspace-1',
+                  user_id: 'user-1',
+                  topic_id: 'topic-1',
+                  topic_path: '9709/trigonometry/equations',
+                  slot_state: {
+                    canonical_worked_example: 'fresh',
+                    review_queue: 'active',
+                  },
+                  linked_reference_summary: {
+                    total_linked_references: 3,
+                  },
+                  updated_at: '2026-03-21T10:00:00.000Z',
+                  slots: [
+                    {
+                      workspace_slot_id: 'slot-1',
+                      slot_key: 'canonical_worked_example',
+                      primary_artifact_ref: {
+                        kind: 'artifact',
+                        artifact_id: 'artifact-1',
+                      },
+                      linked_reference_refs: [
+                        { kind: 'artifact', artifact_id: 'artifact-2' },
+                        { kind: 'artifact', artifact_id: 'artifact-3' },
+                      ],
+                      updated_at: '2026-03-21T10:00:00.000Z',
+                    },
+                    {
+                      workspace_slot_id: 'slot-2',
+                      slot_key: 'review_queue',
+                      primary_artifact_ref: null,
+                      linked_reference_refs: [
+                        { kind: 'review_task', review_task_id: 'review-1' },
+                      ],
+                      updated_at: '2026-03-21T10:05:00.000Z',
+                    },
+                  ],
+                },
+                error: null,
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('workspace-repository', () => {
+  test('fetchWorkspaceProjection returns stable slot payloads and linked references separately', async () => {
+    const db = createWorkspaceDb();
+
+    const payload = await fetchWorkspaceProjection(db, {
+      userId: 'user-1',
+      topicId: 'topic-1',
+    });
+
+    expect(db.selects).toEqual([
+      {
+        table: 'learning_workspace_projection',
+        selection: '*',
+        filters: [
+          { column: 'user_id', value: 'user-1' },
+          { column: 'topic_id', value: 'topic-1' },
+        ],
+      },
+    ]);
+
+    expect(payload.workspace_id).toBe('workspace-1');
+    expect(payload.slots).toMatchObject({
+      overview_map: null,
+      core_method_derivation: null,
+      canonical_worked_example: {
+        workspace_slot_id: 'slot-1',
+        primary_artifact_ref: {
+          kind: 'artifact',
+          artifact_id: 'artifact-1',
+        },
+        updated_at: '2026-03-21T10:00:00.000Z',
+      },
+      common_traps: null,
+      my_notes: null,
+      review_queue: {
+        workspace_slot_id: 'slot-2',
+        primary_artifact_ref: null,
+        updated_at: '2026-03-21T10:05:00.000Z',
+      },
+    });
+    expect(payload.slots.canonical_worked_example).not.toHaveProperty('linked_reference_refs');
+
+    expect(payload.linked_references).toEqual({
+      overview_map: [],
+      core_method_derivation: [],
+      canonical_worked_example: [
+        { kind: 'artifact', artifact_id: 'artifact-2' },
+        { kind: 'artifact', artifact_id: 'artifact-3' },
+      ],
+      common_traps: [],
+      my_notes: [],
+      review_queue: [
+        { kind: 'review_task', review_task_id: 'review-1' },
+      ],
+    });
+    expect(payload.linked_reference_summary).toEqual({
+      total_linked_references: 3,
+    });
+  });
+});

--- a/api/learning/lib/repositories/question-registry-repository.js
+++ b/api/learning/lib/repositories/question-registry-repository.js
@@ -1,0 +1,106 @@
+function buildClassificationSnapshotRef(classificationSnapshotId) {
+  return {
+    kind: 'classification_snapshot',
+    classification_snapshot_id: classificationSnapshotId,
+  };
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function buildQuestionInsertRow(input) {
+  const classification = input.classification || {};
+
+  return {
+    source_kind: 'imported_question',
+    subject_code: input.subject_code,
+    paper_scope: input.paper_scope ?? null,
+    primary_topic_id: classification.primary_topic_id ?? input.primary_topic_id ?? null,
+    secondary_topic_ids: normalizeArray(
+      classification.secondary_topic_ids ?? input.secondary_topic_ids,
+    ),
+    family_id: classification.family_id ?? input.family_id ?? null,
+    primary_question_type_id:
+      classification.primary_question_type_id ?? input.primary_question_type_id ?? null,
+    secondary_question_type_ids: normalizeArray(
+      classification.secondary_question_type_ids ?? input.secondary_question_type_ids,
+    ),
+    variant_tags: normalizeArray(classification.variant_tags ?? input.variant_tags),
+    release_scope_status: input.release_scope_status ?? 'non_released_fallback',
+    prompt_representation: input.prompt_representation,
+    provenance_summary: input.provenance_summary ?? {},
+  };
+}
+
+function buildClassificationSnapshotRow(questionId, input) {
+  const classification = input.classification || {};
+
+  return {
+    question_id: questionId,
+    primary_topic_id: classification.primary_topic_id ?? input.primary_topic_id ?? null,
+    secondary_topic_ids: normalizeArray(
+      classification.secondary_topic_ids ?? input.secondary_topic_ids,
+    ),
+    family_id: classification.family_id ?? input.family_id ?? null,
+    primary_question_type_id:
+      classification.primary_question_type_id ?? input.primary_question_type_id ?? null,
+    secondary_question_type_ids: normalizeArray(
+      classification.secondary_question_type_ids ?? input.secondary_question_type_ids,
+    ),
+    variant_tags: normalizeArray(classification.variant_tags ?? input.variant_tags),
+    classification_source: classification.classification_source ?? 'imported_question',
+    classification_confidence: classification.classification_confidence ?? null,
+    candidate_rubric_refs: normalizeArray(classification.candidate_rubric_refs),
+  };
+}
+
+export async function insertImportedQuestion(client, input) {
+  const questionRow = buildQuestionInsertRow(input);
+  const { data: insertedQuestion, error: questionError } = await client
+    .from('question_bank')
+    .insert(questionRow)
+    .select(
+      'question_id, source_kind, subject_code, paper_scope, primary_topic_id, secondary_topic_ids, family_id, primary_question_type_id, secondary_question_type_ids, variant_tags, release_scope_status, prompt_representation, provenance_summary',
+    )
+    .single();
+
+  if (questionError || !insertedQuestion) {
+    throw new Error(
+      `Failed to insert imported question: ${questionError?.message || 'no data returned'}`,
+    );
+  }
+
+  const snapshotRow = buildClassificationSnapshotRow(insertedQuestion.question_id, input);
+  const { data: insertedSnapshot, error: snapshotError } = await client
+    .from('learning_question_analysis_snapshots')
+    .insert(snapshotRow)
+    .select('classification_snapshot_id')
+    .single();
+
+  if (snapshotError || !insertedSnapshot) {
+    throw new Error(
+      `Failed to insert question classification snapshot: ${snapshotError?.message || 'no data returned'}`,
+    );
+  }
+
+  const classification_snapshot_ref = buildClassificationSnapshotRef(
+    insertedSnapshot.classification_snapshot_id,
+  );
+
+  const { error: updateError } = await client
+    .from('question_bank')
+    .update({ classification_snapshot_ref })
+    .eq('question_id', insertedQuestion.question_id);
+
+  if (updateError) {
+    throw new Error(
+      `Failed to persist classification snapshot ref on question: ${updateError.message}`,
+    );
+  }
+
+  return {
+    ...insertedQuestion,
+    classification_snapshot_ref,
+  };
+}

--- a/api/learning/lib/repositories/session-repository.js
+++ b/api/learning/lib/repositories/session-repository.js
@@ -1,0 +1,107 @@
+function buildLineageRef({
+  parent_session_id = null,
+  handoff_kind = null,
+} = {}) {
+  return {
+    parent_session_id,
+    handoff_kind,
+  };
+}
+
+function buildLineageSummary(summaryState) {
+  return summaryState ?? {};
+}
+
+function hydrateSession(sessionRow, lineageRow) {
+  const lineage = {
+    parent_session_id:
+      lineageRow?.parent_session_id ?? sessionRow?.lineage_ref?.parent_session_id ?? null,
+    handoff_kind: lineageRow?.handoff_kind ?? sessionRow?.lineage_ref?.handoff_kind ?? null,
+    summary_snapshot:
+      lineageRow?.summary_snapshot ?? buildLineageSummary(sessionRow?.summary_state),
+  };
+
+  return {
+    ...sessionRow,
+    lineage,
+  };
+}
+
+export async function insertSession(client, input) {
+  const lineage_ref = buildLineageRef();
+  const sessionRow = {
+    user_id: input.user_id,
+    subject_code: input.subject_code,
+    session_goal: input.session_goal ?? null,
+    mode: input.mode,
+    state: input.state ?? 'active',
+    active_scope_bundle: input.active_scope_bundle,
+    current_anchor_kind: input.current_anchor_kind,
+    current_anchor_ref: input.current_anchor_ref,
+    current_question_id: input.current_question_id ?? null,
+    current_question_type_id: input.current_question_type_id ?? null,
+    summary_state: input.summary_state ?? {},
+    open_questions: input.open_questions ?? [],
+    key_artifact_refs: input.key_artifact_refs ?? [],
+    misconceptions_in_focus: input.misconceptions_in_focus ?? [],
+    lineage_ref,
+  };
+
+  const { data: insertedSession, error: sessionError } = await client
+    .from('learning_sessions')
+    .insert(sessionRow)
+    .select('*')
+    .single();
+
+  if (sessionError || !insertedSession) {
+    throw new Error(`Failed to insert learning session: ${sessionError?.message || 'no data returned'}`);
+  }
+
+  const lineageRow = {
+    parent_session_id: null,
+    child_session_id: insertedSession.session_id,
+    handoff_kind: null,
+    summary_snapshot: buildLineageSummary(insertedSession.summary_state),
+  };
+
+  const { data: insertedLineage, error: lineageError } = await client
+    .from('learning_session_lineage')
+    .insert(lineageRow)
+    .select('*')
+    .single();
+
+  if (lineageError || !insertedLineage) {
+    throw new Error(
+      `Failed to insert learning session lineage stub: ${lineageError?.message || 'no data returned'}`,
+    );
+  }
+
+  return hydrateSession(insertedSession, insertedLineage);
+}
+
+export async function getSession(client, { sessionId, userId } = {}) {
+  let query = client
+    .from('learning_session_resume_projection')
+    .select('*')
+    .eq('session_id', sessionId);
+
+  if (userId) {
+    query = query.eq('user_id', userId);
+  }
+
+  const { data, error } = await query.maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load learning session: ${error.message}`);
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return hydrateSession(data, {
+    parent_session_id: data.parent_session_id ?? null,
+    handoff_kind: data.handoff_kind ?? null,
+    summary_snapshot: data.summary_snapshot ?? buildLineageSummary(data.summary_state),
+  });
+}

--- a/api/learning/lib/repositories/workspace-repository.js
+++ b/api/learning/lib/repositories/workspace-repository.js
@@ -1,0 +1,65 @@
+const STABLE_SLOT_KEYS = [
+  'overview_map',
+  'core_method_derivation',
+  'canonical_worked_example',
+  'common_traps',
+  'my_notes',
+  'review_queue',
+];
+
+function buildStableSlotMap(fillValue) {
+  return Object.fromEntries(STABLE_SLOT_KEYS.map((slotKey) => [slotKey, fillValue(slotKey)]));
+}
+
+function separateWorkspaceSlots(slotRows) {
+  const slots = buildStableSlotMap(() => null);
+  const linked_references = buildStableSlotMap(() => []);
+
+  for (const slot of Array.isArray(slotRows) ? slotRows : []) {
+    if (!STABLE_SLOT_KEYS.includes(slot.slot_key)) {
+      continue;
+    }
+
+    slots[slot.slot_key] = {
+      workspace_slot_id: slot.workspace_slot_id,
+      primary_artifact_ref: slot.primary_artifact_ref ?? null,
+      updated_at: slot.updated_at ?? null,
+    };
+    linked_references[slot.slot_key] = Array.isArray(slot.linked_reference_refs)
+      ? slot.linked_reference_refs
+      : [];
+  }
+
+  return { slots, linked_references };
+}
+
+export async function fetchWorkspaceProjection(client, { userId, topicId } = {}) {
+  const { data, error } = await client
+    .from('learning_workspace_projection')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('topic_id', topicId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load learning workspace projection: ${error.message}`);
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const { slots, linked_references } = separateWorkspaceSlots(data.slots);
+
+  return {
+    workspace_id: data.workspace_id,
+    user_id: data.user_id,
+    topic_id: data.topic_id,
+    topic_path: data.topic_path,
+    slot_state: data.slot_state ?? {},
+    linked_reference_summary: data.linked_reference_summary ?? {},
+    updated_at: data.updated_at ?? null,
+    slots,
+    linked_references,
+  };
+}


### PR DESCRIPTION
## Summary
- add a question registry repository for imported-question writes and typed classification snapshot refs
- add a session repository for create/read flows with lineage stub creation on insert
- add a workspace repository that separates stable slot payloads from linked references

## Verification
- `npm test -- --runInBand api/learning/__tests__/question-registry-repository.test.js api/learning/__tests__/session-repository.test.js api/learning/__tests__/workspace-repository.test.js --verbose`
- `npm test -- --runInBand api/learning/__tests__/schema-contract.test.js api/learning/__tests__/question-registry-repository.test.js api/learning/__tests__/session-repository.test.js api/learning/__tests__/workspace-repository.test.js --verbose`

## Notes
- Stacked on top of #30 / `feat/17` because issue #18 is blocked on the schema branch.
- Refs #18
- The issue's literal `-v` Jest flag is not accepted by this repo's Jest CLI, so verification uses `--verbose`.
