### PR TITLE
feat(web): add learning runtime session client and shell

### DIFF
--- a/src/api/__tests__/learningRuntimeApi.test.js
+++ b/src/api/__tests__/learningRuntimeApi.test.js
@@ -1,0 +1,261 @@
+import { jest } from '@jest/globals';
+
+const mockRequireSessionAccessToken = jest.fn();
+const mockSupabase = {
+  auth: {
+    getSession: jest.fn(),
+  },
+};
+
+jest.unstable_mockModule('../../services/utils/sessionAccessToken.js', () => ({
+  requireSessionAccessToken: mockRequireSessionAccessToken,
+}));
+
+jest.unstable_mockModule('../../utils/supabase.js', () => ({
+  supabase: mockSupabase,
+}));
+
+const {
+  learningRuntimeApi,
+  normalizeAskResponse,
+  normalizeSessionResponse,
+} = await import('../learningRuntimeApi.js');
+
+function createSessionEnvelope() {
+  return {
+    session: {
+      session_id: 'sess-1',
+      mode: 'spaced_review',
+      state: 'active',
+      session_goal: 'Repair trigonometric equation solving',
+      current_anchor_kind: 'review_task',
+      current_anchor_ref: {
+        kind: 'review_task',
+        review_task_id: 'review-task-1',
+      },
+      current_question_id: null,
+      current_question_type_id: '9709.trigonometry.equations',
+      active_scope_bundle: {
+        primary_topic_id: 'topic-trig-equations',
+        primary_topic_path: '9709/trigonometry/equations',
+        secondary_topics_in_scope: [],
+        allowed_prerequisites: [],
+        paper_context: null,
+        mode: 'spaced_review',
+        session_goal: 'Repair trigonometric equation solving',
+        current_anchor_kind: 'review_task',
+        current_anchor_ref: {
+          kind: 'review_task',
+          review_task_id: 'review-task-1',
+        },
+        current_question_ref: null,
+        current_question_type_ref: {
+          kind: 'question_type',
+          question_type_id: '9709.trigonometry.equations',
+        },
+      },
+      lineage_ref: {
+        parent_session_id: null,
+        handoff_kind: null,
+      },
+      open_questions: [],
+      key_artifact_refs: [],
+      misconceptions_in_focus: [],
+      created_at: '2026-03-22T00:00:00.000Z',
+      updated_at: '2026-03-22T00:00:00.000Z',
+    },
+    anchor_validity: {
+      ok: true,
+      anchor_kind: 'review_task',
+      anchor_ref: {
+        kind: 'review_task',
+        review_task_id: 'review-task-1',
+      },
+      canonical_home_topic_ref: {
+        kind: 'topic',
+        topic_id: 'topic-trig-equations',
+        topic_path: '9709/trigonometry/equations',
+      },
+    },
+    canonical_home_context: {
+      source_anchor_kind: 'review_task',
+      topic_ref: {
+        kind: 'topic',
+        topic_id: 'topic-trig-equations',
+        topic_path: '9709/trigonometry/equations',
+      },
+    },
+    feature_flags: {
+      learning_runtime_enabled: true,
+      session_create_read_enabled: true,
+    },
+    request_id: 'req-session-1',
+  };
+}
+
+describe('learning runtime api', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    mockRequireSessionAccessToken.mockReset();
+    mockRequireSessionAccessToken.mockResolvedValue('token-123');
+    mockSupabase.auth.getSession.mockReset();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('exports the shared session, workspace, import, and artifact contract', () => {
+    expect(Object.keys(learningRuntimeApi).sort()).toEqual([
+      'askInSession',
+      'createSession',
+      'getSession',
+      'getWorkspace',
+      'importQuestion',
+      'listReviewTasks',
+      'updateArtifact',
+    ].sort());
+  });
+
+  test('normalizes typed anchor refs from session envelopes into frontend fields', () => {
+    const payload = normalizeSessionResponse(createSessionEnvelope());
+
+    expect(payload.session.activeScope.currentAnchor).toEqual({
+      kind: 'review_task',
+      reviewTaskId: 'review-task-1',
+    });
+    expect(payload.session.activeScope.currentQuestionType).toEqual({
+      kind: 'question_type',
+      questionTypeId: '9709.trigonometry.equations',
+    });
+    expect(payload.anchorValidity.anchorRef.reviewTaskId).toBe('review-task-1');
+    expect(payload.canonicalHomeContext.topicRef.topicPath).toBe('9709/trigonometry/equations');
+    expect(payload.session.currentQuestion).toBeNull();
+    expect(payload.session.currentQuestionTypeId).toBe('9709.trigonometry.equations');
+  });
+
+  test('normalizes fallback posture and typed refs from ask responses', () => {
+    const payload = normalizeAskResponse({
+      assistant_message: 'I can help with a conservative walkthrough here.',
+      evidence_summary: {
+        source_topic_path: '9709.integration.application',
+        retrieved_evidence_count: 0,
+      },
+      fallback_posture: {
+        fallback_mode: 'non_released_fallback',
+        authoritative_scoring_allowed: false,
+        fallback_reason_code: 'non_pilot_question_type',
+        classification_confidence: null,
+        learning_signal_posture: 'conservative_fallback',
+      },
+      session_delta: {
+        client_turn_id: 'local-turn-001',
+        current_question_ref: null,
+        current_question_type_ref: {
+          kind: 'question_type',
+          question_type_id: '9709.integration.application',
+        },
+      },
+      suggested_actions: [
+        {
+          kind: 'review_workspace',
+          workspace_id: 'workspace-1',
+        },
+      ],
+      request_id: 'req-ask-1',
+    });
+
+    expect(payload.fallbackPosture).toEqual({
+      fallbackMode: 'non_released_fallback',
+      authoritativeScoringAllowed: false,
+      fallbackReasonCode: 'non_pilot_question_type',
+      classificationConfidence: null,
+      learningSignalPosture: 'conservative_fallback',
+    });
+    expect(payload.sessionDelta.currentQuestion).toBeNull();
+    expect(payload.sessionDelta.currentQuestionType).toEqual({
+      kind: 'question_type',
+      questionTypeId: '9709.integration.application',
+    });
+    expect(payload.suggestedActions[0]).toEqual({
+      kind: 'review_workspace',
+      workspaceId: 'workspace-1',
+    });
+  });
+
+  test('createSession posts to the learning runtime route with auth and idempotency headers', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => createSessionEnvelope(),
+    });
+
+    const response = await learningRuntimeApi.createSession({
+      subject_code: '9709',
+      mode: 'spaced_review',
+      session_goal: 'Repair trigonometric equation solving',
+      anchor_kind: 'review_task',
+      anchor_ref: {
+        kind: 'review_task',
+        review_task_id: 'review-task-1',
+      },
+      current_question_id: null,
+      current_question_type_id: '9709.trigonometry.equations',
+    }, {
+      idempotencyKey: 'session-create-24',
+    });
+
+    expect(mockRequireSessionAccessToken).toHaveBeenCalledWith(mockSupabase);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe('/api/learning/sessions');
+
+    const init = global.fetch.mock.calls[0][1];
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer token-123',
+      'Content-Type': 'application/json',
+      'Idempotency-Key': 'session-create-24',
+    });
+    expect(JSON.parse(init.body)).toMatchObject({
+      anchor_kind: 'review_task',
+      current_question_type_id: '9709.trigonometry.equations',
+    });
+
+    expect(response.session.activeScope.currentAnchor.reviewTaskId).toBe('review-task-1');
+  });
+
+  test('listReviewTasks encodes the frozen query params for the shared client surface', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        scope: 'global_queue_projection',
+        topic_id: 'topic-1',
+        status: 'queued',
+        due_before: '2026-03-22',
+        items: [
+          {
+            review_task_id: 'review-queued-1',
+          },
+        ],
+        request_id: 'req-review-1',
+      }),
+    });
+
+    const payload = await learningRuntimeApi.listReviewTasks({
+      topicId: 'topic-1',
+      status: 'queued',
+      dueBefore: '2026-03-22',
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/learning/review-tasks?topic_id=topic-1&status=queued&due_before=2026-03-22',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token-123',
+        }),
+      }),
+    );
+    expect(payload.topicId).toBe('topic-1');
+    expect(payload.items[0].reviewTaskId).toBe('review-queued-1');
+  });
+});

