### PR TITLE
[codex] Add imported question runtime intake

### DIFF
--- a/src/api/__tests__/learningRuntimeApi.test.js
+++ b/src/api/__tests__/learningRuntimeApi.test.js
@@ -18,6 +18,7 @@ jest.unstable_mockModule('../../utils/supabase.js', () => ({
 const {
   learningRuntimeApi,
   normalizeAskResponse,
+  normalizeImportQuestionResponse,
   normalizeSessionResponse,
 } = await import('../learningRuntimeApi.js');
 
@@ -125,6 +126,36 @@ function createAskEnvelope() {
   };
 }
 
+function createImportEnvelope() {
+  return {
+    question: {
+      question_id: 'question-import-1',
+      source_kind: 'imported_question',
+      subject_code: '9709',
+      primary_topic_id: 'topic-integration-1',
+      family_id: '9709.integration_techniques',
+      primary_question_type_id: '9709.integration.application',
+      release_scope_status: 'non_released_fallback',
+      prompt_representation: {
+        type: 'text',
+        value: 'Find the value of integral of (2x+1)(x^2+x)^4 dx.',
+      },
+      provenance_summary: {
+        import_source: 'manual_paste',
+      },
+    },
+    scoring_scope_posture: {
+      release_scope_status: 'non_released_fallback',
+      authoritative_scoring_allowed: false,
+      fallback_mode: 'non_released_fallback',
+      fallback_reason_code: 'non_pilot_question_type',
+      classification_confidence: 0.77,
+      learning_signal_posture: 'conservative_fallback',
+    },
+    request_id: 'req-import-1',
+  };
+}
+
 describe('learning runtime api', () => {
   beforeEach(() => {
     global.fetch = jest.fn();
@@ -215,6 +246,30 @@ describe('learning runtime api', () => {
     });
   });
 
+  test('normalizes imported question envelopes and explicit scoring posture', () => {
+    const payload = normalizeImportQuestionResponse(createImportEnvelope());
+
+    expect(payload.question).toEqual(expect.objectContaining({
+      questionId: 'question-import-1',
+      sourceKind: 'imported_question',
+      primaryTopicId: 'topic-integration-1',
+      primaryQuestionTypeId: '9709.integration.application',
+      releaseScopeStatus: 'non_released_fallback',
+    }));
+    expect(payload.question.promptRepresentation).toEqual({
+      type: 'text',
+      value: 'Find the value of integral of (2x+1)(x^2+x)^4 dx.',
+    });
+    expect(payload.scoringScopePosture).toEqual({
+      releaseScopeStatus: 'non_released_fallback',
+      authoritativeScoringAllowed: false,
+      fallbackMode: 'non_released_fallback',
+      fallbackReasonCode: 'non_pilot_question_type',
+      classificationConfidence: 0.77,
+      learningSignalPosture: 'conservative_fallback',
+    });
+  });
+
   test('createSession posts to the learning runtime route with auth and idempotency headers', async () => {
     global.fetch.mockResolvedValue({
       ok: true,
@@ -291,6 +346,54 @@ describe('learning runtime api', () => {
         questionTypeId: '9709.trigonometry.equations',
       },
     }));
+  });
+
+  test('importQuestion posts imported-question payloads to the shared learning route', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => createImportEnvelope(),
+    });
+
+    const response = await learningRuntimeApi.importQuestion({
+      subject_code: '9709',
+      prompt_representation: {
+        type: 'text',
+        value: 'Find the value of integral of (2x+1)(x^2+x)^4 dx.',
+      },
+      provenance_summary: {
+        import_source: 'manual_paste',
+      },
+      classification: {
+        primary_question_type_id: '9709.integration.application',
+        primary_topic_id: 'topic-integration-1',
+      },
+    }, {
+      idempotencyKey: 'import-question-45',
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe('/api/learning/questions/import');
+
+    const init = global.fetch.mock.calls[0][1];
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer token-123',
+      'Content-Type': 'application/json',
+      'Idempotency-Key': 'import-question-45',
+    });
+    expect(JSON.parse(init.body)).toMatchObject({
+      subject_code: '9709',
+      prompt_representation: {
+        type: 'text',
+        value: 'Find the value of integral of (2x+1)(x^2+x)^4 dx.',
+      },
+      classification: {
+        primary_question_type_id: '9709.integration.application',
+        primary_topic_id: 'topic-integration-1',
+      },
+    });
+    expect(response.question.questionId).toBe('question-import-1');
+    expect(response.scoringScopePosture.fallbackMode).toBe('non_released_fallback');
   });
 
   test('createSession throws structured learning runtime errors for actionable UI states', async () => {

--- a/src/api/learningRuntimeApi.js
+++ b/src/api/learningRuntimeApi.js
@@ -174,6 +174,7 @@ export function normalizeImportQuestionResponse(payload = {}) {
   const camelized = camelizeKeys(payload);
   return {
     ...camelized,
+    question: camelized.question || null,
     scoringScopePosture: camelized.scoringScopePosture || null,
   };
 }

--- a/src/components/learning-runtime/ImportPostureBanner.js
+++ b/src/components/learning-runtime/ImportPostureBanner.js
@@ -1,0 +1,83 @@
+import React from 'react';
+
+const h = React.createElement;
+
+function renderDetail(label, value) {
+  if (value === null || typeof value === 'undefined' || value === '') {
+    return null;
+  }
+
+  return h('div', {
+    key: label,
+    className: 'rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700',
+  }, [
+    h('p', { key: 'label', className: 'font-medium text-slate-500' }, label),
+    h('p', { key: 'value', className: 'mt-1 text-slate-950' }, String(value)),
+  ]);
+}
+
+export default function ImportPostureBanner({
+  question,
+  posture,
+  handoffStatus = 'idle',
+  handoffError = null,
+  onStartSession = null,
+}) {
+  if (!question && !posture) {
+    return null;
+  }
+
+  const isSubmitting = handoffStatus === 'submitting';
+  const releaseScopeStatus = posture?.releaseScopeStatus
+    ?? question?.releaseScopeStatus
+    ?? null;
+
+  return h('section', {
+    className: 'rounded-3xl border border-amber-200 bg-amber-50 p-6 shadow-sm',
+  }, [
+    h('div', { key: 'heading' }, [
+      h('p', {
+        key: 'eyebrow',
+        className: 'text-xs font-semibold uppercase tracking-[0.24em] text-amber-700',
+      }, 'Returned posture'),
+      h('h2', {
+        key: 'title',
+        className: 'mt-3 text-2xl font-semibold tracking-tight text-slate-950',
+      }, 'Imported question ready'),
+      h('p', {
+        key: 'body',
+        className: 'mt-2 text-sm leading-6 text-amber-950',
+      }, 'The import call finished and returned the runtime scoring posture below. Review it before you enter the session.'),
+    ]),
+    h('div', { key: 'details', className: 'mt-6 grid gap-3 md:grid-cols-2' }, [
+      renderDetail('Question ID', question?.questionId),
+      renderDetail('Question type', question?.primaryQuestionTypeId),
+      renderDetail('Release scope status', releaseScopeStatus),
+      renderDetail('Fallback mode', posture?.fallbackMode),
+      renderDetail('Fallback reason', posture?.fallbackReasonCode),
+      renderDetail('Learning signal posture', posture?.learningSignalPosture),
+      renderDetail('Classification confidence', posture?.classificationConfidence),
+    ].filter(Boolean)),
+    handoffError
+      ? h('div', {
+        key: 'error',
+        className: 'mt-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700',
+      }, handoffError)
+      : null,
+    onStartSession
+      ? h('div', { key: 'actions', className: 'mt-6 flex items-center justify-end' }, [
+        h('button', {
+          key: 'start-session',
+          type: 'button',
+          onClick: () => {
+            if (!isSubmitting) {
+              onStartSession();
+            }
+          },
+          disabled: isSubmitting,
+          className: 'rounded-full bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300',
+        }, isSubmitting ? 'Creating runtime session...' : 'Enter runtime session'),
+      ])
+      : null,
+  ]);
+}

--- a/src/components/learning-runtime/ImportPostureBanner.jsx
+++ b/src/components/learning-runtime/ImportPostureBanner.jsx
@@ -1,0 +1,1 @@
+export { default } from './ImportPostureBanner.js';

--- a/src/components/learning-runtime/ImportedQuestionIntake.js
+++ b/src/components/learning-runtime/ImportedQuestionIntake.js
@@ -1,0 +1,276 @@
+import React from 'react';
+
+const h = React.createElement;
+
+const DEFAULT_SUBJECT_CODE = '9709';
+const DEFAULT_RUNTIME_CONTEXT_ID = '9709.trigonometry.equations';
+
+export const IMPORTED_QUESTION_RUNTIME_CONTEXT_OPTIONS = Object.freeze([
+  {
+    value: '9709.trigonometry.equations',
+    label: 'Trigonometric equations',
+    topicId: 'topic-trig-equations',
+    topicPath: '9709/trigonometry/equations',
+    questionTypeId: '9709.trigonometry.equations',
+    postureLabel: 'pilot runtime family',
+  },
+  {
+    value: '9709.trigonometry.identities',
+    label: 'Trigonometric identities',
+    topicId: 'topic-trig-identities',
+    topicPath: '9709/trigonometry/identities',
+    questionTypeId: '9709.trigonometry.identities',
+    postureLabel: 'pilot runtime family',
+  },
+  {
+    value: '9709.integration.application',
+    label: 'Integration applications',
+    topicId: 'topic-integration-1',
+    topicPath: '9709.integration.application',
+    questionTypeId: '9709.integration.application',
+    postureLabel: 'fallback-only family',
+  },
+]);
+
+function normalizeString(value) {
+  if (value === null || typeof value === 'undefined') {
+    return '';
+  }
+
+  return String(value).trim();
+}
+
+function findRuntimeContextOption(runtimeContextId) {
+  return (
+    IMPORTED_QUESTION_RUNTIME_CONTEXT_OPTIONS.find((option) => option.value === runtimeContextId)
+    || IMPORTED_QUESTION_RUNTIME_CONTEXT_OPTIONS[0]
+    || null
+  );
+}
+
+function baseInputProps(disabled) {
+  return {
+    className:
+      'w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none transition focus:border-slate-900',
+    disabled,
+  };
+}
+
+function renderField(fieldKey, label, control, hint = null) {
+  return h('label', { key: fieldKey, className: 'grid gap-2 text-sm text-slate-700' }, [
+    h('span', { key: 'label', className: 'font-medium text-slate-900' }, label),
+    control,
+    hint
+      ? h('span', { key: 'hint', className: 'text-xs leading-5 text-slate-500' }, hint)
+      : null,
+  ].filter(Boolean));
+}
+
+export function createImportedQuestionDraft(overrides = {}) {
+  const runtimeContextId = normalizeString(overrides.runtimeContextId)
+    || DEFAULT_RUNTIME_CONTEXT_ID;
+  const runtimeContext = findRuntimeContextOption(runtimeContextId);
+
+  return {
+    subjectCode: normalizeString(overrides.subjectCode) || DEFAULT_SUBJECT_CODE,
+    runtimeContextId: runtimeContext?.value ?? DEFAULT_RUNTIME_CONTEXT_ID,
+    promptValue: normalizeString(overrides.promptValue),
+    topicId: normalizeString(overrides.topicId) || runtimeContext?.topicId || '',
+    topicPath: normalizeString(overrides.topicPath) || runtimeContext?.topicPath || '',
+    questionTypeId:
+      normalizeString(overrides.questionTypeId) || runtimeContext?.questionTypeId || '',
+  };
+}
+
+export function patchImportedQuestionDraft(currentDraft = {}, patch = {}) {
+  const nextDraft = {
+    ...createImportedQuestionDraft(currentDraft),
+    ...patch,
+  };
+
+  const runtimeContext = findRuntimeContextOption(
+    normalizeString(patch.runtimeContextId) || nextDraft.runtimeContextId,
+  );
+
+  if (runtimeContext) {
+    nextDraft.runtimeContextId = runtimeContext.value;
+    nextDraft.topicId = runtimeContext.topicId;
+    nextDraft.topicPath = runtimeContext.topicPath;
+    nextDraft.questionTypeId = runtimeContext.questionTypeId;
+  }
+
+  return createImportedQuestionDraft(nextDraft);
+}
+
+export function canSubmitImportedQuestionDraft(draft = {}) {
+  const normalizedDraft = createImportedQuestionDraft(draft);
+  return Boolean(
+    normalizedDraft.subjectCode
+    && normalizedDraft.runtimeContextId
+    && normalizedDraft.promptValue,
+  );
+}
+
+export function buildImportQuestionPayload(draft = {}) {
+  const normalizedDraft = createImportedQuestionDraft(draft);
+
+  return {
+    subject_code: normalizedDraft.subjectCode,
+    prompt_representation: {
+      type: 'text',
+      value: normalizedDraft.promptValue,
+    },
+    provenance_summary: {
+      import_source: 'manual_paste',
+    },
+    classification: {
+      primary_question_type_id: normalizedDraft.questionTypeId || null,
+      primary_topic_id: normalizedDraft.topicId || null,
+    },
+  };
+}
+
+export function buildImportedQuestionSessionPayload({
+  draft = {},
+  importResult = {},
+} = {}) {
+  const normalizedDraft = createImportedQuestionDraft(draft);
+  const question = importResult?.question || {};
+  const questionId = question.questionId ?? null;
+  const currentQuestionTypeId = question.primaryQuestionTypeId
+    ?? normalizedDraft.questionTypeId
+    ?? null;
+
+  if (!questionId) {
+    return null;
+  }
+
+  return {
+    subject_code: normalizedDraft.subjectCode,
+    mode: 'guided_solve',
+    session_goal: 'Work through imported question',
+    anchor_kind: 'question',
+    anchor_ref: {
+      kind: 'question',
+      question_id: questionId,
+    },
+    current_question_id: questionId,
+    current_question_type_id: currentQuestionTypeId,
+  };
+}
+
+export default function ImportedQuestionIntake({
+  intake,
+  onChange = () => {},
+  onSubmit = () => {},
+}) {
+  const draft = createImportedQuestionDraft(intake?.draft || {});
+  const isSubmitting = intake?.status === 'submitting';
+  const canSubmit = typeof intake?.canSubmit === 'boolean'
+    ? intake.canSubmit
+    : canSubmitImportedQuestionDraft(draft);
+  const runtimeContext = findRuntimeContextOption(draft.runtimeContextId);
+
+  return h('section', { className: 'rounded-3xl border border-slate-200 bg-white p-6 shadow-sm' }, [
+    h('div', { key: 'heading' }, [
+      h('p', {
+        key: 'eyebrow',
+        className: 'text-xs font-semibold uppercase tracking-[0.24em] text-slate-500',
+      }, 'Imported question'),
+      h('h2', {
+        key: 'title',
+        className: 'mt-3 text-2xl font-semibold tracking-tight text-slate-950',
+      }, 'Import into runtime'),
+      h('p', {
+        key: 'body',
+        className: 'mt-2 text-sm leading-6 text-slate-600',
+      }, 'Paste a question, create a durable runtime question, and review the returned scoring posture before you enter the session.'),
+    ]),
+    h('form', {
+      key: 'form',
+      className: 'mt-6 grid gap-4',
+      onSubmit: (event) => {
+        event.preventDefault();
+        if (!canSubmit || isSubmitting) {
+          return;
+        }
+        onSubmit();
+      },
+    }, [
+      renderField(
+        'subject-code',
+        'Subject code',
+        h('input', {
+          ...baseInputProps(true),
+          key: 'subject-code',
+          type: 'text',
+          name: 'subjectCode',
+          value: draft.subjectCode,
+          readOnly: true,
+        }),
+      ),
+      renderField(
+        'runtime-context',
+        'Runtime context',
+        h(
+          'select',
+          {
+            ...baseInputProps(isSubmitting),
+            key: 'runtime-context',
+            name: 'runtimeContextId',
+            value: draft.runtimeContextId,
+            onChange: (event) => onChange({ runtimeContextId: event.target.value }),
+          },
+          IMPORTED_QUESTION_RUNTIME_CONTEXT_OPTIONS.map((option) => h(
+            'option',
+            {
+              key: option.value,
+              value: option.value,
+            },
+            `${option.label} (${option.postureLabel})`,
+          )),
+        ),
+        'Choose the intended runtime context so the imported question can anchor to a canonical topic.',
+      ),
+      renderField(
+        'topic-path',
+        'Canonical topic path',
+        h('input', {
+          ...baseInputProps(true),
+          key: 'topic-path',
+          type: 'text',
+          name: 'topicPath',
+          value: runtimeContext?.topicPath || draft.topicPath,
+          readOnly: true,
+        }),
+      ),
+      renderField(
+        'prompt-value',
+        'Question content',
+        h('textarea', {
+          ...baseInputProps(isSubmitting),
+          key: 'prompt-value',
+          rows: 7,
+          name: 'promptValue',
+          value: draft.promptValue,
+          onChange: (event) => onChange({ promptValue: event.target.value }),
+        }),
+        'The intake stores this as a durable imported question instead of route-scoped chat state.',
+      ),
+      intake?.errorMessage
+        ? h('div', {
+          key: 'error',
+          className: 'rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700',
+        }, intake.errorMessage)
+        : null,
+      h('div', { key: 'actions', className: 'flex items-center justify-end' }, [
+        h('button', {
+          key: 'submit',
+          type: 'submit',
+          disabled: !canSubmit || isSubmitting,
+          className: 'rounded-full bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300',
+        }, isSubmitting ? 'Importing question...' : 'Import question'),
+      ]),
+    ].filter(Boolean)),
+  ]);
+}

--- a/src/components/learning-runtime/ImportedQuestionIntake.jsx
+++ b/src/components/learning-runtime/ImportedQuestionIntake.jsx
@@ -1,0 +1,2 @@
+export { default } from './ImportedQuestionIntake.js';
+export * from './ImportedQuestionIntake.js';

--- a/src/components/learning-runtime/__tests__/ImportPostureBanner.test.js
+++ b/src/components/learning-runtime/__tests__/ImportPostureBanner.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import ImportPostureBanner from '../ImportPostureBanner.js';
+
+describe('ImportPostureBanner', () => {
+  test('renders explicit fallback posture and handoff controls before entering a session', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ImportPostureBanner, {
+        question: {
+          questionId: 'question-import-1',
+          primaryQuestionTypeId: '9709.integration.application',
+          releaseScopeStatus: 'non_released_fallback',
+        },
+        posture: {
+          releaseScopeStatus: 'non_released_fallback',
+          authoritativeScoringAllowed: false,
+          fallbackMode: 'non_released_fallback',
+          fallbackReasonCode: 'non_pilot_question_type',
+          classificationConfidence: 0.77,
+          learningSignalPosture: 'conservative_fallback',
+        },
+        handoffStatus: 'idle',
+        onStartSession: () => {},
+      }),
+    );
+
+    expect(html).toContain('Imported question ready');
+    expect(html).toContain('non_released_fallback');
+    expect(html).toContain('non_pilot_question_type');
+    expect(html).toContain('question-import-1');
+    expect(html).toContain('Enter runtime session');
+  });
+});

