### PR TITLE
feat(learning): add part-aware runtime scoring ingestion

### DIFF
--- a/api/learning/__tests__/reconciliation-service.test.js
+++ b/api/learning/__tests__/reconciliation-service.test.js
@@ -102,4 +102,65 @@ describe('reconciliation-service', () => {
       },
     });
   });
+
+  test('reconciliation preserves local part signals and summarizes ambiguous mappings', async () => {
+    const runs = [];
+    const service = createReconciliationService({
+      reconciliationRepository: {
+        async insertRun(payload) {
+          runs.push(payload);
+          return {
+            reconciliation_run_id: 'recon-2',
+            ...payload,
+          };
+        },
+      },
+    });
+
+    const result = await service.reconcileDerivedState({
+      triggerSource: 'marking_correction',
+      sourceRef: {
+        kind: 'mark_run',
+        mark_run_id: 'mark-run-2',
+      },
+      historical: {},
+      derivedState: {
+        local_signals: [
+          {
+            scope_kind: 'subpart',
+            question_type_id: '9709.trigonometry.equations',
+            part_id: 'a',
+            subpart_id: 'a_i',
+            signal_direction: 'positive',
+          },
+        ],
+        marking_result: {
+          marking_summary: {
+            ambiguous_rubric_point_result_count: 1,
+          },
+          part_results: [
+            {
+              part_id: 'a',
+              subpart_id: 'a_i',
+              score_awarded: 1,
+              score_max: 2,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.derived_state.local_signals).toEqual([
+      expect.objectContaining({
+        part_id: 'a',
+        subpart_id: 'a_i',
+      }),
+    ]);
+    expect(runs[0].result_summary).toMatchObject({
+      revised_derived_objects: 1,
+      local_signal_count: 1,
+      part_result_count: 1,
+      ambiguous_part_mapping_count: 1,
+    });
+  });
 });

--- a/api/learning/__tests__/review-task-service.test.js
+++ b/api/learning/__tests__/review-task-service.test.js
@@ -39,6 +39,95 @@ function buildStoredReviewTask(overrides = {}) {
 }
 
 describe('learning orchestration', () => {
+  test('part-local released scoring emits local signals instead of whole-question positive mastery', async () => {
+    const reviewTaskService = createSpyService('generateTasksFromOutcome', async () => []);
+    const artifactService = createSpyService('buildArtifactCandidates', async () => []);
+    const reconciliationService = createSpyService('reconcileDerivedState', async ({ derivedState }) => ({
+      reconciliation_run_id: 'recon-part-1',
+      status: 'completed',
+      derived_state: derivedState,
+    }));
+
+    const result = await applyLearningEffects(
+      {
+        user_id: 'student-1',
+        question_id: 'question-part-1',
+        question_context: {
+          family_id: '9709.trigonometry_manipulation_equations',
+          question_type_id: '9709.trigonometry.equations',
+          question_type_release_state: 'released',
+          primary_topic_id: 'topic-trig-equations',
+          primary_topic_path: '9709/trigonometry/equations',
+          classification_confidence: 0.93,
+          candidate_rubric_refs: [
+            {
+              kind: 'rubric_release',
+              rubric_version_id: 'trig-eq-v1',
+              release_state: 'released',
+            },
+          ],
+        },
+        source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-part-1' },
+        source_mark_run_ref: { kind: 'mark_run', mark_run_id: 'mark-run-part-1' },
+        decisions: [
+          {
+            awarded: true,
+            awarded_marks: 1,
+            alignment_confidence: 0.94,
+          },
+        ],
+        marking_result: {
+          marking_summary: {
+            coverage_scope: 'subpart',
+            local_signal_only: true,
+            ambiguous_rubric_point_result_count: 0,
+          },
+          part_results: [
+            {
+              part_id: 'a',
+              subpart_id: 'a_i',
+              score_awarded: 1,
+              score_max: 2,
+              rubric_point_results: [
+                {
+                  rubric_id: 'rubric-1',
+                  awarded: true,
+                  awarded_marks: 1,
+                  part_id: 'a',
+                  subpart_id: 'a_i',
+                },
+              ],
+            },
+          ],
+        },
+        uncertainty_validated: true,
+      },
+      {
+        reviewTaskService,
+        artifactService,
+        reconciliationService,
+      },
+    );
+
+    expect(result.mastery_updates).toEqual([]);
+    expect(result.local_signals).toEqual([
+      expect.objectContaining({
+        scope_kind: 'subpart',
+        part_id: 'a',
+        subpart_id: 'a_i',
+        question_type_id: '9709.trigonometry.equations',
+        signal_direction: 'positive',
+      }),
+    ]);
+    expect(reviewTaskService.calls).toHaveLength(0);
+    expect(reconciliationService.calls[0].derivedState.local_signals).toEqual([
+      expect.objectContaining({
+        part_id: 'a',
+        subpart_id: 'a_i',
+      }),
+    ]);
+  });
+
   test('pilot scoring run can create a type-level positive update', async () => {
     const reviewTaskService = createSpyService('generateTasksFromOutcome', async () => []);
     const artifactService = createSpyService('buildArtifactCandidates', async () => []);
@@ -226,6 +315,61 @@ describe('learning orchestration', () => {
     expect(reviewTaskService.calls[0]).toMatchObject({
       authoritative_scoring_allowed: false,
       repair_target_topic_id: 'repair-target-topic',
+    });
+  });
+});
+
+describe('review task service generation', () => {
+  test('fallback review tasks keep explicit part/subpart scope in success criteria', async () => {
+    const service = createReviewTaskService({
+      now: () => new Date('2026-03-24T10:00:00.000Z'),
+    });
+
+    const [task] = await service.generateTasksFromOutcome({
+      user_id: 'student-1',
+      question_id: 'question-1',
+      authoritative_scoring_allowed: false,
+      repair_target_topic_id: 'topic-1',
+      repair_target_topic_path: '9709/trigonometry/equations',
+      question_context: {
+        family_id: '9709.trigonometry_manipulation_equations',
+        question_type_id: '9709.trigonometry.equations',
+      },
+      marking_result: {
+        marking_summary: {
+          coverage_scope: 'subpart',
+          local_signal_only: true,
+          ambiguous_rubric_point_result_count: 0,
+        },
+        part_results: [
+          {
+            part_id: 'a',
+            subpart_id: 'a_i',
+            score_awarded: 1,
+            score_max: 2,
+          },
+        ],
+      },
+    });
+
+    expect(task).toMatchObject({
+      target_kind: 'question_type',
+      target_question_type_id: '9709.trigonometry.equations',
+      success_criteria: {
+        posture: 'conservative_fallback',
+        authoritative_scoring_allowed: false,
+        coverage_scope: 'subpart',
+        local_signal_only: true,
+        ambiguous_part_mapping_count: 0,
+        part_results: [
+          {
+            part_id: 'a',
+            subpart_id: 'a_i',
+            score_awarded: 1,
+            score_max: 2,
+          },
+        ],
+      },
     });
   });
 });

--- a/api/learning/lib/mastery/mastery-orchestrator.js
+++ b/api/learning/lib/mastery/mastery-orchestrator.js
@@ -31,12 +31,64 @@ function buildReleaseScopePosture(input = {}) {
   });
 }
 
+function getMarkingResult(input = {}) {
+  return input.marking_result && typeof input.marking_result === 'object'
+    ? input.marking_result
+    : null;
+}
+
 function hasPositiveAuthoritativeSignal(decisions = []) {
   return decisions.some((decision) =>
     decision?.awarded === true && Number(decision?.awarded_marks ?? 0) > 0);
 }
 
-function buildMasteryUpdates(input = {}, releaseScopePosture = {}) {
+function hasConservativePartMapping(markingResult = null) {
+  return Boolean(
+    markingResult?.marking_summary?.conservative_part_mapping
+    || Number(markingResult?.marking_summary?.ambiguous_rubric_point_result_count ?? 0) > 0,
+  );
+}
+
+function buildLocalSignals(input = {}, releaseScopePosture = {}) {
+  const questionContext = getQuestionContext(input);
+  const repairTopicId =
+    input.repair_target_topic_id
+    || questionContext.primary_topic_id
+    || input.source_attempt_context?.topic_id
+    || null;
+  const questionTypeId = questionContext.question_type_id ?? null;
+  const familyId = questionContext.family_id ?? null;
+
+  return normalizeArray(getMarkingResult(input)?.part_results)
+    .filter((partResult) => Number(partResult?.score_awarded ?? 0) > 0)
+    .map((partResult) => ({
+      scope_kind: partResult?.subpart_id ? 'subpart' : 'part',
+      topic_id: repairTopicId,
+      family_id: familyId,
+      question_type_id: questionTypeId,
+      part_id: partResult?.part_id ?? null,
+      subpart_id: partResult?.subpart_id ?? null,
+      signal_direction: 'positive',
+      signal_weight: releaseScopePosture.authoritative_scoring_allowed
+        ? 'authoritative_local'
+        : 'conservative_local',
+      release_scope_status: releaseScopePosture.release_scope_status,
+      score_awarded: Number(partResult?.score_awarded ?? 0),
+      score_max: Number(partResult?.score_max ?? 0),
+    }));
+}
+
+function shouldPromoteQuestionType(input = {}, releaseScopePosture = {}) {
+  const markingResult = getMarkingResult(input);
+  return Boolean(
+    releaseScopePosture.authoritative_scoring_allowed
+    && hasPositiveAuthoritativeSignal(input.decisions)
+    && !markingResult?.marking_summary?.local_signal_only
+    && !hasConservativePartMapping(markingResult),
+  );
+}
+
+function buildMasteryUpdates(input = {}, releaseScopePosture = {}, { localSignals = [] } = {}) {
   const questionContext = getQuestionContext(input);
   const questionTypeId = questionContext.question_type_id ?? null;
   const familyId = questionContext.family_id ?? null;
@@ -47,7 +99,7 @@ function buildMasteryUpdates(input = {}, releaseScopePosture = {}) {
     || null;
   const updates = [];
 
-  if (releaseScopePosture.authoritative_scoring_allowed && hasPositiveAuthoritativeSignal(input.decisions)) {
+  if (shouldPromoteQuestionType(input, releaseScopePosture)) {
     updates.push({
       level: 'question_type',
       topic_id: repairTopicId,
@@ -57,7 +109,7 @@ function buildMasteryUpdates(input = {}, releaseScopePosture = {}) {
       signal_weight: 'authoritative',
       release_scope_status: releaseScopePosture.release_scope_status,
     });
-  } else if (familyId && releaseScopePosture.classification_confidence !== null) {
+  } else if (localSignals.length === 0 && familyId && releaseScopePosture.classification_confidence !== null) {
     updates.push({
       level: 'family',
       topic_id: repairTopicId,
@@ -170,7 +222,10 @@ export function createMasteryOrchestrator({
         source_mark_run_ref: sourceMarkRunRef,
         source_session_id: input.source_session_id ?? null,
       };
-      const masteryUpdates = buildMasteryUpdates(input, releaseScopePosture);
+      const localSignals = buildLocalSignals(input, releaseScopePosture);
+      const masteryUpdates = buildMasteryUpdates(input, releaseScopePosture, {
+        localSignals,
+      });
       const reviewTasks = releaseScopePosture.authoritative_scoring_allowed
         ? []
         : await reviewTaskService.generateTasksFromOutcome(reviewTaskInput);
@@ -191,6 +246,8 @@ export function createMasteryOrchestrator({
           review_tasks: reviewTasks,
           artifacts: artifactCandidates,
           error_book_hooks: errorBookHooks,
+          local_signals: localSignals,
+          marking_result: input.marking_result ?? null,
         },
         oldSnapshotRefs: normalizeArray(input.old_snapshot_refs),
         newSnapshotRefs: normalizeArray(
@@ -203,6 +260,7 @@ export function createMasteryOrchestrator({
       return {
         ...releaseScopePosture,
         mastery_updates: masteryUpdates,
+        local_signals: localSignals,
         review_tasks: reviewTasks,
         artifact_candidates: artifactCandidates,
         error_book_hooks: errorBookHooks,

--- a/api/learning/lib/reconciliation/reconciliation-service.js
+++ b/api/learning/lib/reconciliation/reconciliation-service.js
@@ -22,6 +22,18 @@ function countDerivedObjects(derivedState = {}) {
   }, 0);
 }
 
+function countPartResults(derivedState = {}) {
+  return normalizeArray(derivedState?.marking_result?.part_results).length;
+}
+
+function countLocalSignals(derivedState = {}) {
+  return normalizeArray(derivedState?.local_signals).length;
+}
+
+function countAmbiguousPartMappings(derivedState = {}) {
+  return Number(derivedState?.marking_result?.marking_summary?.ambiguous_rubric_point_result_count ?? 0);
+}
+
 function buildAffectedObjectRefs(derivedState = {}) {
   return [
     ...normalizeArray(derivedState.type_masteries).flatMap((item) =>
@@ -52,6 +64,9 @@ export function createReconciliationService({
         revised_derived_objects: countDerivedObjects(nextDerivedState),
         historical_attempt_count: normalizeArray(historicalSnapshot?.attempts).length,
         historical_mark_run_count: normalizeArray(historicalSnapshot?.mark_runs).length,
+        local_signal_count: countLocalSignals(nextDerivedState),
+        part_result_count: countPartResults(nextDerivedState),
+        ambiguous_part_mapping_count: countAmbiguousPartMappings(nextDerivedState),
       };
 
       let run = null;

--- a/api/learning/lib/review/review-task-service.js
+++ b/api/learning/lib/review/review-task-service.js
@@ -268,6 +268,15 @@ function buildReviewTaskPayload(input = {}, now = new Date()) {
     targetQuestionTypeId,
     familyId: input.question_context?.family_id ?? null,
   });
+  const partResults = normalizeArray(input.marking_result?.part_results).map((partResult) => ({
+    part_id: partResult?.part_id ?? null,
+    subpart_id: partResult?.subpart_id ?? null,
+    score_awarded: Number(partResult?.score_awarded ?? 0),
+    score_max: Number(partResult?.score_max ?? 0),
+  }));
+  const ambiguousPartMappingCount = Number(
+    input.marking_result?.marking_summary?.ambiguous_rubric_point_result_count ?? 0,
+  );
 
   return {
     user_id: input.user_id,
@@ -287,6 +296,10 @@ function buildReviewTaskPayload(input = {}, now = new Date()) {
     success_criteria: {
       posture: 'conservative_fallback',
       authoritative_scoring_allowed: false,
+      coverage_scope: input.marking_result?.marking_summary?.coverage_scope ?? 'question',
+      local_signal_only: input.marking_result?.marking_summary?.local_signal_only === true,
+      ambiguous_part_mapping_count: ambiguousPartMappingCount,
+      part_results: partResults,
     },
     completion_evidence: {},
     status: 'open',

--- a/api/marking/__tests__/evaluate-v1.test.js
+++ b/api/marking/__tests__/evaluate-v1.test.js
@@ -374,6 +374,50 @@ describe('v0 compat mode', () => {
 });
 
 describe('learning-runtime orchestration', () => {
+  it('returns part-aware marking_result payloads and passes them into learning orchestration', async () => {
+    const req = mockReq({
+      body: {
+        ...mockReq().body,
+        subpart: 'a_i',
+      },
+    });
+    const res = mockRes();
+
+    await handler(req, res);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.marking_result).toMatchObject({
+      attempt_id: 'att-001',
+      mark_run_id: 'mr-001',
+      marking_summary: {
+        coverage_scope: 'subpart',
+        local_signal_only: true,
+      },
+      part_results: [
+        {
+          part_id: 'a',
+          subpart_id: 'a_i',
+        },
+      ],
+    });
+    expect(mockApplyLearningEffects).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marking_result: expect.objectContaining({
+          marking_summary: expect.objectContaining({
+            coverage_scope: 'subpart',
+          }),
+          part_results: [
+            expect.objectContaining({
+              part_id: 'a',
+              subpart_id: 'a_i',
+            }),
+          ],
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
   it('returns released-scope learning effects for a persisted pilot scoring run', async () => {
     mockApplyLearningEffects.mockResolvedValueOnce({
       release_scope_status: 'released_scoring',
@@ -414,6 +458,10 @@ describe('learning-runtime orchestration', () => {
         question_id: 'q-001',
         source_attempt_ref: { kind: 'attempt', attempt_id: 'att-001' },
         source_mark_run_ref: { kind: 'mark_run', mark_run_id: 'mr-001' },
+        marking_result: expect.objectContaining({
+          attempt_id: 'att-001',
+          mark_run_id: 'mr-001',
+        }),
       }),
       expect.any(Object),
     );

--- a/api/marking/__tests__/marking-result-contract.test.js
+++ b/api/marking/__tests__/marking-result-contract.test.js
@@ -1,0 +1,172 @@
+import { buildMarkingResult } from '../lib/marking-result-contract.js';
+
+describe('marking-result-contract', () => {
+  test('maps rubric point results back to explicit part and subpart ids', () => {
+    const result = buildMarkingResult({
+      questionId: 'question-1',
+      attemptId: 'attempt-1',
+      markRunId: 'mark-run-1',
+      questionTypeId: '9709.trigonometry.equations',
+      decisions: [
+        {
+          rubric_id: 'rubric-1',
+          mark_label: 'M1',
+          awarded: true,
+          awarded_marks: 1,
+          reason: 'best_match',
+          alignment_confidence: 0.91,
+        },
+        {
+          rubric_id: 'rubric-2',
+          mark_label: 'A1',
+          awarded: false,
+          awarded_marks: 0,
+          reason: 'no_match',
+          alignment_confidence: 0.42,
+        },
+      ],
+      rubricPoints: [
+        {
+          rubric_id: 'rubric-1',
+          mark_label: 'M1',
+          marks: 1,
+          subpart: 'a_i',
+        },
+        {
+          rubric_id: 'rubric-2',
+          mark_label: 'A1',
+          marks: 2,
+          part_id: 'b',
+          subpart_id: 'b_ii',
+        },
+      ],
+    });
+
+    expect(result.marking_summary).toMatchObject({
+      total_awarded: 1,
+      total_available: 3,
+      coverage_scope: 'question',
+      local_signal_only: false,
+      part_result_count: 2,
+      ambiguous_rubric_point_result_count: 0,
+    });
+    expect(result.part_results).toEqual([
+      expect.objectContaining({
+        part_id: 'a',
+        subpart_id: 'a_i',
+        score_awarded: 1,
+        score_max: 1,
+        mapped_question_type_refs: [
+          {
+            kind: 'question_type',
+            question_type_id: '9709.trigonometry.equations',
+          },
+        ],
+        rubric_point_results: [
+          expect.objectContaining({
+            rubric_id: 'rubric-1',
+            part_id: 'a',
+            subpart_id: 'a_i',
+            score_max: 1,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        part_id: 'b',
+        subpart_id: 'b_ii',
+        score_awarded: 0,
+        score_max: 2,
+      }),
+    ]);
+  });
+
+  test('inherits explicit request scope for local subpart runs', () => {
+    const result = buildMarkingResult({
+      questionId: 'question-1',
+      attemptId: 'attempt-1',
+      markRunId: 'mark-run-1',
+      requestSubpartId: 'a_i',
+      decisions: [
+        {
+          rubric_id: 'rubric-1',
+          mark_label: 'M1',
+          awarded: true,
+          awarded_marks: 1,
+          reason: 'best_match',
+        },
+      ],
+      rubricPoints: [
+        {
+          rubric_id: 'rubric-1',
+          mark_label: 'M1',
+          marks: 1,
+        },
+      ],
+    });
+
+    expect(result.marking_summary).toMatchObject({
+      coverage_scope: 'subpart',
+      local_signal_only: true,
+      ambiguous_rubric_point_result_count: 0,
+    });
+    expect(result.part_results).toEqual([
+      expect.objectContaining({
+        part_id: 'a',
+        subpart_id: 'a_i',
+        score_awarded: 1,
+        score_max: 1,
+      }),
+    ]);
+  });
+
+  test('falls back conservatively when point mappings are incomplete', () => {
+    const result = buildMarkingResult({
+      questionId: 'question-1',
+      attemptId: 'attempt-1',
+      markRunId: 'mark-run-1',
+      decisions: [
+        {
+          rubric_id: 'rubric-1',
+          mark_label: 'M1',
+          awarded: true,
+          awarded_marks: 1,
+          reason: 'best_match',
+        },
+        {
+          rubric_id: 'rubric-2',
+          mark_label: 'A1',
+          awarded: false,
+          awarded_marks: 0,
+          reason: 'no_match',
+        },
+      ],
+      rubricPoints: [
+        {
+          rubric_id: 'rubric-1',
+          mark_label: 'M1',
+          marks: 1,
+          subpart: 'a_i',
+        },
+        {
+          rubric_id: 'rubric-2',
+          mark_label: 'A1',
+          marks: 1,
+        },
+      ],
+    });
+
+    expect(result.marking_summary).toMatchObject({
+      ambiguous_rubric_point_result_count: 1,
+      conservative_part_mapping: true,
+    });
+    expect(result.learning_hints).toMatchObject({
+      conservative_part_mapping: true,
+    });
+    expect(result.part_results).toEqual([
+      expect.objectContaining({
+        part_id: 'a',
+        subpart_id: 'a_i',
+      }),
+    ]);
+  });
+});

--- a/api/marking/evaluate-v1.js
+++ b/api/marking/evaluate-v1.js
@@ -10,6 +10,7 @@ import { runDecisionEngine, SCORING_ENGINE_VERSION as ENGINE_VERSION } from './l
 import { resolveUserId, AuthError } from './lib/auth-helper.js';
 import { resolveQuestionId, ValidationError } from './lib/attempt-repository.js';
 import { writeLedger } from './lib/ledger-orchestrator.js';
+import { buildMarkingResult } from './lib/marking-result-contract.js';
 import { applyLearningEffects } from '../learning/lib/mastery/mastery-orchestrator.js';
 
 // ── Feature flag (evaluated per-request so env changes take effect) ──────────
@@ -158,6 +159,19 @@ async function loadLearningQuestionContext(supabase, questionId) {
     };
 }
 
+function getEmptyLearningQuestionContext(questionId) {
+  return {
+    question_id: questionId,
+    primary_topic_id: null,
+    family_id: null,
+    question_type_id: null,
+    question_type_release_state: null,
+    classification_confidence: null,
+    candidate_rubric_refs: [],
+    release_scope_status: null,
+  };
+}
+
 // ── Scoring engine version constant (re-exported from decision engine) ──────
 const SCORING_ENGINE_VERSION = ENGINE_VERSION;
 
@@ -189,6 +203,8 @@ export default async function handler(req, res) {
     const {
       storage_key,
       q_number,
+      part_id = null,
+      subpart_id = null,
       subpart = null,
       student_steps,
       rubric_source_version: requestedVersion = null,
@@ -228,6 +244,19 @@ export default async function handler(req, res) {
         return errorResponse(res, ErrorCodes.QUESTION_NOT_FOUND, qErr.message, { run_id });
       }
       throw qErr;
+    }
+
+    let questionContext = getEmptyLearningQuestionContext(question_id);
+    try {
+      questionContext = await loadLearningQuestionContext(supabase, question_id);
+    } catch (questionContextError) {
+      console.warn(JSON.stringify({
+        event: 'evaluate_v1_learning_question_context_error',
+        run_id,
+        question_id,
+        error: questionContextError?.message || String(questionContextError),
+        ts: new Date().toISOString(),
+      }));
     }
 
     // ── Audit log (structured) ────────────────────────────────────────────
@@ -289,8 +318,19 @@ export default async function handler(req, res) {
     // ── Evidence Ledger write ─────────────────────────────────────────────
     let ledger_write_status = null;
     let learningEffects = null;
+    let markingResult = null;
+    const requestScopedPartId = part_id;
+    const requestScopedSubpartId = subpart_id ?? subpart ?? null;
 
     try {
+      const baseMarkingResult = buildMarkingResult({
+        questionId: question_id,
+        questionTypeId: questionContext.question_type_id,
+        requestPartId: requestScopedPartId,
+        requestSubpartId: requestScopedSubpartId,
+        decisions,
+        rubricPoints: rubric_points,
+      });
       const ledgerResult = await writeLedger({
         supabase,
         user_id,
@@ -314,10 +354,21 @@ export default async function handler(req, res) {
         response_summary: {
           decisions,
           rubric_rows_used,
+          marking_result: baseMarkingResult,
         },
       });
 
       ledger_write_status = ledgerResult.decision_write_status;
+      markingResult = buildMarkingResult({
+        questionId: question_id,
+        attemptId: ledgerResult.attempt_id,
+        markRunId: ledgerResult.mark_run_id,
+        questionTypeId: questionContext.question_type_id,
+        requestPartId: requestScopedPartId,
+        requestSubpartId: requestScopedSubpartId,
+        decisions,
+        rubricPoints: rubric_points,
+      });
 
       console.log(JSON.stringify({
         event: 'evaluate_v1_ledger_write_done',
@@ -332,7 +383,6 @@ export default async function handler(req, res) {
 
       if (ledgerResult.decision_write_status === 'success') {
         try {
-          const questionContext = await loadLearningQuestionContext(supabase, question_id);
           learningEffects = await applyLearningEffects({
             supabase,
             user_id,
@@ -361,6 +411,7 @@ export default async function handler(req, res) {
             },
             source_attempt_context: ledgerResult.attempt_context ?? null,
             decisions,
+            marking_result: markingResult,
             uncertainty_validated: true,
           }, {
             supabase,
@@ -393,6 +444,7 @@ export default async function handler(req, res) {
       rubric_rows_used,
       decisions,
       ledger_write_status,
+      marking_result: markingResult,
     };
 
     if (learningEffects) {

--- a/api/marking/lib/marking-result-contract.js
+++ b/api/marking/lib/marking-result-contract.js
@@ -1,0 +1,295 @@
+import {
+  buildQuestionRef,
+  buildQuestionTypeRef,
+} from '../../learning/lib/contracts/runtime-contract.js';
+
+function normalizeNullableString(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function toNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function uniq(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function parseLegacyScopeToken(value) {
+  const normalized = normalizeNullableString(value);
+  if (!normalized) {
+    return {
+      part_id: null,
+      subpart_id: null,
+    };
+  }
+
+  const [root] = normalized.split('_');
+  const normalizedRoot = normalizeNullableString(root);
+  if (!normalizedRoot) {
+    return {
+      part_id: null,
+      subpart_id: null,
+    };
+  }
+
+  return {
+    part_id: normalizedRoot,
+    subpart_id: normalized.includes('_') ? normalized : null,
+  };
+}
+
+function normalizePartSubpart(partValue, subpartValue) {
+  const normalizedPartId = normalizeNullableString(partValue);
+  const normalizedSubpartToken = normalizeNullableString(subpartValue);
+  const parsedToken = parseLegacyScopeToken(normalizedSubpartToken);
+
+  if (
+    normalizedPartId
+    && parsedToken.part_id
+    && parsedToken.part_id !== normalizedPartId
+  ) {
+    return {
+      part_id: null,
+      subpart_id: null,
+      ambiguous: true,
+    };
+  }
+
+  return {
+    part_id: normalizedPartId || parsedToken.part_id || null,
+    subpart_id: parsedToken.subpart_id,
+    ambiguous: false,
+  };
+}
+
+function resolveRequestScope({
+  requestPartId = null,
+  requestSubpartId = null,
+} = {}) {
+  return normalizePartSubpart(requestPartId, requestSubpartId);
+}
+
+function resolvePartMapping({
+  decision = {},
+  rubricPoint = {},
+  requestScope = {},
+} = {}) {
+  const candidates = [
+    {
+      source: 'decision',
+      partValue: decision.part_id ?? decision.partId ?? decision.part ?? null,
+      subpartValue: decision.subpart_id ?? decision.subpartId ?? decision.subpart ?? null,
+    },
+    {
+      source: 'rubric',
+      partValue: rubricPoint.part_id ?? rubricPoint.partId ?? rubricPoint.part ?? null,
+      subpartValue: rubricPoint.subpart_id ?? rubricPoint.subpartId ?? rubricPoint.subpart ?? null,
+    },
+    {
+      source: 'request',
+      partValue: requestScope.part_id ?? null,
+      subpartValue: requestScope.subpart_id ?? null,
+    },
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizePartSubpart(candidate.partValue, candidate.subpartValue);
+    if (normalized.ambiguous) {
+      return {
+        part_id: null,
+        subpart_id: null,
+        mapping_source: 'ambiguous',
+      };
+    }
+
+    if (normalized.part_id || normalized.subpart_id) {
+      return {
+        part_id: normalized.part_id,
+        subpart_id: normalized.subpart_id,
+        mapping_source: candidate.source,
+      };
+    }
+  }
+
+  return {
+    part_id: null,
+    subpart_id: null,
+    mapping_source: 'none',
+  };
+}
+
+function buildUncertainFlags(decision = {}) {
+  return uniq([
+    normalizeNullableString(decision.uncertain_reason),
+    decision.reason && decision.reason !== 'best_match'
+      ? normalizeNullableString(decision.reason)
+      : null,
+  ]);
+}
+
+function buildRubricPointResult({
+  decision = {},
+  rubricPoint = {},
+  mapping = {},
+} = {}) {
+  return {
+    rubric_id: decision.rubric_id ?? rubricPoint.rubric_id ?? null,
+    mark_label: decision.mark_label ?? rubricPoint.mark_label ?? null,
+    awarded: decision.awarded === true,
+    awarded_marks: toNumber(decision.awarded_marks),
+    score_max: toNumber(rubricPoint.marks),
+    reason: decision.reason ?? null,
+    alignment_confidence:
+      decision.alignment_confidence === undefined ? null : decision.alignment_confidence,
+    evidence_spans: normalizeArray(decision.evidence_spans),
+    part_id: mapping.part_id,
+    subpart_id: mapping.subpart_id,
+    mapping_source: mapping.mapping_source,
+    uncertain_flags: buildUncertainFlags(decision),
+  };
+}
+
+function buildDiagnostics(partResults = [], pointResults = []) {
+  return {
+    by_part: partResults.map((partResult) => ({
+      part_id: partResult.part_id,
+      subpart_id: partResult.subpart_id,
+      incorrect_rubric_ids: partResult.rubric_point_results
+        .filter((item) => item.awarded !== true)
+        .map((item) => item.rubric_id),
+    })),
+    aggregate: {
+      awarded_rubric_ids: pointResults
+        .filter((item) => item.awarded === true)
+        .map((item) => item.rubric_id),
+      incorrect_rubric_ids: pointResults
+        .filter((item) => item.awarded !== true)
+        .map((item) => item.rubric_id),
+    },
+  };
+}
+
+export function buildMarkingResult({
+  questionId,
+  attemptId = null,
+  markRunId = null,
+  questionTypeId = null,
+  requestPartId = null,
+  requestSubpartId = null,
+  decisions = [],
+  rubricPoints = [],
+} = {}) {
+  const requestScope = resolveRequestScope({
+    requestPartId,
+    requestSubpartId,
+  });
+  const decisionByRubricId = new Map(
+    normalizeArray(decisions).map((decision) => [String(decision.rubric_id), decision]),
+  );
+  const pointByRubricId = new Map(
+    normalizeArray(rubricPoints).map((point) => [String(point.rubric_id), point]),
+  );
+  const rubricIds = uniq([
+    ...normalizeArray(rubricPoints).map((point) => normalizeNullableString(point.rubric_id)),
+    ...normalizeArray(decisions).map((decision) => normalizeNullableString(decision.rubric_id)),
+  ]);
+
+  const rubricPointResults = rubricIds.map((rubricId) => {
+    const decision = decisionByRubricId.get(String(rubricId)) ?? {};
+    const rubricPoint = pointByRubricId.get(String(rubricId)) ?? {};
+    const mapping = resolvePartMapping({
+      decision,
+      rubricPoint,
+      requestScope,
+    });
+
+    return buildRubricPointResult({
+      decision,
+      rubricPoint,
+      mapping,
+    });
+  });
+
+  const mappedPointResults = rubricPointResults.filter((item) => item.part_id || item.subpart_id);
+  const ambiguousPointResults = rubricPointResults.filter((item) =>
+    item.mapping_source === 'none' || item.mapping_source === 'ambiguous');
+  const groupedPartResults = new Map();
+
+  for (const pointResult of mappedPointResults) {
+    const key = `${pointResult.part_id || ''}::${pointResult.subpart_id || ''}`;
+    const existing = groupedPartResults.get(key) || {
+      part_id: pointResult.part_id,
+      subpart_id: pointResult.subpart_id,
+      mapped_question_type_refs: questionTypeId
+        ? [buildQuestionTypeRef(questionTypeId)]
+        : [],
+      rubric_point_results: [],
+      score_awarded: 0,
+      score_max: 0,
+      uncertain_flags: [],
+      diagnostic_refs: [],
+    };
+
+    existing.rubric_point_results.push(pointResult);
+    existing.score_awarded += toNumber(pointResult.awarded_marks);
+    existing.score_max += toNumber(pointResult.score_max);
+    existing.uncertain_flags = uniq([
+      ...existing.uncertain_flags,
+      ...normalizeArray(pointResult.uncertain_flags),
+    ]);
+    groupedPartResults.set(key, existing);
+  }
+
+  const partResults = [...groupedPartResults.values()];
+  const totalAwarded = rubricPointResults.reduce(
+    (sum, pointResult) => sum + toNumber(pointResult.awarded_marks),
+    0,
+  );
+  const totalAvailable = rubricPointResults.reduce(
+    (sum, pointResult) => sum + toNumber(pointResult.score_max),
+    0,
+  );
+  const coverageScope = requestScope.subpart_id
+    ? 'subpart'
+    : requestScope.part_id
+      ? 'part'
+      : 'question';
+  const localSignalOnly = coverageScope !== 'question';
+  const conservativePartMapping = ambiguousPointResults.length > 0;
+
+  return {
+    attempt_id: attemptId,
+    mark_run_id: markRunId,
+    question_ref: questionId ? buildQuestionRef(questionId) : null,
+    classification: {
+      question_type_ref: questionTypeId ? buildQuestionTypeRef(questionTypeId) : null,
+    },
+    marking_summary: {
+      total_awarded: totalAwarded,
+      total_available: totalAvailable,
+      coverage_scope: coverageScope,
+      local_signal_only: localSignalOnly,
+      part_result_count: partResults.length,
+      mapped_rubric_point_result_count: mappedPointResults.length,
+      ambiguous_rubric_point_result_count: ambiguousPointResults.length,
+      conservative_part_mapping: conservativePartMapping,
+    },
+    part_results: partResults,
+    diagnostics: buildDiagnostics(partResults, rubricPointResults),
+    learning_hints: {
+      local_signal_only: localSignalOnly,
+      conservative_part_mapping: conservativePartMapping,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add an explicit part/subpart-aware `marking_result` contract to the runtime scoring path and surface it from `evaluate-v1`
- carry local part signals through learning orchestration so subpart-only evidence no longer creates whole-question positive mastery
- keep fallback review and reconciliation outputs explainable with explicit part/subpart scope and conservative ambiguity counts

Closes #67

## Testing
- `npm test -- --runInBand api/marking/__tests__/marking-result-contract.test.js api/marking/__tests__/evaluate-v1.test.js api/learning/__tests__/reconciliation-service.test.js api/learning/__tests__/review-task-service.test.js`