### PR TITLE
fix(test-infra): make learning-runtime verification sandbox-safe

### DIFF
--- a/api/learning/__tests__/loopback-test-client.js
+++ b/api/learning/__tests__/loopback-test-client.js
@@ -1,0 +1,76 @@
+import http from 'node:http';
+import request from 'supertest';
+
+export const LOOPBACK_HOST = '127.0.0.1';
+
+function closeServer(server) {
+  if (!server || !server.listening) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+export function listenOnLoopback(server, { host = LOOPBACK_HOST, port = 0 } = {}) {
+  if (!server || typeof server.listen !== 'function' || typeof server.address !== 'function') {
+    throw new TypeError('listenOnLoopback requires a Node.js HTTP server instance.');
+  }
+
+  if (server.listening) {
+    const address = server.address();
+
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected a TCP server address for the learning test harness.');
+    }
+
+    return Promise.resolve(address);
+  }
+
+  return new Promise((resolve, reject) => {
+    const handleError = (error) => {
+      server.off('listening', handleListening);
+      reject(error);
+    };
+
+    const handleListening = () => {
+      server.off('error', handleError);
+      const address = server.address();
+
+      if (!address || typeof address === 'string') {
+        reject(new Error('Expected a TCP server address for the learning test harness.'));
+        return;
+      }
+
+      resolve(address);
+    };
+
+    server.once('error', handleError);
+    server.once('listening', handleListening);
+    server.listen(port, host);
+  });
+}
+
+export async function createLoopbackHttpTestClient(appOrServer, options = {}) {
+  const server = typeof appOrServer === 'function'
+    ? http.createServer(appOrServer)
+    : appOrServer;
+
+  const address = await listenOnLoopback(server, options);
+  const origin = `http://${LOOPBACK_HOST}:${address.port}`;
+
+  return {
+    origin,
+    request: request(origin),
+    server,
+    close: () => closeServer(server),
+  };
+}

--- a/api/learning/__tests__/loopback-test-client.test.js
+++ b/api/learning/__tests__/loopback-test-client.test.js
@@ -1,0 +1,37 @@
+import http from 'node:http';
+import { createLoopbackHttpTestClient, LOOPBACK_HOST } from './loopback-test-client.js';
+
+describe('createLoopbackHttpTestClient', () => {
+  test('binds test servers to loopback instead of relying on wildcard host defaults', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(204);
+      res.end();
+    });
+    const harness = await createLoopbackHttpTestClient(server);
+
+    try {
+      expect(server.listening).toBe(true);
+      expect(server.address()).toMatchObject({
+        address: LOOPBACK_HOST,
+      });
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test('routes requests through the loopback-bound supertest client', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, url: req.url }));
+    });
+    const harness = await createLoopbackHttpTestClient(server);
+
+    try {
+      const res = await harness.request.get('/health');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, url: '/health' });
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/api/learning/__tests__/question-import-service.test.js
+++ b/api/learning/__tests__/question-import-service.test.js
@@ -1,7 +1,6 @@
 import { jest } from '@jest/globals';
-import http from 'node:http';
-import request from 'supertest';
 import { buildIdempotencyRequestFingerprint } from '../lib/repositories/request-idempotency-repository.js';
+import { createLoopbackHttpTestClient } from './loopback-test-client.js';
 
 process.env.NODE_ENV = 'test';
 process.env.AUTH_LOCAL_TEST_MODE = 'true';