--- a/src/api/learningRuntimeApi.js
+++ b/src/api/learningRuntimeApi.js
@@ -1,0 +1,266 @@
+import { requireSessionAccessToken } from '../services/utils/sessionAccessToken.js';
+import { supabase } from '../utils/supabase.js';
+
+const LEARNING_RUNTIME_API_BASE = '/api/learning';
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function camelizeKey(key) {
+  return String(key).replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+function camelizeKeys(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => camelizeKeys(entry));
+  }
+
+  if (!isPlainObject(value)) {
+    return value ?? null;
+  }
+
+  return Object.entries(value).reduce((acc, [key, entry]) => {
+    acc[camelizeKey(key)] = camelizeKeys(entry);
+    return acc;
+  }, {});
+}
+
+function buildQuestionRef(questionId) {
+  return questionId ? { kind: 'question', questionId } : null;
+}
+
+function buildQuestionTypeRef(questionTypeId) {
+  return questionTypeId ? { kind: 'question_type', questionTypeId } : null;
+}
+
+function normalizeSessionRecord(session = {}) {
+  const activeScopeBundle = isPlainObject(session.activeScopeBundle)
+    ? session.activeScopeBundle
+    : {};
+  const activeScope = {
+    ...activeScopeBundle,
+    currentAnchorKind: activeScopeBundle.currentAnchorKind ?? session.currentAnchorKind ?? null,
+    currentAnchor: activeScopeBundle.currentAnchorRef ?? session.currentAnchorRef ?? null,
+    currentQuestion:
+      activeScopeBundle.currentQuestionRef ?? buildQuestionRef(session.currentQuestionId ?? null),
+    currentQuestionType:
+      activeScopeBundle.currentQuestionTypeRef
+      ?? buildQuestionTypeRef(session.currentQuestionTypeId ?? null),
+  };
+
+  return {
+    ...session,
+    currentAnchor: session.currentAnchorRef ?? activeScope.currentAnchor,
+    currentQuestion: activeScope.currentQuestion,
+    currentQuestionType: activeScope.currentQuestionType,
+    activeScope,
+  };
+}
+
+function normalizeRequestPayload(payload) {
+  return typeof payload === 'undefined' ? null : payload;
+}
+
+async function readJson(response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function createLearningRuntimeError(response, payload) {
+  const error = new Error(
+    payload?.error?.message
+      || payload?.message
+      || `HTTP ${response.status}: ${response.statusText || 'Request failed'}`,
+  );
+  error.name = 'LearningRuntimeApiError';
+  error.status = response.status;
+  error.code = payload?.error?.code ?? 'http_error';
+  error.retryable = payload?.error?.retryable ?? false;
+  error.details = payload?.error?.details ?? {};
+  error.requestId = payload?.request_id ?? null;
+  return error;
+}
+
+async function learningRequest(path, {
+  method = 'GET',
+  body,
+  headers = {},
+  idempotencyKey = null,
+} = {}) {
+  const accessToken = await requireSessionAccessToken(supabase);
+  const requestHeaders = {
+    Authorization: `Bearer ${accessToken}`,
+    ...headers,
+  };
+
+  const hasBody = typeof body !== 'undefined';
+  if (hasBody) {
+    requestHeaders['Content-Type'] = 'application/json';
+  }
+  if (idempotencyKey) {
+    requestHeaders['Idempotency-Key'] = idempotencyKey;
+  }
+
+  const response = await fetch(`${LEARNING_RUNTIME_API_BASE}${path}`, {
+    method,
+    headers: requestHeaders,
+    body: hasBody ? JSON.stringify(normalizeRequestPayload(body)) : undefined,
+  });
+
+  const payload = await readJson(response);
+  if (!response.ok) {
+    throw createLearningRuntimeError(response, payload);
+  }
+
+  return payload ?? {};
+}
+
+function buildQuery(params = {}, keyMap = {}) {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === null || typeof value === 'undefined' || value === '') {
+      return;
+    }
+    searchParams.set(keyMap[key] || key, String(value));
+  });
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+export function normalizeSessionResponse(payload = {}) {
+  const camelized = camelizeKeys(payload);
+
+  return {
+    ...camelized,
+    session: normalizeSessionRecord(camelized.session || {}),
+    anchorValidity: camelized.anchorValidity || null,
+    canonicalHomeContext: camelized.canonicalHomeContext || null,
+    featureFlags: camelized.featureFlags || {},
+  };
+}
+
+export function normalizeAskResponse(payload = {}) {
+  const camelized = camelizeKeys(payload);
+  const sessionDelta = isPlainObject(camelized.sessionDelta)
+    ? camelized.sessionDelta
+    : {};
+
+  return {
+    ...camelized,
+    fallbackPosture: camelized.fallbackPosture || null,
+    evidenceSummary: camelized.evidenceSummary || null,
+    sessionDelta: {
+      ...sessionDelta,
+      currentQuestion:
+        sessionDelta.currentQuestionRef
+        ?? buildQuestionRef(sessionDelta.currentQuestionId ?? null),
+      currentQuestionType:
+        sessionDelta.currentQuestionTypeRef
+        ?? buildQuestionTypeRef(sessionDelta.currentQuestionTypeId ?? null),
+    },
+    suggestedActions: Array.isArray(camelized.suggestedActions)
+      ? camelized.suggestedActions
+      : [],
+  };
+}
+
+export function normalizeImportQuestionResponse(payload = {}) {
+  const camelized = camelizeKeys(payload);
+  return {
+    ...camelized,
+    scoringScopePosture: camelized.scoringScopePosture || null,
+  };
+}
+
+export function normalizeReviewTaskListResponse(payload = {}) {
+  const camelized = camelizeKeys(payload);
+  return {
+    ...camelized,
+    items: Array.isArray(camelized.items) ? camelized.items : [],
+  };
+}
+
+export function normalizeWorkspaceResponse(payload = {}) {
+  const camelized = camelizeKeys(payload);
+  return {
+    ...camelized,
+    workspace: camelized.workspace || null,
+    reviewQueue: normalizeReviewTaskListResponse(camelized.reviewQueue || {}),
+  };
+}
+
+export function normalizeArtifactResponse(payload = {}) {
+  const camelized = camelizeKeys(payload);
+  return {
+    ...camelized,
+    artifact: camelized.artifact || null,
+    slotTransition: camelized.slotTransition || null,
+  };
+}
+
+export async function createSession(payload, options = {}) {
+  return normalizeSessionResponse(await learningRequest('/sessions', {
+    method: 'POST',
+    body: payload,
+    idempotencyKey: options.idempotencyKey ?? null,
+  }));
+}
+
+export async function getSession(sessionId) {
+  return normalizeSessionResponse(await learningRequest(`/sessions/${encodeURIComponent(sessionId)}`));
+}
+
+export async function askInSession(sessionId, payload) {
+  return normalizeAskResponse(await learningRequest(`/sessions/${encodeURIComponent(sessionId)}/ask`, {
+    method: 'POST',
+    body: payload,
+  }));
+}
+
+export async function importQuestion(payload, options = {}) {
+  return normalizeImportQuestionResponse(await learningRequest('/questions/import', {
+    method: 'POST',
+    body: payload,
+    idempotencyKey: options.idempotencyKey ?? null,
+  }));
+}
+
+export async function getWorkspace(topicId) {
+  return normalizeWorkspaceResponse(await learningRequest(`/workspaces/${encodeURIComponent(topicId)}`));
+}
+
+export async function listReviewTasks(params = {}) {
+  const query = buildQuery(params, {
+    topicId: 'topic_id',
+    dueBefore: 'due_before',
+  });
+
+  return normalizeReviewTaskListResponse(
+    await learningRequest(`/review-tasks${query}`),
+  );
+}
+
+export async function updateArtifact(artifactId, payload) {
+  return normalizeArtifactResponse(await learningRequest(`/artifacts/${encodeURIComponent(artifactId)}`, {
+    method: 'PATCH',
+    body: payload,
+  }));
+}
+
+export const learningRuntimeApi = {
+  createSession,
+  getSession,
+  askInSession,
+  importQuestion,
+  getWorkspace,
+  listReviewTasks,
+  updateArtifact,
+};
+
+export default learningRuntimeApi;