--- a/src/components/learning-runtime/__tests__/ImportedQuestionIntake.test.js
+++ b/src/components/learning-runtime/__tests__/ImportedQuestionIntake.test.js
@@ -1,0 +1,132 @@
+import { jest } from '@jest/globals';
+import React from 'react';
+import ImportedQuestionIntake, {
+  buildImportQuestionPayload,
+  buildImportedQuestionSessionPayload,
+  canSubmitImportedQuestionDraft,
+  createImportedQuestionDraft,
+} from '../ImportedQuestionIntake.js';
+
+function findElement(node, predicate) {
+  if (!node || typeof node !== 'object') {
+    return null;
+  }
+
+  if (predicate(node)) {
+    return node;
+  }
+
+  const children = React.Children.toArray(node.props?.children);
+  for (const child of children) {
+    const match = findElement(child, predicate);
+    if (match) {
+      return match;
+    }
+  }
+
+  return null;
+}
+
+describe('ImportedQuestionIntake', () => {
+  test('builds import payloads from pasted content and runtime context selection', () => {
+    const payload = buildImportQuestionPayload(createImportedQuestionDraft({
+      promptValue: 'Solve 2sinx = 1 for 0 <= x <= 360.',
+      runtimeContextId: '9709.trigonometry.equations',
+    }));
+
+    expect(payload).toEqual({
+      subject_code: '9709',
+      prompt_representation: {
+        type: 'text',
+        value: 'Solve 2sinx = 1 for 0 <= x <= 360.',
+      },
+      provenance_summary: {
+        import_source: 'manual_paste',
+      },
+      classification: {
+        primary_question_type_id: '9709.trigonometry.equations',
+        primary_topic_id: 'topic-trig-equations',
+      },
+    });
+  });
+
+  test('builds guided-solve session payloads anchored to imported questions', () => {
+    const payload = buildImportedQuestionSessionPayload({
+      draft: createImportedQuestionDraft({
+        runtimeContextId: '9709.integration.application',
+      }),
+      importResult: {
+        question: {
+          questionId: 'question-import-1',
+          primaryQuestionTypeId: '9709.integration.application',
+        },
+      },
+    });
+
+    expect(payload).toEqual({
+      subject_code: '9709',
+      mode: 'guided_solve',
+      session_goal: 'Work through imported question',
+      anchor_kind: 'question',
+      anchor_ref: {
+        kind: 'question',
+        question_id: 'question-import-1',
+      },
+      current_question_id: 'question-import-1',
+      current_question_type_id: '9709.integration.application',
+    });
+  });
+
+  test('only submits once the intake has pasted content and wires field changes back up', () => {
+    expect(canSubmitImportedQuestionDraft(createImportedQuestionDraft())).toBe(false);
+
+    const onChange = jest.fn();
+    const onSubmit = jest.fn();
+    const tree = ImportedQuestionIntake({
+      intake: {
+        draft: createImportedQuestionDraft(),
+        status: 'idle',
+        canSubmit: false,
+      },
+      onChange,
+      onSubmit,
+    });
+
+    const contextSelect = findElement(
+      tree,
+      (element) => element.type === 'select' && element.props.name === 'runtimeContextId',
+    );
+    contextSelect.props.onChange({ target: { value: '9709.integration.application' } });
+
+    const promptTextarea = findElement(
+      tree,
+      (element) => element.type === 'textarea' && element.props.name === 'promptValue',
+    );
+    promptTextarea.props.onChange({ target: { value: 'Find the value of integral of (2x+1)(x^2+x)^4 dx.' } });
+
+    const blockedForm = findElement(tree, (element) => element.type === 'form');
+    blockedForm.props.onSubmit({ preventDefault() {} });
+
+    const readyTree = ImportedQuestionIntake({
+      intake: {
+        draft: createImportedQuestionDraft({
+          promptValue: 'Find the value of integral of (2x+1)(x^2+x)^4 dx.',
+          runtimeContextId: '9709.integration.application',
+        }),
+        status: 'idle',
+        canSubmit: true,
+      },
+      onChange: jest.fn(),
+      onSubmit,
+    });
+
+    const readyForm = findElement(readyTree, (element) => element.type === 'form');
+    readyForm.props.onSubmit({ preventDefault() {} });
+
+    expect(onChange).toHaveBeenNthCalledWith(1, { runtimeContextId: '9709.integration.application' });
+    expect(onChange).toHaveBeenNthCalledWith(2, {
+      promptValue: 'Find the value of integral of (2x+1)(x^2+x)^4 dx.',
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/AskAI.jsx
+++ b/src/pages/AskAI.jsx
@@ -36,12 +36,30 @@ const AskAI = () => {
             </div>
 
             <p className="mt-6 max-w-3xl text-base leading-7 text-slate-600">
-              The legacy AskAI page no longer owns canonical learning state. Use a runtime workspace
-              to review stable slots, linked references, and the topic-filtered review queue for the
-              pilot trigonometry slice.
+              The legacy AskAI page no longer owns canonical learning state. Start with a runtime
+              import or workspace entry so the session contract, fallback posture, and canonical
+              topic handoff all stay inside the new learning-runtime flow.
             </p>
 
-            <div className="mt-8 grid gap-4 md:grid-cols-2">
+            <div className="mt-8 grid gap-4 md:grid-cols-3">
+              <Link
+                to="/learn/session/new?entry=imported_question"
+                className="group rounded-3xl border border-slate-900 bg-slate-900 p-6 text-white transition hover:bg-slate-800"
+              >
+                <p className="text-sm font-medium uppercase tracking-[0.24em] text-slate-300">
+                  Runtime intake
+                </p>
+                <h2 className="mt-3 text-2xl font-semibold">Paste an imported question</h2>
+                <p className="mt-2 text-sm text-slate-200">
+                  Turn pasted content into a durable runtime question, review the returned scoring
+                  posture, and only then enter the session.
+                </p>
+                <span className="mt-5 inline-flex items-center gap-2 text-sm font-medium text-white">
+                  Open import flow
+                  <ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
+                </span>
+              </Link>
+
               {LEARNING_RUNTIME_ENTRY_TOPICS.map((topic) => (
                 <Link
                   key={topic.topicId}

--- a/src/pages/learning-runtime/LearningSessionPage.jsx
+++ b/src/pages/learning-runtime/LearningSessionPage.jsx
@@ -10,7 +10,16 @@ import {
   askInSession,
   createSession,
   getSession,
+  importQuestion,
 } from '../../api/learningRuntimeApi.js';
+import ImportPostureBanner from '../../components/learning-runtime/ImportPostureBanner.jsx';
+import ImportedQuestionIntake, {
+  buildImportQuestionPayload,
+  buildImportedQuestionSessionPayload,
+  canSubmitImportedQuestionDraft,
+  createImportedQuestionDraft,
+  patchImportedQuestionDraft,
+} from '../../components/learning-runtime/ImportedQuestionIntake.jsx';
 import LearningSessionShell from '../../components/learning-runtime/LearningSessionShell.jsx';
 import { buildSessionViewModel } from '../../components/learning-runtime/view-models/session-view-model.js';
 import {
@@ -37,7 +46,11 @@ export default function LearningSessionPage() {
   const location = useLocation();
   const navigate = useNavigate();
   const isLauncherSurface = !sessionId || sessionId === NEW_SESSION_SENTINEL;
+  const launcherEntry = new URLSearchParams(location.search).get('entry');
+  const isImportedQuestionEntry = isLauncherSurface && launcherEntry === 'imported_question';
   const activeLaunchRequestKeyRef = useRef(null);
+  const activeImportRequestKeyRef = useRef(null);
+  const activeImportHandoffRequestKeyRef = useRef(null);
   const activeRouteSessionIdRef = useRef(isLauncherSurface ? null : sessionId);
   const isLauncherSurfaceRef = useRef(false);
   const isMountedRef = useRef(false);
@@ -52,6 +65,12 @@ export default function LearningSessionPage() {
   ));
   const [launchStatus, setLaunchStatus] = useState('idle');
   const [launchError, setLaunchError] = useState(null);
+  const [importDraft, setImportDraft] = useState(() => createImportedQuestionDraft());
+  const [importStatus, setImportStatus] = useState('idle');
+  const [importError, setImportError] = useState(null);
+  const [importResult, setImportResult] = useState(null);
+  const [importHandoffStatus, setImportHandoffStatus] = useState('idle');
+  const [importHandoffError, setImportHandoffError] = useState(null);
   const [askMessage, setAskMessage] = useState('');
   const [askStatus, setAskStatus] = useState('idle');
   const [askError, setAskError] = useState(null);
@@ -154,6 +173,19 @@ export default function LearningSessionPage() {
     setLaunchDraft(createSessionLaunchDraft(location.state.launchPayload));
   }, [isLauncherSurface, location.key, location.state]);
 
+  useEffect(() => {
+    if (!isLauncherSurface) {
+      return;
+    }
+
+    setImportDraft(createImportedQuestionDraft());
+    setImportStatus('idle');
+    setImportError(null);
+    setImportResult(null);
+    setImportHandoffStatus('idle');
+    setImportHandoffError(null);
+  }, [isLauncherSurface, launcherEntry, location.key]);
+
   async function handleLaunch() {
     if (launchStatus === 'submitting') {
       return;
@@ -225,6 +257,129 @@ export default function LearningSessionPage() {
   function handleLaunchFieldChange(patch) {
     setLaunchError(null);
     setLaunchDraft((currentDraft) => patchSessionLaunchDraft(currentDraft, patch));
+  }
+
+  function handleImportDraftChange(patch) {
+    setImportError(null);
+    setImportHandoffError(null);
+    setImportResult(null);
+    setImportDraft((currentDraft) => patchImportedQuestionDraft(currentDraft, patch));
+  }
+
+  async function handleImportQuestion() {
+    if (importStatus === 'submitting') {
+      return;
+    }
+
+    setImportStatus('submitting');
+    setImportError(null);
+    setImportHandoffError(null);
+    const importRequestKey = createRequestKey('import-request');
+    activeImportRequestKeyRef.current = importRequestKey;
+
+    try {
+      const payload = await importQuestion(
+        buildImportQuestionPayload(importDraft),
+        {
+          idempotencyKey: createRequestKey('learning-import'),
+        },
+      );
+
+      if (
+        !isMountedRef.current
+        || !isLauncherSurfaceRef.current
+        || activeImportRequestKeyRef.current !== importRequestKey
+      ) {
+        return;
+      }
+
+      startTransition(() => {
+        setImportResult(payload);
+        setImportStatus('idle');
+      });
+    } catch (requestError) {
+      if (
+        !isMountedRef.current
+        || !isLauncherSurfaceRef.current
+        || activeImportRequestKeyRef.current !== importRequestKey
+      ) {
+        return;
+      }
+
+      startTransition(() => {
+        setImportError(requestError);
+        setImportStatus('idle');
+      });
+    }
+  }
+
+  async function handleImportHandoff() {
+    if (importHandoffStatus === 'submitting') {
+      return;
+    }
+
+    const sessionPayload = buildImportedQuestionSessionPayload({
+      draft: importDraft,
+      importResult,
+    });
+
+    if (!sessionPayload) {
+      setImportHandoffError(new Error('Imported question is missing a durable question ID.'));
+      return;
+    }
+
+    setImportHandoffStatus('submitting');
+    setImportHandoffError(null);
+    const handoffRequestKey = createRequestKey('import-handoff');
+    activeImportHandoffRequestKeyRef.current = handoffRequestKey;
+
+    try {
+      const payload = await createSession(
+        sessionPayload,
+        {
+          idempotencyKey: createRequestKey('learning-import-session'),
+        },
+      );
+      const createdSessionId = payload?.session?.sessionId || null;
+
+      if (
+        !isMountedRef.current
+        || !isLauncherSurfaceRef.current
+        || activeImportHandoffRequestKeyRef.current !== handoffRequestKey
+      ) {
+        return;
+      }
+
+      startTransition(() => {
+        setSessionPayload(payload);
+        setTurnHistory([]);
+        setAskMessage('');
+        setAskError(null);
+        setImportHandoffStatus('idle');
+        setSurfaceState('ready');
+        setError(null);
+      });
+
+      if (createdSessionId) {
+        skipReloadSessionIdRef.current = createdSessionId;
+        navigate(`/learn/session/${createdSessionId}`, {
+          replace: true,
+        });
+      }
+    } catch (requestError) {
+      if (
+        !isMountedRef.current
+        || !isLauncherSurfaceRef.current
+        || activeImportHandoffRequestKeyRef.current !== handoffRequestKey
+      ) {
+        return;
+      }
+
+      startTransition(() => {
+        setImportHandoffError(requestError);
+        setImportHandoffStatus('idle');
+      });
+    }
   }
 
   function handleAskMessageChange(nextMessage) {
@@ -301,6 +456,18 @@ export default function LearningSessionPage() {
       error: askError,
     },
   });
+  const importIntake = {
+    draft: importDraft,
+    status: importStatus,
+    errorMessage: importError?.message || null,
+    canSubmit: canSubmitImportedQuestionDraft(importDraft),
+  };
+  const sessionEntryTitle = isLauncherSurface
+    ? (isImportedQuestionEntry ? 'Import question' : 'Launch session')
+    : 'Session';
+  const sessionEntryBody = isLauncherSurface && isImportedQuestionEntry
+    ? 'Paste a question, review the returned scoring posture, then hand off into a live runtime session anchored to the durable imported question.'
+    : 'Create a live runtime session from a valid anchor payload, then keep the ask loop in the same session contract instead of the legacy AskAI page flow.';
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-100">
@@ -319,11 +486,10 @@ export default function LearningSessionPage() {
               Learning Runtime
             </p>
             <h1 className="mt-3 text-4xl font-semibold tracking-tight text-slate-950">
-              {isLauncherSurface ? 'Launch session' : 'Session'}
+              {sessionEntryTitle}
             </h1>
             <p className="mt-2 text-base leading-7 text-slate-600">
-              Create a live runtime session from a valid anchor payload, then keep the ask loop in
-              the same session contract instead of the legacy AskAI page flow.
+              {sessionEntryBody}
             </p>
           </div>
         </div>
@@ -340,7 +506,26 @@ export default function LearningSessionPage() {
           </div>
         ) : null}
 
-        {surfaceState === 'ready' ? (
+        {surfaceState === 'ready' && isImportedQuestionEntry ? (
+          <div className="mb-6 grid gap-6">
+            <ImportedQuestionIntake
+              intake={importIntake}
+              onChange={handleImportDraftChange}
+              onSubmit={handleImportQuestion}
+            />
+            {importResult ? (
+              <ImportPostureBanner
+                question={importResult.question}
+                posture={importResult.scoringScopePosture}
+                handoffStatus={importHandoffStatus}
+                handoffError={importHandoffError?.message || null}
+                onStartSession={handleImportHandoff}
+              />
+            ) : null}
+          </div>
+        ) : null}
+
+        {surfaceState === 'ready' && !isImportedQuestionEntry ? (
           <LearningSessionShell
             viewModel={viewModel}
             onLauncherChange={handleLaunchFieldChange}


### PR DESCRIPTION
Closes #45

## Summary
This PR adds the missing product-level imported-question intake for the learning runtime. The old AskAI compatibility surface now routes users into a runtime-owned import entry, the runtime session page can paste/import a question through the existing `/api/learning/questions/import` client, and the UI shows the returned scoring posture before creating the question-anchored session handoff.

## User impact
Before this change, pasted questions had no product runtime entry path even though the backend import contract already existed. Users were effectively forced back toward legacy chat-first behavior. After this change, imported questions become durable runtime questions first, the returned posture stays explicit, and the user enters a real learning session anchored to that imported question rather than legacy AskAI route state.

## Implementation notes
The browser client now normalizes imported-question envelopes explicitly. A new `ImportedQuestionIntake` component owns the pasted-question payload shaping and question-anchor session payload shaping, while `ImportPostureBanner` surfaces the returned release-scope/fallback posture and controls the handoff into a guided-solve runtime session. `LearningSessionPage` owns the import-first flow on `/learn/session/new?entry=imported_question`, and `AskAI` remains a compatibility shell that links into that runtime entry path.

The intake keeps the scope narrow and reuses the existing backend import protocol. It does not reintroduce legacy Study Hub or AskAI state as runtime truth, and it keeps fallback posture explicit for non-pilot question types instead of inventing authoritative scoring in the UI.

## Verification
I first attempted the issue's exact Jest command, but this repo's Jest wrapper rejects `-v` as an unsupported option. I then ran the equivalent commands with `--verbose`.

- `npm test -- --runInBand --verbose src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/view-models.test.js src/components/learning-runtime/__tests__/ImportedQuestionIntake.test.js src/components/learning-runtime/__tests__/ImportPostureBanner.test.js src/pages/__tests__/legacy-entry-mode.test.js`
- `npm run build`