@@ -859,19 +858,14 @@ describe('question import service', () => {
 });
 
 describe('learning question import api', () => {
-  let server;
+  let harness;
 
-  beforeAll(() => {
-    server = http.createServer(apiHandler);
+  beforeAll(async () => {
+    harness = await createLoopbackHttpTestClient(apiHandler);
   });
 
-  afterAll((done) => {
-    if (!server || !server.listening) {
-      done();
-      return;
-    }
-
-    server.close(done);
+  afterAll(async () => {
+    await harness?.close();
   });
 
   beforeEach(() => {
@@ -881,7 +875,7 @@ describe('learning question import api', () => {
   });
 
   test('POST /api/learning/questions/import returns a durable question and scoring posture metadata', async () => {
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/questions/import')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -898,14 +892,14 @@ describe('learning question import api', () => {
   });
 
   test('POST /api/learning/questions/import returns 409 idempotency_conflict on conflicting replay', async () => {
-    const first = await request(server)
+    const first = await harness.request
       .post('/api/learning/questions/import')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
       .set('Idempotency-Key', 'import-1')
       .send(buildTrigIdentityInput());
 
-    const second = await request(server)
+    const second = await harness.request
       .post('/api/learning/questions/import')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -918,7 +912,7 @@ describe('learning question import api', () => {
   });
 
   test('import -> create session -> ask -> workspace read keeps fallback posture and canonical-home consistency', async () => {
-    const importRes = await request(server)
+    const importRes = await harness.request
       .post('/api/learning/questions/import')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -932,7 +926,7 @@ describe('learning question import api', () => {
     });
 
     const questionId = importRes.body.question.question_id;
-    const createSessionRes = await request(server)
+    const createSessionRes = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -996,7 +990,7 @@ describe('learning question import api', () => {
       ],
     });
 
-    const askRes = await request(server)
+    const askRes = await harness.request
       .post(`/api/learning/sessions/${sessionId}/ask`)
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -1032,7 +1026,7 @@ describe('learning question import api', () => {
       fallback_reason_code: 'unvalidated_uncertainty_posture',
     });
 
-    const workspaceRes = await request(server)
+    const workspaceRes = await harness.request
       .get('/api/learning/workspaces/topic-integration-1')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student');

--- a/api/learning/__tests__/session-api.test.js
+++ b/api/learning/__tests__/session-api.test.js
@@ -1,7 +1,6 @@
 import { jest } from '@jest/globals';
-import http from 'node:http';
-import request from 'supertest';
 import { buildIdempotencyRequestFingerprint } from '../lib/repositories/request-idempotency-repository.js';
+import { createLoopbackHttpTestClient } from './loopback-test-client.js';
 
 process.env.NODE_ENV = 'test';
 process.env.AUTH_LOCAL_TEST_MODE = 'true';
@@ -404,18 +403,14 @@ function buildStoredSession(overrides = {}) {
 }
 
 describe('learning session api', () => {
-  let server;
+  let harness;
 
-  beforeAll(() => {
-    server = http.createServer(apiHandler);
+  beforeAll(async () => {
+    harness = await createLoopbackHttpTestClient(apiHandler);
   });
 
-  afterAll((done) => {
-    if (!server || !server.listening) {
-      done();
-      return;
-    }
-    server.close(done);
+  afterAll(async () => {
+    await harness?.close();
   });
 
   beforeEach(() => {
@@ -437,7 +432,7 @@ describe('learning session api', () => {
   });
 
   test('POST /api/learning/sessions returns persisted active_scope_bundle and typed anchor', async () => {
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -494,7 +489,7 @@ describe('learning session api', () => {
       created_at: '2026-03-21T13:30:00.000Z',
     });
 
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -567,7 +562,7 @@ describe('learning session api', () => {
       created_at: '2026-03-21T13:30:00.000Z',
     });
 
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -588,7 +583,7 @@ describe('learning session api', () => {
   });
 
   test('POST /api/learning/sessions returns invalid_payload when parent_session_id is malformed', async () => {
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -608,7 +603,7 @@ describe('learning session api', () => {
   });
 
   test('POST /api/learning/sessions returns 404 anchor_target_not_found when the anchor object is missing', async () => {
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -630,7 +625,7 @@ describe('learning session api', () => {
   });
 
   test('POST /api/learning/sessions returns 403 auth_forbidden when the anchor belongs to another user', async () => {
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -646,7 +641,7 @@ describe('learning session api', () => {
   });
 
   test('POST /api/learning/sessions returns 400 invalid_payload for malformed anchor refs', async () => {
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -661,7 +656,7 @@ describe('learning session api', () => {
   });
 
   test('POST /api/learning/sessions returns 400 invalid_anchor_kind for unknown anchors', async () => {
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -678,7 +673,7 @@ describe('learning session api', () => {
   });
 
   test('POST /api/learning/sessions returns 409 unsupported_mode_for_anchor for illegal create combinations', async () => {
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -691,14 +686,14 @@ describe('learning session api', () => {
   });
 
   test('POST /api/learning/sessions returns 409 idempotency_conflict on conflicting replay', async () => {
-    const first = await request(server)
+    const first = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
       .set('Idempotency-Key', 'sess-create-1')
       .send(buildSessionPayload());
 
-    const second = await request(server)
+    const second = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -716,14 +711,14 @@ describe('learning session api', () => {
     const gate = createDeferred();
     clientState.sessionInsertGate = gate;
 
-    const firstRequest = dispatch(request(server)
+    const firstRequest = dispatch(harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
       .set('Idempotency-Key', 'sess-race-1')
       .send(buildSessionPayload()));
 
-    const secondRequest = dispatch(request(server)
+    const secondRequest = dispatch(harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -800,7 +795,7 @@ describe('learning session api', () => {
       },
     );
 
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -817,7 +812,7 @@ describe('learning session api', () => {
   });
 
   test('POST /api/learning/sessions/extra segments does not hit create-session', async () => {
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions/session-1/extra')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -828,14 +823,14 @@ describe('learning session api', () => {
   });
 
   test('GET /api/learning/sessions/:id resolves the dynamic route', async () => {
-    const created = await request(server)
+    const created = await harness.request
       .post('/api/learning/sessions')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
       .send(buildSessionPayload());
 
     const sessionId = created.body.session.session_id;
-    const res = await request(server)
+    const res = await harness.request
       .get(`/api/learning/sessions/${sessionId}`)
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student');
@@ -897,7 +892,7 @@ describe('learning session api', () => {
       created_at: '2026-03-21T13:30:00.000Z',
     });
 
-    const res = await request(server)
+    const res = await harness.request
       .get('/api/learning/sessions/session-suggested-1')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student');
@@ -929,7 +924,7 @@ describe('learning session api', () => {
   });
 
   test('GET /api/learning/sessions/:id returns 404 session_not_found with the frozen envelope', async () => {
-    const res = await request(server)
+    const res = await harness.request
       .get('/api/learning/sessions/missing-session')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student');

--- a/api/learning/__tests__/session-ask.test.js
+++ b/api/learning/__tests__/session-ask.test.js
@@ -1,6 +1,5 @@
 import { jest } from '@jest/globals';
-import http from 'node:http';
-import request from 'supertest';
+import { createLoopbackHttpTestClient } from './loopback-test-client.js';
 
 process.env.NODE_ENV = 'test';
 process.env.AUTH_LOCAL_TEST_MODE = 'true';
@@ -122,18 +121,14 @@ function buildStoredSession(overrides = {}) {
 }
 
 describe('learning session ask api', () => {
-  let server;
+  let harness;
 
-  beforeAll(() => {
-    server = http.createServer(apiHandler);
+  beforeAll(async () => {
+    harness = await createLoopbackHttpTestClient(apiHandler);
   });
 
-  afterAll((done) => {
-    if (!server || !server.listening) {
-      done();
-      return;
-    }
-    server.close(done);
+  afterAll(async () => {
+    await harness?.close();
   });
 
   beforeEach(() => {
@@ -174,7 +169,7 @@ describe('learning session ask api', () => {
       ],
     });
 
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions/sess-1/ask')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -214,7 +209,7 @@ describe('learning session ask api', () => {
   test('POST /api/learning/sessions/:id/ask maps unknown ask failures to internal_error with 500', async () => {
     mockAskWithinLearningSession.mockRejectedValue(new Error('workspace projection crashed'));
 
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions/sess-1/ask')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
@@ -241,7 +236,7 @@ describe('learning session ask api', () => {
     error.details = { state: 'completed' };
     mockAskWithinLearningSession.mockRejectedValue(error);
 
-    const res = await request(server)
+    const res = await harness.request
       .post('/api/learning/sessions/sess-1/ask')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')

--- a/docs/superpowers/plans/2026-03-20-prd-learning-runtime-pilot-slice-execution.md
+++ b/docs/superpowers/plans/2026-03-20-prd-learning-runtime-pilot-slice-execution.md
@@ -165,7 +165,7 @@ test('seeded pilot question-type membership is trigonometry only', () => {
 
 - [ ] **Step 2: Run the focused contract tests and verify they fail**
 
-Run: `npm test -- --runInBand api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/released-scope.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/released-scope.test.js --verbose`
 Expected: FAIL because the contract modules do not exist yet.
 
 - [ ] **Step 3: Implement the shared contract modules with a single ownership boundary**
@@ -179,7 +179,7 @@ Expected: FAIL because the contract modules do not exist yet.
 
 - [ ] **Step 4: Re-run the focused contract tests and verify they pass**
 
-Run: `npm test -- --runInBand api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/released-scope.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/released-scope.test.js --verbose`
 Expected: PASS for all three suites.
 
 - [ ] **Step 5: Commit**
@@ -292,7 +292,7 @@ test('learning http helper emits the frozen error envelope', () => {
 
 - [ ] **Step 2: Run the validator/helper suites and verify they fail**
 
-Run: `npm test -- --runInBand api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-validator.test.js api/learning/__tests__/learning-http.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-validator.test.js api/learning/__tests__/learning-http.test.js --verbose`
 Expected: FAIL because the validator and helper files do not exist yet.
 
 - [ ] **Step 3: Implement the validators and HTTP helpers**
@@ -312,7 +312,7 @@ export function validateQuestionImportInput(input) {
 
 - [ ] **Step 4: Re-run the validator/helper suites and verify they pass**
 
-Run: `npm test -- --runInBand api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-validator.test.js api/learning/__tests__/learning-http.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-validator.test.js api/learning/__tests__/learning-http.test.js --verbose`
 Expected: PASS with coverage for `concept`, `question`, `review_task`, `artifact`, and `workspace_slot` create-time rules, including questionless entry and the `workspace_slot.review_queue` exception.
 
 - [ ] **Step 5: Commit**
@@ -455,7 +455,7 @@ test('learning runtime migrations declare every frozen canonical table', () => {
 
 - [ ] **Step 2: Run the schema contract test and verify it fails**
 
-Run: `npm test -- --runInBand api/learning/__tests__/schema-contract.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/schema-contract.test.js --verbose`
 Expected: FAIL because the learning-runtime migrations do not exist yet.
 
 - [ ] **Step 3: Implement the migrations with the full canonical table set**
@@ -576,7 +576,7 @@ on conflict (question_type_id) do nothing;
 
 - [ ] **Step 4: Re-run the schema contract test and verify it passes**
 
-Run: `npm test -- --runInBand api/learning/__tests__/schema-contract.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/schema-contract.test.js --verbose`
 Expected: PASS with question-bank widening, canonical registry seed data, relational invariants, and all canonical runtime tables present in the migrations.
 
 - [ ] **Step 5: Commit**
@@ -619,7 +619,7 @@ test('fetchWorkspaceProjection returns slot payloads and linked references separ
 
 - [ ] **Step 2: Run the repository tests and verify they fail**
 
-Run: `npm test -- --runInBand api/learning/__tests__/question-registry-repository.test.js api/learning/__tests__/session-repository.test.js api/learning/__tests__/workspace-repository.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/question-registry-repository.test.js api/learning/__tests__/session-repository.test.js api/learning/__tests__/workspace-repository.test.js --verbose`
 Expected: FAIL because the repository files do not exist yet.
 
 - [ ] **Step 3: Implement the repositories with one responsibility per file**
@@ -640,7 +640,7 @@ export async function fetchWorkspaceProjection(client, input) {
 
 - [ ] **Step 4: Re-run the repository tests and verify they pass**
 
-Run: `npm test -- --runInBand api/learning/__tests__/question-registry-repository.test.js api/learning/__tests__/session-repository.test.js api/learning/__tests__/workspace-repository.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/question-registry-repository.test.js api/learning/__tests__/session-repository.test.js api/learning/__tests__/workspace-repository.test.js --verbose`
 Expected: PASS with question-registry, snapshot, session-lineage, slot, and linked-reference coverage.
 
 - [ ] **Step 5: Commit**
@@ -746,7 +746,7 @@ test('route registry reserves every frozen /api/learning endpoint before backend
 
 - [ ] **Step 2: Run the session API suite and verify it fails**
 
-Run: `npm test -- --runInBand api/learning/__tests__/session-api.test.js api/_runtime/__tests__/route-registry-learning.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/session-api.test.js api/_runtime/__tests__/route-registry-learning.test.js --verbose`
 Expected: FAIL because the route registry and handlers do not exist yet.
 
 - [ ] **Step 3: Implement the route registration, dynamic matcher, and session skeleton**
@@ -796,7 +796,7 @@ Expected: FAIL because the route registry and handlers do not exist yet.
 
 - [ ] **Step 4: Re-run the session API suite and verify it passes**
 
-Run: `npm test -- --runInBand api/learning/__tests__/session-api.test.js api/_runtime/__tests__/route-registry-learning.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/session-api.test.js api/_runtime/__tests__/route-registry-learning.test.js --verbose`
 Expected: PASS with typed anchor, anchor-validity summary, canonical-home context, feature-flag metadata, `invalid_payload`, `invalid_anchor_kind`, `unsupported_mode_for_anchor`, `idempotency_conflict`, missing-anchor, forbidden-anchor, and `session_not_found` error mapping, dynamic `GET /sessions/:id` coverage, and canonical typed-ref `active_scope_bundle` coverage.
 
 - [ ] **Step 5: Commit**
@@ -859,7 +859,7 @@ test('POST /api/learning/questions/import returns 409 idempotency_conflict on co
 
 - [ ] **Step 2: Run the import suite and verify it fails**
 
-Run: `npm test -- --runInBand api/learning/__tests__/question-import-service.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/question-import-service.test.js --verbose`
 Expected: FAIL until pilot family classification and posture logic exist.
 
 - [ ] **Step 3: Implement import service and consume the canonical pilot registry**
@@ -877,7 +877,7 @@ export async function resolveReleasedScoringPosture(deps, analysisSnapshot) {
 
 - [ ] **Step 4: Re-run the import suite and verify it passes**
 
-Run: `npm test -- --runInBand api/learning/__tests__/question-import-service.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/question-import-service.test.js --verbose`
 Expected: PASS with registry-backed pilot/fallback posture assertions, released-rubric gating, import-handler response coverage, and import idempotency coverage green.
 
 - [ ] **Step 5: Commit**
@@ -931,7 +931,7 @@ test('POST /api/learning/sessions/:id/ask returns the frozen session-ask respons
 
 - [ ] **Step 2: Run the session ask suites and verify they fail**
 
-Run: `npm test -- --runInBand api/learning/__tests__/session-ask.test.js api/rag/__tests__/ask-service.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/session-ask.test.js api/rag/__tests__/ask-service.test.js --verbose`
 Expected: FAIL because the session wrapper and fallback contract are not wired in yet.
 
 - [ ] **Step 3: Implement the ask wrapper and current `ask-service` bridge**
@@ -944,7 +944,7 @@ export async function askWithinLearningSession(deps, { session, message }) {
 
 - [ ] **Step 4: Re-run the session ask suites and verify they pass**
 
-Run: `npm test -- --runInBand api/learning/__tests__/session-ask.test.js api/rag/__tests__/ask-service.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/session-ask.test.js api/rag/__tests__/ask-service.test.js --verbose`
 Expected: PASS with explicit fallback posture, frozen session-ask response fields, and no fake question ids.
 
 - [ ] **Step 5: Commit**
@@ -1029,7 +1029,7 @@ test('superseding a pinned artifact moves the pin to the successor or clears the
 
 - [ ] **Step 2: Run the orchestration suites and verify they fail**
 
-Run: `npm test -- --runInBand api/learning/__tests__/artifact-api.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/marking/__tests__/evaluate-v1.test.js api/error-book/error-book.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/artifact-api.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/marking/__tests__/evaluate-v1.test.js api/error-book/error-book.test.js --verbose`
 Expected: FAIL until orchestration and reconciliation behavior exists.
 
 - [ ] **Step 3: Implement the minimal orchestration services**
@@ -1044,7 +1044,7 @@ export async function applyLearningEffects(input) {
 
 - [ ] **Step 4: Re-run the orchestration suites and verify they pass**
 
-Run: `npm test -- --runInBand api/learning/__tests__/artifact-api.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/marking/__tests__/evaluate-v1.test.js api/error-book/error-book.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/artifact-api.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/marking/__tests__/evaluate-v1.test.js api/error-book/error-book.test.js --verbose`
 Expected: PASS with released-scope, artifact lifecycle success/conflict paths, explicit write intents, misconception-card homing, supersede pin migration semantics, reconciliation assertions, and legacy-marking/error-book regressions green.
 
 - [ ] **Step 5: Commit**
@@ -1100,7 +1100,7 @@ test('evidence context exposes learning-runtime anchor and workspace state for p
 
 - [ ] **Step 2: Run the workspace/read-model suite and verify it fails**
 
-Run: `npm test -- --runInBand api/learning/__tests__/workspace-read-service.test.js api/evidence/__tests__/context.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/workspace-read-service.test.js api/evidence/__tests__/context.test.js --verbose`
 Expected: FAIL because projection services and handlers are not complete.
 
 - [ ] **Step 3: Implement workspace and review-task read services**
@@ -1113,7 +1113,7 @@ export async function getWorkspaceView(client, { userId, topicId }) {
 
 - [ ] **Step 4: Re-run the workspace/read-model suite and verify it passes**
 
-Run: `npm test -- --runInBand api/learning/__tests__/workspace-read-service.test.js api/evidence/__tests__/context.test.js -v`
+Run: `npm test -- --runInBand api/learning/__tests__/workspace-read-service.test.js api/evidence/__tests__/context.test.js --verbose`
 Expected: PASS with canonical-home, linked-reference, workspace handler, review-queue handler, and evidence-context assertions green.
 
 - [ ] **Step 5: Commit**
@@ -1173,7 +1173,7 @@ test('LearningSessionShell renders questionless sessions without placeholder que
 
 - [ ] **Step 2: Run the client/view-model suites and verify they fail**
 
-Run: `npm test -- --runInBand src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/view-models.test.js -v`
+Run: `npm test -- --runInBand src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/view-models.test.js --verbose`
 Expected: FAIL because the browser client and view-model files do not exist yet.
 
 - [ ] **Step 3: Implement the client and session shell**
@@ -1195,7 +1195,7 @@ export const learningRuntimeApi = {
 
 - [ ] **Step 4: Re-run the client/view-model suites and verify they pass**
 
-Run: `npm test -- --runInBand src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/view-models.test.js -v`
+Run: `npm test -- --runInBand src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/view-models.test.js --verbose`
 Expected: PASS with the shared browser-client contract, including imported-question entry, typed refs, fallback posture, questionless-session state normalized in the view-model, and shell-level questionless rendering coverage.
 
 - [ ] **Step 5: Commit**
@@ -1249,7 +1249,7 @@ test('legacy surfaces demote to compatibility entry modes and App exposes runtim
 
 - [ ] **Step 2: Run the workspace view-model suite and verify it fails**
 
-Run: `npm test -- --runInBand src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/pages/__tests__/legacy-entry-mode.test.js src/components/learning-runtime/__tests__/view-models.test.js -v`
+Run: `npm test -- --runInBand src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/pages/__tests__/legacy-entry-mode.test.js src/components/learning-runtime/__tests__/view-models.test.js --verbose`
 Expected: FAIL until workspace view-model and UI wiring are implemented.
 
 - [ ] **Step 3: Implement workspace UI and route demotion**
@@ -1261,7 +1261,7 @@ Expected: FAIL until workspace view-model and UI wiring are implemented.
 
 - [ ] **Step 4: Re-run the workspace view-model suite and a production build**
 
-Run: `npm test -- --runInBand src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/pages/__tests__/legacy-entry-mode.test.js src/components/learning-runtime/__tests__/view-models.test.js -v && npm run build`
+Run: `npm test -- --runInBand src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/pages/__tests__/legacy-entry-mode.test.js src/components/learning-runtime/__tests__/view-models.test.js --verbose && npm run build`
 Expected: PASS for the shell/page verification suites and a successful Vite production build.
 
 - [ ] **Step 5: Commit**
@@ -1306,7 +1306,7 @@ test('marking effect -> review task -> workspace projection -> artifact patch ke
 
 - [ ] **Step 2: Run the full learning API suite and verify any new scenario tests fail**
 
-Run: `npm test -- --runInBand api/_runtime/__tests__/route-registry-learning.test.js api/evidence/__tests__/context.test.js api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/learning-http.test.js api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/session-api.test.js api/learning/__tests__/session-ask.test.js api/learning/__tests__/workspace-read-service.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-api.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/learning/__tests__/released-scope.test.js -v`
+Run: `npm test -- --runInBand api/_runtime/__tests__/route-registry-learning.test.js api/evidence/__tests__/context.test.js api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/learning-http.test.js api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/session-api.test.js api/learning/__tests__/session-ask.test.js api/learning/__tests__/workspace-read-service.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-api.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/learning/__tests__/released-scope.test.js --verbose`
 Expected: FAIL only on the new end-to-end boundary cases you just added.
 
 - [ ] **Step 3: Implement the minimal glue fixes needed for end-to-end consistency**
@@ -1317,7 +1317,7 @@ Expected: FAIL only on the new end-to-end boundary cases you just added.
 
 - [ ] **Step 4: Re-run the full learning API suite and verify it passes**
 
-Run: `npm test -- --runInBand api/_runtime/__tests__/route-registry-learning.test.js api/evidence/__tests__/context.test.js api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/learning-http.test.js api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/session-api.test.js api/learning/__tests__/session-ask.test.js api/learning/__tests__/workspace-read-service.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-api.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/learning/__tests__/released-scope.test.js -v`
+Run: `npm test -- --runInBand api/_runtime/__tests__/route-registry-learning.test.js api/evidence/__tests__/context.test.js api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/learning-http.test.js api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/session-api.test.js api/learning/__tests__/session-ask.test.js api/learning/__tests__/workspace-read-service.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-api.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/learning/__tests__/released-scope.test.js --verbose`
 Expected: PASS across the full learning runtime API boundary suite.
 
 - [ ] **Step 5: Commit**
@@ -1361,12 +1361,12 @@ test('legacy learning path stays a compatibility shell under the runtime feature
 
 - [ ] **Step 2: Run the final smoke checks and verify the new assertions fail**
 
-Run: `npm test -- --runInBand api/rag/__tests__/ask-service.test.js src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/pages/__tests__/legacy-entry-mode.test.js src/components/learning-runtime/__tests__/view-models.test.js -v`
+Run: `npm test -- --runInBand api/rag/__tests__/ask-service.test.js src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/pages/__tests__/legacy-entry-mode.test.js src/components/learning-runtime/__tests__/view-models.test.js --verbose`
 Expected: FAIL only on the new smoke assertions.
 
 - [ ] **Step 3: Implement the final glue and run the full verification set**
 
-Run: `npm test -- --runInBand api/_runtime/__tests__/route-registry-learning.test.js api/evidence/__tests__/context.test.js api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/learning-http.test.js api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/session-api.test.js api/learning/__tests__/session-ask.test.js api/learning/__tests__/workspace-read-service.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-api.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/learning/__tests__/released-scope.test.js api/rag/__tests__/ask-service.test.js src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/pages/__tests__/legacy-entry-mode.test.js src/components/learning-runtime/__tests__/view-models.test.js -v && npm run build`
+Run: `npm test -- --runInBand api/_runtime/__tests__/route-registry-learning.test.js api/evidence/__tests__/context.test.js api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/learning-http.test.js api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/session-api.test.js api/learning/__tests__/session-ask.test.js api/learning/__tests__/workspace-read-service.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-api.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/learning/__tests__/released-scope.test.js api/rag/__tests__/ask-service.test.js src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/pages/__tests__/legacy-entry-mode.test.js src/components/learning-runtime/__tests__/view-models.test.js --verbose && npm run build`
 Expected: all test suites PASS and Vite build completes successfully.
 
 - [ ] **Step 4: Record rollout and migration notes**

--- a/docs/superpowers/runbooks/2026-03-20-learning-runtime-pilot-rollout.md
+++ b/docs/superpowers/runbooks/2026-03-20-learning-runtime-pilot-rollout.md
@@ -56,9 +56,20 @@ Scope: first `9709` runtime pilot slice for session-centric AskAI, workspace ent
 
 ## Verification Record
 
-Use the Task 13 verification set with `--verbose` for Jest in this repo:
+Canonical learning-runtime verification in this repo should use `npm test -- --runInBand ...`.
+Do not use Jest's short `-v` flag here; the current wrapper accepts long-form flags such as `--verbose`, but the canonical closeout recipes below do not require verbosity flags at all.
 
 ```bash
-npm test -- --runInBand api/_runtime/__tests__/route-registry-learning.test.js api/evidence/__tests__/context.test.js api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/learning-http.test.js api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/session-api.test.js api/learning/__tests__/session-ask.test.js api/learning/__tests__/workspace-read-service.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-api.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/learning/__tests__/released-scope.test.js api/rag/__tests__/ask-service.test.js src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/pages/__tests__/legacy-entry-mode.test.js src/components/learning-runtime/__tests__/view-models.test.js --verbose
+# Pure unit, repository, and schema verification
+npm test -- --runInBand api/learning/__tests__/schema-contract.test.js api/learning/__tests__/request-idempotency-repository.test.js api/learning/__tests__/session-repository.test.js api/learning/__tests__/question-registry-repository.test.js
+
+# Handler and API verification
+npm test -- --runInBand api/learning/__tests__/session-api.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/session-ask.test.js
+
+# Full learning-runtime slice verification
+npm test -- --runInBand api/_runtime/__tests__/route-registry-learning.test.js api/evidence/__tests__/context.test.js api/learning/__tests__/runtime-contract.test.js api/learning/__tests__/error-contract.test.js api/learning/__tests__/learning-http.test.js api/learning/__tests__/session-validator.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/session-api.test.js api/learning/__tests__/session-ask.test.js api/learning/__tests__/workspace-read-service.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-api.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/reconciliation-service.test.js api/learning/__tests__/released-scope.test.js api/rag/__tests__/ask-service.test.js src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/pages/__tests__/legacy-entry-mode.test.js src/components/learning-runtime/__tests__/view-models.test.js
 npm run build
 ```
+
+Learning-runtime handler suites now bind their test server on `127.0.0.1` instead of relying on `supertest`'s default wildcard bind.
+If a local sandbox blocks loopback listens too, treat that as an environment-limited handler run and report the pure-suite results separately instead of misclassifying the failure as a product regression.


### PR DESCRIPTION
Closes #63

## Summary
- add a loopback-safe learning-runtime HTTP test harness that binds handler suites on `127.0.0.1`
- switch `session-api`, `question-import-service`, and `session-ask` to the shared harness instead of relying on `supertest` to call `app.listen(0)` with no host
- add regression coverage for the helper and update the learning-runtime docs to use current Jest syntax and separate pure verification from handler/API verification

## Root Cause
Passing an unbound `http.Server` to `supertest` causes it to call `app.listen(0)` internally with no explicit host. In restricted environments that can fail with `listen EPERM ... 0.0.0.0`, which is a harness problem rather than a learning-runtime regression.

## Verification
- `npm test -- --runInBand api/learning/__tests__/session-api.test.js api/learning/__tests__/question-import-service.test.js`
  - PASS (2 suites, 26 tests)
- `npm test -- --runInBand api/learning/__tests__/schema-contract.test.js api/learning/__tests__/request-idempotency-repository.test.js api/learning/__tests__/session-repository.test.js api/learning/__tests__/question-registry-repository.test.js`
  - PASS (4 suites, 12 tests)
- `npm test -- --runInBand api/learning/__tests__/session-ask.test.js api/learning/__tests__/loopback-test-client.test.js`
  - PASS (2 suites, 5 tests)
- `npm test -- --runInBand api/learning/__tests__/loopback-test-client.test.js api/learning/__tests__/session-api.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/session-ask.test.js`
  - PASS (4 suites, 31 tests)

## Residual Environment Note
- This change removes avoidable wildcard-bind failures by forcing loopback binding.
- If a sandbox blocks loopback listens too, handler/API suites should be reported as environment-limited rather than as product regressions, while the pure verification recipe remains valid.