--- a/src/components/learning-runtime/LearningSessionShell.js
+++ b/src/components/learning-runtime/LearningSessionShell.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import SessionHeader from './SessionHeader.js';
+import SessionTimeline from './SessionTimeline.js';
+
+const h = React.createElement;
+
+function renderSessionMeta(session) {
+  const rows = [
+    {
+      label: 'Session state',
+      value: session?.state || 'active',
+    },
+    {
+      label: 'Question type',
+      value: session?.currentQuestionTypeId || 'not set',
+    },
+  ];
+
+  return h(
+    'dl',
+    { className: 'grid gap-4 sm:grid-cols-2' },
+    rows.map((row) => h(
+      'div',
+      {
+        key: row.label,
+        className: 'rounded-2xl border border-slate-200 bg-white p-4 shadow-sm',
+      },
+      [
+        h('dt', { key: 'label', className: 'text-sm font-medium text-slate-500' }, row.label),
+        h('dd', { key: 'value', className: 'mt-2 text-lg font-semibold text-slate-950' }, row.value),
+      ],
+    )),
+  );
+}
+
+export default function LearningSessionShell({ viewModel }) {
+  const session = viewModel?.session || {};
+
+  return h('div', { className: 'grid gap-6' }, [
+    h(SessionHeader, {
+      key: 'header',
+      header: viewModel?.header || {},
+      session,
+    }),
+    h('div', { key: 'meta' }, renderSessionMeta(session)),
+    session.hasQuestion && session.currentQuestionId
+      ? h('section', {
+        key: 'question-card',
+        className: 'rounded-3xl border border-slate-200 bg-white p-6 shadow-sm',
+      }, [
+        h('h2', {
+          key: 'title',
+          className: 'text-xl font-semibold tracking-tight text-slate-950',
+        }, 'Current question'),
+        h('p', {
+          key: 'value',
+          className: 'mt-2 text-sm text-slate-700',
+        }, session.currentQuestionId),
+      ])
+      : null,
+    h(SessionTimeline, {
+      key: 'timeline',
+      timeline: viewModel?.timeline || [],
+    }),
+  ].filter(Boolean));
+}

