### PR TITLE
feat(learning-runtime): harden review scheduler policy

### DIFF
--- a/api/learning/__tests__/review-scheduler-policy.test.js
+++ b/api/learning/__tests__/review-scheduler-policy.test.js
@@ -1,0 +1,179 @@
+import {
+  buildReviewTaskSchedulerSeed,
+  deriveReviewQueueProjection,
+  REVIEW_SCHEDULER_POLICY,
+} from '../lib/review/review-scheduler-policy.js';
+
+function buildTask(overrides = {}) {
+  return {
+    review_task_id: 'review-task-1',
+    user_id: 'student-1',
+    target_kind: 'question_type',
+    target_topic_id: 'topic-1',
+    target_topic_path: '9709/trigonometry/equations',
+    target_family_id: '9709.trigonometry_manipulation_equations',
+    target_question_type_id: '9709.trigonometry.equations',
+    target_misconception_tags: [],
+    related_artifact_refs: [],
+    trigger_type: 'short_delay',
+    mode: 'redo_variant',
+    due_at: '2026-03-26T08:00:00.000Z',
+    priority: 'normal',
+    estimated_minutes: 15,
+    success_criteria: {
+      scheduler_policy: {
+        route: 'short_delay',
+        freshness_bucket: 'cooling',
+      },
+    },
+    completion_evidence: {},
+    status: 'open',
+    created_at: '2026-03-25T08:00:00.000Z',
+    updated_at: '2026-03-25T08:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('review scheduler policy', () => {
+  test('buildReviewTaskSchedulerSeed gives fresh immediate-repair tasks explicit overload and freshness policy', () => {
+    const scheduler = buildReviewTaskSchedulerSeed({
+      misconceptionTags: ['domain:interval'],
+      fallbackReasonCode: 'non_released_fallback',
+      now: new Date('2026-03-25T10:00:00.000Z'),
+    });
+
+    expect(scheduler).toEqual(expect.objectContaining({
+      triggerType: 'immediate_repair',
+      mode: 'trap_fix',
+      priority: 'high',
+      dueAt: '2026-03-25T10:00:00.000Z',
+      policy: expect.objectContaining({
+        route: 'immediate_repair',
+        freshness_bucket: 'fresh',
+        daily_recommendation_cap: REVIEW_SCHEDULER_POLICY.DAILY_RECOMMENDATION_CAP,
+        max_high_priority_open_per_type: REVIEW_SCHEDULER_POLICY.MAX_HIGH_PRIORITY_OPEN_PER_TYPE,
+        immediate_repair_max_deferral_at: '2026-03-25T22:00:00.000Z',
+        fallback_reason_code: 'non_released_fallback',
+      }),
+    }));
+  });
+
+  test('deriveReviewQueueProjection blocks overflowed tasks after the daily recommendation cap', () => {
+    const projection = deriveReviewQueueProjection([
+      buildTask({
+        review_task_id: 'review-task-urgent',
+        trigger_type: 'immediate_repair',
+        priority: 'high',
+        due_at: '2026-03-25T09:00:00.000Z',
+        success_criteria: {
+          scheduler_policy: {
+            route: 'immediate_repair',
+            freshness_bucket: 'fresh',
+          },
+        },
+      }),
+      buildTask({
+        review_task_id: 'review-task-due',
+        trigger_type: 'regression_recovery',
+        target_question_type_id: '9709.trigonometry.identities',
+        priority: 'urgent',
+        due_at: '2026-03-25T09:30:00.000Z',
+        success_criteria: {
+          scheduler_policy: {
+            route: 'regression_recovery',
+            freshness_bucket: 'stale',
+          },
+        },
+      }),
+      buildTask({
+        review_task_id: 'review-task-open-1',
+        target_question_type_id: '9709.trigonometry.functions',
+        due_at: '2026-03-25T09:45:00.000Z',
+        success_criteria: {
+          scheduler_policy: {
+            route: 'short_delay',
+            freshness_bucket: 'cooling',
+          },
+        },
+      }),
+      buildTask({
+        review_task_id: 'review-task-open-2',
+        target_question_type_id: '9709.trigonometry.mixed',
+        target_topic_id: 'topic-2',
+        due_at: '2026-03-26T08:00:00.000Z',
+        success_criteria: {
+          scheduler_policy: {
+            route: 'spaced_review',
+            freshness_bucket: 'current',
+          },
+        },
+      }),
+    ], {
+      now: '2026-03-25T10:00:00.000Z',
+    });
+
+    expect(projection.summary).toEqual(expect.objectContaining({
+      total: 4,
+      escalated: 2,
+      due: 1,
+      blocked: 1,
+    }));
+    expect(projection.items.find((item) => item.review_task_id === 'review-task-open-2'))
+      .toEqual(expect.objectContaining({
+        scheduler_state: expect.objectContaining({
+          value: 'blocked',
+          reason_code: 'daily_recommendation_cap',
+        }),
+        scheduler_reasons: expect.arrayContaining([
+          expect.objectContaining({
+            code: 'daily_recommendation_cap',
+          }),
+        ]),
+      }));
+  });
+
+  test('deriveReviewQueueProjection keeps only one active high-priority task per question type', () => {
+    const projection = deriveReviewQueueProjection([
+      buildTask({
+        review_task_id: 'review-task-primary',
+        trigger_type: 'immediate_repair',
+        priority: 'high',
+        due_at: '2026-03-25T09:00:00.000Z',
+        success_criteria: {
+          scheduler_policy: {
+            route: 'immediate_repair',
+            freshness_bucket: 'fresh',
+          },
+        },
+      }),
+      buildTask({
+        review_task_id: 'review-task-shadowed',
+        trigger_type: 'regression_recovery',
+        priority: 'urgent',
+        due_at: '2026-03-25T09:30:00.000Z',
+        success_criteria: {
+          scheduler_policy: {
+            route: 'regression_recovery',
+            freshness_bucket: 'stale',
+          },
+        },
+      }),
+    ], {
+      now: '2026-03-25T10:00:00.000Z',
+    });
+
+    expect(projection.items.find((item) => item.review_task_id === 'review-task-primary'))
+      .toEqual(expect.objectContaining({
+        scheduler_state: expect.objectContaining({
+          value: 'blocked',
+          reason_code: 'high_priority_type_limit',
+        }),
+      }));
+    expect(projection.items.find((item) => item.review_task_id === 'review-task-shadowed'))
+      .toEqual(expect.objectContaining({
+        scheduler_state: expect.objectContaining({
+          value: 'escalated',
+        }),
+      }));
+  });
+});

