### PR TITLE
feat(learning): add workspace and review queue projections

### DIFF
--- a/api/evidence/__tests__/context.test.js
+++ b/api/evidence/__tests__/context.test.js
@@ -1,0 +1,172 @@
+import { getEvidenceContext } from '../context.js';
+
+function createEvidenceDb() {
+  const sessionRow = {
+    session_id: 'session-1',
+    user_id: 'student-1',
+    subject_code: '9709',
+    session_goal: 'Repair trigonometric equations',
+    mode: 'spaced_review',
+    state: 'active',
+    active_scope_bundle: {
+      primary_topic_id: 'topic-1',
+      primary_topic_path: '9709/trigonometry/equations',
+      secondary_topics_in_scope: [
+        { kind: 'topic', topic_id: 'topic-2', topic_path: '9709/trigonometry/identities' },
+      ],
+      allowed_prerequisites: [],
+      paper_context: null,
+      mode: 'spaced_review',
+      session_goal: 'Repair trigonometric equations',
+      current_anchor_kind: 'review_task',
+      current_anchor_ref: { kind: 'review_task', review_task_id: 'review-queued-1' },
+      current_question_ref: { kind: 'question', question_id: 'question-1' },
+      current_question_type_ref: {
+        kind: 'question_type',
+        question_type_id: '9709.trigonometry.equations',
+      },
+    },
+    current_anchor_kind: 'review_task',
+    current_anchor_ref: { kind: 'review_task', review_task_id: 'review-queued-1' },
+    current_question_id: 'question-1',
+    current_question_type_id: '9709.trigonometry.equations',
+    summary_state: {},
+    open_questions: [],
+    key_artifact_refs: [],
+    misconceptions_in_focus: ['domain:interval'],
+    lineage_ref: { parent_session_id: null, handoff_kind: null },
+    created_at: '2026-03-22T08:00:00.000Z',
+    updated_at: '2026-03-22T08:00:00.000Z',
+    parent_session_id: null,
+    handoff_kind: null,
+    summary_snapshot: {},
+  };
+
+  const workspaceRow = {
+    workspace_id: 'workspace-1',
+    user_id: 'student-1',
+    topic_id: 'topic-1',
+    topic_path: '9709/trigonometry/equations',
+    slot_state: {
+      common_traps: 'active',
+      review_queue: 'active',
+    },
+    linked_reference_summary: {
+      total_linked_references: 2,
+    },
+    updated_at: '2026-03-22T08:05:00.000Z',
+    slots: [
+      {
+        workspace_slot_id: 'slot-common-traps',
+        slot_key: 'common_traps',
+        primary_artifact_ref: {
+          kind: 'artifact',
+          artifact_id: 'artifact-primary',
+        },
+        linked_reference_refs: [
+          { kind: 'artifact', artifact_id: 'artifact-linked-1' },
+        ],
+        updated_at: '2026-03-22T08:05:00.000Z',
+      },
+    ],
+  };
+
+  class QueryBuilder {
+    constructor(table) {
+      this.table = table;
+      this.filters = [];
+    }
+
+    select() {
+      return this;
+    }
+
+    eq(column, value) {
+      this.filters.push({ column, value });
+      return this;
+    }
+
+    async maybeSingle() {
+      if (this.table === 'learning_session_resume_projection') {
+        return { data: sessionRow, error: null };
+      }
+
+      if (this.table === 'learning_workspace_projection') {
+        return { data: workspaceRow, error: null };
+      }
+
+      throw new Error(`Unexpected maybeSingle table: ${this.table}`);
+    }
+  }
+
+  return {
+    async rpc(name) {
+      if (name !== 'get_evidence_context') {
+        throw new Error(`Unexpected RPC: ${name}`);
+      }
+
+      return {
+        data: {
+          mastery: {
+            score: 0.42,
+            sample_count: 4,
+            weighted_sample_count: 5.5,
+            low_confidence: true,
+          },
+          recent_decisions: [],
+          misconception_tags: [
+            { tag: 'domain:interval', weighted_count: 2 },
+          ],
+          recent_errors: [],
+        },
+        error: null,
+      };
+    },
+    from(table) {
+      return new QueryBuilder(table);
+    },
+  };
+}
+
+describe('evidence context learning-runtime extension', () => {
+  test('evidence context exposes learning-runtime anchor and workspace state for projections', async () => {
+    const payload = await getEvidenceContext(
+      {
+        client: createEvidenceDb(),
+      },
+      {
+        userId: 'student-1',
+        topicPath: '9709/trigonometry/equations',
+        topicId: 'topic-1',
+        sessionId: 'session-1',
+        limit: 5,
+      },
+    );
+
+    expect(payload.learning_runtime.current_anchor_kind).toBe('review_task');
+    expect(payload.learning_runtime.current_anchor_ref).toEqual({
+      kind: 'review_task',
+      review_task_id: 'review-queued-1',
+    });
+    expect(payload.learning_runtime.current_question_ref).toEqual({
+      kind: 'question',
+      question_id: 'question-1',
+    });
+    expect(payload.learning_runtime.workspace).toMatchObject({
+      workspace_id: 'workspace-1',
+      topic_id: 'topic-1',
+      slots: {
+        common_traps: {
+          workspace_slot_id: 'slot-common-traps',
+          primary_artifact_ref: {
+            kind: 'artifact',
+            artifact_id: 'artifact-primary',
+          },
+          linked_references: [
+            { kind: 'artifact', artifact_id: 'artifact-linked-1' },
+          ],
+        },
+      },
+    });
+  });
+});