--- a/src/components/learning-runtime/LearningSessionShell.jsx
+++ b/src/components/learning-runtime/LearningSessionShell.jsx
@@ -1,0 +1,1 @@
+export { default } from './LearningSessionShell.js';

--- a/src/components/learning-runtime/SessionHeader.js
+++ b/src/components/learning-runtime/SessionHeader.js
@@ -1,0 +1,49 @@
+import React from 'react';
+
+const h = React.createElement;
+
+function renderPill(label, value) {
+  if (!value && value !== false) {
+    return null;
+  }
+
+  return h(
+    'div',
+    {
+      key: `${label}:${value}`,
+      className: 'rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-700',
+    },
+    [
+      h('span', { key: 'label', className: 'font-medium text-slate-500' }, `${label}: `),
+      h('span', { key: 'value', className: 'text-slate-900' }, String(value)),
+    ],
+  );
+}
+
+export default function SessionHeader({ header, session }) {
+  const pills = [
+    renderPill('Anchor', header?.anchorKind),
+    renderPill('Topic', header?.topicPath),
+    header?.fallbackMode ? renderPill('Fallback', header.fallbackMode) : null,
+  ].filter(Boolean);
+
+  return h('section', { className: 'rounded-3xl border border-slate-200 bg-white p-6 shadow-sm' }, [
+    h('p', {
+      key: 'eyebrow',
+      className: 'text-xs font-semibold uppercase tracking-[0.24em] text-slate-500',
+    }, 'Learning runtime session'),
+    h('div', { key: 'content', className: 'mt-3 flex flex-col gap-3' }, [
+      h('div', { key: 'title-block' }, [
+        h('h1', {
+          key: 'title',
+          className: 'text-3xl font-semibold tracking-tight text-slate-950',
+        }, header?.modeLabel || 'learning session'),
+        h('p', {
+          key: 'subtitle',
+          className: 'mt-2 text-sm leading-6 text-slate-600',
+        }, session?.sessionGoal || header?.anchorLabel || 'Session context is loading.'),
+      ]),
+      h('div', { key: 'pills', className: 'flex flex-wrap gap-3' }, pills),
+    ]),
+  ]);
+}

