### PR TITLE
fix: stop Pages Jekyll from parsing README JSX

### DIFF
--- a/src/styles/README.md
+++ b/src/styles/README.md
@@ -101,6 +101,7 @@ The design system is automatically imported in `src/index.css`:
 
 ### Using Design Tokens in JavaScript
 
+{% raw %}
 ```javascript
 import { useDesignSystem } from '../hooks/useDesignSystem';
 
@@ -118,6 +119,7 @@ const MyComponent = () => {
   );
 };
 ```
+{% endraw %}
 
 ### Using CSS Classes
 

--- a/src/styles/__tests__/readme-jekyll-escaping.test.js
+++ b/src/styles/__tests__/readme-jekyll-escaping.test.js
@@ -1,0 +1,14 @@
+import fs from 'node:fs';
+
+import { describe, expect, test } from '@jest/globals';
+
+const readmePath = new URL('../README.md', import.meta.url);
+const readmeContents = fs.readFileSync(readmePath, 'utf8');
+
+describe('src/styles README Jekyll escaping', () => {
+  test('wraps the JSX design token example in raw tags so Liquid does not parse style braces', () => {
+    expect(readmeContents).toMatch(
+      /### Using Design Tokens in JavaScript\s+\{% raw %\}\s*```javascript[\s\S]*?<div style=\{\{[\s\S]*?```\s*\{% endraw %\}/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- wrap the Liquid-sensitive JSX example in `src/styles/README.md` with Jekyll raw tags
- add a focused regression test that asserts the `style={{ ... }}` example stays shielded
- keep the README diff minimal so the docs content is otherwise unchanged

Closes #60

## Verification
- `npm test -- --runInBand src/styles/__tests__/readme-jekyll-escaping.test.js`
- `npm run build`
- `rsync -a --exclude .git --exclude node_modules --exclude .env /home/samsen/.worktrees/ciecopilot-home/cie-31/ /tmp/tmp.5N3u4vaPII/ && timeout 180s docker run --rm -e GITHUB_WORKSPACE=/github/workspace -e GITHUB_REPOSITORY=Samsen879/ciecopilot-home -e GITHUB_API_URL=https://api.github.com -e INPUT_SOURCE=. -e INPUT_DESTINATION=./_site -e INPUT_FUTURE=false -e INPUT_BUILD_REVISION=$(git rev-parse HEAD) -e INPUT_VERBOSE=true -e INPUT_TOKEN=$(gh auth token) -v /tmp/tmp.5N3u4vaPII:/github/workspace ghcr.io/actions/jekyll-build-pages:v1.0.13`
