### PR TITLE
feat: add workspace artifact lifecycle actions

### DIFF
--- a/src/api/__tests__/learningRuntimeApi.test.js
+++ b/src/api/__tests__/learningRuntimeApi.test.js
@@ -17,9 +17,14 @@ jest.unstable_mockModule('../../utils/supabase.js', () => ({
 
 const {
   learningRuntimeApi,
+  markArtifactContested,
   normalizeAskResponse,
+  normalizeArtifactResponse,
   normalizeImportQuestionResponse,
   normalizeSessionResponse,
+  pinArtifact,
+  supersedeArtifact,
+  unpinArtifact,
 } = await import('../learningRuntimeApi.js');
 
 function createSessionEnvelope() {
@@ -212,6 +217,10 @@ describe('learning runtime api', () => {
       'getWorkspace',
       'importQuestion',
       'listReviewTasks',
+      'markArtifactContested',
+      'pinArtifact',
+      'supersedeArtifact',
+      'unpinArtifact',
       'updateArtifact',
     ].sort());
   });
@@ -525,5 +534,143 @@ describe('learning runtime api', () => {
     );
     expect(payload.topicId).toBe('topic-1');
     expect(payload.items[0].reviewTaskId).toBe('review-queued-1');
+  });
+
+  test('pinArtifact and unpinArtifact send explicit placement intents and normalize slot transitions', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          artifact: {
+            artifact_id: 'artifact-note-1',
+            artifact_kind: 'free_note',
+            slot_key: 'my_notes',
+            placement_status: 'pinned',
+            lifecycle_status: 'active',
+          },
+          slot_transition: {
+            outcome: 'pinned_to_slot',
+            slot_key: 'my_notes',
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          artifact: {
+            artifact_id: 'artifact-note-1',
+            artifact_kind: 'free_note',
+            slot_key: 'my_notes',
+            placement_status: 'inbox',
+            lifecycle_status: 'active',
+          },
+          slot_transition: {
+            outcome: 'slot_cleared',
+            slot_key: 'my_notes',
+          },
+        }),
+      });
+
+    const pinned = await pinArtifact('artifact-note-1');
+    const unpinned = await unpinArtifact('artifact-note-1');
+
+    expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual({
+      intent: 'set_placement_status',
+      placement_status: 'pinned',
+    });
+    expect(JSON.parse(global.fetch.mock.calls[1][1].body)).toEqual({
+      intent: 'set_placement_status',
+      placement_status: 'inbox',
+    });
+    expect(pinned.slotTransition).toEqual({
+      outcome: 'pinned_to_slot',
+      slotKey: 'my_notes',
+    });
+    expect(unpinned.slotTransition).toEqual({
+      outcome: 'slot_cleared',
+      slotKey: 'my_notes',
+    });
+  });
+
+  test('markArtifactContested and supersedeArtifact use explicit lifecycle intents', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          artifact: {
+            artifact_id: 'artifact-contested',
+            artifact_kind: 'misconception_card',
+            slot_key: 'common_traps',
+            trust_status: 'contested',
+            placement_status: 'inbox',
+            lifecycle_status: 'active',
+          },
+          slot_transition: null,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          artifact: {
+            artifact_id: 'artifact-primary',
+            artifact_kind: 'misconception_card',
+            slot_key: 'common_traps',
+            placement_status: 'archived',
+            lifecycle_status: 'superseded',
+            superseded_by_artifact_id: 'artifact-successor',
+          },
+          slot_transition: {
+            outcome: 'moved_to_successor',
+            slot_key: 'common_traps',
+          },
+        }),
+      });
+
+    const contested = await markArtifactContested('artifact-contested');
+    const superseded = await supersedeArtifact('artifact-primary', {
+      kind: 'artifact',
+      artifact_id: 'artifact-successor',
+    });
+
+    expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual({
+      intent: 'mark_contested',
+    });
+    expect(JSON.parse(global.fetch.mock.calls[1][1].body)).toEqual({
+      intent: 'attach_superseded_by',
+      successor_artifact_ref: {
+        kind: 'artifact',
+        artifact_id: 'artifact-successor',
+      },
+    });
+    expect(contested.artifact.trustStatus).toBe('contested');
+    expect(superseded.artifact.supersededByArtifactId).toBe('artifact-successor');
+    expect(superseded.slotTransition).toEqual({
+      outcome: 'moved_to_successor',
+      slotKey: 'common_traps',
+    });
+  });
+
+  test('normalizeArtifactResponse camelizes artifact lifecycle payloads', () => {
+    const payload = normalizeArtifactResponse({
+      artifact: {
+        artifact_id: 'artifact-primary',
+        slot_key: 'common_traps',
+        superseded_by_artifact_id: 'artifact-successor',
+      },
+      slot_transition: {
+        outcome: 'slot_cleared_pending_confirmation',
+        slot_key: 'common_traps',
+      },
+    });
+
+    expect(payload.artifact).toEqual({
+      artifactId: 'artifact-primary',
+      slotKey: 'common_traps',
+      supersededByArtifactId: 'artifact-successor',
+    });
+    expect(payload.slotTransition).toEqual({
+      outcome: 'slot_cleared_pending_confirmation',
+      slotKey: 'common_traps',
+    });
   });
 });

--- a/src/api/learningRuntimeApi.js
+++ b/src/api/learningRuntimeApi.js
@@ -272,6 +272,33 @@ export async function updateArtifact(artifactId, payload) {
   }));
 }
 
+export async function pinArtifact(artifactId) {
+  return updateArtifact(artifactId, {
+    intent: 'set_placement_status',
+    placement_status: 'pinned',
+  });
+}
+
+export async function unpinArtifact(artifactId) {
+  return updateArtifact(artifactId, {
+    intent: 'set_placement_status',
+    placement_status: 'inbox',
+  });
+}
+
+export async function markArtifactContested(artifactId) {
+  return updateArtifact(artifactId, {
+    intent: 'mark_contested',
+  });
+}
+
+export async function supersedeArtifact(artifactId, successorArtifactRef) {
+  return updateArtifact(artifactId, {
+    intent: 'attach_superseded_by',
+    successor_artifact_ref: successorArtifactRef,
+  });
+}
+
 export const learningRuntimeApi = {
   createSession,
   getSession,
@@ -279,6 +306,10 @@ export const learningRuntimeApi = {
   importQuestion,
   getWorkspace,
   listReviewTasks,
+  pinArtifact,
+  unpinArtifact,
+  markArtifactContested,
+  supersedeArtifact,
   updateArtifact,
 };
 

--- a/src/components/learning-runtime/ArtifactInboxPanel.js
+++ b/src/components/learning-runtime/ArtifactInboxPanel.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import ArtifactLifecycleActions from './ArtifactLifecycleActions.js';
+import WorkspaceArtifactCard from './WorkspaceArtifactCard.js';
 
 const h = React.createElement;
 
@@ -18,7 +20,16 @@ function renderMetric(label, value) {
   ]);
 }
 