--- a/src/components/learning-runtime/SessionHeader.jsx
+++ b/src/components/learning-runtime/SessionHeader.jsx
@@ -1,0 +1,1 @@
+export { default } from './SessionHeader.js';

--- a/src/components/learning-runtime/SessionTimeline.js
+++ b/src/components/learning-runtime/SessionTimeline.js
@@ -1,0 +1,68 @@
+import React from 'react';
+
+const h = React.createElement;
+
+function renderEntry(entry) {
+  const metaLines = [];
+
+  if (entry.questionTypeId) {
+    metaLines.push(
+      h('p', { key: 'question-type', className: 'text-sm text-slate-600' }, `Question type: ${entry.questionTypeId}`),
+    );
+  }
+
+  if (entry.fallbackReasonCode) {
+    metaLines.push(
+      h('p', { key: 'fallback-reason', className: 'text-sm text-amber-700' }, `Fallback reason: ${entry.fallbackReasonCode}`),
+    );
+  }
+
+  if (entry.learningSignalPosture) {
+    metaLines.push(
+      h('p', { key: 'learning-signal', className: 'text-sm text-slate-600' }, `Learning signal posture: ${entry.learningSignalPosture}`),
+    );
+  }
+
+  if (entry.evidenceTopicPath) {
+    metaLines.push(
+      h('p', { key: 'evidence-topic', className: 'text-sm text-slate-600' }, `Evidence topic: ${entry.evidenceTopicPath}`),
+    );
+  }
+
+  return h('article', {
+    key: entry.id,
+    className: 'rounded-2xl border border-slate-200 bg-slate-50 p-4',
+  }, [
+    h('h3', { key: 'title', className: 'text-base font-semibold text-slate-950' }, entry.title),
+    entry.message
+      ? h('p', { key: 'message', className: 'mt-2 text-sm leading-6 text-slate-700' }, entry.message)
+      : null,
+    entry.description
+      ? h('p', { key: 'description', className: 'mt-2 text-sm leading-6 text-slate-700' }, entry.description)
+      : null,
+    entry.questionId
+      ? h('p', { key: 'question-id', className: 'mt-2 text-sm text-slate-700' }, entry.questionId)
+      : null,
+    ...metaLines,
+  ]);
+}
+
+export default function SessionTimeline({ timeline = [] }) {
+  return h('section', { className: 'rounded-3xl border border-slate-200 bg-white p-6 shadow-sm' }, [
+    h('div', { key: 'heading' }, [
+      h('p', {
+        key: 'eyebrow',
+        className: 'text-xs font-semibold uppercase tracking-[0.24em] text-slate-500',
+      }, 'Timeline'),
+      h('h2', {
+        key: 'title',
+        className: 'mt-3 text-2xl font-semibold tracking-tight text-slate-950',
+      }, 'Session flow'),
+    ]),
+    h(
+      'div',
+      { key: 'entries', className: 'mt-6 grid gap-4' },
+      timeline.map((entry) => renderEntry(entry)),
+    ),
+  ]);
+}

--- a/src/components/learning-runtime/SessionTimeline.jsx
+++ b/src/components/learning-runtime/SessionTimeline.jsx
@@ -1,0 +1,1 @@
+export { default } from './SessionTimeline.js';

