### PR TITLE
Ship explicit Post-mortem Review mode with misconception-focused artifacts and repair handoff

### DIFF
--- a/api/learning/__tests__/session-api.test.js
+++ b/api/learning/__tests__/session-api.test.js
@@ -11,6 +11,7 @@ process.env.SUPABASE_ANON_KEY = 'anon-key';
 process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
 
 const clientState = {
+  artifacts: new Map(),
   calls: [],
   idempotencyRows: new Map(),
   nextIdempotencyId: 1,
@@ -176,10 +177,31 @@ function buildResumeProjection(sessionId) {
 }
 
 function resolveQuery(query) {
+  if (query.table === 'learning_artifacts' && query.operation === 'select') {
+    const artifactId = findFilter(query, 'artifact_id');
+    return {
+      data: artifactId ? clientState.artifacts.get(artifactId) || null : null,
+      error: null,
+    };
+  }
+
   if (query.table === 'learning_review_queue_projection' && query.operation === 'select') {
     const reviewTaskId = findFilter(query, 'review_task_id');
-    const row = clientState.reviewTasks.get(reviewTaskId) || null;
-    return { data: row, error: null };
+    const userId = findFilter(query, 'user_id');
+
+    let rows = [...clientState.reviewTasks.values()];
+    if (reviewTaskId) {
+      rows = rows.filter((row) => row.review_task_id === reviewTaskId);
+    }
+    if (userId) {
+      rows = rows.filter((row) => row.user_id === userId);
+    }
+
+    if (query.options?.single || query.options?.maybeSingle) {
+      return { data: rows[0] || null, error: null };
+    }
+
+    return { data: rows, error: null };
   }
 
   if (query.table === 'learning_request_idempotency') {
@@ -402,6 +424,31 @@ function buildStoredSession(overrides = {}) {
   };
 }
 
+function buildArtifact(overrides = {}) {
+  return {
+    artifact_id: 'artifact-misconception-1',
+    artifact_kind: 'misconception_card',
+    canonical_home_topic_id: 'topic-trig-equations',
+    source_session_id: null,
+    source_attempt_id: 'attempt-trig-1',
+    source_mark_run_id: 'mark-run-trig-1',
+    target_family_id: '9709.trigonometry_manipulation_equations',
+    target_question_type_id: '9709.trigonometry.equations',
+    slot_key: 'common_traps',
+    trust_status: 'unverified',
+    placement_status: 'inbox',
+    lifecycle_status: 'active',
+    grounding_refs: [
+      { kind: 'attempt', attempt_id: 'attempt-trig-1' },
+      { kind: 'mark_run', mark_run_id: 'mark-run-trig-1' },
+    ],
+    misconception_tags: ['domain:interval', 'sign:inverse'],
+    created_at: '2026-03-21T13:30:00.000Z',
+    updated_at: '2026-03-21T13:30:00.000Z',
+    ...overrides,
+  };
+}
+
 describe('learning session api', () => {
   let harness;
 
@@ -414,6 +461,9 @@ describe('learning session api', () => {
   });
 
   beforeEach(() => {
+    clientState.artifacts = new Map([
+      ['artifact-misconception-1', buildArtifact()],
+    ]);
     clientState.calls = [];
     clientState.idempotencyRows = new Map();
     clientState.nextIdempotencyId = 1;
@@ -972,6 +1022,138 @@ describe('learning session api', () => {
       anchor_kind: 'concept',
     });
     expect(res.body.session.active_scope_bundle.current_question_ref).toBeNull();
+  });
+
+  test('GET /api/learning/sessions/:id derives explicit post-mortem diagnostics, misconception focus, artifacts, and repair handoff from runtime truth', async () => {
+    clientState.sessions.set('session-post-mortem-1', buildStoredSession({
+      session_id: 'session-post-mortem-1',
+      mode: 'post_mortem_review',
+      state: 'handoff_suggested',
+      session_goal: 'Review the scored attempt before starting repair',
+      active_scope_bundle: {
+        primary_topic_id: 'topic-trig-equations',
+        primary_topic_path: '9709.trigonometry.equations',
+        secondary_topics_in_scope: [],
+        allowed_prerequisites: [],
+        paper_context: null,
+        mode: 'post_mortem_review',
+        session_goal: 'Review the scored attempt before starting repair',
+        current_anchor_kind: 'artifact',
+        current_anchor_ref: {
+          kind: 'artifact',
+          artifact_id: 'artifact-misconception-1',
+        },
+        current_question_ref: {
+          kind: 'question',
+          question_id: 'question-trig-1',
+        },
+        current_question_type_ref: {
+          kind: 'question_type',
+          question_type_id: '9709.trigonometry.equations',
+        },
+      },
+      current_anchor_kind: 'artifact',
+      current_anchor_ref: {
+        kind: 'artifact',
+        artifact_id: 'artifact-misconception-1',
+      },
+      current_question_id: 'question-trig-1',
+      current_question_type_id: '9709.trigonometry.equations',
+      summary_state: {},
+    }));
+    clientState.lineage.set('session-post-mortem-1', {
+      lineage_id: 'lineage-session-post-mortem-1',
+      parent_session_id: null,
+      child_session_id: 'session-post-mortem-1',
+      handoff_kind: null,
+      summary_snapshot: {},
+      created_at: '2026-03-21T13:30:00.000Z',
+    });
+    clientState.reviewTasks.set('review-task-post-mortem-1', buildReviewTask({
+      review_task_id: 'review-task-post-mortem-1',
+      target_topic_id: 'topic-trig-equations',
+      target_topic_path: '9709.trigonometry.equations',
+      target_question_type_id: '9709.trigonometry.equations',
+      target_misconception_tags: ['domain:interval', 'sign:inverse'],
+      source_question_id: 'question-trig-1',
+      trigger_type: 'non_released_fallback',
+      success_criteria: {
+        authoritative_scoring_allowed: false,
+        part_results: [
+          {
+            part_id: 'b',
+            score_awarded: 0,
+            score_max: 2,
+          },
+        ],
+      },
+      status: 'open',
+    }));
+
+    const res = await harness.request
+      .get('/api/learning/sessions/session-post-mortem-1')
+      .set('Origin', 'http://localhost:3000')
+      .set('Authorization', 'Bearer test-user:student-1:student');
+
+    expect(res.status).toBe(200);
+    expect(res.body.session.misconceptions_in_focus).toEqual([
+      'domain:interval',
+      'sign:inverse',
+    ]);
+    expect(res.body.session.key_artifact_refs).toEqual([
+      {
+        kind: 'artifact',
+        artifact_id: 'artifact-misconception-1',
+      },
+    ]);
+    expect(res.body.session.summary_state.post_mortem_review).toMatchObject({
+      scoring_posture: {
+        release_scope_status: 'non_released_fallback',
+        authoritative_scoring_allowed: false,
+        fallback_reason_code: 'non_released_fallback',
+      },
+      diagnostic_focus: {
+        title: 'Misconception-focused diagnostic',
+        source_question_id: 'question-trig-1',
+        source_attempt_ref: {
+          kind: 'attempt',
+          attempt_id: 'attempt-trig-1',
+        },
+        source_mark_run_ref: {
+          kind: 'mark_run',
+          mark_run_id: 'mark-run-trig-1',
+        },
+      },
+      artifact_candidates: [
+        {
+          artifact_id: 'artifact-misconception-1',
+          artifact_kind: 'misconception_card',
+        },
+      ],
+      repair_handoff: {
+        action_label: 'Launch repair session',
+        launch_payload: {
+          anchor_kind: 'review_task',
+          review_task_id: 'review-task-post-mortem-1',
+          mode: 'spaced_review',
+        },
+      },
+    });
+    expect(res.body.session.handoff).toMatchObject({
+      suggested_handoff: {
+        should_handoff: true,
+        handoff_kind: 'explicit_new_session',
+        reason_code: 'post_mortem_repair_ready',
+      },
+      explicit_new_session: {
+        recommended_mode: 'spaced_review',
+        recommended_anchor_kind: 'review_task',
+        recommended_anchor_ref: {
+          kind: 'review_task',
+          review_task_id: 'review-task-post-mortem-1',
+        },
+      },
+    });
   });
 
   test('GET /api/learning/sessions/:id returns 404 session_not_found with the frozen envelope', async () => {

--- a/api/learning/lib/session-runtime/session-service.js
+++ b/api/learning/lib/session-runtime/session-service.js
@@ -78,6 +78,10 @@ function normalizeNullableString(value) {
   return normalized || null;
 }
 
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
 function isUuidString(value) {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
     normalizeString(value),
@@ -123,6 +127,10 @@ function makeTopicRef(topicId, topicPath) {
   return topicId || topicPath
     ? { kind: 'topic', topic_id: topicId ?? null, topic_path: topicPath ?? null }
     : null;
+}
+
+function makeArtifactRef(artifactId) {
+  return artifactId ? { kind: 'artifact', artifact_id: artifactId } : null;
 }
 
 function normalizeSessionBundle({
@@ -210,6 +218,280 @@ function normalizeSessionResponse(session) {
     handoff: createSessionHandoff(normalized),
     resume_guidance: buildSessionResumeGuidance(normalized),
   };
+}
+
+async function loadArtifactForPostMortem(client, artifactId) {
+  const { data, error } = await client
+    .from('learning_artifacts')
+    .select('*')
+    .eq('artifact_id', artifactId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load post-mortem artifact: ${error.message}`);
+  }
+
+  return data ?? null;
+}
+
+async function listUserReviewTaskProjections(client, userId) {
+  const { data, error } = await client
+    .from('learning_review_queue_projection')
+    .select('*')
+    .eq('user_id', userId);
+
+  if (error) {
+    throw new Error(`Failed to load post-mortem review-task projection: ${error.message}`);
+  }
+
+  return Array.isArray(data) ? data : [];
+}
+
+function uniqueStrings(values = []) {
+  return [...new Set(normalizeArray(values).map((value) => normalizeNullableString(value)).filter(Boolean))];
+}
+
+function buildPostMortemScoringPosture(reviewTasks = []) {
+  const conservativeTask = reviewTasks.find((task) =>
+    task?.trigger_type === 'non_released_fallback'
+    || task?.success_criteria?.authoritative_scoring_allowed === false);
+
+  if (!conservativeTask) {
+    return null;
+  }
+
+  return {
+    release_scope_status: 'non_released_fallback',
+    authoritative_scoring_allowed: false,
+    fallback_reason_code:
+      normalizeNullableString(conservativeTask.trigger_type) ?? 'non_released_fallback',
+  };
+}
+
+function selectPostMortemReviewTasks(reviewTasks = [], {
+  topicId = null,
+  questionTypeId = null,
+  currentQuestionId = null,
+} = {}) {
+  const normalizedTasks = normalizeArray(reviewTasks);
+  const sourceQuestionMatches = currentQuestionId
+    ? normalizedTasks.filter((task) => task?.source_question_id === currentQuestionId)
+    : [];
+  const candidateTasks = sourceQuestionMatches.length > 0 ? sourceQuestionMatches : normalizedTasks;
+
+  return candidateTasks.filter((task) => {
+    if (currentQuestionId && task?.source_question_id === currentQuestionId) {
+      return true;
+    }
+
+    if (topicId && task?.target_topic_id !== topicId) {
+      return false;
+    }
+
+    if (questionTypeId && task?.target_question_type_id && task.target_question_type_id !== questionTypeId) {
+      return false;
+    }
+
+    return Boolean(topicId);
+  });
+}
+
+function pickPreferredRepairTask(reviewTasks = []) {
+  return reviewTasks.find((task) => ['open', 'partial'].includes(task?.status))
+    || reviewTasks[0]
+    || null;
+}
+
+function buildPostMortemDiagnosticSummary({ misconceptionTags = [], partResults = [] } = {}) {
+  if (misconceptionTags.length > 0) {
+    return `Focus on ${misconceptionTags.join(', ')} before starting the repair step.`;
+  }
+
+  if (partResults.length > 0) {
+    return 'Use the scored part breakdown before moving into the repair step.';
+  }
+
+  return 'Use the saved scored attempt and misconception evidence before starting repair.';
+}
+
+function buildPostMortemArtifactCandidate(artifact = {}) {
+  return {
+    artifact_id: artifact.artifact_id,
+    artifact_kind: artifact.artifact_kind,
+    canonical_home_topic_id: artifact.canonical_home_topic_id,
+    target_question_type_id: artifact.target_question_type_id ?? null,
+    trust_status: artifact.trust_status ?? null,
+    placement_status: artifact.placement_status ?? null,
+    lifecycle_status: artifact.lifecycle_status ?? null,
+    slot_key: artifact.slot_key ?? null,
+  };
+}
+
+function buildRepairHandoff({
+  currentQuestionId,
+  currentQuestionTypeId,
+  preferredReviewTask,
+  topicId,
+  topicPath,
+} = {}) {
+  if (preferredReviewTask?.review_task_id) {
+    return {
+      title: 'Start the repair session',
+      message: 'Use the projected review task to retry the misconception inside canonical runtime flows.',
+      action_label: 'Launch repair session',
+      launch_payload: {
+        anchor_kind: 'review_task',
+        review_task_id: preferredReviewTask.review_task_id,
+        mode: 'spaced_review',
+        topic_id: preferredReviewTask.target_topic_id ?? topicId ?? null,
+        topic_path: preferredReviewTask.target_topic_path ?? topicPath ?? null,
+        current_question_type_id:
+          preferredReviewTask.target_question_type_id ?? currentQuestionTypeId ?? null,
+      },
+    };
+  }
+
+  if (currentQuestionId) {
+    return {
+      title: 'Retry the source question',
+      message: 'Return to the source question in guided solve once the misconception focus is clear.',
+      action_label: 'Launch guided solve',
+      launch_payload: {
+        anchor_kind: 'question',
+        question_id: currentQuestionId,
+        mode: 'guided_solve',
+        topic_id: topicId ?? null,
+        topic_path: topicPath ?? null,
+        current_question_id: currentQuestionId,
+        current_question_type_id: currentQuestionTypeId ?? null,
+      },
+    };
+  }
+
+  return null;
+}
+
+async function enrichPostMortemSession(client, {
+  userId,
+  session,
+} = {}) {
+  if (session?.mode !== 'post_mortem_review') {
+    return session;
+  }
+
+  const bundle = normalizeStoredBundle(session);
+  const anchorKind = bundle.current_anchor_kind ?? session?.current_anchor_kind ?? null;
+  if (anchorKind !== 'artifact') {
+    return session;
+  }
+
+  const artifactId = normalizeNullableString(
+    bundle.current_anchor_ref?.artifact_id
+    ?? bundle.current_anchor_ref?.artifactId
+    ?? session?.current_anchor_ref?.artifact_id
+    ?? session?.current_anchor_ref?.artifactId,
+  );
+  if (!artifactId) {
+    return session;
+  }
+
+  const artifact = await loadArtifactForPostMortem(client, artifactId);
+  if (!artifact) {
+    return session;
+  }
+
+  const topicId = artifact.canonical_home_topic_id ?? bundle.primary_topic_id ?? null;
+  const topicPath = bundle.primary_topic_path ?? null;
+  const currentQuestionId = normalizeNullableString(session?.current_question_id);
+  const currentQuestionTypeId =
+    normalizeNullableString(artifact.target_question_type_id)
+    ?? normalizeNullableString(session?.current_question_type_id)
+    ?? null;
+  const reviewTasks = selectPostMortemReviewTasks(
+    await listUserReviewTaskProjections(client, userId),
+    {
+      topicId,
+      questionTypeId: currentQuestionTypeId,
+      currentQuestionId,
+    },
+  );
+  const preferredReviewTask = pickPreferredRepairTask(reviewTasks);
+  const misconceptionTags = uniqueStrings([
+    ...normalizeArray(artifact.misconception_tags),
+    ...reviewTasks.flatMap((task) => normalizeArray(task?.target_misconception_tags)),
+  ]);
+  const partResults = normalizeArray(preferredReviewTask?.success_criteria?.part_results).map((part) => ({
+    part_id: part?.part_id ?? null,
+    subpart_id: part?.subpart_id ?? null,
+    score_awarded: Number(part?.score_awarded ?? 0),
+    score_max: Number(part?.score_max ?? 0),
+  }));
+  const scoringPosture = buildPostMortemScoringPosture(reviewTasks);
+  const repairHandoff = buildRepairHandoff({
+    currentQuestionId,
+    currentQuestionTypeId,
+    preferredReviewTask,
+    topicId,
+    topicPath,
+  });
+  const summaryState = {
+    ...(isPlainObject(session?.summary_state) ? cloneJson(session.summary_state) : {}),
+    post_mortem_review: {
+      scoring_posture: scoringPosture,
+      misconception_tags: misconceptionTags,
+      diagnostic_focus: {
+        title: 'Misconception-focused diagnostic',
+        summary: buildPostMortemDiagnosticSummary({
+          misconceptionTags,
+          partResults,
+        }),
+        source_question_id: currentQuestionId,
+        source_attempt_ref: artifact.source_attempt_id
+          ? { kind: 'attempt', attempt_id: artifact.source_attempt_id }
+          : null,
+        source_mark_run_ref: artifact.source_mark_run_id
+          ? { kind: 'mark_run', mark_run_id: artifact.source_mark_run_id }
+          : null,
+        part_results: partResults,
+      },
+      artifact_candidates: [buildPostMortemArtifactCandidate(artifact)],
+      repair_handoff: repairHandoff,
+    },
+  };
+
+  if (repairHandoff?.launch_payload && !summaryState.suggested_handoff_kind) {
+    summaryState.suggested_handoff_kind = 'explicit_new_session';
+    summaryState.suggested_handoff_reason_code = 'post_mortem_repair_ready';
+    summaryState.suggested_handoff_message = repairHandoff.message;
+    summaryState.recommended_mode = repairHandoff.launch_payload.mode;
+    summaryState.recommended_anchor_kind = repairHandoff.launch_payload.anchor_kind;
+    summaryState.recommended_anchor_ref = repairHandoff.launch_payload.anchor_kind === 'review_task'
+      ? {
+        kind: 'review_task',
+        review_task_id: repairHandoff.launch_payload.review_task_id,
+      }
+      : {
+        kind: 'question',
+        question_id: repairHandoff.launch_payload.question_id,
+      };
+  }
+
+  return {
+    ...session,
+    summary_state: summaryState,
+    key_artifact_refs: [makeArtifactRef(artifact.artifact_id)].filter(Boolean),
+    misconceptions_in_focus: misconceptionTags,
+  };
+}
+
+async function enrichSessionForResponse(client, {
+  userId,
+  session,
+} = {}) {
+  return enrichPostMortemSession(client, {
+    userId,
+    session,
+  });
 }
 
 function assertRequiredString(value, field) {
@@ -463,7 +745,12 @@ async function maybeRecoverCreateSessionResponse(client, {
     return null;
   }
 
-  return buildLearningSessionResponse(session);
+  return buildLearningSessionResponse(
+    await enrichSessionForResponse(client, {
+      userId,
+      session,
+    }),
+  );
 }
 
 async function resolveCreateSessionReplay(client, {
@@ -602,7 +889,10 @@ async function performCreateLearningSession(client, {
     misconceptions_in_focus: [],
   });
 
-  return buildLearningSessionResponse(session, {
+  return buildLearningSessionResponse(await enrichSessionForResponse(client, {
+    userId,
+    session,
+  }), {
     anchorKind: normalized.anchorKind,
     anchorRef: normalized.anchorRef,
     canonicalHome: resolvedAnchor.canonicalHome,
@@ -732,5 +1022,8 @@ export async function readLearningSession(client, { userId, sessionId } = {}) {
     throw createLearningError('session_not_found');
   }
 
-  return buildLearningSessionResponse(session);
+  return buildLearningSessionResponse(await enrichSessionForResponse(client, {
+    userId,
+    session,
+  }));
 }

--- a/src/api/__tests__/learningRuntimeApi.test.js
+++ b/src/api/__tests__/learningRuntimeApi.test.js
@@ -90,6 +90,40 @@ function createSessionEnvelope() {
           questionless: true,
         },
       },
+      summary_state: {
+        post_mortem_review: {
+          scoring_posture: {
+            release_scope_status: 'non_released_fallback',
+            authoritative_scoring_allowed: false,
+            fallback_reason_code: 'non_released_fallback',
+          },
+          diagnostic_focus: {
+            title: 'Misconception-focused diagnostic',
+            source_attempt_ref: {
+              kind: 'attempt',
+              attempt_id: 'attempt-trig-1',
+            },
+            source_mark_run_ref: {
+              kind: 'mark_run',
+              mark_run_id: 'mark-run-trig-1',
+            },
+          },
+          artifact_candidates: [
+            {
+              artifact_id: 'artifact-misconception-1',
+              artifact_kind: 'misconception_card',
+            },
+          ],
+          repair_handoff: {
+            action_label: 'Launch repair session',
+            launch_payload: {
+              anchor_kind: 'review_task',
+              review_task_id: 'review-task-1',
+              mode: 'spaced_review',
+            },
+          },
+        },
+      },
       resume_guidance: {
         title: 'Resume this session',
         message: 'Re-enter through the review-task anchor without inventing a question.',
@@ -279,6 +313,38 @@ describe('learning runtime api', () => {
       parentSessionId: 'sess-parent-1',
       handoffKind: 'explicit_new_session',
     }));
+    expect(payload.session.summaryState.postMortemReview).toEqual({
+      scoringPosture: {
+        releaseScopeStatus: 'non_released_fallback',
+        authoritativeScoringAllowed: false,
+        fallbackReasonCode: 'non_released_fallback',
+      },
+      diagnosticFocus: {
+        title: 'Misconception-focused diagnostic',
+        sourceAttemptRef: {
+          kind: 'attempt',
+          attemptId: 'attempt-trig-1',
+        },
+        sourceMarkRunRef: {
+          kind: 'mark_run',
+          markRunId: 'mark-run-trig-1',
+        },
+      },
+      artifactCandidates: [
+        {
+          artifactId: 'artifact-misconception-1',
+          artifactKind: 'misconception_card',
+        },
+      ],
+      repairHandoff: {
+        actionLabel: 'Launch repair session',
+        launchPayload: {
+          anchorKind: 'review_task',
+          reviewTaskId: 'review-task-1',
+          mode: 'spaced_review',
+        },
+      },
+    });
   });
 
   test('normalizes fallback posture and typed refs from ask responses', () => {

--- a/src/components/learning-runtime/LearningSessionShell.js
+++ b/src/components/learning-runtime/LearningSessionShell.js
@@ -158,10 +158,154 @@ function renderContinuity(viewModel) {
   ]);
 }
 
+function renderPostMortem(viewModel, onPostMortemLaunch) {
+  const postMortem = viewModel?.postMortem || null;
+  if (!postMortem?.visible) {
+    return null;
+  }
+
+  const scoringPosture = postMortem.scoringPosture || null;
+  const diagnosticFocus = postMortem.diagnosticFocus || {};
+  const evidenceRows = [
+    diagnosticFocus.sourceQuestionId
+      ? `Question: ${diagnosticFocus.sourceQuestionId}`
+      : null,
+    diagnosticFocus.sourceAttemptId
+      ? `Attempt: ${diagnosticFocus.sourceAttemptId}`
+      : null,
+    diagnosticFocus.sourceMarkRunId
+      ? `Mark run: ${diagnosticFocus.sourceMarkRunId}`
+      : null,
+  ].filter(Boolean);
+
+  return h('section', {
+    key: 'post-mortem',
+    className: 'rounded-3xl border border-slate-200 bg-white p-6 shadow-sm',
+  }, [
+    h('div', { key: 'heading' }, [
+      h('p', {
+        key: 'eyebrow',
+        className: 'text-xs font-semibold uppercase tracking-[0.24em] text-slate-500',
+      }, 'Post-mortem review'),
+      h('h2', {
+        key: 'title',
+        className: 'mt-3 text-2xl font-semibold tracking-tight text-slate-950',
+      }, postMortem.title || 'Post-mortem review'),
+      h('p', {
+        key: 'summary',
+        className: 'mt-2 text-sm leading-6 text-slate-600',
+      }, postMortem.summary),
+    ]),
+    scoringPosture && scoringPosture.authoritativeScoringAllowed === false
+      ? h('div', {
+        key: 'scoring-posture',
+        className: 'mt-5 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900',
+      }, [
+        h('p', { key: 'title', className: 'font-semibold' }, 'Conservative post-mortem posture'),
+        h('p', { key: 'body', className: 'mt-1 leading-6' }, [
+          `Release scope: ${scoringPosture.releaseScopeStatus || 'non_released_fallback'}.`,
+          scoringPosture.fallbackReasonCode ? ` Reason: ${scoringPosture.fallbackReasonCode}.` : '',
+        ].join('')),
+      ])
+      : null,
+    h('div', { key: 'diagnostic', className: 'mt-5 rounded-2xl border border-slate-200 bg-slate-50 p-4' }, [
+      h('h3', {
+        key: 'title',
+        className: 'text-base font-semibold text-slate-950',
+      }, diagnosticFocus.title || 'Misconception-focused diagnostic'),
+      diagnosticFocus.summary
+        ? h('p', {
+          key: 'body',
+          className: 'mt-2 text-sm leading-6 text-slate-700',
+        }, diagnosticFocus.summary)
+        : null,
+      ...evidenceRows.map((row) => h('p', {
+        key: row,
+        className: 'mt-2 text-sm text-slate-600',
+      }, row)),
+    ].filter(Boolean)),
+    postMortem.misconceptions?.length
+      ? h('div', { key: 'misconceptions', className: 'mt-5' }, [
+        h('p', {
+          key: 'label',
+          className: 'text-sm font-medium text-slate-500',
+        }, 'Misconceptions in focus'),
+        h('div', {
+          key: 'chips',
+          className: 'mt-3 flex flex-wrap gap-2',
+        }, postMortem.misconceptions.map((item) => h('span', {
+          key: item.tag,
+          className: 'rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-sm text-amber-900',
+        }, item.label))),
+      ])
+      : null,
+    postMortem.artifactCandidates?.length
+      ? h('div', { key: 'artifacts', className: 'mt-5 grid gap-3' }, [
+        h('p', {
+          key: 'label',
+          className: 'text-sm font-medium text-slate-500',
+        }, 'Misconception-focused artifacts'),
+        ...postMortem.artifactCandidates.map((candidate) => h('article', {
+          key: candidate.artifactId,
+          className: 'rounded-2xl border border-slate-200 bg-slate-50 p-4',
+        }, [
+          h('div', {
+            key: 'header',
+            className: 'flex flex-wrap items-start justify-between gap-3',
+          }, [
+            h('div', { key: 'copy' }, [
+              h('h3', {
+                key: 'title',
+                className: 'text-base font-semibold text-slate-950',
+              }, candidate.artifactId),
+              h('p', {
+                key: 'meta',
+                className: 'mt-1 text-sm text-slate-600',
+              }, candidate.artifactKind),
+            ]),
+            candidate.launch
+              ? h('button', {
+                key: 'launch',
+                type: 'button',
+                onClick: () => onPostMortemLaunch(candidate.launch.launchPayload),
+                className: 'rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-900 hover:text-slate-900',
+              }, candidate.launch.ctaLabel || 'Open artifact')
+              : null,
+          ].filter(Boolean)),
+        ])),
+      ])
+      : null,
+    postMortem.repairHandoff
+      ? h('div', {
+        key: 'repair-handoff',
+        className: 'mt-5 rounded-2xl border border-slate-200 bg-slate-50 p-4',
+      }, [
+        h('h3', {
+          key: 'title',
+          className: 'text-base font-semibold text-slate-950',
+        }, postMortem.repairHandoff.title || 'Repair handoff'),
+        h('p', {
+          key: 'body',
+          className: 'mt-2 text-sm leading-6 text-slate-700',
+        }, postMortem.repairHandoff.message),
+        postMortem.repairHandoff.launchPayload
+          ? h('button', {
+            key: 'launch',
+            type: 'button',
+            onClick: () => onPostMortemLaunch(postMortem.repairHandoff.launchPayload),
+            className: 'mt-4 rounded-full bg-slate-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800',
+          }, postMortem.repairHandoff.actionLabel || 'Launch repair session')
+          : null,
+      ])
+      : null,
+  ].filter(Boolean));
+}
+
 export default function LearningSessionShell({
   viewModel,
   onLauncherChange = () => {},
   onLaunch = () => {},
+  onPostMortemLaunch = () => {},
   onAskChange = () => {},
   onAsk = () => {},
 }) {
@@ -183,6 +327,7 @@ export default function LearningSessionShell({
       })
       : null,
     hasSession ? h('div', { key: 'meta' }, renderSessionMeta(session)) : null,
+    hasSession ? renderPostMortem(viewModel, onPostMortemLaunch) : null,
     hasSession ? renderContinuity(viewModel) : null,
     hasSession && session.hasQuestion && session.currentQuestionId
       ? h('section', {

--- a/src/components/learning-runtime/__tests__/LearningSessionShell.test.js
+++ b/src/components/learning-runtime/__tests__/LearningSessionShell.test.js
@@ -105,6 +105,103 @@ function createContinuitySessionPayload() {
   };
 }
 
+function createPostMortemSessionPayload() {
+  return {
+    session: {
+      sessionId: 'sess-post-mortem-1',
+      mode: 'post_mortem_review',
+      state: 'handoff_suggested',
+      sessionGoal: 'Review the scored attempt before starting repair',
+      currentQuestionId: 'question-trig-1',
+      currentQuestionTypeId: '9709.trigonometry.equations',
+      currentQuestion: {
+        kind: 'question',
+        questionId: 'question-trig-1',
+      },
+      currentQuestionType: {
+        kind: 'question_type',
+        questionTypeId: '9709.trigonometry.equations',
+      },
+      activeScope: {
+        primaryTopicId: 'topic-trig-equations',
+        primaryTopicPath: '9709/trigonometry/equations',
+        currentAnchorKind: 'artifact',
+        currentAnchor: {
+          kind: 'artifact',
+          artifactId: 'artifact-misconception-1',
+        },
+      },
+      keyArtifactRefs: [
+        {
+          kind: 'artifact',
+          artifactId: 'artifact-misconception-1',
+        },
+      ],
+      misconceptionsInFocus: ['domain:interval', 'sign:inverse'],
+      summaryState: {
+        postMortemReview: {
+          scoringPosture: {
+            releaseScopeStatus: 'non_released_fallback',
+            authoritativeScoringAllowed: false,
+            fallbackReasonCode: 'non_released_fallback',
+          },
+          diagnosticFocus: {
+            title: 'Interval restrictions drove the miss',
+            summary: 'The scored attempt lost marks on the interval restriction and inverse-sign handling.',
+            sourceQuestionId: 'question-trig-1',
+            sourceAttemptRef: {
+              kind: 'attempt',
+              attemptId: 'attempt-trig-1',
+            },
+            sourceMarkRunRef: {
+              kind: 'mark_run',
+              markRunId: 'mark-run-trig-1',
+            },
+          },
+          artifactCandidates: [
+            {
+              artifactId: 'artifact-misconception-1',
+              artifactKind: 'misconception_card',
+              canonicalHomeTopicId: 'topic-trig-equations',
+              targetQuestionTypeId: '9709.trigonometry.equations',
+              trustStatus: 'unverified',
+              placementStatus: 'inbox',
+              lifecycleStatus: 'active',
+              slotKey: 'common_traps',
+            },
+          ],
+          repairHandoff: {
+            title: 'Start the repair session',
+            message: 'Use the projected review task to retry the misconception inside canonical runtime flows.',
+            actionLabel: 'Launch repair session',
+            launchPayload: {
+              anchorKind: 'review_task',
+              reviewTaskId: 'review-task-1',
+              mode: 'spaced_review',
+              topicId: 'topic-trig-equations',
+              topicPath: '9709/trigonometry/equations',
+              currentQuestionTypeId: '9709.trigonometry.equations',
+            },
+          },
+        },
+      },
+      createdAt: '2026-03-22T00:00:00.000Z',
+      updatedAt: '2026-03-22T00:05:00.000Z',
+    },
+    canonicalHomeContext: {
+      sourceAnchorKind: 'artifact',
+      topicRef: {
+        kind: 'topic',
+        topicId: 'topic-trig-equations',
+        topicPath: '9709/trigonometry/equations',
+      },
+    },
+    featureFlags: {
+      learningRuntimeEnabled: true,
+    },
+  };
+}
+
 describe('LearningSessionShell', () => {
   test('renders questionless sessions without placeholder question chrome', () => {
     const questionlessSessionVm = buildSessionViewModel(createQuestionlessSessionPayload());
@@ -209,5 +306,23 @@ describe('LearningSessionShell', () => {
     expect(html).toContain('internal compaction');
     expect(html).toContain('session_turn_limit');
     expect(html).not.toContain('Current question');
+  });
+
+  test('renders a dedicated post-mortem review section with diagnosis, misconception focus, evidence, and repair handoff', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(LearningSessionShell, {
+        viewModel: buildSessionViewModel(createPostMortemSessionPayload()),
+      }),
+    );
+
+    expect(html).toContain('Post-mortem review');
+    expect(html).toContain('Interval restrictions drove the miss');
+    expect(html).toContain('domain interval');
+    expect(html).toContain('sign inverse');
+    expect(html).toContain('attempt-trig-1');
+    expect(html).toContain('mark-run-trig-1');
+    expect(html).toContain('artifact-misconception-1');
+    expect(html).toContain('Launch repair session');
+    expect(html).toContain('Use the projected review task to retry the misconception inside canonical runtime flows.');
   });
 });

--- a/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
+++ b/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
@@ -218,6 +218,7 @@ describe('WorkspaceShell', () => {
     expect(html).toContain('Visible inbox artifacts');
     expect(html).toContain('artifact-successor');
     expect(html).toContain('Pin to slot');
+    expect(html).toContain('Start post-mortem review');
     expect(html).toContain('Unpin');
     expect(html).toContain('Mark contested');
     expect(html).toContain('Supersede');

--- a/src/components/learning-runtime/__tests__/view-models.test.js
+++ b/src/components/learning-runtime/__tests__/view-models.test.js
@@ -296,6 +296,119 @@ function createContinuitySessionPayload() {
   };
 }
 
+function createPostMortemSessionPayload() {
+  return {
+    session: {
+      sessionId: 'sess-post-mortem-1',
+      mode: 'post_mortem_review',
+      state: 'handoff_suggested',
+      sessionGoal: 'Review the scored attempt before starting repair',
+      currentQuestionId: 'question-trig-1',
+      currentQuestionTypeId: '9709.trigonometry.equations',
+      currentQuestion: {
+        kind: 'question',
+        questionId: 'question-trig-1',
+      },
+      currentQuestionType: {
+        kind: 'question_type',
+        questionTypeId: '9709.trigonometry.equations',
+      },
+      activeScope: {
+        primaryTopicId: 'topic-trig-equations',
+        primaryTopicPath: '9709/trigonometry/equations',
+        currentAnchorKind: 'artifact',
+        currentAnchor: {
+          kind: 'artifact',
+          artifactId: 'artifact-misconception-1',
+        },
+      },
+      keyArtifactRefs: [
+        {
+          kind: 'artifact',
+          artifactId: 'artifact-misconception-1',
+        },
+      ],
+      misconceptionsInFocus: ['domain:interval', 'sign:inverse'],
+      summaryState: {
+        postMortemReview: {
+          scoringPosture: {
+            releaseScopeStatus: 'non_released_fallback',
+            authoritativeScoringAllowed: false,
+            fallbackReasonCode: 'non_released_fallback',
+          },
+          diagnosticFocus: {
+            title: 'Interval restrictions drove the miss',
+            summary: 'The scored attempt lost marks on the interval restriction and inverse-sign handling.',
+            sourceQuestionId: 'question-trig-1',
+            sourceAttemptRef: {
+              kind: 'attempt',
+              attemptId: 'attempt-trig-1',
+            },
+            sourceMarkRunRef: {
+              kind: 'mark_run',
+              markRunId: 'mark-run-trig-1',
+            },
+            partResults: [
+              {
+                partId: 'b',
+                scoreAwarded: 0,
+                scoreMax: 2,
+              },
+            ],
+          },
+          artifactCandidates: [
+            {
+              artifactId: 'artifact-misconception-1',
+              artifactKind: 'misconception_card',
+              canonicalHomeTopicId: 'topic-trig-equations',
+              targetQuestionTypeId: '9709.trigonometry.equations',
+              trustStatus: 'unverified',
+              placementStatus: 'inbox',
+              lifecycleStatus: 'active',
+              slotKey: 'common_traps',
+            },
+          ],
+          repairHandoff: {
+            title: 'Start the repair session',
+            message: 'Use the projected review task to retry the misconception inside canonical runtime flows.',
+            actionLabel: 'Launch repair session',
+            launchPayload: {
+              anchorKind: 'review_task',
+              reviewTaskId: 'review-task-1',
+              mode: 'spaced_review',
+              topicId: 'topic-trig-equations',
+              topicPath: '9709/trigonometry/equations',
+              currentQuestionTypeId: '9709.trigonometry.equations',
+            },
+          },
+        },
+      },
+      handoff: {
+        supported: true,
+        suggestedHandoff: {
+          shouldHandoff: true,
+          handoffKind: 'explicit_new_session',
+          reasonCode: 'post_mortem_repair_ready',
+          message: 'Start the repair session from the projected review task.',
+        },
+      },
+      createdAt: '2026-03-22T00:00:00.000Z',
+      updatedAt: '2026-03-22T00:05:00.000Z',
+    },
+    canonicalHomeContext: {
+      sourceAnchorKind: 'artifact',
+      topicRef: {
+        kind: 'topic',
+        topicId: 'topic-trig-equations',
+        topicPath: '9709/trigonometry/equations',
+      },
+    },
+    featureFlags: {
+      learningRuntimeEnabled: true,
+    },
+  };
+}
+
 describe('learning runtime session view model', () => {
   test('preserves questionless runtime state without placeholder ids', () => {
     const vm = buildSessionViewModel(createQuestionlessSessionPayload());
@@ -369,6 +482,56 @@ describe('learning runtime session view model', () => {
       }),
     }));
     expect(vm.timeline.some((entry) => entry.kind === 'question')).toBe(false);
+  });
+
+  test('builds a dedicated post-mortem surface from diagnostic, misconception, artifact, and repair-handoff data', () => {
+    const vm = buildSessionViewModel(createPostMortemSessionPayload());
+
+    expect(vm.postMortem).toEqual(expect.objectContaining({
+      visible: true,
+      title: 'Post-mortem review',
+      misconceptions: [
+        expect.objectContaining({
+          tag: 'domain:interval',
+          label: 'domain interval',
+        }),
+        expect.objectContaining({
+          tag: 'sign:inverse',
+          label: 'sign inverse',
+        }),
+      ],
+      diagnosticFocus: expect.objectContaining({
+        title: 'Interval restrictions drove the miss',
+        sourceQuestionId: 'question-trig-1',
+        sourceAttemptId: 'attempt-trig-1',
+        sourceMarkRunId: 'mark-run-trig-1',
+      }),
+      scoringPosture: expect.objectContaining({
+        releaseScopeStatus: 'non_released_fallback',
+        authoritativeScoringAllowed: false,
+      }),
+      artifactCandidates: [
+        expect.objectContaining({
+          artifactId: 'artifact-misconception-1',
+          artifactKind: 'misconception_card',
+          launch: expect.objectContaining({
+            launchPayload: expect.objectContaining({
+              anchorKind: 'artifact',
+              artifactId: 'artifact-misconception-1',
+              mode: 'post_mortem_review',
+            }),
+          }),
+        }),
+      ],
+      repairHandoff: expect.objectContaining({
+        actionLabel: 'Launch repair session',
+        launchPayload: expect.objectContaining({
+          anchorKind: 'review_task',
+          reviewTaskId: 'review-task-1',
+          mode: 'spaced_review',
+        }),
+      }),
+    }));
   });
 
   test('builds launch payloads that keep concept sessions questionless', () => {
@@ -667,21 +830,21 @@ describe('learning runtime session view model', () => {
       },
     });
     expect(vm.slots.common_traps.primaryArtifactCard.launch).toEqual({
-      ctaLabel: 'Open artifact',
+      ctaLabel: 'Start post-mortem review',
       launchPayload: {
         anchorKind: 'artifact',
         artifactId: 'artifact-primary',
-        mode: 'learn_concept',
+        mode: 'post_mortem_review',
         topicId: 'topic-trig-equations',
         topicPath: '9709/trigonometry/equations',
       },
     });
     expect(vm.slots.common_traps.linkedReferenceCards[0].launch).toEqual({
-      ctaLabel: 'Open artifact',
+      ctaLabel: 'Start post-mortem review',
       launchPayload: {
         anchorKind: 'artifact',
         artifactId: 'artifact-linked-1',
-        mode: 'learn_concept',
+        mode: 'post_mortem_review',
         topicId: 'topic-trig-equations',
         topicPath: '9709/trigonometry/equations',
       },

--- a/src/components/learning-runtime/view-models/session-view-model.js
+++ b/src/components/learning-runtime/view-models/session-view-model.js
@@ -13,13 +13,36 @@ function normalizeText(value, fallback = '') {
   return trimmed || fallback;
 }
 
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeRefId(ref, key) {
+  if (!ref || typeof ref !== 'object') {
+    return null;
+  }
+
+  return normalizeText(ref[key] ?? ref[key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)], null);
+}
+
 function labelForMode(mode) {
+  if (mode === 'post_mortem_review') {
+    return 'Post-mortem review';
+  }
+
   return normalizeText(mode, 'learning session').replace(/_/g, ' ');
 }
 
 function labelForHandoffKind(handoffKind) {
   return normalizeText(handoffKind, '')
     .replace(/_/g, ' ')
+    .trim();
+}
+
+function labelForFocusTag(tag) {
+  return normalizeText(tag, '')
+    .replace(/[:_]/g, ' ')
+    .replace(/\s+/g, ' ')
     .trim();
 }
 
@@ -246,6 +269,122 @@ function buildComposerViewModel(composer = {}, hasSession) {
   };
 }
 
+function buildPostMortemArtifactLaunch(candidate, topicPath) {
+  const artifactId = normalizeText(candidate?.artifactId ?? candidate?.artifact_id, null);
+  if (!artifactId) {
+    return null;
+  }
+
+  return {
+    ctaLabel: 'Start post-mortem review',
+    launchPayload: {
+      anchorKind: 'artifact',
+      artifactId,
+      mode: 'post_mortem_review',
+      topicId: normalizeText(candidate?.canonicalHomeTopicId ?? candidate?.canonical_home_topic_id, ''),
+      topicPath: normalizeText(candidate?.canonicalHomeTopicPath ?? candidate?.canonical_home_topic_path, topicPath || ''),
+      currentQuestionTypeId: normalizeText(
+        candidate?.targetQuestionTypeId ?? candidate?.target_question_type_id,
+        '',
+      ),
+    },
+  };
+}
+
+function buildPostMortemViewModel(sessionPayload = {}, session, topicPath) {
+  if (session?.mode !== 'post_mortem_review') {
+    return null;
+  }
+
+  const summaryState = sessionPayload.summaryState || sessionPayload.summary_state || {};
+  const raw = summaryState.postMortemReview || summaryState.post_mortem_review || {};
+  const scoringPosture = raw.scoringPosture || raw.scoring_posture || null;
+  const diagnosticFocus = raw.diagnosticFocus || raw.diagnostic_focus || {};
+  const repairHandoff = raw.repairHandoff || raw.repair_handoff || null;
+  const misconceptionTags = normalizeArray(
+    sessionPayload.misconceptionsInFocus
+    ?? sessionPayload.misconceptions_in_focus
+    ?? raw.misconceptionTags
+    ?? raw.misconception_tags,
+  );
+  const artifactCandidates = normalizeArray(raw.artifactCandidates ?? raw.artifact_candidates)
+    .map((candidate) => {
+      const artifactId = normalizeText(candidate?.artifactId ?? candidate?.artifact_id, null);
+      if (!artifactId) {
+        return null;
+      }
+
+      return {
+        artifactId,
+        artifactKind: normalizeText(candidate?.artifactKind ?? candidate?.artifact_kind, 'artifact'),
+        trustStatus: normalizeText(candidate?.trustStatus ?? candidate?.trust_status, null),
+        placementStatus: normalizeText(candidate?.placementStatus ?? candidate?.placement_status, null),
+        lifecycleStatus: normalizeText(candidate?.lifecycleStatus ?? candidate?.lifecycle_status, null),
+        slotKey: normalizeText(candidate?.slotKey ?? candidate?.slot_key, null),
+        launch: buildPostMortemArtifactLaunch(candidate, topicPath),
+      };
+    })
+    .filter(Boolean);
+  const sourceAttemptId = normalizeRefId(
+    diagnosticFocus.sourceAttemptRef ?? diagnosticFocus.source_attempt_ref,
+    'attemptId',
+  );
+  const sourceMarkRunId = normalizeRefId(
+    diagnosticFocus.sourceMarkRunRef ?? diagnosticFocus.source_mark_run_ref,
+    'markRunId',
+  );
+
+  return {
+    visible: true,
+    title: 'Post-mortem review',
+    summary: normalizeText(
+      diagnosticFocus.summary,
+      'Stay anchored to the scored attempt and the saved runtime evidence before starting repair.',
+    ),
+    scoringPosture: scoringPosture
+      ? {
+        releaseScopeStatus:
+          scoringPosture.releaseScopeStatus ?? scoringPosture.release_scope_status ?? null,
+        authoritativeScoringAllowed:
+          typeof scoringPosture.authoritativeScoringAllowed === 'boolean'
+            ? scoringPosture.authoritativeScoringAllowed
+            : scoringPosture.authoritative_scoring_allowed ?? null,
+        fallbackReasonCode:
+          scoringPosture.fallbackReasonCode ?? scoringPosture.fallback_reason_code ?? null,
+      }
+      : null,
+    diagnosticFocus: {
+      title: normalizeText(diagnosticFocus.title, 'Misconception-focused diagnostic'),
+      summary: normalizeText(diagnosticFocus.summary, ''),
+      sourceQuestionId:
+        normalizeText(diagnosticFocus.sourceQuestionId ?? diagnosticFocus.source_question_id, null)
+        ?? session.currentQuestionId,
+      sourceAttemptId,
+      sourceMarkRunId,
+      partResults: normalizeArray(diagnosticFocus.partResults ?? diagnosticFocus.part_results),
+    },
+    misconceptions: misconceptionTags.map((tag) => ({
+      tag,
+      label: labelForFocusTag(tag),
+    })),
+    artifactCandidates,
+    repairHandoff: repairHandoff
+      ? {
+        title: normalizeText(repairHandoff.title, 'Repair handoff'),
+        message: normalizeText(
+          repairHandoff.message,
+          'Continue into the next repair step through the canonical runtime flow.',
+        ),
+        actionLabel: normalizeText(
+          repairHandoff.actionLabel ?? repairHandoff.action_label,
+          'Launch repair session',
+        ),
+        launchPayload: repairHandoff.launchPayload ?? repairHandoff.launch_payload ?? null,
+      }
+      : null,
+  };
+}
+
 export function buildSessionViewModel(payload = {}, options = {}) {
   const sessionPayload = payload.session || {};
   const activeScope = sessionPayload.activeScope || sessionPayload.activeScopeBundle || {};
@@ -278,6 +417,12 @@ export function buildSessionViewModel(payload = {}, options = {}) {
     currentQuestionTypeId,
     hasQuestion: Boolean(currentQuestionId),
     topicPath,
+    misconceptionsInFocus: normalizeArray(
+      sessionPayload.misconceptionsInFocus ?? sessionPayload.misconceptions_in_focus,
+    ),
+    keyArtifactRefs: normalizeArray(
+      sessionPayload.keyArtifactRefs ?? sessionPayload.key_artifact_refs,
+    ),
     lineage,
     handoff,
     resumeGuidance,
@@ -293,6 +438,7 @@ export function buildSessionViewModel(payload = {}, options = {}) {
     lineage,
     resumeGuidance,
   });
+  const postMortem = buildPostMortemViewModel(sessionPayload, session, topicPath);
 
   return {
     hasSession,
@@ -317,6 +463,7 @@ export function buildSessionViewModel(payload = {}, options = {}) {
     latestResponse,
     timeline: hasSession ? buildTimeline(session, latestResponse, options.turnHistory || []) : [],
     continuity,
+    postMortem,
     launcher,
     composer,
     timelineUpdating: composer.status === 'submitting',

--- a/src/components/learning-runtime/view-models/workspace-view-model.js
+++ b/src/components/learning-runtime/view-models/workspace-view-model.js
@@ -220,6 +220,47 @@ function buildReferenceLaunch(ref, workspace) {
   return null;
 }
 
+function defaultArtifactKindForSlot(slotKey) {
+  switch (slotKey) {
+    case 'overview_map':
+      return 'summary_card';
+    case 'core_method_derivation':
+      return 'derivation_card';
+    case 'canonical_worked_example':
+      return 'worked_example_card';
+    case 'common_traps':
+      return 'misconception_card';
+    case 'my_notes':
+      return 'free_note';
+    default:
+      return null;
+  }
+}
+
+function buildArtifactLaunch(record, workspace) {
+  if (!record?.artifactId) {
+    return null;
+  }
+
+  const isPostMortemArtifact = record.artifactKind === 'misconception_card';
+  const launchPayload = {
+    anchorKind: 'artifact',
+    artifactId: record.artifactId,
+    mode: isPostMortemArtifact ? 'post_mortem_review' : 'learn_concept',
+    topicId: workspace.topicId,
+    topicPath: workspace.topicPath,
+  };
+
+  if (record.targetQuestionTypeId) {
+    launchPayload.currentQuestionTypeId = record.targetQuestionTypeId;
+  }
+
+  return {
+    ctaLabel: isPostMortemArtifact ? 'Start post-mortem review' : 'Open artifact',
+    launchPayload,
+  };
+}
+
 function readArtifactInbox(workspace = {}) {
   return workspace.artifactInbox || workspace.artifact_inbox || {};
 }
@@ -246,6 +287,10 @@ function normalizeArtifactRecord(artifact = {}, { source = 'artifact_inbox' } = 
     trustStatus: normalizeString(artifact.trustStatus ?? artifact.trust_status, null),
     lifecycleStatus: normalizeString(artifact.lifecycleStatus ?? artifact.lifecycle_status, 'active'),
     slotKey: normalizeString(artifact.slotKey ?? artifact.slot_key, null),
+    targetQuestionTypeId: normalizeString(
+      artifact.targetQuestionTypeId ?? artifact.target_question_type_id,
+      null,
+    ),
     updatedAt: artifact.updatedAt ?? artifact.updated_at ?? null,
     source,
   };
@@ -355,10 +400,7 @@ function buildArtifactCard(record, {
     description,
     updatedAtLabel: buildUpdatedAtLabel(record.updatedAt),
     state: buildArtifactStatusState(record, fallbackState),
-    launch: buildReferenceLaunch({
-      kind: 'artifact',
-      artifactId: record.artifactId,
-    }, workspace),
+    launch: buildArtifactLaunch(record, workspace),
     availableActions: buildArtifactActionState(record, workspace),
   };
 }
@@ -368,6 +410,7 @@ function buildCardViewModel(ref, {
   description,
   updatedAt,
   state,
+  launch = null,
   workspace,
 } = {}) {
   if (!ref) {
@@ -381,7 +424,7 @@ function buildCardViewModel(ref, {
     description,
     updatedAtLabel: buildUpdatedAtLabel(updatedAt),
     state,
-    launch: buildReferenceLaunch(ref, workspace),
+    launch: launch || buildReferenceLaunch(ref, workspace),
   };
 }
 
@@ -391,6 +434,7 @@ function buildSlotViewModel(definition, slots, slotState, workspace) {
   const primaryArtifactRecord = primaryArtifact
     ? normalizeArtifactRecord({
       artifactId: primaryArtifact.artifactId ?? primaryArtifact.artifact_id,
+      artifactKind: defaultArtifactKindForSlot(definition.key),
       canonicalHomeTopicId: workspace.topicId,
       lifecycleStatus: 'active',
       placementStatus: 'pinned',
@@ -431,6 +475,19 @@ function buildSlotViewModel(definition, slots, slotState, workspace) {
       description: 'Linked from another canonical-home topic.',
       updatedAt: null,
       state: null,
+      launch:
+        definition.key === 'common_traps' && reference.kind === 'artifact'
+          ? {
+            ctaLabel: 'Start post-mortem review',
+            launchPayload: {
+              anchorKind: 'artifact',
+              artifactId: normalizeString(reference.artifactId ?? reference.artifact_id),
+              mode: 'post_mortem_review',
+              topicId: workspace.topicId,
+              topicPath: workspace.topicPath,
+            },
+          }
+          : null,
       workspace,
     })),
     updatedAt,

--- a/src/pages/learning-runtime/LearningSessionPage.jsx
+++ b/src/pages/learning-runtime/LearningSessionPage.jsx
@@ -259,6 +259,56 @@ export default function LearningSessionPage() {
     setLaunchDraft((currentDraft) => patchSessionLaunchDraft(currentDraft, patch));
   }
 
+  async function handlePostMortemLaunch(launchPayload) {
+    if (!launchPayload || launchStatus === 'submitting') {
+      return;
+    }
+
+    setLaunchStatus('submitting');
+    setLaunchError(null);
+
+    try {
+      const payload = await createSession(
+        buildSessionLaunchPayload(createSessionLaunchDraft(launchPayload)),
+        {
+          idempotencyKey: createRequestKey('learning-session-handoff'),
+        },
+      );
+      const createdSessionId = payload?.session?.sessionId || null;
+
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      startTransition(() => {
+        setSessionPayload(payload);
+        setTurnHistory([]);
+        setAskMessage('');
+        setAskError(null);
+        setLaunchStatus('idle');
+        setSurfaceState('ready');
+        setError(null);
+      });
+
+      if (createdSessionId) {
+        skipReloadSessionIdRef.current = createdSessionId;
+        navigate(`/learn/session/${createdSessionId}`, {
+          replace: true,
+          state: { handoffFromPostMortem: true },
+        });
+      }
+    } catch (requestError) {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      startTransition(() => {
+        setLaunchError(requestError);
+        setLaunchStatus('idle');
+      });
+    }
+  }
+
   function handleImportDraftChange(patch) {
     setImportError(null);
     setImportHandoffError(null);
@@ -530,6 +580,7 @@ export default function LearningSessionPage() {
             viewModel={viewModel}
             onLauncherChange={handleLaunchFieldChange}
             onLaunch={handleLaunch}
+            onPostMortemLaunch={handlePostMortemLaunch}
             onAskChange={handleAskMessageChange}
             onAsk={handleAsk}
           />


### PR DESCRIPTION
## Summary

This PR makes Post-mortem Review a first-class runtime mode instead of leaving scored-attempt reflection buried inside generic learning-session surfaces. The runtime contract, validators, and misconception artifacts already reserved `post_mortem_review`, but the product still lacked an end-to-end flow that stayed anchored to real attempt and marking truth and then handed the learner into canonical repair work.

The root gap was that artifact-anchored post-mortem sessions were not being enriched into explicit diagnostic state, misconception focus, artifact candidates, or repair-session launch data. On the frontend, misconception artifacts still opened like generic concept study, so users were not getting a distinct post-mark review experience.

This change adds backend session enrichment for artifact-anchored `post_mortem_review` sessions, deriving conservative scored-attempt diagnostics, misconception tags, artifact candidates, and explicit repair handoff data from canonical runtime truth. It also adds a dedicated post-mortem surface in the learning session shell, wires repair handoff launches into canonical session creation, and retargets misconception-card launches from workspace/common-traps surfaces into `post_mortem_review` instead of generic `learn_concept`.

Non-released scoring remains clearly conservative. When projected review-task truth indicates fallback posture, the session shows an explicit non-authoritative release-scope warning instead of pretending to be authoritative post-mark review.

Closes #69

## Verification

`npm test -- --runInBand api/learning/__tests__/session-api.test.js api/learning/__tests__/session-validator.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/workspace-read-service.test.js`
Result: 5 suites passed, 45 tests passed.

`npm test -- --runInBand src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/view-models.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js`
Result: 4 suites passed, 38 tests passed.