--- a/api/learning/__tests__/review-task-service.test.js
+++ b/api/learning/__tests__/review-task-service.test.js
@@ -320,6 +320,114 @@ describe('learning orchestration', () => {
 });
 
 describe('review task service generation', () => {
+  test('fallback review tasks now route through immediate repair with explicit scheduler policy', async () => {
+    const service = createReviewTaskService({
+      now: () => new Date('2026-03-24T10:00:00.000Z'),
+    });
+
+    const [task] = await service.generateTasksFromOutcome({
+      user_id: 'student-1',
+      question_id: 'question-1',
+      authoritative_scoring_allowed: false,
+      fallback_reason_code: 'non_released_fallback',
+      repair_target_topic_id: 'topic-1',
+      repair_target_topic_path: '9709/trigonometry/equations',
+      misconception_tags: ['domain:interval'],
+      question_context: {
+        family_id: '9709.trigonometry_manipulation_equations',
+        question_type_id: '9709.trigonometry.equations',
+      },
+      marking_result: {
+        marking_summary: {
+          coverage_scope: 'question',
+          local_signal_only: true,
+        },
+      },
+    });
+
+    expect(task).toMatchObject({
+      trigger_type: 'immediate_repair',
+      mode: 'trap_fix',
+      due_at: '2026-03-24T10:00:00.000Z',
+      priority: 'high',
+      success_criteria: {
+        scheduler_policy: expect.objectContaining({
+          route: 'immediate_repair',
+          freshness_bucket: 'fresh',
+          fallback_reason_code: 'non_released_fallback',
+          immediate_repair_max_deferral_at: '2026-03-24T22:00:00.000Z',
+        }),
+      },
+    });
+  });
+
+  test('fallback review tasks fold into an existing active repair task instead of growing the queue', async () => {
+    let storedTask = buildStoredReviewTask({
+      review_task_id: 'review-task-existing',
+      trigger_type: 'immediate_repair',
+      mode: 'trap_fix',
+      priority: 'high',
+      due_at: '2026-03-24T10:00:00.000Z',
+      target_misconception_tags: ['domain:interval'],
+      success_criteria: {
+        scheduler_policy: {
+          route: 'immediate_repair',
+          freshness_bucket: 'fresh',
+          immediate_repair_max_deferral_at: '2026-03-24T22:00:00.000Z',
+        },
+      },
+    });
+    const reviewTaskRepository = {
+      insertCalls: [],
+      updateCalls: [],
+      async listReviewTaskProjectionsByUser() {
+        return [storedTask];
+      },
+      async insertReviewTask(input) {
+        this.insertCalls.push(input);
+        return input;
+      },
+      async updateReviewTask(reviewTaskId, patch) {
+        this.updateCalls.push({ reviewTaskId, patch });
+        storedTask = {
+          ...storedTask,
+          ...patch,
+        };
+        return storedTask;
+      },
+    };
+    const service = createReviewTaskService({
+      reviewTaskRepository,
+      now: () => new Date('2026-03-24T10:00:00.000Z'),
+    });
+
+    const [task] = await service.generateTasksFromOutcome({
+      user_id: 'student-1',
+      question_id: 'question-1',
+      authoritative_scoring_allowed: false,
+      fallback_reason_code: 'non_released_fallback',
+      repair_target_topic_id: 'topic-1',
+      repair_target_topic_path: '9709/trigonometry/equations',
+      misconception_tags: ['domain:interval', 'identity:rewrite'],
+      question_context: {
+        family_id: '9709.trigonometry_manipulation_equations',
+        question_type_id: '9709.trigonometry.equations',
+      },
+    });
+
+    expect(reviewTaskRepository.insertCalls).toEqual([]);
+    expect(reviewTaskRepository.updateCalls).toHaveLength(1);
+    expect(task).toMatchObject({
+      review_task_id: 'review-task-existing',
+      target_misconception_tags: ['domain:interval', 'identity:rewrite'],
+      success_criteria: {
+        scheduler_policy: expect.objectContaining({
+          route: 'immediate_repair',
+        }),
+      },
+    });
+  });
+
   test('fallback review tasks keep explicit part/subpart scope in success criteria', async () => {
     const service = createReviewTaskService({
       now: () => new Date('2026-03-24T10:00:00.000Z'),
@@ -479,6 +587,49 @@ describe('review task service write semantics', () => {
         reviewTaskId: 'review-task-1',
         intent: 'snooze',
         dueAt: '2026-03-24T12:00:00.000Z',
+      }),
+    ).rejects.toMatchObject({
+      code: 'invalid_payload',
+      status: 400,
+      details: { field: 'due_at' },
+    });
+  });
+
+  test('immediate-repair tasks cannot be deferred beyond the freshness window', async () => {
+    const service = createReviewTaskService({
+      reviewTaskRepository: {
+        async getReviewTaskById() {
+          return buildStoredReviewTask({
+            trigger_type: 'immediate_repair',
+            mode: 'trap_fix',
+            priority: 'high',
+            due_at: '2026-03-24T10:00:00.000Z',
+            success_criteria: {
+              scheduler_policy: {
+                route: 'immediate_repair',
+                freshness_bucket: 'fresh',
+                immediate_repair_max_deferral_at: '2026-03-24T22:00:00.000Z',
+              },
+            },
+          });
+        },
+        async updateReviewTask(reviewTaskId, patch) {
+          return {
+            ...buildStoredReviewTask(),
+            review_task_id: reviewTaskId,
+            ...patch,
+          };
+        },
+      },
+      now: () => new Date('2026-03-24T10:00:00.000Z'),
+    });
+
+    await expect(
+      service.patchReviewTask({
+        userId: 'student-1',
+        reviewTaskId: 'review-task-1',
+        intent: 'reschedule',
+        dueAt: '2026-03-25T12:00:00.000Z',
       }),
     ).rejects.toMatchObject({
       code: 'invalid_payload',

--- a/api/learning/__tests__/workspace-read-service.test.js
+++ b/api/learning/__tests__/workspace-read-service.test.js
@@ -109,6 +109,96 @@ function createLearningDb() {
       created_at: '2026-03-22T08:15:00.000Z',
       updated_at: '2026-03-22T08:15:00.000Z',
     },
+    {
+      review_task_id: 'review-overload-1',
+      user_id: 'student-1',
+      target_kind: 'question_type',
+      target_topic_id: 'topic-3',
+      target_topic_path: '9709/trigonometry/functions',
+      target_family_id: '9709.trigonometry_manipulation_equations',
+      target_family_title: 'Trigonometric manipulation / equations',
+      target_question_type_id: '9709.trigonometry.functions',
+      target_question_type_title: 'Trigonometric functions',
+      target_misconception_tags: [],
+      related_artifact_refs: [],
+      source_question_id: 'question-3',
+      source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-3' },
+      trigger_type: 'immediate_repair',
+      mode: 'trap_fix',
+      due_at: '2026-03-22T07:00:00.000Z',
+      priority: 'high',
+      estimated_minutes: 12,
+      success_criteria: {
+        scheduler_policy: {
+          route: 'immediate_repair',
+          freshness_bucket: 'fresh',
+        },
+      },
+      completion_evidence: {},
+      status: 'open',
+      created_at: '2026-03-22T08:05:00.000Z',
+      updated_at: '2026-03-22T08:05:00.000Z',
+    },
+    {
+      review_task_id: 'review-overload-2',
+      user_id: 'student-1',
+      target_kind: 'question_type',
+      target_topic_id: 'topic-4',
+      target_topic_path: '9709/trigonometry/mixed',
+      target_family_id: '9709.trigonometry_manipulation_equations',
+      target_family_title: 'Trigonometric manipulation / equations',
+      target_question_type_id: '9709.trigonometry.mixed',
+      target_question_type_title: 'Mixed trigonometric practice',
+      target_misconception_tags: [],
+      related_artifact_refs: [],
+      source_question_id: 'question-4',
+      source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-4' },
+      trigger_type: 'regression_recovery',
+      mode: 'redo_variant',
+      due_at: '2026-03-22T07:30:00.000Z',
+      priority: 'urgent',
+      estimated_minutes: 20,
+      success_criteria: {
+        scheduler_policy: {
+          route: 'regression_recovery',
+          freshness_bucket: 'stale',
+        },
+      },
+      completion_evidence: {},
+      status: 'open',
+      created_at: '2026-03-22T08:07:00.000Z',
+      updated_at: '2026-03-22T08:07:00.000Z',
+    },
+    {
+      review_task_id: 'review-overload-3',
+      user_id: 'student-1',
+      target_kind: 'question_type',
+      target_topic_id: 'topic-5',
+      target_topic_path: '9709/trigonometry/revision',
+      target_family_id: '9709.trigonometry_manipulation_equations',
+      target_family_title: 'Trigonometric manipulation / equations',
+      target_question_type_id: '9709.trigonometry.revision',
+      target_question_type_title: 'Revision sprint',
+      target_misconception_tags: [],
+      related_artifact_refs: [],
+      source_question_id: 'question-5',
+      source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-5' },
+      trigger_type: 'exam_polish',
+      mode: 'timed_check',
+      due_at: '2026-03-22T07:45:00.000Z',
+      priority: 'high',
+      estimated_minutes: 18,
+      success_criteria: {
+        scheduler_policy: {
+          route: 'exam_polish',
+          freshness_bucket: 'cooling',
+        },
+      },
+      completion_evidence: {},
+      status: 'open',
+      created_at: '2026-03-22T08:08:00.000Z',
+      updated_at: '2026-03-22T08:08:00.000Z',
+    },
   ];
 
   class QueryBuilder {
@@ -647,10 +737,20 @@ describe('workspace read service', () => {
 
     expect(payload.scope).toBe('global_queue_projection');
     expect(payload.topic_id).toBe('topic-1');
+    expect(payload.policy).toEqual(expect.objectContaining({
+      daily_recommendation_cap: 3,
+      max_high_priority_open_per_type: 1,
+    }));
     expect(payload.items).toHaveLength(1);
     expect(payload.items[0]).toMatchObject({
       review_task_id: 'review-queued-1',
       target_topic_id: 'topic-1',
+      scheduler_state: {
+        value: 'blocked',
+        label: 'Blocked',
+        tone: 'danger',
+        reason_code: 'daily_recommendation_cap',
+      },
     });
   });
 

--- a/api/learning/lib/repositories/review-task-repository.js
+++ b/api/learning/lib/repositories/review-task-repository.js
@@ -48,6 +48,30 @@ function buildUpdateRow(patch = {}) {
     row.updated_at = patch.updated_at;
   }
 
+  if (Object.prototype.hasOwnProperty.call(patch, 'trigger_type')) {
+    row.trigger_type = patch.trigger_type;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(patch, 'mode')) {
+    row.mode = patch.mode;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(patch, 'priority')) {
+    row.priority = patch.priority;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(patch, 'success_criteria')) {
+    row.success_criteria = normalizeObject(patch.success_criteria);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(patch, 'target_misconception_tags')) {
+    row.target_misconception_tags = normalizeArray(patch.target_misconception_tags);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(patch, 'related_artifact_refs')) {
+    row.related_artifact_refs = normalizeArray(patch.related_artifact_refs);
+  }
+
   return row;
 }
 
@@ -77,6 +101,10 @@ export function createReviewTaskRepository(client) {
 
     async updateReviewTask(reviewTaskId, patch) {
       return updateReviewTask(client, reviewTaskId, patch);
+    },
+
+    async listReviewTaskProjectionsByUser(userId) {
+      return listReviewTaskProjectionsByUser(client, userId);
     },
   };
 }
@@ -128,4 +156,19 @@ export async function updateReviewTask(client, reviewTaskId, patch = {}) {
       .single(),
     'Failed to update learning review task',
   );
+}
+
+export async function listReviewTaskProjectionsByUser(client, userId) {
+  const { data, error } = await client
+    .from('learning_review_queue_projection')
+    .select('*')
+    .eq('user_id', userId)
+    .order('due_at', { ascending: true, nullsFirst: false })
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load learning review-task projections: ${error.message}`);
+  }
+
+  return Array.isArray(data) ? data : [];
 }

--- a/api/learning/lib/review/review-scheduler-policy.js
+++ b/api/learning/lib/review/review-scheduler-policy.js
@@ -1,0 +1,539 @@
+const ACTIVE_REVIEW_TASK_STATUSES = new Set(['open', 'partial']);
+const HIGH_PRIORITY_VALUES = new Set(['high', 'urgent']);
+const VALID_TRIGGER_TYPES = new Set([
+  'immediate_repair',
+  'short_delay',
+  'spaced_review',
+  'regression_recovery',
+  'exam_polish',
+]);
+
+const PRIORITY_WEIGHT = Object.freeze({
+  low: 1,
+  normal: 2,
+  high: 3,
+  urgent: 4,
+});
+
+const ROUTE_WEIGHT = Object.freeze({
+  spaced_review: 1,
+  short_delay: 2,
+  exam_polish: 3,
+  immediate_repair: 4,
+  regression_recovery: 5,
+});
+
+export const REVIEW_SCHEDULER_POLICY = Object.freeze({
+  DAILY_RECOMMENDATION_CAP: 3,
+  MAX_HIGH_PRIORITY_OPEN_PER_TYPE: 1,
+  IMMEDIATE_REPAIR_MAX_DEFERRAL_HOURS: 12,
+  SHORT_DELAY_HOURS: 24,
+  SPACED_REVIEW_HOURS: 72,
+  EXAM_POLISH_HOURS: 12,
+});
+
+function normalizeString(value, fallback = null) {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  const normalized = String(value).trim();
+  return normalized || fallback;
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function clone(value) {
+  return value ? JSON.parse(JSON.stringify(value)) : value;
+}
+
+function parseTimestamp(value) {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function addHours(date, hours) {
+  return new Date(date.getTime() + (hours * 60 * 60 * 1000));
+}
+
+function priorityWeight(priority) {
+  return PRIORITY_WEIGHT[normalizeString(priority, 'normal')] ?? PRIORITY_WEIGHT.normal;
+}
+
+function routeWeight(route) {
+  return ROUTE_WEIGHT[normalizeString(route, 'short_delay')] ?? ROUTE_WEIGHT.short_delay;
+}
+
+function normalizeRoute(task = {}) {
+  const storedPolicy = normalizeObject(task?.success_criteria)?.scheduler_policy;
+  const storedRoute = normalizeString(storedPolicy?.route);
+  if (storedRoute && VALID_TRIGGER_TYPES.has(storedRoute)) {
+    return storedRoute;
+  }
+
+  const triggerType = normalizeString(task?.trigger_type);
+  if (triggerType && VALID_TRIGGER_TYPES.has(triggerType)) {
+    return triggerType;
+  }
+
+  return 'short_delay';
+}
+
+function buildReason(code, summary) {
+  return { code, summary };
+}
+
+function typeGroupingKey(task = {}) {
+  return normalizeString(task?.target_question_type_id)
+    || normalizeString(task?.target_family_id)
+    || normalizeString(task?.target_topic_id)
+    || normalizeString(task?.review_task_id)
+    || 'untyped';
+}
+
+function compareTaskRank(left, right) {
+  const leftRoute = routeWeight(normalizeRoute(left));
+  const rightRoute = routeWeight(normalizeRoute(right));
+  if (leftRoute !== rightRoute) {
+    return rightRoute - leftRoute;
+  }
+
+  const leftPriority = priorityWeight(left?.priority);
+  const rightPriority = priorityWeight(right?.priority);
+  if (leftPriority !== rightPriority) {
+    return rightPriority - leftPriority;
+  }
+
+  const leftDue = parseTimestamp(left?.due_at)?.getTime() ?? Number.POSITIVE_INFINITY;
+  const rightDue = parseTimestamp(right?.due_at)?.getTime() ?? Number.POSITIVE_INFINITY;
+  if (leftDue !== rightDue) {
+    return leftDue - rightDue;
+  }
+
+  return String(left?.created_at ?? '').localeCompare(String(right?.created_at ?? ''));
+}
+
+function summarizeReasonForState(state, route) {
+  if (state === 'escalated' && route === 'regression_recovery') {
+    return buildReason(
+      'regression_recovery_due',
+      'Escalated because repeated regression needs immediate recovery work.',
+    );
+  }
+
+  if (state === 'escalated') {
+    return buildReason(
+      'fresh_immediate_repair',
+      'Fresh repair evidence should be retried before it is spaced.',
+    );
+  }
+
+  if (state === 'due') {
+    return buildReason(
+      'due_window_open',
+      'Due because the current review window has opened.',
+    );
+  }
+
+  if (state === 'deferred') {
+    return buildReason(
+      'freshness_window',
+      'Deferred until the next spaced-review freshness window opens.',
+    );
+  }
+
+  return null;
+}
+
+function buildStoredPolicy(policy = {}, fallbackReasonCode = null) {
+  const normalizedPolicy = normalizeObject(policy);
+  return {
+    daily_recommendation_cap: REVIEW_SCHEDULER_POLICY.DAILY_RECOMMENDATION_CAP,
+    max_high_priority_open_per_type: REVIEW_SCHEDULER_POLICY.MAX_HIGH_PRIORITY_OPEN_PER_TYPE,
+    ...normalizedPolicy,
+    ...(fallbackReasonCode ? { fallback_reason_code: fallbackReasonCode } : {}),
+  };
+}
+
+export function buildReviewTaskSchedulerSeed({
+  now = new Date(),
+  misconceptionTags = [],
+  triggerType = null,
+  regressionRecovery = false,
+  learnerGoal = null,
+  fallbackReasonCode = null,
+  freshnessBucket = null,
+} = {}) {
+  const nowDate = now instanceof Date ? now : new Date(now);
+  const normalizedTriggerType = normalizeString(triggerType);
+  const route = normalizedTriggerType && VALID_TRIGGER_TYPES.has(normalizedTriggerType)
+    ? normalizedTriggerType
+    : regressionRecovery
+      ? 'regression_recovery'
+      : normalizeString(learnerGoal) === 'exam_polish'
+        ? 'exam_polish'
+        : normalizeArray(misconceptionTags).length > 0
+          ? 'immediate_repair'
+          : 'short_delay';
+
+  const dueDate = route === 'regression_recovery' || route === 'immediate_repair'
+    ? nowDate
+    : route === 'exam_polish'
+      ? addHours(nowDate, REVIEW_SCHEDULER_POLICY.EXAM_POLISH_HOURS)
+      : route === 'spaced_review'
+        ? addHours(nowDate, REVIEW_SCHEDULER_POLICY.SPACED_REVIEW_HOURS)
+        : addHours(nowDate, REVIEW_SCHEDULER_POLICY.SHORT_DELAY_HOURS);
+
+  const mode = route === 'spaced_review'
+    ? 'quick_recall'
+    : route === 'exam_polish'
+      ? 'timed_check'
+      : normalizeArray(misconceptionTags).length > 0
+        ? 'trap_fix'
+        : 'redo_variant';
+
+  const priority = route === 'regression_recovery'
+    ? 'urgent'
+    : route === 'immediate_repair' || route === 'exam_polish'
+      ? 'high'
+      : 'normal';
+
+  const resolvedFreshnessBucket = freshnessBucket
+    || (route === 'immediate_repair'
+      ? 'fresh'
+      : route === 'regression_recovery'
+        ? 'stale'
+        : route === 'spaced_review'
+          ? 'current'
+          : 'cooling');
+
+  return {
+    triggerType: route,
+    mode,
+    priority,
+    dueAt: dueDate.toISOString(),
+    policy: buildStoredPolicy({
+      route,
+      freshness_bucket: resolvedFreshnessBucket,
+      immediate_repair_max_deferral_at:
+        route === 'immediate_repair'
+          ? addHours(
+            nowDate,
+            REVIEW_SCHEDULER_POLICY.IMMEDIATE_REPAIR_MAX_DEFERRAL_HOURS,
+          ).toISOString()
+          : null,
+    }, fallbackReasonCode),
+  };
+}
+
+export function buildSchedulerStateFromTask(task = {}, options = {}) {
+  const nowDate = parseTimestamp(options.now) || new Date();
+  const route = normalizeRoute(task);
+  const dueAtDate = parseTimestamp(task?.due_at);
+
+  if (!ACTIVE_REVIEW_TASK_STATUSES.has(task?.status)) {
+    return {
+      value: task?.status === 'completed' ? 'completed' : 'open',
+      label: task?.status === 'completed' ? 'Completed' : 'Open',
+      tone: task?.status === 'completed' ? 'success' : 'neutral',
+      reason_code: null,
+      reason_summary: null,
+    };
+  }
+
+  if (
+    (route === 'immediate_repair' || route === 'regression_recovery')
+    && dueAtDate
+    && dueAtDate.getTime() <= nowDate.getTime()
+  ) {
+    const reason = summarizeReasonForState('escalated', route);
+    return {
+      value: 'escalated',
+      label: 'Escalated',
+      tone: 'danger',
+      reason_code: reason.code,
+      reason_summary: reason.summary,
+    };
+  }
+
+  if (dueAtDate && dueAtDate.getTime() <= nowDate.getTime()) {
+    const reason = summarizeReasonForState('due', route);
+    return {
+      value: 'due',
+      label: 'Due',
+      tone: 'warning',
+      reason_code: reason.code,
+      reason_summary: reason.summary,
+    };
+  }
+
+  if (dueAtDate) {
+    const reason = summarizeReasonForState('deferred', route);
+    return {
+      value: 'deferred',
+      label: 'Deferred',
+      tone: 'neutral',
+      reason_code: reason.code,
+      reason_summary: reason.summary,
+    };
+  }
+
+  return {
+    value: 'open',
+    label: 'Open',
+    tone: 'neutral',
+    reason_code: null,
+    reason_summary: null,
+  };
+}
+
+export function summarizeReviewQueueItems(items = []) {
+  return (Array.isArray(items) ? items : []).reduce((acc, item) => {
+    const key = item?.scheduler_state?.value;
+    if (key && Object.prototype.hasOwnProperty.call(acc, key)) {
+      acc[key] += 1;
+    }
+    acc.total += 1;
+    return acc;
+  }, {
+    total: 0,
+    escalated: 0,
+    due: 0,
+    open: 0,
+    deferred: 0,
+    completed: 0,
+    blocked: 0,
+  });
+}
+
+export function deriveReviewQueueProjection(tasks = [], options = {}) {
+  const nowDate = parseTimestamp(options.now) || new Date();
+  const items = normalizeArray(tasks).map((task) => {
+    const successCriteria = normalizeObject(task?.success_criteria);
+    const schedulerPolicy = buildStoredPolicy(
+      successCriteria.scheduler_policy,
+      successCriteria.scheduler_policy?.fallback_reason_code
+        ?? successCriteria.fallback_reason_code
+        ?? null,
+    );
+
+    return {
+      ...task,
+      success_criteria: successCriteria,
+      scheduler_policy: schedulerPolicy,
+      scheduler_state: buildSchedulerStateFromTask(task, { now: nowDate.toISOString() }),
+      scheduler_reasons: [],
+    };
+  });
+
+  const activeItems = items
+    .filter((task) => ACTIVE_REVIEW_TASK_STATUSES.has(task?.status))
+    .sort(compareTaskRank);
+
+  const strongestHighPriorityTaskIdByType = new Map();
+  for (const task of activeItems) {
+    if (!HIGH_PRIORITY_VALUES.has(normalizeString(task?.priority, 'normal'))) {
+      continue;
+    }
+
+    const groupKey = typeGroupingKey(task);
+    if (!strongestHighPriorityTaskIdByType.has(groupKey)) {
+      strongestHighPriorityTaskIdByType.set(groupKey, task.review_task_id);
+    }
+  }
+
+  const primaryCandidates = [];
+  for (const task of activeItems) {
+    const groupKey = typeGroupingKey(task);
+    const primaryHighPriorityTaskId = strongestHighPriorityTaskIdByType.get(groupKey);
+    if (
+      HIGH_PRIORITY_VALUES.has(normalizeString(task?.priority, 'normal'))
+      && primaryHighPriorityTaskId
+      && primaryHighPriorityTaskId !== task.review_task_id
+    ) {
+      task.scheduler_state = {
+        value: 'blocked',
+        label: 'Blocked',
+        tone: 'danger',
+        reason_code: 'high_priority_type_limit',
+        reason_summary:
+          'Blocked because this question type already has a stronger high-priority repair task.',
+      };
+      task.scheduler_reasons = [
+        buildReason(
+          'high_priority_type_limit',
+          'Blocked because this question type already has a stronger high-priority repair task.',
+        ),
+      ];
+      continue;
+    }
+
+    primaryCandidates.push(task);
+  }
+
+  const recommendedIds = new Set(
+    primaryCandidates
+      .slice(0, REVIEW_SCHEDULER_POLICY.DAILY_RECOMMENDATION_CAP)
+      .map((task) => task.review_task_id),
+  );
+
+  for (const task of items) {
+    if (!ACTIVE_REVIEW_TASK_STATUSES.has(task?.status)) {
+      continue;
+    }
+
+    if (task.scheduler_state?.value === 'blocked') {
+      continue;
+    }
+
+    if (!recommendedIds.has(task.review_task_id)) {
+      task.scheduler_state = {
+        value: 'blocked',
+        label: 'Blocked',
+        tone: 'danger',
+        reason_code: 'daily_recommendation_cap',
+        reason_summary:
+          'Blocked by overload control because the canonical queue already has 3 higher-priority tasks.',
+      };
+      task.scheduler_reasons = [
+        buildReason(
+          'daily_recommendation_cap',
+          'Blocked by overload control because the canonical queue already has 3 higher-priority tasks.',
+        ),
+      ];
+      continue;
+    }
+
+    const reason = task.scheduler_state?.reason_code
+      ? buildReason(task.scheduler_state.reason_code, task.scheduler_state.reason_summary)
+      : null;
+    task.scheduler_reasons = reason ? [reason] : [];
+  }
+
+  return {
+    policy: {
+      daily_recommendation_cap: REVIEW_SCHEDULER_POLICY.DAILY_RECOMMENDATION_CAP,
+      max_high_priority_open_per_type: REVIEW_SCHEDULER_POLICY.MAX_HIGH_PRIORITY_OPEN_PER_TYPE,
+      immediate_repair_max_deferral_hours:
+        REVIEW_SCHEDULER_POLICY.IMMEDIATE_REPAIR_MAX_DEFERRAL_HOURS,
+    },
+    items,
+    summary: summarizeReviewQueueItems(items),
+  };
+}
+
+export function buildMergedSchedulerPolicy(existingTask = {}, candidateTask = {}) {
+  const existingPolicy = buildStoredPolicy(
+    normalizeObject(existingTask?.success_criteria)?.scheduler_policy,
+    normalizeObject(existingTask?.success_criteria)?.fallback_reason_code ?? null,
+  );
+  const candidatePolicy = buildStoredPolicy(
+    normalizeObject(candidateTask?.success_criteria)?.scheduler_policy,
+    normalizeObject(candidateTask?.success_criteria)?.fallback_reason_code ?? null,
+  );
+
+  const strongestRoute = routeWeight(existingPolicy.route) >= routeWeight(candidatePolicy.route)
+    ? existingPolicy.route
+    : candidatePolicy.route;
+
+  return buildStoredPolicy({
+    ...existingPolicy,
+    ...candidatePolicy,
+    route: strongestRoute,
+    freshness_bucket: routeWeight(existingPolicy.route) >= routeWeight(candidatePolicy.route)
+      ? existingPolicy.freshness_bucket ?? candidatePolicy.freshness_bucket ?? null
+      : candidatePolicy.freshness_bucket ?? existingPolicy.freshness_bucket ?? null,
+    immediate_repair_max_deferral_at:
+      candidatePolicy.immediate_repair_max_deferral_at
+      ?? existingPolicy.immediate_repair_max_deferral_at
+      ?? null,
+  }, candidatePolicy.fallback_reason_code ?? existingPolicy.fallback_reason_code ?? null);
+}
+
+export function pickReviewTaskMergeCandidate(tasks = [], candidateTask = {}) {
+  const candidateMisconceptionTags = new Set(
+    normalizeArray(candidateTask?.target_misconception_tags).map((tag) => normalizeString(tag)).filter(Boolean),
+  );
+
+  return normalizeArray(tasks)
+    .filter((task) => ACTIVE_REVIEW_TASK_STATUSES.has(task?.status))
+    .filter((task) => task?.target_topic_id === candidateTask?.target_topic_id)
+    .filter((task) => {
+      if (
+        normalizeString(task?.target_question_type_id)
+        && normalizeString(task?.target_question_type_id)
+          === normalizeString(candidateTask?.target_question_type_id)
+      ) {
+        return true;
+      }
+
+      return normalizeArray(task?.target_misconception_tags).some((tag) =>
+        candidateMisconceptionTags.has(normalizeString(tag)));
+    })
+    .sort(compareTaskRank)[0] ?? null;
+}
+
+export function mergeReviewTaskPayload(existingTask = {}, candidateTask = {}, timestamp) {
+  const mergedSchedulerPolicy = buildMergedSchedulerPolicy(existingTask, candidateTask);
+  const existingSuccessCriteria = clone(normalizeObject(existingTask?.success_criteria));
+  const candidateSuccessCriteria = clone(normalizeObject(candidateTask?.success_criteria));
+  const dueAtDate = [existingTask?.due_at, candidateTask?.due_at]
+    .map((value) => parseTimestamp(value))
+    .filter(Boolean)
+    .sort((left, right) => left.getTime() - right.getTime())[0];
+
+  return {
+    due_at: dueAtDate ? dueAtDate.toISOString() : existingTask?.due_at ?? candidateTask?.due_at ?? null,
+    trigger_type: routeWeight(normalizeRoute(existingTask)) >= routeWeight(normalizeRoute(candidateTask))
+      ? normalizeRoute(existingTask)
+      : normalizeRoute(candidateTask),
+    mode: routeWeight(normalizeRoute(existingTask)) >= routeWeight(normalizeRoute(candidateTask))
+      ? existingTask?.mode ?? candidateTask?.mode
+      : candidateTask?.mode ?? existingTask?.mode,
+    priority: priorityWeight(existingTask?.priority) >= priorityWeight(candidateTask?.priority)
+      ? existingTask?.priority ?? candidateTask?.priority
+      : candidateTask?.priority ?? existingTask?.priority,
+    target_misconception_tags: [
+      ...new Set([
+        ...normalizeArray(existingTask?.target_misconception_tags),
+        ...normalizeArray(candidateTask?.target_misconception_tags),
+      ]),
+    ],
+    related_artifact_refs: [
+      ...new Set(
+        [...normalizeArray(existingTask?.related_artifact_refs), ...normalizeArray(candidateTask?.related_artifact_refs)]
+          .map((ref) => JSON.stringify(ref)),
+      ),
+    ].map((ref) => JSON.parse(ref)),
+    success_criteria: {
+      ...existingSuccessCriteria,
+      ...candidateSuccessCriteria,
+      scheduler_policy: mergedSchedulerPolicy,
+    },
+    updated_at: timestamp,
+  };
+}
+
+export function normalizeSchedulerProjectionItem(item = {}) {
+  const schedulerPolicy = normalizeObject(item?.scheduler_policy);
+  const schedulerState = normalizeObject(item?.scheduler_state);
+  const schedulerReasons = normalizeArray(item?.scheduler_reasons);
+
+  return {
+    ...item,
+    scheduler_policy: schedulerPolicy,
+    scheduler_state: schedulerState,
+    scheduler_reasons: schedulerReasons,
+  };
+}

--- a/api/learning/lib/review/review-task-service.js
+++ b/api/learning/lib/review/review-task-service.js
@@ -1,8 +1,12 @@
 import { createReviewTaskRepository } from '../repositories/review-task-repository.js';
 import { LEARNING_ERROR_CODES } from '../contracts/error-contract.js';
 import { LearningHttpError } from '../http/learning-http.js';
+import {
+  buildReviewTaskSchedulerSeed,
+  mergeReviewTaskPayload,
+  pickReviewTaskMergeCandidate,
+} from './review-scheduler-policy.js';
 
-const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
 const REVIEW_TASK_INTENTS = new Set(['complete', 'reschedule', 'snooze', 'reopen']);
 const REVIEW_TASK_COMPLETION_OUTCOMES = new Set(['completed', 'partial']);
 const ACTIVE_REVIEW_TASK_STATUSES = new Set(['open', 'partial']);
@@ -198,6 +202,20 @@ function buildSchedulePatch(reviewTask, intent, dueAt, timestamp) {
     }
   }
 
+  const schedulerPolicy = reviewTask?.success_criteria?.scheduler_policy ?? {};
+  if (schedulerPolicy?.route === 'immediate_repair') {
+    const maxDeferralAt = normalizeString(schedulerPolicy.immediate_repair_max_deferral_at);
+    if (maxDeferralAt) {
+      const maxDeferralAtMs = new Date(maxDeferralAt).getTime();
+      if (Number.isFinite(maxDeferralAtMs) && nextDueAtMs > maxDeferralAtMs) {
+        throw buildInvalidPayload(
+          'Immediate-repair tasks cannot move beyond the freshness deferral window.',
+          { field: 'due_at' },
+        );
+      }
+    }
+  }
+
   return {
     due_at: normalizedDueAt,
     updated_at: timestamp,
@@ -259,11 +277,18 @@ function pickTargetKind({ targetQuestionTypeId, familyId } = {}) {
 }
 
 function buildReviewTaskPayload(input = {}, now = new Date()) {
-  const dueAt = new Date(now.getTime() + ONE_DAY_IN_MS).toISOString();
   const targetQuestionTypeId =
     input.repair_target_question_type_id
     || input.question_context?.question_type_id
     || null;
+  const scheduler = buildReviewTaskSchedulerSeed({
+    now,
+    misconceptionTags: input.misconception_tags,
+    triggerType: input.trigger_type,
+    regressionRecovery: input.regression_recovery === true,
+    learnerGoal: input.learner_goal ?? null,
+    fallbackReasonCode: input.fallback_reason_code ?? null,
+  });
   const targetKind = pickTargetKind({
     targetQuestionTypeId,
     familyId: input.question_context?.family_id ?? null,
@@ -288,10 +313,10 @@ function buildReviewTaskPayload(input = {}, now = new Date()) {
     related_artifact_refs: normalizeArray(input.related_artifact_refs),
     source_question_id: input.question_id ?? null,
     source_attempt_ref: input.source_attempt_ref ?? null,
-    trigger_type: input.fallback_reason_code || 'non_released_fallback',
-    mode: normalizeArray(input.misconception_tags).length > 0 ? 'trap_fix' : 'redo_variant',
-    due_at: dueAt,
-    priority: 'normal',
+    trigger_type: scheduler.triggerType,
+    mode: scheduler.mode,
+    due_at: scheduler.dueAt,
+    priority: scheduler.priority,
     estimated_minutes: 15,
     success_criteria: {
       posture: 'conservative_fallback',
@@ -300,6 +325,8 @@ function buildReviewTaskPayload(input = {}, now = new Date()) {
       local_signal_only: input.marking_result?.marking_summary?.local_signal_only === true,
       ambiguous_part_mapping_count: ambiguousPartMappingCount,
       part_results: partResults,
+      fallback_reason_code: input.fallback_reason_code ?? null,
+      scheduler_policy: scheduler.policy,
     },
     completion_evidence: {},
     status: 'open',
@@ -325,6 +352,29 @@ export function createReviewTaskService({
 
       if (!reviewTaskRepository) {
         return [payload];
+      }
+
+      const activeTasks = await reviewTaskRepository.listReviewTaskProjectionsByUser?.(payload.user_id)
+        ?? [];
+      const mergeCandidate = pickReviewTaskMergeCandidate(activeTasks, payload);
+      if (mergeCandidate?.review_task_id) {
+        const mergedPatch = mergeReviewTaskPayload(
+          mergeCandidate,
+          payload,
+          now().toISOString(),
+        );
+        const merged = await reviewTaskRepository.updateReviewTask(
+          mergeCandidate.review_task_id,
+          mergedPatch,
+        );
+        return [
+          {
+            ...mergeCandidate,
+            ...merged,
+            target_topic_path:
+              payload.target_topic_path ?? mergeCandidate.target_topic_path ?? null,
+          },
+        ];
       }
 
       const stored = await reviewTaskRepository.insertReviewTask(payload);

--- a/api/learning/lib/session-runtime/session-service.js
+++ b/api/learning/lib/session-runtime/session-service.js
@@ -264,7 +264,12 @@ function buildPostMortemScoringPosture(reviewTasks = []) {
     release_scope_status: 'non_released_fallback',
     authoritative_scoring_allowed: false,
     fallback_reason_code:
-      normalizeNullableString(conservativeTask.trigger_type) ?? 'non_released_fallback',
+      normalizeNullableString(
+        conservativeTask?.success_criteria?.scheduler_policy?.fallback_reason_code,
+      )
+      ?? normalizeNullableString(conservativeTask?.success_criteria?.fallback_reason_code)
+      ?? normalizeNullableString(conservativeTask.trigger_type)
+      ?? 'non_released_fallback',
   };
 }
 

--- a/api/learning/lib/workspaces/workspace-read-service.js
+++ b/api/learning/lib/workspaces/workspace-read-service.js
@@ -1,6 +1,10 @@
 import { STABLE_SLOT_KEYS } from '../contracts/runtime-contract.js';
 import { LearningHttpError } from '../http/learning-http.js';
 import { fetchWorkspaceProjection } from '../repositories/workspace-repository.js';
+import {
+  deriveReviewQueueProjection,
+  summarizeReviewQueueItems,
+} from '../review/review-scheduler-policy.js';
 
 const ACTIVE_REVIEW_TASK_STATUSES = new Set(['open', 'partial']);
 
@@ -117,13 +121,33 @@ function buildWorkspaceNotFound(topicId) {
   });
 }
 
-function applyOptionalFilter(query, methodName, column, value) {
-  const normalizedValue = normalizeString(value);
-  if (!normalizedValue || typeof query?.[methodName] !== 'function') {
-    return query;
-  }
+function filterReviewQueueItems(items, {
+  topicId = null,
+  status = null,
+  dueBefore = null,
+} = {}) {
+  const normalizedTopicId = normalizeString(topicId);
+  const normalizedStatus = normalizeString(status);
+  const normalizedDueBefore = normalizeString(dueBefore);
 
-  return query[methodName](column, normalizedValue);
+  return (Array.isArray(items) ? items : []).filter((item) => {
+    if (normalizedTopicId && item?.target_topic_id !== normalizedTopicId) {
+      return false;
+    }
+
+    if (normalizedStatus && item?.status !== normalizedStatus) {
+      return false;
+    }
+
+    if (normalizedDueBefore) {
+      const itemDueAt = normalizeString(item?.due_at);
+      if (!itemDueAt || itemDueAt > normalizedDueBefore) {
+        return false;
+      }
+    }
+
+    return true;
+  });
 }
 
 export async function listReviewTasks(
@@ -140,10 +164,6 @@ export async function listReviewTasks(
     .select('*')
     .eq('user_id', userId);
 
-  query = applyOptionalFilter(query, 'eq', 'target_topic_id', topicId);
-  query = applyOptionalFilter(query, 'eq', 'status', status);
-  query = applyOptionalFilter(query, 'lte', 'due_at', dueBefore);
-
   if (typeof query?.order === 'function') {
     query = query
       .order('due_at', { ascending: true, nullsFirst: false })
@@ -156,12 +176,21 @@ export async function listReviewTasks(
     throw new Error(`Failed to load learning review queue projection: ${error.message}`);
   }
 
+  const derivedProjection = deriveReviewQueueProjection(Array.isArray(data) ? data : []);
+  const filteredItems = filterReviewQueueItems(derivedProjection.items, {
+    topicId,
+    status,
+    dueBefore,
+  });
+
   return {
     scope: 'global_queue_projection',
     topic_id: normalizeString(topicId),
     status: normalizeString(status),
     due_before: normalizeString(dueBefore),
-    items: Array.isArray(data) ? data : [],
+    policy: derivedProjection.policy,
+    items: filteredItems,
+    summary: summarizeReviewQueueItems(filteredItems),
   };
 }
 

--- a/src/components/learning-runtime/ReviewQueuePanel.js
+++ b/src/components/learning-runtime/ReviewQueuePanel.js
@@ -87,6 +87,12 @@ function renderReviewItem(item, {
       key: 'meta',
       className: 'mt-3 text-sm text-slate-600',
     }, `Due ${item.dueAtLabel} · ${item.estimatedMinutesLabel}`),
+    item.schedulerExplanation?.summary
+      ? h('div', {
+        key: 'scheduler-summary',
+        className: 'mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800',
+      }, item.schedulerExplanation.summary)
+      : null,
     item.resultFeedback?.summary
       ? h('div', {
         key: 'result-summary',
@@ -149,8 +155,9 @@ export default function ReviewQueuePanel({
     ].filter(Boolean)),
     h('div', {
       key: 'summary',
-      className: 'mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5',
+      className: 'mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-6',
     }, [
+      renderSummaryChip('escalated', 'Escalated', summary.escalated ?? 0),
       renderSummaryChip('due', 'Due', summary.due ?? 0),
       renderSummaryChip('deferred', 'Deferred', summary.deferred ?? 0),
       renderSummaryChip('open', 'Open', summary.open ?? 0),

--- a/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
+++ b/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
@@ -160,6 +160,18 @@ function createWorkspacePayload() {
           status: 'open',
           dueAt: '2026-03-21T00:00:00.000Z',
           estimatedMinutes: 15,
+          schedulerState: {
+            value: 'escalated',
+            label: 'Escalated',
+            tone: 'danger',
+            reasonCode: 'fresh_immediate_repair',
+          },
+          schedulerReasons: [
+            {
+              code: 'fresh_immediate_repair',
+              summary: 'Fresh repair evidence should be retried before it is spaced.',
+            },
+          ],
         },
         {
           reviewTaskId: 'review-task-2',
@@ -225,8 +237,9 @@ describe('WorkspaceShell', () => {
     expect(html).toContain('Unpin before marking contested.');
     expect(html).toContain('Review queue');
     expect(html).toContain('redo variant');
-    expect(html).toContain('Due');
+    expect(html).toContain('Escalated');
     expect(html).toContain('Completed');
+    expect(html).toContain('Fresh repair evidence should be retried before it is spaced.');
     expect(html).toContain('Start spaced review');
     expect(html).toContain('Mark complete');
     expect(html).toContain('Reschedule');

--- a/src/components/learning-runtime/__tests__/view-models.test.js
+++ b/src/components/learning-runtime/__tests__/view-models.test.js
@@ -187,6 +187,10 @@ function createWorkspacePayload() {
     },
     reviewQueue: {
       scope: 'global_queue_projection',
+      policy: {
+        dailyRecommendationCap: 3,
+        maxHighPriorityOpenPerType: 1,
+      },
       topicId: 'topic-trig-equations',
       items: [
         {
@@ -199,6 +203,22 @@ function createWorkspacePayload() {
           status: 'open',
           dueAt: '2026-03-21T00:00:00.000Z',
           estimatedMinutes: 15,
+          schedulerState: {
+            value: 'escalated',
+            label: 'Escalated',
+            tone: 'danger',
+            reasonCode: 'fresh_immediate_repair',
+          },
+          schedulerPolicy: {
+            route: 'immediate_repair',
+            freshnessBucket: 'fresh',
+          },
+          schedulerReasons: [
+            {
+              code: 'fresh_immediate_repair',
+              summary: 'Fresh repair evidence should be retried before it is spaced.',
+            },
+          ],
         },
         {
           reviewTaskId: 'review-task-2',
@@ -210,6 +230,22 @@ function createWorkspacePayload() {
           status: 'open',
           dueAt: '2026-03-24T00:00:00.000Z',
           estimatedMinutes: 20,
+          schedulerState: {
+            value: 'deferred',
+            label: 'Deferred',
+            tone: 'neutral',
+            reasonCode: 'freshness_window',
+          },
+          schedulerPolicy: {
+            route: 'spaced_review',
+            freshnessBucket: 'cooling',
+          },
+          schedulerReasons: [
+            {
+              code: 'freshness_window',
+              summary: 'Deferred until the next spaced-review freshness window opens.',
+            },
+          ],
         },
         {
           reviewTaskId: 'review-task-3',
@@ -752,8 +788,11 @@ describe('learning runtime session view model', () => {
       reviewTaskId: 'review-task-1',
       modeLabel: 'redo variant',
       queueState: expect.objectContaining({
-        value: 'due',
-        label: 'Due',
+        value: 'escalated',
+        label: 'Escalated',
+      }),
+      schedulerExplanation: expect.objectContaining({
+        summary: 'Fresh repair evidence should be retried before it is spaced.',
       }),
       launchPayload: {
         anchorKind: 'review_task',
@@ -768,6 +807,8 @@ describe('learning runtime session view model', () => {
       value: 'deferred',
       label: 'Deferred',
       tone: 'neutral',
+      reasonCode: 'freshness_window',
+      reasonSummary: null,
     });
     expect(vm.reviewQueue.items[2]).toEqual(expect.objectContaining({
       queueState: {
@@ -782,7 +823,8 @@ describe('learning runtime session view model', () => {
     }));
     expect(vm.reviewQueue.summary).toEqual({
       total: 3,
-      due: 1,
+      escalated: 1,
+      due: 0,
       open: 0,
       deferred: 1,
       completed: 1,

--- a/src/components/learning-runtime/view-models/review-queue-view-model.js
+++ b/src/components/learning-runtime/view-models/review-queue-view-model.js
@@ -105,6 +105,57 @@ function buildQueueState(status, dueAt, now) {
   };
 }
 
+function normalizeSchedulerState(value) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  return {
+    value: normalizeString(value.value),
+    label: normalizeString(value.label),
+    tone: normalizeString(value.tone, 'neutral'),
+    reasonCode: normalizeString(value.reasonCode ?? value.reason_code),
+    reasonSummary: normalizeString(value.reasonSummary ?? value.reason_summary),
+  };
+}
+
+function normalizeSchedulerPolicy(value) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  return {
+    route: normalizeString(value.route),
+    freshnessBucket: normalizeString(value.freshnessBucket ?? value.freshness_bucket),
+    dailyRecommendationCap: value.dailyRecommendationCap ?? value.daily_recommendation_cap ?? null,
+    maxHighPriorityOpenPerType:
+      value.maxHighPriorityOpenPerType ?? value.max_high_priority_open_per_type ?? null,
+    immediateRepairMaxDeferralAt:
+      normalizeString(value.immediateRepairMaxDeferralAt ?? value.immediate_repair_max_deferral_at),
+  };
+}
+
+function normalizeSchedulerReasons(value) {
+  return (Array.isArray(value) ? value : []).map((reason) => ({
+    code: normalizeString(reason?.code),
+    summary: normalizeString(reason?.summary),
+  })).filter((reason) => reason.code || reason.summary);
+}
+
+function buildSchedulerExplanation(schedulerState, schedulerReasons, schedulerPolicy) {
+  const primaryReason = schedulerReasons[0] || null;
+  if (!schedulerState && !primaryReason && !schedulerPolicy) {
+    return null;
+  }
+
+  return {
+    summary: primaryReason?.summary || schedulerState?.reasonSummary || null,
+    reasonCode: primaryReason?.code || schedulerState?.reasonCode || null,
+    route: schedulerPolicy?.route || null,
+    freshnessBucket: schedulerPolicy?.freshnessBucket || null,
+  };
+}
+
 function buildResultFeedback(status, completionEvidence) {
   const summary = normalizeString(completionEvidence?.summary ?? completionEvidence?.note);
   const outcome = normalizeString(completionEvidence?.outcome);
@@ -160,6 +211,9 @@ export function buildReviewQueueViewModel(reviewQueue = {}, options = {}) {
   const items = Array.isArray(reviewQueue?.items) ? reviewQueue.items : [];
   const normalizedItems = items.map((item) => {
     const status = normalizeString(item.status, 'open');
+    const schedulerState = normalizeSchedulerState(item.schedulerState ?? item.scheduler_state);
+    const schedulerPolicy = normalizeSchedulerPolicy(item.schedulerPolicy ?? item.scheduler_policy);
+    const schedulerReasons = normalizeSchedulerReasons(item.schedulerReasons ?? item.scheduler_reasons);
 
     return {
       ...item,
@@ -178,7 +232,7 @@ export function buildReviewQueueViewModel(reviewQueue = {}, options = {}) {
       modeLabel: labelFromToken(item.mode),
       status,
       statusLabel: labelFromToken(status),
-      queueState: buildQueueState(status, item.dueAt ?? item.due_at, now),
+      queueState: schedulerState || buildQueueState(status, item.dueAt ?? item.due_at, now),
       dueAt: normalizeString(item.dueAt ?? item.due_at),
       dueAtLabel: formatTimestampLabel(item.dueAt ?? item.due_at),
       estimatedMinutes: item.estimatedMinutes ?? item.estimated_minutes ?? 0,
@@ -187,6 +241,14 @@ export function buildReviewQueueViewModel(reviewQueue = {}, options = {}) {
       resultFeedback: buildResultFeedback(
         status,
         item.completionEvidence ?? item.completion_evidence ?? null,
+      ),
+      schedulerState,
+      schedulerPolicy,
+      schedulerReasons,
+      schedulerExplanation: buildSchedulerExplanation(
+        schedulerState,
+        schedulerReasons,
+        schedulerPolicy,
       ),
       launchPayload: buildLaunchPayload(item),
       workspaceLink: {
@@ -209,6 +271,7 @@ export function buildReviewQueueViewModel(reviewQueue = {}, options = {}) {
     return acc;
   }, {
     total: 0,
+    escalated: 0,
     due: 0,
     open: 0,
     deferred: 0,
@@ -219,6 +282,7 @@ export function buildReviewQueueViewModel(reviewQueue = {}, options = {}) {
   return {
     scope: normalizeString(reviewQueue?.scope),
     topicId: normalizeString(reviewQueue?.topicId ?? reviewQueue?.topic_id),
+    policy: normalizeSchedulerPolicy(reviewQueue?.policy),
     items: normalizedItems,
     summary,
     actionDrafts: buildReviewQueueActionDrafts(normalizedItems, {}, { now }),


### PR DESCRIPTION
## Summary
- add a dedicated review-scheduler policy layer with explicit overload caps, freshness windows, routing rules, and explainable queue states
- fold duplicate repair tasks into existing active work and enforce immediate-repair reschedule limits so the canonical queue stays bounded
- project scheduler reasons into the workspace/review-queue runtime payloads and surface them in the review queue UI

## Testing
- npm test -- --runInBand api/learning/__tests__/review-scheduler-policy.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/workspace-read-service.test.js src/components/learning-runtime/__tests__/view-models.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js api/learning/__tests__/review-task-api.test.js
- npm test -- --runInBand api/learning/__tests__/session-api.test.js -t "post-mortem"

Closes #70