--- a/src/components/learning-runtime/__tests__/LearningSessionShell.test.js
+++ b/src/components/learning-runtime/__tests__/LearningSessionShell.test.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import LearningSessionShell from '../LearningSessionShell.js';
+import { buildSessionViewModel } from '../view-models/session-view-model.js';
+
+function createQuestionlessSessionPayload() {
+  return {
+    session: {
+      sessionId: 'sess-concept-1',
+      mode: 'learn_concept',
+      state: 'active',
+      sessionGoal: 'Build trig identity intuition',
+      currentQuestion: null,
+      currentQuestionId: null,
+      currentQuestionTypeId: '9709.trigonometry.identities',
+      currentQuestionType: {
+        kind: 'question_type',
+        questionTypeId: '9709.trigonometry.identities',
+      },
+      activeScope: {
+        primaryTopicId: 'topic-trig-identities',
+        primaryTopicPath: '9709/trigonometry/identities',
+        currentAnchorKind: 'concept',
+        currentAnchor: {
+          kind: 'concept',
+          topicId: 'topic-trig-identities',
+          topicPath: '9709/trigonometry/identities',
+        },
+      },
+      createdAt: '2026-03-22T00:00:00.000Z',
+      updatedAt: '2026-03-22T00:05:00.000Z',
+      openQuestions: [],
+      keyArtifactRefs: [],
+      misconceptionsInFocus: [],
+    },
+    canonicalHomeContext: {
+      sourceAnchorKind: 'concept',
+      topicRef: {
+        kind: 'topic',
+        topicId: 'topic-trig-identities',
+        topicPath: '9709/trigonometry/identities',
+      },
+    },
+    featureFlags: {
+      learningRuntimeEnabled: true,
+    },
+  };
+}
+
+describe('LearningSessionShell', () => {
+  test('renders questionless sessions without placeholder question chrome', () => {
+    const questionlessSessionVm = buildSessionViewModel(createQuestionlessSessionPayload());
+    const html = renderToStaticMarkup(
+      React.createElement(LearningSessionShell, {
+        viewModel: questionlessSessionVm,
+      }),
+    );
+
+    expect(html).toContain('learn concept');
+    expect(html).toContain('Questionless entry');
+    expect(html).toContain('9709/trigonometry/identities');
+    expect(html).not.toContain('Current question');
+    expect(html).not.toContain('placeholder-question-id');
+  });
+});

--- a/src/components/learning-runtime/__tests__/view-models.test.js
+++ b/src/components/learning-runtime/__tests__/view-models.test.js
@@ -1,0 +1,92 @@
+import { buildSessionViewModel } from '../view-models/session-view-model.js';
+
+function createQuestionlessSessionPayload() {
+  return {
+    session: {
+      sessionId: 'sess-concept-1',
+      mode: 'learn_concept',
+      state: 'active',
+      sessionGoal: 'Build trig identity intuition',
+      currentQuestion: null,
+      currentQuestionId: null,
+      currentQuestionTypeId: '9709.trigonometry.identities',
+      currentQuestionType: {
+        kind: 'question_type',
+        questionTypeId: '9709.trigonometry.identities',
+      },
+      activeScope: {
+        primaryTopicId: 'topic-trig-identities',
+        primaryTopicPath: '9709/trigonometry/identities',
+        currentAnchorKind: 'concept',
+        currentAnchor: {
+          kind: 'concept',
+          topicId: 'topic-trig-identities',
+          topicPath: '9709/trigonometry/identities',
+        },
+      },
+      lineageRef: {
+        parentSessionId: null,
+        handoffKind: null,
+      },
+      openQuestions: [],
+      keyArtifactRefs: [],
+      misconceptionsInFocus: [],
+      createdAt: '2026-03-22T00:00:00.000Z',
+      updatedAt: '2026-03-22T00:05:00.000Z',
+    },
+    canonicalHomeContext: {
+      sourceAnchorKind: 'concept',
+      topicRef: {
+        kind: 'topic',
+        topicId: 'topic-trig-identities',
+        topicPath: '9709/trigonometry/identities',
+      },
+    },
+    featureFlags: {
+      learningRuntimeEnabled: true,
+    },
+  };
+}
+
+describe('learning runtime session view model', () => {
+  test('preserves questionless runtime state without placeholder ids', () => {
+    const vm = buildSessionViewModel(createQuestionlessSessionPayload());
+
+    expect(vm.session.currentQuestion).toBeNull();
+    expect(vm.session.currentQuestionId).toBeNull();
+    expect(vm.session.currentQuestionTypeId).toBe('9709.trigonometry.identities');
+    expect(vm.session.hasQuestion).toBe(false);
+    expect(vm.header.modeLabel).toBe('learn concept');
+    expect(vm.header.anchorKind).toBe('concept');
+    expect(vm.header.topicPath).toBe('9709/trigonometry/identities');
+    expect(vm.timeline.some((entry) => entry.kind === 'question')).toBe(false);
+  });
+
+  test('surfaces explicit fallback posture instead of synthesizing score state', () => {
+    const vm = buildSessionViewModel({
+      ...createQuestionlessSessionPayload(),
+      latestResponse: {
+        assistantMessage: 'Let us stay in concept mode before scoring.',
+        fallbackPosture: {
+          fallbackMode: 'non_released_fallback',
+          authoritativeScoringAllowed: false,
+          fallbackReasonCode: 'non_pilot_question_type',
+          classificationConfidence: null,
+          learningSignalPosture: 'conservative_fallback',
+        },
+        evidenceSummary: {
+          sourceTopicPath: '9709/trigonometry/identities',
+          retrievedEvidenceCount: 0,
+        },
+      },
+    });
+
+    expect(vm.header.fallbackMode).toBe('non_released_fallback');
+    expect(vm.header.authoritativeScoringAllowed).toBe(false);
+    expect(vm.timeline[0]).toEqual(expect.objectContaining({
+      kind: 'assistant_response',
+      fallbackReasonCode: 'non_pilot_question_type',
+      learningSignalPosture: 'conservative_fallback',
+    }));
+  });
+});