--- a/api/evidence/context.js
+++ b/api/evidence/context.js
@@ -1,5 +1,7 @@
 import { getServiceClient } from '../lib/supabase/client.js';
 import { resolveUserId, AuthError } from '../marking/lib/auth-helper.js';
+import { getSession } from '../learning/lib/repositories/session-repository.js';
+import { getWorkspaceView } from '../learning/lib/workspaces/workspace-read-service.js';
 import { sendContextError, sendContextJson } from './lib/evidence-context-http.js';
 import { serializeEvidenceContextPayload } from './lib/evidence-context-contract.js';
 import {
@@ -40,6 +42,159 @@ function isSubtreeMatch(candidatePath, prefix) {
   return candidatePath === prefix || candidatePath.startsWith(prefix + '.');
 }
 
+function normalizeString(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+function buildQuestionRef(questionId) {
+  return normalizeString(questionId)
+    ? { kind: 'question', question_id: normalizeString(questionId) }
+    : null;
+}
+
+function buildQuestionTypeRef(questionTypeId) {
+  return normalizeString(questionTypeId)
+    ? { kind: 'question_type', question_type_id: normalizeString(questionTypeId) }
+    : null;
+}
+
+function buildLearningRuntimeSummary({ session, workspace } = {}) {
+  if (!session && !workspace) {
+    return null;
+  }
+
+  const bundle =
+    session?.active_scope_bundle && typeof session.active_scope_bundle === 'object'
+      ? session.active_scope_bundle
+      : {};
+
+  const currentAnchorRef = bundle.current_anchor_ref ?? session?.current_anchor_ref ?? null;
+  const currentQuestionRef =
+    bundle.current_question_ref ?? buildQuestionRef(session?.current_question_id ?? null);
+  const currentQuestionTypeRef =
+    bundle.current_question_type_ref ??
+    buildQuestionTypeRef(session?.current_question_type_id ?? null);
+
+  return {
+    session_id: session?.session_id ?? null,
+    current_anchor_kind: bundle.current_anchor_kind ?? session?.current_anchor_kind ?? null,
+    current_anchor_ref: currentAnchorRef,
+    current_question_ref: currentQuestionRef,
+    current_question_type_ref: currentQuestionTypeRef,
+    workspace: workspace ?? null,
+  };
+}
+
+async function maybeLoadLearningWorkspace(
+  loadWorkspace,
+  client,
+  {
+    userId,
+    topicId,
+  } = {},
+) {
+  if (!normalizeString(topicId)) {
+    return null;
+  }
+
+  try {
+    const payload = await loadWorkspace(client, {
+      userId,
+      topicId,
+    });
+    return payload?.workspace ?? null;
+  } catch (error) {
+    if (error?.code === 'workspace_not_found') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function getEvidenceContext(
+  {
+    client = getClient(),
+    loadSession = getSession,
+    loadWorkspace = getWorkspaceView,
+  } = {},
+  {
+    userId,
+    topicPath,
+    topicId = null,
+    sessionId = null,
+    limit = 10,
+  } = {},
+) {
+  const fastPath = await fetchContextViaRpc(client, userId, topicPath, limit);
+  let source = 'rpc';
+  let mastery;
+  let recentDecisions;
+  let misconceptionTags;
+  let recentErrors;
+
+  if (fastPath) {
+    mastery = fastPath.mastery;
+    recentDecisions = fastPath.recentDecisions;
+    misconceptionTags = fastPath.misconceptionTags;
+    recentErrors = fastPath.recentErrors;
+  } else {
+    source = 'fallback';
+    const subjectCode = extractSubjectCode(topicPath);
+    const [masteryPayload, decisions, errors] = await Promise.all([
+      fetchMastery(client, userId, subjectCode, topicPath),
+      fetchRecentDecisions(client, userId, subjectCode, topicPath, limit),
+      fetchRecentErrors(client, userId, topicPath),
+    ]);
+
+    mastery = masteryPayload.data;
+    recentDecisions = decisions;
+    misconceptionTags = masteryPayload._misconceptionTags;
+    recentErrors = errors;
+  }
+
+  const session = normalizeString(sessionId)
+    ? await loadSession(client, {
+      sessionId: sessionId,
+      userId,
+    })
+    : null;
+  const resolvedTopicId =
+    normalizeString(topicId)
+    || bundleTopicId(session?.active_scope_bundle)
+    || null;
+  const workspace = await maybeLoadLearningWorkspace(loadWorkspace, client, {
+    userId,
+    topicId: resolvedTopicId,
+  });
+
+  return serializeEvidenceContextPayload({
+    mastery,
+    recentDecisions,
+    misconceptionTags,
+    recentErrors,
+    topicPath,
+    limit,
+    source,
+    learningRuntime: buildLearningRuntimeSummary({
+      session,
+      workspace,
+    }),
+  });
+}
+
+function bundleTopicId(bundle) {
+  if (!bundle || typeof bundle !== 'object') {
+    return null;
+  }
+
+  return normalizeString(bundle.primary_topic_id);
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
     return sendContextError(req, res, {
@@ -64,7 +219,12 @@ export default async function handler(req, res) {
     throw err;
   }
 
-  const { topic_path: topicPath, limit } = requestParams;
+  const {
+    topic_path: topicPath,
+    topic_id: topicId,
+    session_id: sessionId,
+    limit,
+  } = requestParams;
 
   let userId;
   try {
@@ -88,42 +248,22 @@ export default async function handler(req, res) {
   }
 
   try {
-    const cacheKey = `${userId}:${topicPath}:${limit}`;
+    const cacheKey = `${userId}:${topicPath}:${topicId || ''}:${sessionId || ''}:${limit}`;
     const cached = readContextCache(cacheKey);
     if (cached) {
       return sendContextJson(res, cached);
     }
 
-    const supabase = getClient();
-    const fastPath = await fetchContextViaRpc(supabase, userId, topicPath, limit);
-    if (fastPath) {
-      const payload = serializeEvidenceContextPayload({
-        ...fastPath,
+    const payload = await getEvidenceContext(
+      { client: getClient() },
+      {
+        userId,
         topicPath,
+        topicId,
+        sessionId,
         limit,
-        source: 'rpc',
-      });
-      writeContextCache(cacheKey, payload);
-      return sendContextJson(res, payload);
-    }
-
-    const subjectCode = extractSubjectCode(topicPath);
-    const [mastery, recentDecisions, recentErrors] = await Promise.all([
-      fetchMastery(supabase, userId, subjectCode, topicPath),
-      fetchRecentDecisions(supabase, userId, subjectCode, topicPath, limit),
-      fetchRecentErrors(supabase, userId, topicPath),
-    ]);
-
-    const payload = serializeEvidenceContextPayload({
-      mastery: mastery.data,
-      recentDecisions,
-      misconceptionTags: mastery._misconceptionTags,
-      recentErrors,
-      topicPath,
-      limit,
-      source: 'fallback',
-    });
-
+      },
+    );
     writeContextCache(cacheKey, payload);
     return sendContextJson(res, payload);
   } catch (err) {

--- a/api/evidence/lib/evidence-context-contract.js
+++ b/api/evidence/lib/evidence-context-contract.js
@@ -136,6 +136,87 @@ function serializeList(items, serializer) {
     .filter(Boolean);
 }
 
+function serializeRef(ref) {
+  if (!isObject(ref) || !normalizeString(ref.kind)) {
+    return null;
+  }
+
+  const normalizedEntries = Object.entries(ref).map(([key, value]) => {
+    if (key === 'kind') {
+      return [key, normalizeString(value)];
+    }
+
+    if (value === null || value === undefined || value === '') {
+      return [key, null];
+    }
+
+    return [key, normalizeString(value) ?? null];
+  });
+
+  return Object.fromEntries(normalizedEntries);
+}
+
+function serializeWorkspaceSlot(slot) {
+  if (!isObject(slot)) {
+    return null;
+  }
+
+  return {
+    workspace_slot_id: normalizePresentValue(slot, 'workspace_slot_id', normalizeString),
+    primary_artifact_ref: serializeRef(slot.primary_artifact_ref),
+    linked_references: serializeList(slot.linked_references, serializeRef),
+    updated_at: normalizePresentValue(slot, 'updated_at', normalizeTimestamp),
+  };
+}
+
+function serializeWorkspace(workspace) {
+  if (!isObject(workspace)) {
+    return null;
+  }
+
+  const slots = isObject(workspace.slots)
+    ? Object.fromEntries(
+      Object.entries(workspace.slots)
+        .map(([slotKey, slot]) => [slotKey, serializeWorkspaceSlot(slot)])
+        .filter(([, slot]) => slot),
+    )
+    : undefined;
+
+  const normalized = compactObject({
+    workspace_id: normalizePresentValue(workspace, 'workspace_id', normalizeString),
+    topic_id: normalizePresentValue(workspace, 'topic_id', normalizeString),
+    topic_path: normalizePresentValue(workspace, 'topic_path', normalizeString),
+    updated_at: normalizePresentValue(workspace, 'updated_at', normalizeTimestamp),
+  });
+
+  if (slots && Object.keys(slots).length > 0) {
+    normalized.slots = slots;
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function serializeLearningRuntime(learningRuntime) {
+  if (!isObject(learningRuntime)) {
+    return null;
+  }
+
+  const normalized = compactObject({
+    session_id: normalizePresentValue(learningRuntime, 'session_id', normalizeString),
+    current_anchor_kind: normalizePresentValue(
+      learningRuntime,
+      'current_anchor_kind',
+      normalizeString,
+    ),
+    current_anchor_ref: serializeRef(learningRuntime.current_anchor_ref),
+    current_question_ref: serializeRef(learningRuntime.current_question_ref),
+    current_question_type_ref: serializeRef(learningRuntime.current_question_type_ref),
+    workspace: serializeWorkspace(learningRuntime.workspace),
+  });
+
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
 export function serializeEvidenceContextPayload({
   mastery,
   recentDecisions,
@@ -144,12 +225,14 @@ export function serializeEvidenceContextPayload({
   topicPath,
   limit,
   source,
+  learningRuntime,
 } = {}) {
   return {
     mastery: serializeMastery(mastery),
     recent_decisions: serializeList(recentDecisions, serializeDecision),
     misconception_tags: serializeList(misconceptionTags, serializeMisconceptionTag),
     recent_errors: serializeList(recentErrors, serializeErrorEvent),
+    learning_runtime: serializeLearningRuntime(learningRuntime),
     meta: compactObject({
       topic_path: normalizeString(topicPath),
       limit: normalizeFiniteNumber(limit),

--- a/api/evidence/lib/evidence-context-validator.js
+++ b/api/evidence/lib/evidence-context-validator.js
@@ -42,6 +42,15 @@ function normalizeTopicPath(value) {
   return normalized || null;
 }
 
+function normalizeOptionalString(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
 function normalizeLimit(value) {
   const parsed = Number.parseInt(String(value ?? DEFAULT_LIMIT), 10);
   if (!Number.isFinite(parsed) || parsed < 1) {
@@ -62,5 +71,7 @@ export function parseEvidenceContextRequest(req = {}) {
   return {
     topic_path: topicPath,
     limit: normalizeLimit(readQueryValue(req, 'limit')),
+    topic_id: normalizeOptionalString(readQueryValue(req, 'topic_id')),
+    session_id: normalizeOptionalString(readQueryValue(req, 'session_id')),
   };
 }

--- a/api/learning/__tests__/workspace-read-service.test.js
+++ b/api/learning/__tests__/workspace-read-service.test.js
@@ -1,0 +1,327 @@
+import { jest } from '@jest/globals';
+
+const mockGetServiceClient = jest.fn();
+
+jest.unstable_mockModule('../../lib/supabase/client.js', () => ({
+  getServiceClient: mockGetServiceClient,
+}));
+
+const {
+  getWorkspaceView,
+  listReviewTasks,
+} = await import('../lib/workspaces/workspace-read-service.js');
+const { default: workspaceHandler } = await import('../workspaces/[topicId].js');
+const { default: reviewTasksHandler } = await import('../review-tasks/index.js');
+
+function createLearningDb() {
+  const queries = [];
+  const workspaceProjection = {
+    workspace_id: 'workspace-1',
+    user_id: 'student-1',
+    topic_id: 'topic-1',
+    topic_path: '9709/trigonometry/equations',
+    slot_state: {
+      common_traps: 'active',
+      review_queue: 'active',
+    },
+    linked_reference_summary: {
+      total_linked_references: 3,
+    },
+    updated_at: '2026-03-22T08:00:00.000Z',
+    slots: [
+      {
+        workspace_slot_id: 'slot-common-traps',
+        slot_key: 'common_traps',
+        primary_artifact_ref: {
+          kind: 'artifact',
+          artifact_id: 'artifact-primary',
+        },
+        linked_reference_refs: [
+          { kind: 'artifact', artifact_id: 'artifact-primary' },
+          { kind: 'artifact', artifact_id: 'artifact-linked-1' },
+          { kind: 'artifact', artifact_id: 'artifact-linked-1' },
+        ],
+        updated_at: '2026-03-22T08:00:00.000Z',
+      },
+      {
+        workspace_slot_id: 'slot-review-queue',
+        slot_key: 'review_queue',
+        primary_artifact_ref: null,
+        linked_reference_refs: [
+          { kind: 'review_task', review_task_id: 'review-queued-1' },
+        ],
+        updated_at: '2026-03-22T08:05:00.000Z',
+      },
+    ],
+  };
+
+  const reviewTaskRows = [
+    {
+      review_task_id: 'review-queued-1',
+      user_id: 'student-1',
+      target_kind: 'question_type',
+      target_topic_id: 'topic-1',
+      target_topic_path: '9709/trigonometry/equations',
+      target_family_id: '9709.trigonometry_manipulation_equations',
+      target_family_title: 'Trigonometric manipulation / equations',
+      target_question_type_id: '9709.trigonometry.equations',
+      target_question_type_title: 'Trigonometric equations',
+      target_misconception_tags: ['domain:interval'],
+      related_artifact_refs: [],
+      source_question_id: 'question-1',
+      source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
+      trigger_type: 'marking_outcome',
+      mode: 'redo_variant',
+      due_at: '2026-03-23T00:00:00.000Z',
+      priority: 'high',
+      estimated_minutes: 15,
+      success_criteria: {},
+      completion_evidence: {},
+      status: 'open',
+      created_at: '2026-03-22T08:10:00.000Z',
+      updated_at: '2026-03-22T08:10:00.000Z',
+    },
+    {
+      review_task_id: 'review-other-topic',
+      user_id: 'student-1',
+      target_kind: 'question_type',
+      target_topic_id: 'topic-2',
+      target_topic_path: '9709/trigonometry/identities',
+      target_family_id: '9709.trigonometry_manipulation_equations',
+      target_family_title: 'Trigonometric manipulation / equations',
+      target_question_type_id: '9709.trigonometry.identities',
+      target_question_type_title: 'Trigonometric identities',
+      target_misconception_tags: [],
+      related_artifact_refs: [],
+      source_question_id: 'question-2',
+      source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-2' },
+      trigger_type: 'marking_outcome',
+      mode: 'redo_variant',
+      due_at: '2026-03-24T00:00:00.000Z',
+      priority: 'normal',
+      estimated_minutes: 10,
+      success_criteria: {},
+      completion_evidence: {},
+      status: 'open',
+      created_at: '2026-03-22T08:15:00.000Z',
+      updated_at: '2026-03-22T08:15:00.000Z',
+    },
+  ];
+
+  class QueryBuilder {
+    constructor(table) {
+      this.table = table;
+      this.filters = [];
+      this.orders = [];
+      this.selection = null;
+    }
+
+    select(selection) {
+      this.selection = selection;
+      return this;
+    }
+
+    eq(column, value) {
+      this.filters.push({ type: 'eq', column, value });
+      return this;
+    }
+
+    lte(column, value) {
+      this.filters.push({ type: 'lte', column, value });
+      return this;
+    }
+
+    order(column, options = {}) {
+      this.orders.push({ column, options });
+      return this;
+    }
+
+    async maybeSingle() {
+      queries.push({
+        table: this.table,
+        selection: this.selection,
+        filters: [...this.filters],
+        orders: [...this.orders],
+        single: true,
+      });
+
+      if (this.table !== 'learning_workspace_projection') {
+        throw new Error(`Unexpected maybeSingle table: ${this.table}`);
+      }
+
+      const topicId = this.filters.find((filter) => filter.column === 'topic_id')?.value ?? null;
+      const userId = this.filters.find((filter) => filter.column === 'user_id')?.value ?? null;
+
+      if (topicId !== workspaceProjection.topic_id || userId !== workspaceProjection.user_id) {
+        return { data: null, error: null };
+      }
+
+      return { data: workspaceProjection, error: null };
+    }
+
+    then(resolve, reject) {
+      queries.push({
+        table: this.table,
+        selection: this.selection,
+        filters: [...this.filters],
+        orders: [...this.orders],
+        single: false,
+      });
+
+      if (this.table !== 'learning_review_queue_projection') {
+        return Promise.reject(new Error(`Unexpected list table: ${this.table}`)).then(resolve, reject);
+      }
+
+      let rows = [...reviewTaskRows];
+
+      for (const filter of this.filters) {
+        if (filter.type === 'eq') {
+          rows = rows.filter((row) => row[filter.column] === filter.value);
+        }
+
+        if (filter.type === 'lte') {
+          rows = rows.filter((row) => row[filter.column] !== null && row[filter.column] <= filter.value);
+        }
+      }
+
+      return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+    }
+  }
+
+  return {
+    queries,
+    from(table) {
+      return new QueryBuilder(table);
+    },
+  };
+}
+
+function createReq({
+  method = 'GET',
+  query = {},
+  authUserId = 'student-1',
+  requestId = 'req-workspace-1',
+} = {}) {
+  return {
+    method,
+    query,
+    auth_user_id: authUserId,
+    request_id: requestId,
+  };
+}
+
+function createRes() {
+  const headers = {};
+
+  return {
+    statusCode: 200,
+    headers,
+    body: null,
+    writableEnded: false,
+    setHeader(name, value) {
+      headers[String(name).toLowerCase()] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      this.writableEnded = true;
+      return this;
+    },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('workspace read service', () => {
+  test('workspace returns stable slots plus linked references from secondary topics', async () => {
+    const db = createLearningDb();
+
+    const payload = await getWorkspaceView(db, {
+      userId: 'student-1',
+      topicId: 'topic-1',
+    });
+
+    expect(payload.workspace.workspace_id).toBe('workspace-1');
+    expect(payload.workspace.slots.overview_map).toEqual({
+      workspace_slot_id: null,
+      primary_artifact_ref: null,
+      linked_references: [],
+      updated_at: null,
+    });
+    expect(payload.workspace.slots.common_traps).toEqual({
+      workspace_slot_id: 'slot-common-traps',
+      primary_artifact_ref: {
+        kind: 'artifact',
+        artifact_id: 'artifact-primary',
+      },
+      linked_references: [
+        { kind: 'artifact', artifact_id: 'artifact-linked-1' },
+      ],
+      updated_at: '2026-03-22T08:00:00.000Z',
+    });
+    expect(payload.workspace.slots.review_queue.linked_references).toEqual([
+      { kind: 'review_task', review_task_id: 'review-queued-1' },
+    ]);
+    expect(payload.review_queue.items).toHaveLength(1);
+    expect(payload.review_queue.items[0].review_task_id).toBe('review-queued-1');
+  });
+
+  test('review queue endpoint returns global truth with optional topic filter', async () => {
+    const db = createLearningDb();
+
+    const payload = await listReviewTasks(db, {
+      userId: 'student-1',
+      topicId: 'topic-1',
+    });
+
+    expect(payload.scope).toBe('global_queue_projection');
+    expect(payload.topic_id).toBe('topic-1');
+    expect(payload.items).toHaveLength(1);
+    expect(payload.items[0]).toMatchObject({
+      review_task_id: 'review-queued-1',
+      target_topic_id: 'topic-1',
+    });
+  });
+
+  test('GET /api/learning/workspaces/:topicId returns stable slots and linked references', async () => {
+    const db = createLearningDb();
+    mockGetServiceClient.mockReturnValue(db);
+
+    const req = createReq({
+      query: { topicId: 'topic-1' },
+    });
+    const res = createRes();
+
+    await workspaceHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.workspace.slots.common_traps).toMatchObject({
+      workspace_slot_id: 'slot-common-traps',
+      linked_references: [{ kind: 'artifact', artifact_id: 'artifact-linked-1' }],
+    });
+    expect(res.body.review_queue.scope).toBe('global_queue_projection');
+  });
+
+  test('GET /api/learning/review-tasks returns global truth with optional topic filter', async () => {
+    const db = createLearningDb();
+    mockGetServiceClient.mockReturnValue(db);
+
+    const req = createReq({
+      query: { topic_id: 'topic-1' },
+    });
+    const res = createRes();
+
+    await reviewTasksHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.scope).toBe('global_queue_projection');
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].review_task_id).toBe('review-queued-1');
+  });
+});

--- a/api/learning/lib/workspaces/workspace-read-service.js
+++ b/api/learning/lib/workspaces/workspace-read-service.js
@@ -1,0 +1,172 @@
+import { STABLE_SLOT_KEYS } from '../contracts/runtime-contract.js';
+import { LearningHttpError } from '../http/learning-http.js';
+import { fetchWorkspaceProjection } from '../repositories/workspace-repository.js';
+
+function normalizeString(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+function isTypedRef(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value) && typeof value.kind === 'string';
+}
+
+function getTypedRefKey(ref) {
+  if (!isTypedRef(ref)) {
+    return null;
+  }
+
+  const idEntry = Object.entries(ref).find(([key]) => key !== 'kind');
+  if (!idEntry) {
+    return ref.kind;
+  }
+
+  return `${ref.kind}:${idEntry[1]}`;
+}
+
+function createEmptySlot() {
+  return {
+    workspace_slot_id: null,
+    primary_artifact_ref: null,
+    linked_references: [],
+    updated_at: null,
+  };
+}
+
+function normalizeLinkedReferences(linkedReferences, primaryArtifactRef) {
+  const primaryKey = getTypedRefKey(primaryArtifactRef);
+  const seen = new Set();
+
+  return (Array.isArray(linkedReferences) ? linkedReferences : []).filter((ref) => {
+    const refKey = getTypedRefKey(ref);
+    if (!refKey || refKey === primaryKey || seen.has(refKey)) {
+      return false;
+    }
+
+    seen.add(refKey);
+    return true;
+  });
+}
+
+function buildStableSlots(workspaceProjection) {
+  return Object.fromEntries(
+    STABLE_SLOT_KEYS.map((slotKey) => {
+      const slot = workspaceProjection?.slots?.[slotKey] ?? null;
+      const linkedReferences = workspaceProjection?.linked_references?.[slotKey] ?? [];
+
+      if (!slot) {
+        return [slotKey, createEmptySlot()];
+      }
+
+      return [
+        slotKey,
+        {
+          workspace_slot_id: slot.workspace_slot_id ?? null,
+          primary_artifact_ref: slot.primary_artifact_ref ?? null,
+          linked_references: normalizeLinkedReferences(
+            linkedReferences,
+            slot.primary_artifact_ref ?? null,
+          ),
+          updated_at: slot.updated_at ?? null,
+        },
+      ];
+    }),
+  );
+}
+
+function buildWorkspaceNotFound(topicId) {
+  return new LearningHttpError('workspace_not_found', 'Workspace not found.', {
+    status: 404,
+    details: { topic_id: topicId ?? null },
+  });
+}
+
+function applyOptionalFilter(query, methodName, column, value) {
+  const normalizedValue = normalizeString(value);
+  if (!normalizedValue || typeof query?.[methodName] !== 'function') {
+    return query;
+  }
+
+  return query[methodName](column, normalizedValue);
+}
+
+export async function listReviewTasks(
+  client,
+  {
+    userId,
+    topicId = null,
+    status = null,
+    dueBefore = null,
+  } = {},
+) {
+  let query = client
+    .from('learning_review_queue_projection')
+    .select('*')
+    .eq('user_id', userId);
+
+  query = applyOptionalFilter(query, 'eq', 'target_topic_id', topicId);
+  query = applyOptionalFilter(query, 'eq', 'status', status);
+  query = applyOptionalFilter(query, 'lte', 'due_at', dueBefore);
+
+  if (typeof query?.order === 'function') {
+    query = query
+      .order('due_at', { ascending: true, nullsFirst: false })
+      .order('created_at', { ascending: true });
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(`Failed to load learning review queue projection: ${error.message}`);
+  }
+
+  return {
+    scope: 'global_queue_projection',
+    topic_id: normalizeString(topicId),
+    status: normalizeString(status),
+    due_before: normalizeString(dueBefore),
+    items: Array.isArray(data) ? data : [],
+  };
+}
+
+export async function getWorkspaceView(
+  client,
+  {
+    userId,
+    topicId,
+    reviewStatus = null,
+    reviewDueBefore = null,
+  } = {},
+) {
+  const workspaceProjection = await fetchWorkspaceProjection(client, {
+    userId,
+    topicId,
+  });
+
+  if (!workspaceProjection) {
+    throw buildWorkspaceNotFound(topicId);
+  }
+
+  return {
+    workspace: {
+      workspace_id: workspaceProjection.workspace_id,
+      user_id: workspaceProjection.user_id,
+      topic_id: workspaceProjection.topic_id,
+      topic_path: workspaceProjection.topic_path,
+      slot_state: workspaceProjection.slot_state ?? {},
+      linked_reference_summary: workspaceProjection.linked_reference_summary ?? {},
+      updated_at: workspaceProjection.updated_at ?? null,
+      slots: buildStableSlots(workspaceProjection),
+    },
+    review_queue: await listReviewTasks(client, {
+      userId,
+      topicId,
+      status: reviewStatus,
+      dueBefore: reviewDueBefore,
+    }),
+  };
+}

--- a/api/learning/review-tasks/index.js
+++ b/api/learning/review-tasks/index.js
@@ -1,11 +1,76 @@
-import { sendLearningReservedResponse } from '../lib/session-runtime/session-service.js';
+import { requireAuth } from '../../lib/security/auth-guard.js';
+import { getServiceClient } from '../../lib/supabase/client.js';
+import { LEARNING_ERROR_CODES } from '../lib/contracts/error-contract.js';
+import {
+  LearningHttpError,
+  sendLearningError,
+  sendLearningHttpError,
+  sendLearningJson,
+} from '../lib/http/learning-http.js';
+import { listReviewTasks } from '../lib/workspaces/workspace-read-service.js';
+
+async function ensureLearningAuth(req) {
+  if (req?.auth_user_id) {
+    return {
+      ok: true,
+      userId: req.auth_user_id,
+    };
+  }
+
+  const auth = await requireAuth(req);
+  if (!auth.ok) {
+    return auth;
+  }
+
+  return {
+    ok: true,
+    userId: auth.user?.id || req?.auth_user_id || null,
+  };
+}
 
 export default async function handler(req, res) {
-  return sendLearningReservedResponse(req, res, {
-    status: 200,
-    payload: {
-      endpoint: 'GET /api/learning/review-tasks',
-      items: [],
-    },
-  });
+  if (req.method !== 'GET') {
+    return sendLearningError(
+      res,
+      req?.request_id || null,
+      LEARNING_ERROR_CODES.INVALID_PAYLOAD,
+      {
+        status: 405,
+        message: 'Method not allowed.',
+      },
+    );
+  }
+
+  const auth = await ensureLearningAuth(req);
+  if (!auth.ok || !auth.userId) {
+    return sendLearningError(
+      res,
+      req?.request_id || null,
+      auth.code || LEARNING_ERROR_CODES.AUTH_REQUIRED,
+      {
+        status: auth.status || 401,
+        message: auth.message || 'Authentication required.',
+      },
+    );
+  }
+
+  try {
+    const payload = await listReviewTasks(getServiceClient(), {
+      userId: auth.userId,
+      topicId: req?.query?.topic_id || null,
+      status: req?.query?.status || null,
+      dueBefore: req?.query?.due_before || null,
+    });
+
+    return sendLearningJson(res, req?.request_id || null, payload);
+  } catch (error) {
+    if (error instanceof LearningHttpError) {
+      return sendLearningHttpError(res, req?.request_id || null, error);
+    }
+
+    return sendLearningError(res, req?.request_id || null, 'internal_error', {
+      status: 500,
+      message: 'Internal server error.',
+    });
+  }
 }

--- a/api/learning/workspaces/[topicId].js
+++ b/api/learning/workspaces/[topicId].js
@@ -1,12 +1,74 @@
-import { sendLearningReservedResponse } from '../lib/session-runtime/session-service.js';
+import { requireAuth } from '../../lib/security/auth-guard.js';
+import { getServiceClient } from '../../lib/supabase/client.js';
+import { LEARNING_ERROR_CODES } from '../lib/contracts/error-contract.js';
+import {
+  LearningHttpError,
+  sendLearningError,
+  sendLearningHttpError,
+  sendLearningJson,
+} from '../lib/http/learning-http.js';
+import { getWorkspaceView } from '../lib/workspaces/workspace-read-service.js';
+
+async function ensureLearningAuth(req) {
+  if (req?.auth_user_id) {
+    return {
+      ok: true,
+      userId: req.auth_user_id,
+    };
+  }
+
+  const auth = await requireAuth(req);
+  if (!auth.ok) {
+    return auth;
+  }
+
+  return {
+    ok: true,
+    userId: auth.user?.id || req?.auth_user_id || null,
+  };
+}
 
 export default async function handler(req, res) {
-  return sendLearningReservedResponse(req, res, {
-    status: 200,
-    payload: {
-      endpoint: 'GET /api/learning/workspaces/:topicId',
-      workspace: null,
-      topic_id: req?.query?.topicId || null,
-    },
-  });
+  if (req.method !== 'GET') {
+    return sendLearningError(
+      res,
+      req?.request_id || null,
+      LEARNING_ERROR_CODES.INVALID_PAYLOAD,
+      {
+        status: 405,
+        message: 'Method not allowed.',
+      },
+    );
+  }
+
+  const auth = await ensureLearningAuth(req);
+  if (!auth.ok || !auth.userId) {
+    return sendLearningError(
+      res,
+      req?.request_id || null,
+      auth.code || LEARNING_ERROR_CODES.AUTH_REQUIRED,
+      {
+        status: auth.status || 401,
+        message: auth.message || 'Authentication required.',
+      },
+    );
+  }
+
+  try {
+    const payload = await getWorkspaceView(getServiceClient(), {
+      userId: auth.userId,
+      topicId: req?.query?.topicId || null,
+    });
+
+    return sendLearningJson(res, req?.request_id || null, payload);
+  } catch (error) {
+    if (error instanceof LearningHttpError) {
+      return sendLearningHttpError(res, req?.request_id || null, error);
+    }
+
+    return sendLearningError(res, req?.request_id || null, 'internal_error', {
+      status: 500,
+      message: 'Internal server error.',
+    });
+  }
 }


### PR DESCRIPTION
Closes #23

## Summary

This PR implements the learning-runtime workspace and review queue projection slice for Task 9. The workspace endpoint now reads the canonical workspace projection, normalizes stable slots into always-present surfaces, and keeps secondary-topic linked references separate from canonical-home primary artifacts. The review task endpoint now returns the global queue projection with optional topic, status, and due-date filtering instead of placeholder data.

The evidence context read path is extended for learning-runtime consumers. When a session or topic is supplied, it now exposes the persisted anchor state and normalized workspace surface needed by downstream projections without changing the existing mastery, recent decision, misconception tag, or recent error contract.

## Root Cause

The Task 9 endpoints and read model were still reserved placeholders, so downstream consumers had no contract-aligned way to read canonical workspace truth, filtered review queue truth, or learning-runtime anchor/workspace context from evidence. That blocked the workspace/review slice from moving off placeholder behavior even though the underlying projection views already existed.

## Changes

Introduced `api/learning/lib/workspaces/workspace-read-service.js` to compose `learning_workspace_projection` and `learning_review_queue_projection`, dedupe linked references against canonical-home primary artifacts, and return stable slot objects for every frozen slot key.

Replaced the placeholder `GET /api/learning/workspaces/:topicId` and `GET /api/learning/review-tasks` handlers with authenticated read handlers that use the frozen learning error envelope and return projection-backed payloads.

Extended `api/evidence/context.js` and its serializer/validator support so learning-runtime consumers can request a `learning_runtime` payload containing current anchor state and normalized workspace state while preserving the existing evidence-context contract.

Added focused tests for the new workspace read service, both learning handlers, and the evidence-context learning-runtime extension.

## Verification

- `npm test -- --runInBand api/learning/__tests__/workspace-read-service.test.js api/evidence/__tests__/context.test.js --verbose`
- `npm test -- --runInBand api/learning/__tests__/workspace-read-service.test.js api/evidence/__tests__/context.test.js tests/evidence/context-contract.test.js api/learning/__tests__/workspace-repository.test.js --verbose`

## Notes

The issue verification command in the task text uses `-v`, but this repo's Jest CLI on the current lockfile rejects that shorthand. I used the equivalent `--verbose` form for the recorded verification runs above.