-export default function ArtifactInboxPanel({ artifactInbox }) {
+export default function ArtifactInboxPanel({
+  artifactInbox,
+  onLaunch,
+  onMarkContested,
+  onPin,
+  onSupersede,
+  onUnpin,
+  pendingArtifactId = null,
+  pendingIntent = null,
+}) {
   const metrics = [
     ['Canonical residents', artifactInbox?.populatedSlotCount ?? 0],
     ['Empty stable slots', artifactInbox?.emptySlotCount ?? 0],
@@ -27,6 +38,7 @@ export default function ArtifactInboxPanel({ artifactInbox }) {
     ['Linked references', artifactInbox?.totalLinkedReferences ?? 0],
   ];
   const hasCoverage = metrics.some(([, value]) => Number(value) > 0);
+  const items = Array.isArray(artifactInbox?.items) ? artifactInbox.items : [];
 
   return h('section', {
     className: 'rounded-3xl border border-slate-200 bg-white p-6 shadow-sm',
@@ -38,16 +50,52 @@ export default function ArtifactInboxPanel({ artifactInbox }) {
     h('p', {
       key: 'body',
       className: 'mt-2 text-sm leading-6 text-slate-600',
-    }, 'Read-only workspace coverage summary. Slot launch actions live above; artifact lifecycle writes stay out of this issue.'),
+    }, 'Visible inbox artifacts can be pinned, contested, or chosen as supersede successors without leaving the workspace.'),
     h('dl', {
       key: 'metrics',
       className: 'mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5',
     }, metrics.map(([label, value]) => renderMetric(label, value))),
+    items.length
+      ? h('div', {
+        key: 'items',
+        className: 'mt-5 space-y-4',
+      }, [
+        h('p', {
+          key: 'label',
+          className: 'text-sm font-medium text-slate-500',
+        }, 'Visible inbox artifacts'),
+        h('div', {
+          key: 'cards',
+          className: 'grid gap-4',
+        }, items.map((card) => h('div', {
+          key: card.artifactId,
+          className: 'rounded-2xl border border-slate-200 bg-slate-50 p-4',
+        }, [
+          h(WorkspaceArtifactCard, {
+            key: 'card',
+            card,
+            onLaunch,
+          }),
+          h(ArtifactLifecycleActions, {
+            key: 'actions',
+            artifact: card,
+            pendingAction: pendingArtifactId === card.artifactId ? pendingIntent : null,
+            onMarkContested,
+            onPin,
+            onSupersede,
+            onUnpin,
+          }),
+        ]))),
+      ])
+      : h('p', {
+        key: 'empty-items',
+        className: 'mt-5 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600',
+      }, 'No visible inbox artifacts are projected for this workspace yet.'),
     h('p', {
       key: 'note',
       className: 'mt-5 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600',
     }, hasCoverage
-      ? 'Canonical-home coverage is projected here for visibility only; pin, contest, and supersede actions land in later issues.'
+      ? 'Canonical-home and slot-compatibility rules stay conservative here: only visible, compatible inbox artifacts expose pin actions.'
       : 'No canonical slot coverage is projected for this workspace yet.'),
   ]);
 }

--- a/src/components/learning-runtime/ArtifactLifecycleActions.js
+++ b/src/components/learning-runtime/ArtifactLifecycleActions.js
@@ -1,0 +1,91 @@
+import React from 'react';
+
+const h = React.createElement;
+
+function renderActionButton({
+  actionKey,
+  ctaLabel,
+  onClick,
+  pendingAction,
+}) {
+  return h('button', {
+    key: actionKey,
+    type: 'button',
+    onClick,
+    disabled: Boolean(pendingAction),
+    className: 'rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:border-slate-900 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60',
+  }, pendingAction === actionKey ? `${ctaLabel}...` : ctaLabel);
+}
+
+export default function ArtifactLifecycleActions({
+  artifact,
+  pendingAction = null,
+  onMarkContested,
+  onPin,
+  onSupersede,
+  onUnpin,
+}) {
+  const availableActions = artifact?.availableActions || {};
+  const notes = [
+    availableActions.pinBlockedReason,
+    availableActions.contestedBlockedReason,
+  ].filter(Boolean);
+
+  if (
+    !availableActions.canPin
+    && !availableActions.canUnpin
+    && !availableActions.canMarkContested
+    && !availableActions.canSupersede
+    && !notes.length
+  ) {
+    return null;
+  }
+
+  return h('div', {
+    className: 'mt-3 rounded-2xl border border-slate-200 bg-white px-4 py-3',
+  }, [
+    h('div', {
+      key: 'buttons',
+      className: 'flex flex-wrap gap-2',
+    }, [
+      availableActions.canPin
+        ? renderActionButton({
+          actionKey: 'pin',
+          ctaLabel: 'Pin to slot',
+          onClick: () => onPin?.(artifact),
+          pendingAction,
+        })
+        : null,
+      availableActions.canUnpin
+        ? renderActionButton({
+          actionKey: 'unpin',
+          ctaLabel: 'Unpin',
+          onClick: () => onUnpin?.(artifact),
+          pendingAction,
+        })
+        : null,
+      availableActions.canMarkContested
+        ? renderActionButton({
+          actionKey: 'mark_contested',
+          ctaLabel: 'Mark contested',
+          onClick: () => onMarkContested?.(artifact),
+          pendingAction,
+        })
+        : null,
+      availableActions.canSupersede
+        ? renderActionButton({
+          actionKey: 'attach_superseded_by',
+          ctaLabel: 'Supersede',
+          onClick: () => onSupersede?.(artifact),
+          pendingAction,
+        })
+        : null,
+    ].filter(Boolean)),
+    notes.length
+      ? h('div', {
+        key: 'notes',
+        className: 'mt-3 space-y-1 text-sm text-slate-600',
+      }, notes.map((note) => h('p', { key: note }, note)))
+      : null,
+  ].filter(Boolean));
+}

--- a/src/components/learning-runtime/ArtifactLifecycleActions.jsx
+++ b/src/components/learning-runtime/ArtifactLifecycleActions.jsx
@@ -1,0 +1,1 @@
+export { default } from './ArtifactLifecycleActions.js';

--- a/src/components/learning-runtime/ArtifactSupersedeSheet.js
+++ b/src/components/learning-runtime/ArtifactSupersedeSheet.js
@@ -1,0 +1,123 @@
+import React from 'react';
+
+const h = React.createElement;
+
+export default function ArtifactSupersedeSheet({
+  artifact,
+  candidates = [],
+  errorMessage = null,
+  manualArtifactId = '',
+  onCancel,
+  onConfirm,
+  onManualArtifactIdChange,
+  onSelectCandidate,
+  pending = false,
+  selectedArtifactId = '',
+}) {
+  if (!artifact) {
+    return null;
+  }
+
+  return h('section', {
+    className: 'rounded-3xl border border-slate-200 bg-white p-6 shadow-sm',
+  }, [
+    h('div', {
+      key: 'header',
+      className: 'flex items-start justify-between gap-4',
+    }, [
+      h('div', { key: 'copy' }, [
+        h('p', {
+          key: 'eyebrow',
+          className: 'text-sm font-medium uppercase tracking-[0.24em] text-slate-500',
+        }, 'Supersede artifact'),
+        h('h2', {
+          key: 'title',
+          className: 'mt-2 text-xl font-semibold tracking-tight text-slate-950',
+        }, artifact.title || artifact.artifactId),
+        h('p', {
+          key: 'body',
+          className: 'mt-2 text-sm leading-6 text-slate-600',
+        }, 'Choose a visible successor or enter an artifact ID from the same canonical-home slot. Conflicts are rejected explicitly by the runtime contract.'),
+      ]),
+      h('button', {
+        key: 'close',
+        type: 'button',
+        onClick: () => onCancel?.(),
+        className: 'rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:border-slate-900 hover:text-slate-900',
+      }, 'Close'),
+    ]),
+    candidates.length
+      ? h('div', {
+        key: 'candidates',
+        className: 'mt-5 space-y-2',
+      }, candidates.map((candidate) => h('label', {
+        key: candidate.artifactId,
+        className: 'flex cursor-pointer items-start gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700',
+      }, [
+        h('input', {
+          key: 'radio',
+          type: 'radio',
+          name: 'artifact-successor',
+          checked: selectedArtifactId === candidate.artifactId,
+          onChange: () => onSelectCandidate?.(candidate.artifactId),
+        }),
+        h('div', { key: 'copy' }, [
+          h('p', {
+            key: 'title',
+            className: 'font-semibold text-slate-900',
+          }, candidate.title || candidate.artifactId),
+          candidate.description
+            ? h('p', {
+              key: 'description',
+              className: 'mt-1 text-sm text-slate-600',
+            }, candidate.description)
+            : null,
+        ].filter(Boolean)),
+      ])))
+      : h('p', {
+        key: 'empty',
+        className: 'mt-5 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600',
+      }, 'No visible successor candidates are projected for this slot yet.'),
+    h('label', {
+      key: 'manual',
+      className: 'mt-5 block text-sm text-slate-700',
+    }, [
+      h('span', {
+        key: 'label',
+        className: 'font-medium text-slate-900',
+      }, 'Manual successor artifact ID'),
+      h('input', {
+        key: 'input',
+        type: 'text',
+        value: manualArtifactId,
+        onChange: (event) => onManualArtifactIdChange?.(event.target.value),
+        placeholder: 'artifact-successor-id',
+        className: 'mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-slate-900 focus:outline-none',
+      }),
+    ]),
+    errorMessage
+      ? h('p', {
+        key: 'error',
+        className: 'mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700',
+      }, errorMessage)
+      : null,
+    h('div', {
+      key: 'footer',
+      className: 'mt-5 flex flex-wrap gap-2',
+    }, [
+      h('button', {
+        key: 'confirm',
+        type: 'button',
+        onClick: () => onConfirm?.(),
+        disabled: pending,
+        className: 'rounded-full border border-slate-900 bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60',
+      }, pending ? 'Superseding...' : 'Confirm supersede'),
+      h('button', {
+        key: 'cancel',
+        type: 'button',
+        onClick: () => onCancel?.(),
+        className: 'rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-900 hover:text-slate-900',
+      }, 'Cancel'),
+    ]),
+  ]);
+}

--- a/src/components/learning-runtime/ArtifactSupersedeSheet.jsx
+++ b/src/components/learning-runtime/ArtifactSupersedeSheet.jsx
@@ -1,0 +1,1 @@
+export { default } from './ArtifactSupersedeSheet.js';

--- a/src/components/learning-runtime/StableSlotPanel.js
+++ b/src/components/learning-runtime/StableSlotPanel.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ArtifactLifecycleActions from './ArtifactLifecycleActions.js';
 import LinkedReferenceList from './LinkedReferenceList.js';
 import WorkspaceArtifactCard from './WorkspaceArtifactCard.js';
 
@@ -12,13 +13,13 @@ function toneClassName(tone) {
   return 'border-slate-200 bg-slate-50 text-slate-700';
 }
 
-function renderSurfaceState(surfaceState) {
+function renderSurfaceState(surfaceState, key = 'surface-state') {
   if (!surfaceState || !surfaceState.message) {
     return null;
   }
 
   return h('section', {
-    key: 'surface-state',
+    key,
     className: `mt-5 rounded-2xl border px-4 py-3 text-sm ${toneClassName(surfaceState.tone)}`,
   }, [
     h('p', {
@@ -51,8 +52,18 @@ function renderEmptyState(slot) {
   ]);
 }
 
-export default function StableSlotPanel({ onLaunch, slot }) {
+export default function StableSlotPanel({
+  onLaunch,
+  onMarkContested,
+  onPin,
+  onSupersede,
+  onUnpin,
+  pendingArtifactId = null,
+  pendingIntent = null,
+  slot,
+}) {
   const slotLaunch = slot?.slotLaunch || null;
+  const primaryArtifactCard = slot?.primaryArtifactCard || null;
 
   return h('section', {
     className: 'rounded-3xl border border-slate-200 bg-white p-6 shadow-sm',
@@ -87,12 +98,27 @@ export default function StableSlotPanel({ onLaunch, slot }) {
         : null,
     ].filter(Boolean)),
     renderSurfaceState(slot?.surfaceState),
-    slot?.primaryArtifactCard
-      ? h(WorkspaceArtifactCard, {
+    renderSurfaceState(slot?.transitionState, 'transition-state'),
+    primaryArtifactCard
+      ? h('div', {
+        key: 'primary-card-wrap',
+        className: 'mt-5',
+      }, [
+        h(WorkspaceArtifactCard, {
         key: 'primary-card',
-        card: slot.primaryArtifactCard,
+        card: primaryArtifactCard,
         onLaunch,
-      })
+        }),
+        h(ArtifactLifecycleActions, {
+          key: 'primary-actions',
+          artifact: primaryArtifactCard,
+          pendingAction: pendingArtifactId === primaryArtifactCard.artifactId ? pendingIntent : null,
+          onMarkContested,
+          onPin,
+          onSupersede,
+          onUnpin,
+        }),
+      ])
       : h('div', {
         key: 'empty-card',
       }, renderEmptyState(slot)),

--- a/src/components/learning-runtime/WorkspaceShell.js
+++ b/src/components/learning-runtime/WorkspaceShell.js
@@ -1,9 +1,438 @@
 import React from 'react';
+import { isCompatibleArtifactKindForSlot } from '../../../api/learning/lib/contracts/runtime-contract.js';
+import {
+  markArtifactContested,
+  pinArtifact,
+  supersedeArtifact,
+  unpinArtifact,
+} from '../../api/learningRuntimeApi.js';
 import ArtifactInboxPanel from './ArtifactInboxPanel.js';
+import ArtifactSupersedeSheet from './ArtifactSupersedeSheet.js';
 import ReviewQueuePanel from './ReviewQueuePanel.js';
 import StableSlotPanel from './StableSlotPanel.js';
 
 const h = React.createElement;
+
+function labelFromToken(token, fallback = 'workspace') {
+  if (typeof token !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = token.trim();
+  return (trimmed || fallback).replace(/_/g, ' ');
+}
+
+function toneClassName(tone) {
+  if (tone === 'warning') {
+    return 'border-amber-200 bg-amber-50 text-amber-900';
+  }
+
+  if (tone === 'error') {
+    return 'border-rose-200 bg-rose-50 text-rose-700';
+  }
+
+  return 'border-slate-200 bg-slate-50 text-slate-700';
+}
+
+function cloneViewModel(viewModel) {
+  if (!viewModel) {
+    return viewModel;
+  }
+
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(viewModel);
+  }
+
+  return JSON.parse(JSON.stringify(viewModel));
+}
+
+function getSlotDescription(slotKey) {
+  return labelFromToken(slotKey, 'workspace slot');
+}
+
+function buildArtifactState(card) {
+  if (card?.lifecycleStatus === 'superseded') {
+    return {
+      value: 'superseded',
+      label: 'Superseded artifact',
+      tone: 'warning',
+      message: 'This artifact is historical lineage and no longer occupies an active slot.',
+    };
+  }
+
+  if (card?.trustStatus === 'contested') {
+    return {
+      value: 'contested',
+      label: 'Contested artifact',
+      tone: 'warning',
+      message: 'This artifact is contested and cannot be pinned until the conflict is resolved.',
+    };
+  }
+
+  if (card?.placementStatus === 'archived') {
+    return {
+      value: 'archived',
+      label: 'Archived artifact',
+      tone: 'neutral',
+      message: 'Archived artifacts stay visible for lineage but do not occupy a stable slot.',
+    };
+  }
+
+  return card?.state?.value === 'missing_content' ? card.state : null;
+}
+
+function buildAvailableActions(card, workspaceTopicId) {
+  const sameCanonicalHome =
+    !card?.canonicalHomeTopicId || card.canonicalHomeTopicId === workspaceTopicId;
+  const hasCompatibleSlotMetadata =
+    Boolean(card?.slotKey)
+    && Boolean(card?.artifactKind)
+    && isCompatibleArtifactKindForSlot(card.slotKey, card.artifactKind);
+  const canPin =
+    card?.source === 'artifact_inbox'
+    && sameCanonicalHome
+    && card?.placementStatus !== 'pinned'
+    && card?.lifecycleStatus !== 'superseded'
+    && card?.trustStatus !== 'contested'
+    && Boolean(card?.slotKey)
+    && card?.slotKey !== 'review_queue'
+    && hasCompatibleSlotMetadata;
+
+  return {
+    canPin,
+    canUnpin: card?.placementStatus === 'pinned',
+    canMarkContested:
+      card?.lifecycleStatus !== 'superseded'
+      && card?.trustStatus !== 'contested'
+      && card?.placementStatus !== 'pinned',
+    canSupersede: Boolean(card?.artifactId) && card?.lifecycleStatus !== 'superseded',
+    pinBlockedReason:
+      canPin
+        ? null
+        : !sameCanonicalHome
+          ? 'Secondary-topic artifacts cannot be pinned into this workspace.'
+          : card?.trustStatus === 'contested'
+            ? 'Contested artifacts cannot be pinned.'
+            : card?.lifecycleStatus === 'superseded'
+              ? 'Superseded artifacts cannot be pinned.'
+              : card?.slotKey === 'review_queue'
+                ? 'Review queue does not accept artifact residency.'
+                : card?.source === 'artifact_inbox' && !hasCompatibleSlotMetadata
+                  ? 'This artifact is not compatible with its slot contract.'
+                  : card?.placementStatus === 'pinned'
+                    ? 'This artifact is already pinned.'
+                    : null,
+    contestedBlockedReason:
+      card?.placementStatus === 'pinned' ? 'Unpin before marking contested.' : null,
+  };
+}
+
+function refreshCard(card, artifact = {}, viewModel, overrides = {}) {
+  const workspaceTopicId = viewModel?.workspace?.topicId ?? null;
+  const updatedAtLabel = artifact.updatedAt
+    ? `Updated ${artifact.updatedAt}`
+    : overrides.updatedAtLabel ?? card?.updatedAtLabel ?? null;
+  const nextCard = {
+    ...card,
+    ...overrides,
+    artifactId: artifact.artifactId ?? overrides.artifactId ?? card?.artifactId,
+    artifactKind: artifact.artifactKind ?? overrides.artifactKind ?? card?.artifactKind ?? null,
+    canonicalHomeTopicId:
+      artifact.canonicalHomeTopicId
+      ?? overrides.canonicalHomeTopicId
+      ?? card?.canonicalHomeTopicId
+      ?? workspaceTopicId,
+    placementStatus:
+      artifact.placementStatus ?? overrides.placementStatus ?? card?.placementStatus ?? 'inbox',
+    trustStatus: artifact.trustStatus ?? overrides.trustStatus ?? card?.trustStatus ?? null,
+    lifecycleStatus:
+      artifact.lifecycleStatus ?? overrides.lifecycleStatus ?? card?.lifecycleStatus ?? 'active',
+    slotKey: artifact.slotKey ?? overrides.slotKey ?? card?.slotKey ?? null,
+    source: overrides.source ?? card?.source ?? 'artifact_inbox',
+    updatedAtLabel,
+  };
+
+  nextCard.state = overrides.state ?? buildArtifactState(nextCard);
+  nextCard.availableActions = buildAvailableActions(nextCard, workspaceTopicId);
+  return nextCard;
+}
+
+function buildFallbackCard(viewModel, artifactId, slotKey, overrides = {}) {
+  return refreshCard({
+    artifactId,
+    title: artifactId,
+    kindLabel: 'Artifact',
+    placementLabel: 'Canonical resident',
+    description: `Pinned to the canonical ${getSlotDescription(slotKey)} slot for this topic.`,
+    slotKey,
+    slotTitle: labelFromToken(slotKey),
+    source: 'slot_primary',
+    placementStatus: 'pinned',
+    lifecycleStatus: 'active',
+    canonicalHomeTopicId: viewModel?.workspace?.topicId ?? null,
+  }, {}, viewModel, overrides);
+}
+
+function assignSlot(nextViewModel, slotKey, nextSlot) {
+  if (!slotKey || !nextViewModel?.slots) {
+    return;
+  }
+
+  nextViewModel.slots[slotKey] = nextSlot;
+  if (Array.isArray(nextViewModel.slotList)) {
+    nextViewModel.slotList = nextViewModel.slotList.map((slot) => (
+      slot?.slotKey === slotKey ? nextSlot : slot
+    ));
+  }
+}
+
+function removeInboxArtifact(items, artifactId) {
+  return (Array.isArray(items) ? items : []).filter((card) => card.artifactId !== artifactId);
+}
+
+function upsertInboxArtifact(items, card) {
+  const nextItems = removeInboxArtifact(items, card.artifactId);
+  return [...nextItems, card];
+}
+
+function recalcArtifactInbox(nextViewModel) {
+  if (!nextViewModel?.artifactInbox) {
+    return nextViewModel;
+  }
+
+  nextViewModel.artifactInbox.populatedSlotCount = nextViewModel.slotList.filter((slot) => slot.primaryArtifact).length;
+  nextViewModel.artifactInbox.emptySlotCount = nextViewModel.slotList.filter((slot) => !slot.primaryArtifact).length;
+  nextViewModel.artifactInbox.staleSlotCount = nextViewModel.slotList.filter((slot) => slot.surfaceState?.value === 'stale').length;
+  nextViewModel.artifactInbox.missingContentCount = nextViewModel.slotList.filter((slot) => slot.contentState).length;
+  return nextViewModel;
+}
+
+function resetSlotTransitions(nextViewModel) {
+  if (!nextViewModel?.slots) {
+    return nextViewModel;
+  }
+
+  Object.entries(nextViewModel.slots).forEach(([slotKey, slot]) => {
+    assignSlot(nextViewModel, slotKey, {
+      ...slot,
+      transitionState: null,
+    });
+  });
+
+  return nextViewModel;
+}
+
+function buildTransitionState(slotTransition, artifact) {
+  switch (slotTransition?.outcome) {
+    case 'pinned_to_slot':
+      return {
+        value: 'pinned_to_slot',
+        label: 'Slot updated',
+        tone: 'neutral',
+        message: `Pinned ${artifact?.artifactId} to ${getSlotDescription(slotTransition.slotKey)}.`,
+      };
+    case 'slot_cleared':
+      return {
+        value: 'slot_cleared',
+        label: 'Slot cleared',
+        tone: 'neutral',
+        message: `${getSlotDescription(slotTransition.slotKey)} no longer has a pinned resident.`,
+      };
+    case 'moved_to_successor':
+      return {
+        value: 'moved_to_successor',
+        label: 'Slot updated',
+        tone: 'neutral',
+        message: `Pinned residency moved to ${artifact?.supersededByArtifactId}.`,
+      };
+    case 'slot_cleared_pending_confirmation':
+      return {
+        value: 'slot_cleared_pending_confirmation',
+        label: 'Slot cleared',
+        tone: 'warning',
+        message: 'The pinned resident was superseded and the slot now needs an explicit replacement.',
+      };
+    default:
+      return null;
+  }
+}
+
+function findArtifactCard(viewModel, artifactId) {
+  if (!artifactId || !viewModel) {
+    return null;
+  }
+
+  const slotCard = Object.values(viewModel.slots || {}).find(
+    (slot) => slot?.primaryArtifactCard?.artifactId === artifactId,
+  )?.primaryArtifactCard;
+  if (slotCard) {
+    return slotCard;
+  }
+
+  return (Array.isArray(viewModel.artifactInbox?.items) ? viewModel.artifactInbox.items : []).find(
+    (card) => card.artifactId === artifactId,
+  ) || null;
+}
+
+export function getArtifactSupersedeCandidates(viewModel, artifactCard) {
+  const workspaceTopicId = viewModel?.workspace?.topicId ?? null;
+  const items = Array.isArray(viewModel?.artifactInbox?.items) ? viewModel.artifactInbox.items : [];
+
+  return items.filter((card) => (
+    card.artifactId !== artifactCard?.artifactId
+    && card.slotKey === artifactCard?.slotKey
+    && (card.canonicalHomeTopicId ?? workspaceTopicId) === (artifactCard?.canonicalHomeTopicId ?? workspaceTopicId)
+    && card.lifecycleStatus !== 'superseded'
+    && card.trustStatus !== 'contested'
+    && card.placementStatus !== 'archived'
+  ));
+}
+
+export function applyArtifactLifecycleUpdate(viewModel, payload = {}) {
+  const nextViewModel = recalcArtifactInbox(resetSlotTransitions(cloneViewModel(viewModel)));
+  const artifact = payload.artifact || null;
+  const slotTransition = payload.slotTransition || null;
+  const slotKey = slotTransition?.slotKey ?? artifact?.slotKey ?? null;
+  const currentSlot = slotKey ? nextViewModel?.slots?.[slotKey] : null;
+  const currentPrimaryCard = currentSlot?.primaryArtifactCard || null;
+  const currentInboxItems = Array.isArray(nextViewModel?.artifactInbox?.items)
+    ? nextViewModel.artifactInbox.items
+    : [];
+
+  if (artifact && artifact.artifactId) {
+    nextViewModel.artifactInbox.items = currentInboxItems.map((card) => (
+      card.artifactId === artifact.artifactId
+        ? refreshCard(card, artifact, nextViewModel)
+        : card
+    ));
+  }
+
+  if (!slotKey || !currentSlot) {
+    return recalcArtifactInbox(nextViewModel);
+  }
+
+  const transitionState = buildTransitionState(slotTransition, artifact);
+
+  if (slotTransition?.outcome === 'pinned_to_slot') {
+    const pinnedCard = refreshCard(
+      findArtifactCard(nextViewModel, artifact?.artifactId) || buildFallbackCard(nextViewModel, artifact?.artifactId, slotKey),
+      artifact,
+      nextViewModel,
+      {
+        placementLabel: 'Canonical resident',
+        description: 'Pinned to the canonical slot for this topic.',
+        placementStatus: 'pinned',
+        source: 'slot_primary',
+      },
+    );
+
+    assignSlot(nextViewModel, slotKey, {
+      ...currentSlot,
+      primaryArtifact: {
+        kind: 'artifact',
+        artifactId: pinnedCard.artifactId,
+        label: pinnedCard.title,
+      },
+      primaryArtifactCard: pinnedCard,
+      emptyState: null,
+      transitionState,
+    });
+    nextViewModel.artifactInbox.items = removeInboxArtifact(nextViewModel.artifactInbox.items, pinnedCard.artifactId);
+  } else if (slotTransition?.outcome === 'slot_cleared') {
+    const inboxCard = refreshCard(currentPrimaryCard, artifact, nextViewModel, {
+      placementLabel: 'Artifact inbox',
+      description: `Eligible for ${getSlotDescription(slotKey)} residency.`,
+      placementStatus: 'inbox',
+      source: 'artifact_inbox',
+    });
+
+    assignSlot(nextViewModel, slotKey, {
+      ...currentSlot,
+      primaryArtifact: null,
+      primaryArtifactCard: null,
+      emptyState: {
+        label: 'Empty slot',
+        message: 'No canonical artifact is pinned to this slot yet.',
+      },
+      transitionState,
+    });
+    nextViewModel.artifactInbox.items = upsertInboxArtifact(nextViewModel.artifactInbox.items, inboxCard);
+  } else if (slotTransition?.outcome === 'moved_to_successor') {
+    const successorId = artifact?.supersededByArtifactId;
+    const successorCard = refreshCard(
+      findArtifactCard(nextViewModel, successorId) || buildFallbackCard(nextViewModel, successorId, slotKey),
+      {
+        artifactId: successorId,
+        canonicalHomeTopicId: artifact?.canonicalHomeTopicId,
+        placementStatus: 'pinned',
+        lifecycleStatus: 'active',
+        slotKey,
+      },
+      nextViewModel,
+      {
+        placementLabel: 'Canonical resident',
+        description: 'Pinned to the canonical slot for this topic.',
+        source: 'slot_primary',
+      },
+    );
+
+    assignSlot(nextViewModel, slotKey, {
+      ...currentSlot,
+      primaryArtifact: {
+        kind: 'artifact',
+        artifactId: successorCard.artifactId,
+        label: successorCard.title,
+      },
+      primaryArtifactCard: successorCard,
+      emptyState: null,
+      transitionState,
+    });
+    nextViewModel.artifactInbox.items = removeInboxArtifact(nextViewModel.artifactInbox.items, successorId);
+    nextViewModel.artifactInbox.items = removeInboxArtifact(nextViewModel.artifactInbox.items, artifact?.artifactId);
+  } else if (slotTransition?.outcome === 'slot_cleared_pending_confirmation') {
+    assignSlot(nextViewModel, slotKey, {
+      ...currentSlot,
+      primaryArtifact: null,
+      primaryArtifactCard: null,
+      emptyState: {
+        label: 'Empty slot',
+        message: 'No canonical artifact is pinned to this slot yet.',
+      },
+      transitionState,
+    });
+    nextViewModel.artifactInbox.items = removeInboxArtifact(nextViewModel.artifactInbox.items, artifact?.artifactId);
+  } else if (artifact?.trustStatus === 'contested') {
+    nextViewModel.artifactInbox.items = nextViewModel.artifactInbox.items.map((card) => (
+      card.artifactId === artifact.artifactId
+        ? refreshCard(card, artifact, nextViewModel)
+        : card
+    ));
+  }
+
+  return recalcArtifactInbox(nextViewModel);
+}
+
+export function applyArtifactLifecycleError(viewModel, artifactCard, error = {}) {
+  const nextViewModel = resetSlotTransitions(cloneViewModel(viewModel));
+  const slotKey = artifactCard?.slotKey;
+  const currentSlot = slotKey ? nextViewModel?.slots?.[slotKey] : null;
+
+  if (!slotKey || !currentSlot) {
+    return nextViewModel;
+  }
+
+  assignSlot(nextViewModel, slotKey, {
+    ...currentSlot,
+    transitionState: {
+      value: error?.code ?? 'runtime_error',
+      label: error?.code === 'artifact_state_conflict' ? 'Runtime conflict' : 'Runtime error',
+      tone: 'warning',
+      message: error?.message || 'The artifact lifecycle update failed.',
+    },
+  });
+
+  return nextViewModel;
+}
 
 function renderWorkspaceHeader(workspace) {
   return h('section', {
@@ -26,26 +455,195 @@ function renderWorkspaceHeader(workspace) {
 }
 
 export default function WorkspaceShell({ onLaunch, viewModel }) {
-  const slotList = Array.isArray(viewModel?.slotList) ? viewModel.slotList : [];
+  const [localViewModel, setLocalViewModel] = React.useState(viewModel);
+  const [feedback, setFeedback] = React.useState(null);
+  const [pendingMutation, setPendingMutation] = React.useState(null);
+  const [supersedeState, setSupersedeState] = React.useState(null);
+
+  React.useEffect(() => {
+    setLocalViewModel(viewModel);
+    setFeedback(null);
+    setPendingMutation(null);
+    setSupersedeState(null);
+  }, [viewModel]);
+
+  const slotList = Array.isArray(localViewModel?.slotList) ? localViewModel.slotList : [];
+
+  async function runLifecycleMutation(intent, artifactCard, options = {}) {
+    if (!artifactCard?.artifactId) {
+      return;
+    }
+
+    setPendingMutation({
+      artifactId: artifactCard.artifactId,
+      intent,
+    });
+    setFeedback(null);
+
+    try {
+      let result;
+      if (intent === 'pin') {
+        result = await pinArtifact(artifactCard.artifactId);
+      } else if (intent === 'unpin') {
+        result = await unpinArtifact(artifactCard.artifactId);
+      } else if (intent === 'mark_contested') {
+        result = await markArtifactContested(artifactCard.artifactId);
+      } else {
+        result = await supersedeArtifact(artifactCard.artifactId, options.successorArtifactRef);
+      }
+
+      setLocalViewModel((current) => applyArtifactLifecycleUpdate(current, result));
+      setFeedback({
+        tone: result?.slotTransition?.outcome === 'slot_cleared_pending_confirmation' ? 'warning' : 'neutral',
+        label: result?.slotTransition ? 'Workspace updated' : 'Artifact updated',
+        message:
+          result?.slotTransition?.outcome === 'moved_to_successor'
+            ? `Superseded ${artifactCard.title || artifactCard.artifactId}; pinned residency moved to ${result.artifact?.supersededByArtifactId}.`
+            : result?.slotTransition?.outcome === 'slot_cleared_pending_confirmation'
+              ? `Superseded ${artifactCard.title || artifactCard.artifactId}; the slot is now empty pending an explicit replacement.`
+              : result?.slotTransition?.outcome === 'slot_cleared'
+                ? `Unpinned ${artifactCard.title || artifactCard.artifactId}; the slot is now empty.`
+                : result?.slotTransition?.outcome === 'pinned_to_slot'
+                  ? `Pinned ${artifactCard.title || artifactCard.artifactId} into ${getSlotDescription(result.slotTransition.slotKey)}.`
+                  : result?.artifact?.trustStatus === 'contested'
+                    ? `Marked ${artifactCard.title || artifactCard.artifactId} contested.`
+                    : 'Artifact lifecycle update applied.',
+      });
+      if (intent === 'attach_superseded_by') {
+        setSupersedeState(null);
+      }
+    } catch (error) {
+      setLocalViewModel((current) => applyArtifactLifecycleError(current, artifactCard, error));
+      setFeedback({
+        tone: error?.code === 'artifact_state_conflict' ? 'warning' : 'error',
+        label: error?.code === 'artifact_state_conflict' ? 'Runtime conflict' : 'Runtime error',
+        message: error?.message || 'Artifact lifecycle update failed.',
+      });
+
+      if (intent === 'attach_superseded_by') {
+        setSupersedeState((current) => (
+          current
+            ? {
+              ...current,
+              errorMessage: error?.message || 'Artifact lifecycle update failed.',
+            }
+            : current
+        ));
+      }
+    } finally {
+      setPendingMutation(null);
+    }
+  }
+
+  function handleOpenSupersede(artifactCard) {
+    const candidates = getArtifactSupersedeCandidates(localViewModel, artifactCard);
+    setSupersedeState({
+      artifactId: artifactCard.artifactId,
+      selectedArtifactId: candidates[0]?.artifactId ?? '',
+      manualArtifactId: '',
+      errorMessage: null,
+    });
+  }
+
+  function handleConfirmSupersede() {
+    const artifactCard = findArtifactCard(localViewModel, supersedeState?.artifactId);
+    const successorArtifactId = (supersedeState?.manualArtifactId || supersedeState?.selectedArtifactId || '').trim();
+
+    if (!artifactCard) {
+      setSupersedeState(null);
+      return;
+    }
+
+    if (!successorArtifactId) {
+      setSupersedeState((current) => ({
+        ...current,
+        errorMessage: 'Select a successor or enter an artifact ID before confirming.',
+      }));
+      return;
+    }
+
+    runLifecycleMutation('attach_superseded_by', artifactCard, {
+      successorArtifactRef: {
+        kind: 'artifact',
+        artifact_id: successorArtifactId,
+      },
+    });
+  }
 
   return h('div', { className: 'grid gap-6' }, [
     renderWorkspaceHeader(viewModel?.workspace || {}),
+    feedback
+      ? h('section', {
+        key: 'feedback',
+        className: `rounded-3xl border px-5 py-4 text-sm ${toneClassName(feedback.tone)}`,
+      }, [
+        h('p', {
+          key: 'label',
+          className: 'font-semibold',
+        }, feedback.label),
+        h('p', {
+          key: 'message',
+          className: 'mt-1 leading-6',
+        }, feedback.message),
+      ])
+      : null,
+    supersedeState
+      ? h(ArtifactSupersedeSheet, {
+        key: 'supersede-sheet',
+        artifact: findArtifactCard(localViewModel, supersedeState.artifactId),
+        candidates: getArtifactSupersedeCandidates(
+          localViewModel,
+          findArtifactCard(localViewModel, supersedeState.artifactId),
+        ),
+        errorMessage: supersedeState.errorMessage,
+        manualArtifactId: supersedeState.manualArtifactId,
+        onCancel: () => setSupersedeState(null),
+        onConfirm: handleConfirmSupersede,
+        onManualArtifactIdChange: (manualArtifactId) => setSupersedeState((current) => ({
+          ...current,
+          manualArtifactId,
+          errorMessage: null,
+        })),
+        onSelectCandidate: (selectedArtifactId) => setSupersedeState((current) => ({
+          ...current,
+          selectedArtifactId,
+          errorMessage: null,
+        })),
+        pending:
+          pendingMutation?.artifactId === supersedeState.artifactId
+          && pendingMutation?.intent === 'attach_superseded_by',
+        selectedArtifactId: supersedeState.selectedArtifactId,
+      })
+      : null,
     h('section', { key: 'slots', className: 'grid gap-4 lg:grid-cols-2' }, slotList.map((slot) => h(
       StableSlotPanel,
       {
         key: slot.slotKey,
         onLaunch,
+        onMarkContested: (artifactCard) => runLifecycleMutation('mark_contested', artifactCard),
+        onPin: (artifactCard) => runLifecycleMutation('pin', artifactCard),
+        onSupersede: handleOpenSupersede,
+        onUnpin: (artifactCard) => runLifecycleMutation('unpin', artifactCard),
+        pendingArtifactId: pendingMutation?.artifactId ?? null,
+        pendingIntent: pendingMutation?.intent ?? null,
         slot,
       },
     ))),
     h('div', { key: 'secondary', className: 'grid gap-4 lg:grid-cols-2' }, [
       h(ArtifactInboxPanel, {
         key: 'artifact-inbox',
-        artifactInbox: viewModel?.artifactInbox || {},
+        artifactInbox: localViewModel?.artifactInbox || {},
+        onLaunch,
+        onMarkContested: (artifactCard) => runLifecycleMutation('mark_contested', artifactCard),
+        onPin: (artifactCard) => runLifecycleMutation('pin', artifactCard),
+        onSupersede: handleOpenSupersede,
+        onUnpin: (artifactCard) => runLifecycleMutation('unpin', artifactCard),
+        pendingArtifactId: pendingMutation?.artifactId ?? null,
+        pendingIntent: pendingMutation?.intent ?? null,
       }),
       h(ReviewQueuePanel, {
         key: 'review-queue',
-        reviewQueue: viewModel?.reviewQueue || {},
+        reviewQueue: localViewModel?.reviewQueue || {},
       }),
     ]),
   ]);

--- a/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
+++ b/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
@@ -1,7 +1,21 @@
+import { jest } from '@jest/globals';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import WorkspaceShell from '../WorkspaceShell.js';
 import { buildWorkspaceViewModel } from '../view-models/workspace-view-model.js';
+
+jest.unstable_mockModule('../../../api/learningRuntimeApi.js', () => ({
+  markArtifactContested: jest.fn(),
+  pinArtifact: jest.fn(),
+  supersedeArtifact: jest.fn(),
+  unpinArtifact: jest.fn(),
+}));
+
+const {
+  default: WorkspaceShell,
+  applyArtifactLifecycleError,
+  applyArtifactLifecycleUpdate,
+  getArtifactSupersedeCandidates,
+} = await import('../WorkspaceShell.js');
 
 function createWorkspacePayload() {
   return {
@@ -18,6 +32,52 @@ function createWorkspacePayload() {
       },
       linkedReferenceSummary: {
         totalLinkedReferences: 3,
+      },
+      artifactInbox: {
+        items: [
+          {
+            artifactId: 'artifact-successor',
+            artifactKind: 'misconception_card',
+            canonicalHomeTopicId: 'topic-trig-equations',
+            slotKey: 'common_traps',
+            placementStatus: 'inbox',
+            trustStatus: 'grounded',
+            lifecycleStatus: 'active',
+            updatedAt: '2026-03-22T07:56:00.000Z',
+            summary: 'Candidate successor for the canonical misconception slot.',
+          },
+          {
+            artifactId: 'artifact-note-1',
+            artifactKind: 'free_note',
+            canonicalHomeTopicId: 'topic-trig-equations',
+            slotKey: 'my_notes',
+            placementStatus: 'inbox',
+            trustStatus: 'user_confirmed',
+            lifecycleStatus: 'active',
+            updatedAt: '2026-03-22T07:57:00.000Z',
+            title: 'My note candidate',
+          },
+          {
+            artifactId: 'artifact-cross-topic',
+            artifactKind: 'misconception_card',
+            canonicalHomeTopicId: 'topic-trig-identities',
+            slotKey: 'common_traps',
+            placementStatus: 'inbox',
+            trustStatus: 'grounded',
+            lifecycleStatus: 'active',
+            updatedAt: '2026-03-22T07:55:00.000Z',
+          },
+          {
+            artifactId: 'artifact-contested',
+            artifactKind: 'misconception_card',
+            canonicalHomeTopicId: 'topic-trig-equations',
+            slotKey: 'common_traps',
+            placementStatus: 'inbox',
+            trustStatus: 'contested',
+            lifecycleStatus: 'active',
+            updatedAt: '2026-03-22T07:54:00.000Z',
+          },
+        ],
       },
       updatedAt: '2026-03-22T08:00:00.000Z',
       slots: {
@@ -126,7 +186,75 @@ describe('WorkspaceShell', () => {
     expect(html).toContain('Missing artifact content');
     expect(html).toContain('No canonical artifact is pinned to this slot yet.');
     expect(html).toContain('Artifact inbox');
+    expect(html).toContain('Visible inbox artifacts');
+    expect(html).toContain('artifact-successor');
+    expect(html).toContain('Pin to slot');
+    expect(html).toContain('Unpin');
+    expect(html).toContain('Mark contested');
+    expect(html).toContain('Supersede');
+    expect(html).toContain('Unpin before marking contested.');
     expect(html).toContain('Review queue');
     expect(html).toContain('redo variant');
+  });
+
+  test('getArtifactSupersedeCandidates keeps successor choices conservative', () => {
+    const workspaceVm = buildWorkspaceViewModel(createWorkspacePayload());
+
+    expect(
+      getArtifactSupersedeCandidates(
+        workspaceVm,
+        workspaceVm.slots.common_traps.primaryArtifactCard,
+      ).map((card) => card.artifactId),
+    ).toEqual(['artifact-successor']);
+  });
+
+  test('applyArtifactLifecycleUpdate moves a pinned slot to the successor and removes the candidate from inbox', () => {
+    const workspaceVm = buildWorkspaceViewModel(createWorkspacePayload());
+
+    const next = applyArtifactLifecycleUpdate(workspaceVm, {
+      artifact: {
+        artifactId: 'artifact-primary',
+        artifactKind: 'misconception_card',
+        canonicalHomeTopicId: 'topic-trig-equations',
+        slotKey: 'common_traps',
+        placementStatus: 'archived',
+        lifecycleStatus: 'superseded',
+        supersededByArtifactId: 'artifact-successor',
+      },
+      slotTransition: {
+        outcome: 'moved_to_successor',
+        slotKey: 'common_traps',
+      },
+    });
+
+    expect(next.slots.common_traps.primaryArtifactCard.artifactId).toBe('artifact-successor');
+    expect(next.slots.common_traps.emptyState).toBeNull();
+    expect(next.slots.common_traps.transitionState).toEqual({
+      value: 'moved_to_successor',
+      label: 'Slot updated',
+      tone: 'neutral',
+      message: 'Pinned residency moved to artifact-successor.',
+    });
+    expect(next.artifactInbox.items.map((card) => card.artifactId)).not.toContain('artifact-successor');
+  });
+
+  test('applyArtifactLifecycleError adds explicit runtime conflict state to the affected slot', () => {
+    const workspaceVm = buildWorkspaceViewModel(createWorkspacePayload());
+
+    const next = applyArtifactLifecycleError(
+      workspaceVm,
+      workspaceVm.slots.common_traps.primaryArtifactCard,
+      {
+        code: 'artifact_state_conflict',
+        message: 'Successor artifact must share the canonical home topic.',
+      },
+    );
+
+    expect(next.slots.common_traps.transitionState).toEqual({
+      value: 'artifact_state_conflict',
+      label: 'Runtime conflict',
+      tone: 'warning',
+      message: 'Successor artifact must share the canonical home topic.',
+    });
   });
 });

--- a/src/components/learning-runtime/__tests__/view-models.test.js
+++ b/src/components/learning-runtime/__tests__/view-models.test.js
@@ -72,6 +72,52 @@ function createWorkspacePayload() {
       linkedReferenceSummary: {
         totalLinkedReferences: 3,
       },
+      artifactInbox: {
+        items: [
+          {
+            artifactId: 'artifact-successor',
+            artifactKind: 'misconception_card',
+            canonicalHomeTopicId: 'topic-trig-equations',
+            slotKey: 'common_traps',
+            placementStatus: 'inbox',
+            trustStatus: 'grounded',
+            lifecycleStatus: 'active',
+            updatedAt: '2026-03-22T07:56:00.000Z',
+            summary: 'Candidate successor for the canonical misconception slot.',
+          },
+          {
+            artifactId: 'artifact-note-1',
+            artifactKind: 'free_note',
+            canonicalHomeTopicId: 'topic-trig-equations',
+            slotKey: 'my_notes',
+            placementStatus: 'inbox',
+            trustStatus: 'user_confirmed',
+            lifecycleStatus: 'active',
+            updatedAt: '2026-03-22T07:57:00.000Z',
+            title: 'My note candidate',
+          },
+          {
+            artifactId: 'artifact-cross-topic',
+            artifactKind: 'misconception_card',
+            canonicalHomeTopicId: 'topic-trig-identities',
+            slotKey: 'common_traps',
+            placementStatus: 'inbox',
+            trustStatus: 'grounded',
+            lifecycleStatus: 'active',
+            updatedAt: '2026-03-22T07:55:00.000Z',
+          },
+          {
+            artifactId: 'artifact-contested',
+            artifactKind: 'misconception_card',
+            canonicalHomeTopicId: 'topic-trig-equations',
+            slotKey: 'common_traps',
+            placementStatus: 'inbox',
+            trustStatus: 'contested',
+            lifecycleStatus: 'active',
+            updatedAt: '2026-03-22T07:54:00.000Z',
+          },
+        ],
+      },
       updatedAt: '2026-03-22T08:00:00.000Z',
       slots: {
         overviewMap: {
@@ -600,6 +646,25 @@ describe('learning runtime session view model', () => {
       staleSlotCount: 1,
       missingContentCount: 1,
       totalLinkedReferences: 3,
+      items: expect.any(Array),
+    });
+    expect(vm.artifactInbox.items.map((card) => card.artifactId)).toEqual([
+      'artifact-successor',
+      'artifact-note-1',
+      'artifact-cross-topic',
+      'artifact-contested',
+    ]);
+    expect(vm.artifactInbox.items[0].availableActions.canPin).toBe(true);
+    expect(vm.artifactInbox.items[1].availableActions.canPin).toBe(true);
+    expect(vm.artifactInbox.items[2].availableActions.canPin).toBe(false);
+    expect(vm.artifactInbox.items[2].availableActions.pinBlockedReason)
+      .toBe('Secondary-topic artifacts cannot be pinned into this workspace.');
+    expect(vm.artifactInbox.items[3].availableActions.canPin).toBe(false);
+    expect(vm.artifactInbox.items[3].state).toEqual({
+      value: 'contested',
+      label: 'Contested artifact',
+      tone: 'warning',
+      message: 'This artifact is contested and cannot be pinned until the conflict is resolved.',
     });
   });
 });

--- a/src/components/learning-runtime/view-models/workspace-view-model.js
+++ b/src/components/learning-runtime/view-models/workspace-view-model.js
@@ -1,3 +1,5 @@
+import { isCompatibleArtifactKindForSlot } from '../../../../api/learning/lib/contracts/runtime-contract.js';
+
 const SLOT_DEFINITIONS = Object.freeze([
   {
     key: 'overview_map',
@@ -36,6 +38,10 @@ const SLOT_DEFINITIONS = Object.freeze([
     description: 'Filtered review projection for this topic.',
   },
 ]);
+
+const SLOT_DEFINITION_BY_KEY = Object.freeze(
+  Object.fromEntries(SLOT_DEFINITIONS.map((definition) => [definition.key, definition])),
+);
 
 const SLOT_EMPTY_STATE = Object.freeze({
   label: 'Empty slot',
@@ -166,6 +172,10 @@ function kindLabelForRef(refKind) {
   }
 }
 
+function kindLabelForArtifactKind(artifactKind) {
+  return artifactKind ? labelFromToken(artifactKind) : 'Artifact';
+}
+
 function buildUpdatedAtLabel(updatedAt) {
   return normalizeString(updatedAt) ? `Updated ${updatedAt}` : null;
 }
@@ -209,6 +219,149 @@ function buildReferenceLaunch(ref, workspace) {
   return null;
 }
 
+function readArtifactInbox(workspace = {}) {
+  return workspace.artifactInbox || workspace.artifact_inbox || {};
+}
+
+function normalizeArtifactRecord(artifact = {}, { source = 'artifact_inbox' } = {}) {
+  const artifactId = normalizeString(artifact.artifactId ?? artifact.artifact_id);
+  if (!artifactId) {
+    return null;
+  }
+
+  return {
+    artifactId,
+    title: normalizeString(artifact.title, artifactId),
+    summary: normalizeString(artifact.summary ?? artifact.description, null),
+    artifactKind: normalizeString(artifact.artifactKind ?? artifact.artifact_kind, null),
+    canonicalHomeTopicId: normalizeString(
+      artifact.canonicalHomeTopicId ?? artifact.canonical_home_topic_id,
+      null,
+    ),
+    placementStatus: normalizeString(
+      artifact.placementStatus ?? artifact.placement_status,
+      source === 'slot_primary' ? 'pinned' : 'inbox',
+    ),
+    trustStatus: normalizeString(artifact.trustStatus ?? artifact.trust_status, null),
+    lifecycleStatus: normalizeString(artifact.lifecycleStatus ?? artifact.lifecycle_status, 'active'),
+    slotKey: normalizeString(artifact.slotKey ?? artifact.slot_key, null),
+    updatedAt: artifact.updatedAt ?? artifact.updated_at ?? null,
+    source,
+  };
+}
+
+function buildArtifactStatusState(record, fallbackState = null) {
+  if (record?.lifecycleStatus === 'superseded') {
+    return {
+      value: 'superseded',
+      label: 'Superseded artifact',
+      tone: 'warning',
+      message: 'This artifact is historical lineage and no longer occupies an active slot.',
+    };
+  }
+
+  if (record?.trustStatus === 'contested') {
+    return {
+      value: 'contested',
+      label: 'Contested artifact',
+      tone: 'warning',
+      message: 'This artifact is contested and cannot be pinned until the conflict is resolved.',
+    };
+  }
+
+  if (record?.placementStatus === 'archived') {
+    return {
+      value: 'archived',
+      label: 'Archived artifact',
+      tone: 'neutral',
+      message: 'Archived artifacts stay visible for lineage but do not occupy a stable slot.',
+    };
+  }
+
+  return fallbackState;
+}
+
+function buildArtifactActionState(record, workspace) {
+  const sameCanonicalHome =
+    !record?.canonicalHomeTopicId || record.canonicalHomeTopicId === workspace?.topicId;
+  const hasCompatibleSlotMetadata =
+    Boolean(record?.slotKey)
+    && Boolean(record?.artifactKind)
+    && isCompatibleArtifactKindForSlot(record.slotKey, record.artifactKind);
+
+  const canPin =
+    record?.source === 'artifact_inbox'
+    && record?.placementStatus !== 'pinned'
+    && record?.lifecycleStatus !== 'superseded'
+    && record?.trustStatus !== 'contested'
+    && record?.slotKey !== 'review_queue'
+    && sameCanonicalHome
+    && hasCompatibleSlotMetadata;
+
+  return {
+    canPin,
+    canUnpin: record?.placementStatus === 'pinned',
+    canMarkContested:
+      record?.lifecycleStatus !== 'superseded'
+      && record?.trustStatus !== 'contested'
+      && record?.placementStatus !== 'pinned',
+    canSupersede: Boolean(record?.artifactId) && record?.lifecycleStatus !== 'superseded',
+    pinBlockedReason:
+      canPin
+        ? null
+        : !sameCanonicalHome
+          ? 'Secondary-topic artifacts cannot be pinned into this workspace.'
+          : record?.trustStatus === 'contested'
+            ? 'Contested artifacts cannot be pinned.'
+            : record?.lifecycleStatus === 'superseded'
+              ? 'Superseded artifacts cannot be pinned.'
+              : record?.placementStatus === 'pinned'
+                ? 'This artifact is already pinned.'
+                : record?.slotKey === 'review_queue'
+                  ? 'Review queue does not accept artifact residency.'
+                  : record?.source === 'artifact_inbox' && !hasCompatibleSlotMetadata
+                    ? 'This artifact is not compatible with its slot contract.'
+                    : null,
+    contestedBlockedReason:
+      record?.placementStatus === 'pinned' ? 'Unpin before marking contested.' : null,
+  };
+}
+
+function buildArtifactCard(record, {
+  description,
+  fallbackState = null,
+  placementLabel,
+  slotTitle = null,
+  workspace,
+} = {}) {
+  if (!record) {
+    return null;
+  }
+
+  return {
+    artifactId: record.artifactId,
+    artifactKind: record.artifactKind,
+    canonicalHomeTopicId: record.canonicalHomeTopicId,
+    placementStatus: record.placementStatus,
+    trustStatus: record.trustStatus,
+    lifecycleStatus: record.lifecycleStatus,
+    slotKey: record.slotKey,
+    slotTitle: slotTitle || SLOT_DEFINITION_BY_KEY[record.slotKey]?.title || null,
+    source: record.source,
+    title: record.title,
+    kindLabel: kindLabelForArtifactKind(record.artifactKind),
+    placementLabel,
+    description,
+    updatedAtLabel: buildUpdatedAtLabel(record.updatedAt),
+    state: buildArtifactStatusState(record, fallbackState),
+    launch: buildReferenceLaunch({
+      kind: 'artifact',
+      artifactId: record.artifactId,
+    }, workspace),
+    availableActions: buildArtifactActionState(record, workspace),
+  };
+}
+
 function buildCardViewModel(ref, {
   placementLabel,
   description,
@@ -234,6 +387,18 @@ function buildCardViewModel(ref, {
 function buildSlotViewModel(definition, slots, slotState, workspace) {
   const slot = readSlotRecord(slots, definition);
   const primaryArtifact = normalizeRef(slot.primaryArtifactRef ?? slot.primary_artifact_ref ?? null);
+  const primaryArtifactRecord = primaryArtifact
+    ? normalizeArtifactRecord({
+      artifactId: primaryArtifact.artifactId ?? primaryArtifact.artifact_id,
+      canonicalHomeTopicId: workspace.topicId,
+      lifecycleStatus: 'active',
+      placementStatus: 'pinned',
+      slotKey: definition.key,
+      title: primaryArtifact.label,
+    }, {
+      source: 'slot_primary',
+    })
+    : null;
   const linkedReferences = normalizeRefList(slot.linkedReferences ?? slot.linked_references);
   const rawState = readSlotState(slotState, definition);
   const surfaceState = buildSurfaceState(rawState);
@@ -246,7 +411,13 @@ function buildSlotViewModel(definition, slots, slotState, workspace) {
     description: definition.description,
     workspaceSlotId: slot.workspaceSlotId ?? slot.workspace_slot_id ?? null,
     primaryArtifact,
-    primaryArtifactCard: buildCardViewModel(primaryArtifact, {
+    primaryArtifactCard: buildArtifactCard(primaryArtifactRecord, {
+      placementLabel: 'Canonical resident',
+      description: 'Pinned to the canonical slot for this topic.',
+      fallbackState: contentState,
+      slotTitle: definition.title,
+      workspace,
+    }) || buildCardViewModel(primaryArtifact, {
       placementLabel: 'Canonical resident',
       description: 'Pinned to the canonical slot for this topic.',
       updatedAt,
@@ -293,10 +464,28 @@ function buildReviewQueueViewModel(reviewQueue) {
 }
 
 function buildArtifactInboxViewModel(workspace, slotList) {
+  const artifactInbox = readArtifactInbox(workspace);
   const linkedReferenceSummary =
     workspace?.linkedReferenceSummary
     || workspace?.linked_reference_summary
     || {};
+  const items = (Array.isArray(artifactInbox.items) ? artifactInbox.items : [])
+    .map((artifact) => normalizeArtifactRecord(artifact, {
+      source: 'artifact_inbox',
+    }))
+    .filter(Boolean)
+    .map((record) => buildArtifactCard(record, {
+      placementLabel: record.placementStatus === 'pinned' ? 'Pinned artifact' : 'Artifact inbox',
+      description:
+        record.summary
+        || (
+          record.slotKey
+            ? `Eligible for ${SLOT_DEFINITION_BY_KEY[record.slotKey]?.title || 'workspace'} residency.`
+            : 'Visible from the workspace artifact inbox.'
+        ),
+      slotTitle: SLOT_DEFINITION_BY_KEY[record.slotKey]?.title || null,
+      workspace,
+    }));
 
   return {
     populatedSlotCount: slotList.filter((slot) => slot.primaryArtifact).length,
@@ -307,6 +496,7 @@ function buildArtifactInboxViewModel(workspace, slotList) {
       linkedReferenceSummary.totalLinkedReferences
       ?? linkedReferenceSummary.total_linked_references
       ?? 0,
+    items,
   };
 }
 


### PR DESCRIPTION
Closes #49

## Summary
This PR turns the learning runtime workspace from a read-only artifact projection into a write surface for artifact lifecycle actions. Compatible inbox artifacts can now be pinned into stable slots, pinned artifacts can be unpinned, unpinned artifacts can be marked contested, and supersede flows can be started directly from the workspace with explicit slot-transition feedback.

## Root Cause
The backend already supported explicit artifact lifecycle intents and returned slot-transition results, but the browser client only exposed a generic artifact patch call and the workspace UI stopped at summary-only slot and inbox surfaces. That left canonical stable slots and the visible artifact inbox behaviorally incomplete even though the write contract already existed.

## Fix
The browser client now exports explicit lifecycle helpers for pin, unpin, contested, and supersede operations. The workspace view model now carries artifact lifecycle metadata and conservative action gating for visible inbox artifacts so canonical-home and slot-compatibility rules stay visible in the UI. The workspace shell now owns a small local mutation overlay that applies `slot_transition` outcomes immediately, updates stable-slot residency after pin, unpin, and supersede responses, presents a supersede sheet for visible candidates or a manual artifact ID, and surfaces runtime conflicts as explicit workspace errors instead of failing silently.

## Validation
I ran the focused runtime verification and a production build:

`npm test -- --runInBand src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/components/learning-runtime/__tests__/view-models.test.js --verbose`

`npm run build`

The issue text used `-v`, but the current Jest CLI in this repository rejects that short flag, so the equivalent `--verbose` flag was used for verification.