--- a/src/components/learning-runtime/view-models/session-view-model.js
+++ b/src/components/learning-runtime/view-models/session-view-model.js
@@ -1,0 +1,136 @@
+function normalizeText(value, fallback = '') {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+function labelForMode(mode) {
+  return normalizeText(mode, 'learning session').replace(/_/g, ' ');
+}
+
+function buildAnchorLabel(anchor, topicPath) {
+  if (!anchor) {
+    return 'Unknown anchor';
+  }
+
+  switch (anchor.kind) {
+    case 'concept':
+      return topicPath || anchor.topicPath || anchor.topicId || 'Concept anchor';
+    case 'question':
+      return anchor.questionId || 'Question anchor';
+    case 'review_task':
+      return anchor.reviewTaskId || 'Review task anchor';
+    case 'artifact':
+      return anchor.artifactId || 'Artifact anchor';
+    case 'workspace_slot':
+      return anchor.slotKey
+        ? `${anchor.slotKey} workspace slot`
+        : 'Workspace slot anchor';
+    default:
+      return anchor.kind || 'Unknown anchor';
+  }
+}
+
+function buildAssistantResponseEntry(latestResponse) {
+  if (!latestResponse?.assistantMessage) {
+    return null;
+  }
+
+  return {
+    id: 'assistant-response',
+    kind: 'assistant_response',
+    title: 'Assistant response',
+    message: latestResponse.assistantMessage,
+    fallbackReasonCode: latestResponse?.fallbackPosture?.fallbackReasonCode ?? null,
+    learningSignalPosture: latestResponse?.fallbackPosture?.learningSignalPosture ?? null,
+    evidenceTopicPath: latestResponse?.evidenceSummary?.sourceTopicPath ?? null,
+    retrievedEvidenceCount: latestResponse?.evidenceSummary?.retrievedEvidenceCount ?? null,
+  };
+}
+
+function buildQuestionStateEntry(session) {
+  if (session.hasQuestion && session.currentQuestionId) {
+    return {
+      id: 'current-question',
+      kind: 'question',
+      title: 'Current question',
+      questionId: session.currentQuestionId,
+      questionTypeId: session.currentQuestionTypeId,
+    };
+  }
+
+  return {
+    id: 'questionless-state',
+    kind: 'questionless_state',
+    title: 'Questionless entry',
+    description: 'This runtime state is anchored without a current question.',
+    questionTypeId: session.currentQuestionTypeId,
+  };
+}
+
+function buildTimeline(session, latestResponse) {
+  const entries = [];
+  const assistantEntry = buildAssistantResponseEntry(latestResponse);
+  if (assistantEntry) {
+    entries.push(assistantEntry);
+  }
+
+  entries.push(buildQuestionStateEntry(session));
+  return entries;
+}
+
+export function buildSessionViewModel(payload = {}) {
+  const sessionPayload = payload.session || {};
+  const activeScope = sessionPayload.activeScope || sessionPayload.activeScopeBundle || {};
+  const currentAnchor = activeScope.currentAnchor || sessionPayload.currentAnchor || null;
+  const currentQuestion = sessionPayload.currentQuestion ?? activeScope.currentQuestion ?? null;
+  const currentQuestionType = sessionPayload.currentQuestionType ?? activeScope.currentQuestionType ?? null;
+  const currentQuestionId = sessionPayload.currentQuestionId ?? currentQuestion?.questionId ?? null;
+  const currentQuestionTypeId =
+    sessionPayload.currentQuestionTypeId ?? currentQuestionType?.questionTypeId ?? null;
+  const topicPath =
+    payload?.canonicalHomeContext?.topicRef?.topicPath
+    ?? activeScope.primaryTopicPath
+    ?? currentAnchor?.topicPath
+    ?? null;
+  const latestResponse = payload.latestResponse || null;
+
+  const session = {
+    sessionId: sessionPayload.sessionId ?? null,
+    state: sessionPayload.state ?? 'active',
+    mode: sessionPayload.mode ?? null,
+    modeLabel: labelForMode(sessionPayload.mode),
+    sessionGoal: normalizeText(sessionPayload.sessionGoal, ''),
+    currentAnchorKind: activeScope.currentAnchorKind ?? currentAnchor?.kind ?? null,
+    currentAnchor,
+    currentQuestion,
+    currentQuestionId,
+    currentQuestionType,
+    currentQuestionTypeId,
+    hasQuestion: Boolean(currentQuestionId),
+    topicPath,
+    createdAt: sessionPayload.createdAt ?? null,
+    updatedAt: sessionPayload.updatedAt ?? null,
+  };
+
+  return {
+    session,
+    header: {
+      modeLabel: session.modeLabel,
+      anchorKind: session.currentAnchorKind,
+      anchorLabel: buildAnchorLabel(currentAnchor, topicPath),
+      topicPath,
+      fallbackMode: latestResponse?.fallbackPosture?.fallbackMode ?? null,
+      authoritativeScoringAllowed:
+        latestResponse?.fallbackPosture?.authoritativeScoringAllowed ?? null,
+    },
+    latestResponse,
+    timeline: buildTimeline(session, latestResponse),
+    featureFlags: payload.featureFlags || {},
+  };
+}
+
+export default buildSessionViewModel;

--- a/src/pages/learning-runtime/LearningSessionPage.jsx
+++ b/src/pages/learning-runtime/LearningSessionPage.jsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { getSession } from '../../api/learningRuntimeApi.js';
+import LearningSessionShell from '../../components/learning-runtime/LearningSessionShell.jsx';
+import { buildSessionViewModel } from '../../components/learning-runtime/view-models/session-view-model.js';
+
+export default function LearningSessionPage() {
+  const { sessionId = '' } = useParams();
+  const navigate = useNavigate();
+  const [viewModel, setViewModel] = useState(null);
+  const [surfaceState, setSurfaceState] = useState('loading');
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadSession() {
+      if (!sessionId) {
+        if (!active) {
+          return;
+        }
+
+        setSurfaceState('error');
+        setError(new Error('sessionId is required'));
+        return;
+      }
+
+      setSurfaceState('loading');
+      setError(null);
+
+      try {
+        const payload = await getSession(sessionId);
+        if (!active) {
+          return;
+        }
+
+        setViewModel(buildSessionViewModel(payload));
+        setSurfaceState('ready');
+      } catch (loadError) {
+        if (!active) {
+          return;
+        }
+
+        setError(loadError);
+        setSurfaceState('error');
+      }
+    }
+
+    loadSession();
+
+    return () => {
+      active = false;
+    };
+  }, [sessionId]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-100">
+      <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+        <div className="mb-8 flex items-start gap-3">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="rounded-full border border-slate-300 bg-white p-3 text-slate-700 transition hover:border-slate-900 hover:text-slate-900"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+
+          <div>
+            <p className="text-sm font-medium uppercase tracking-[0.24em] text-slate-500">
+              Learning Runtime
+            </p>
+            <h1 className="mt-3 text-4xl font-semibold tracking-tight text-slate-950">
+              Session
+            </h1>
+            <p className="mt-2 text-base leading-7 text-slate-600">
+              Session state now comes from the learning runtime contract instead of the legacy AskAI page flow.
+            </p>
+          </div>
+        </div>
+
+        {surfaceState === 'loading' ? (
+          <div className="rounded-3xl border border-slate-200 bg-white p-10 text-sm text-slate-600 shadow-sm">
+            Loading session...
+          </div>
+        ) : null}
+
+        {surfaceState === 'error' ? (
+          <div className="rounded-3xl border border-rose-200 bg-rose-50 p-10 text-sm text-rose-700 shadow-sm">
+            {error?.message || 'Failed to load session.'}
+          </div>
+        ) : null}
+
+        {surfaceState === 'ready' && viewModel ? <LearningSessionShell viewModel={viewModel} /> : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add the shared browser client for `/api/learning/**` with normalized typed refs and explicit fallback posture fields
- add the learning session view-model plus session shell, header, and timeline rendering for questionless runtime sessions
- add the new learning session page scaffold and focused frontend regression tests for Task 10

Closes #24

## Verification
- `npm test -- --runInBand src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/view-models.test.js`
- `npm run build`

## Notes
- The task-provided Jest command ends with `-v`, but the repo's current Jest CLI rejects that short flag, so the equivalent targeted test run above was used for verification.