### PR TITLE
feat(learning-runtime): make runtime entry default

### DIFF
--- a/docs/superpowers/runbooks/2026-03-20-learning-runtime-pilot-rollout.md
+++ b/docs/superpowers/runbooks/2026-03-20-learning-runtime-pilot-rollout.md
@@ -1,12 +1,12 @@
 # Learning Runtime Pilot Rollout
 
-Date: 2026-03-22
-Scope: first `9709` runtime pilot slice for session-centric AskAI, workspace entry, and legacy entry-point demotion
+Date: 2026-03-25
+Scope: first `9709` runtime pilot slice after runtime-first cutover for session-centric AskAI, workspace entry, and legacy entry-point demotion
 
 ## Rollout Posture
 
 - Canonical runtime entry surfaces are `/learn/session/:sessionId` and `/learn/workspace/:topicId`.
-- Legacy AskAI, Study Hub, and Learning Path remain compatibility-only surfaces during this slice.
+- AskAI, Study Hub, and Learning Path remain compatibility-only surfaces during this slice and no longer gate canonical runtime entry.
 - Authoritative scoring covers the seeded trigonometry types plus the released `9709.integration.application` and `9709.differential_equations.separable` slices and still requires all released-scope gates:
   - registry-backed released question type
   - released rubric ref
@@ -14,45 +14,42 @@ Scope: first `9709` runtime pilot slice for session-centric AskAI, workspace ent
   - validated uncertainty posture
 - Imported or non-promoted questions outside released scope must stay on explicit `non_released_fallback`, including broader `9709.differential_equations.*` cases beyond the promoted separable slice.
 
-## Feature-Flag Default
+## Default Entry Posture
 
-- Frontend flag: `VITE_LEARNING_RUNTIME_ENABLED`
-- Default posture: disabled unless the env var is explicitly set to `true`
-- Disabled behavior:
-  - AskAI stays on `legacy_chat`
-  - Study Hub stays on `legacy_hub`
-  - Learning Path stays on `legacy_path`
-- Enabled behavior:
-  - AskAI becomes a handoff entry into learning-runtime workspace routes
-  - Study Hub becomes a compatibility shell linking into runtime workspaces
-  - Learning Path becomes a compatibility shell linking into runtime workspaces
+- Normal posture: runtime-first by default with no frontend feature flag required for canonical entry.
+- Default behavior:
+  - AskAI resolves to `learning_runtime`
+  - Study Hub resolves to `compatibility_shell`
+  - Learning Path resolves to `compatibility_shell`
+- Retired flag:
+  - `VITE_LEARNING_RUNTIME_ENABLED` no longer controls canonical entry and should be removed from environment configs during cleanup.
 
 ## Migration Order
 
-1. Merge the rollout-hardening branch after the full backend/frontend verification set and Vite build pass.
-2. Leave `VITE_LEARNING_RUNTIME_ENABLED` unset in production by default.
-3. Enable the flag in the target environment when the pilot should route through learning-runtime entry points.
-4. Verify the three entry-point expectations after enabling the flag:
-   - AskAI hands off into runtime entry
+1. Merge the cutover branch after the focused legacy-entry/runtime verification set and Vite build pass.
+2. Remove stale `VITE_LEARNING_RUNTIME_ENABLED` configuration from the deployment target so operators do not mistake it for an active control.
+3. Verify the default entry expectations in the target environment:
+   - AskAI hands off into runtime entry by default
    - Study Hub stays compatibility-only
    - Learning Path stays compatibility-only
-5. Treat `/learn/session/:sessionId` and `/learn/workspace/:topicId` as the only canonical runtime surfaces for the pilot.
+4. Treat `/learn/session/:sessionId` and `/learn/workspace/:topicId` as the only canonical runtime surfaces for the pilot.
 
 ## Legacy Surface Rules After Rollout
 
-- `src/pages/AskAI.jsx`: compatibility entry only under the flag; it must not regain canonical runtime state ownership.
-- `src/pages/StudyHub.jsx`: compatibility shell only under the flag; it must not regain canonical workspace, review-queue, or artifact truth.
-- `src/pages/LearningPath.jsx`: compatibility shell only under the flag; it must not regain canonical runtime truth.
+- `src/pages/AskAI.jsx`: compatibility entry only; it must not regain canonical runtime state ownership.
+- `src/pages/StudyHub.jsx`: compatibility shell only; it must not regain canonical workspace, review-queue, or artifact truth.
+- `src/pages/LearningPath.jsx`: compatibility shell only; it must not regain canonical runtime truth.
 
 ## Rollback Posture
 
-- Primary rollback lever: unset `VITE_LEARNING_RUNTIME_ENABLED` or set it to a non-`true` value.
+- Primary rollback lever: set `VITE_LEARNING_RUNTIME_ROLLBACK_TO_LEGACY=true`.
 - Expected rollback result:
   - AskAI returns to legacy chat entry mode.
   - Study Hub returns to the legacy hub surface.
   - Learning Path returns to the legacy path surface.
 - No legacy surface should be promoted back to canonical runtime truth during rollback; rollback only changes entry routing.
-- If runtime behavior is suspect while the flag is enabled, disable the flag first, then investigate the session/workspace routes separately.
+- If runtime behavior is suspect, set the rollback flag first, confirm legacy entry recovers, and then investigate the session/workspace routes separately.
+- Clearing rollback means removing `VITE_LEARNING_RUNTIME_ROLLBACK_TO_LEGACY` or setting it to a non-`true` value.
 
 ## Verification Record
 

--- a/src/pages/AskAI.jsx
+++ b/src/pages/AskAI.jsx
@@ -30,15 +30,15 @@ const AskAI = () => {
                   Learning Runtime
                 </p>
                 <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">
-                  AskAI now hands off into runtime workspaces
+                  AskAI is now a runtime-first compatibility entry
                 </h1>
               </div>
             </div>
 
             <p className="mt-6 max-w-3xl text-base leading-7 text-slate-600">
-              The legacy AskAI page no longer owns canonical learning state. Start with a runtime
-              import or workspace entry so the session contract, fallback posture, and canonical
-              topic handoff all stay inside the new learning-runtime flow.
+              Normal learning entry now starts with a runtime import or workspace handoff so the
+              session contract, fallback posture, and canonical topic continuity stay inside the
+              learning-runtime flow by default.
             </p>
 
             <div className="mt-8 grid gap-4 md:grid-cols-3">
@@ -80,8 +80,8 @@ const AskAI = () => {
             </div>
 
             <p className="mt-8 text-sm text-slate-500">
-              Legacy AskAI remains a compatibility entry only; stable runtime truth now lives on the
-              new session and workspace routes.
+              AskAI remains a compatibility entry only; stable runtime truth lives on the session
+              and workspace routes, and legacy chat is reserved for explicit rollback only.
             </p>
           </div>
         </div>
@@ -107,10 +107,18 @@ const AskAI = () => {
               AI 问答助手
             </h1>
           </div>
-          
+
           <p className="text-xl text-gray-600 mb-8 max-w-3xl mx-auto leading-relaxed">
             专门为CIE A Level学生定制的AI学习助手，提供精准的数学、物理和进阶数学答疑
           </p>
+
+          <div className="mx-auto mb-8 max-w-3xl rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-left text-sm text-amber-800">
+            <p className="font-semibold uppercase tracking-[0.16em] text-amber-700">Rollback Mode</p>
+            <p className="mt-2">
+              This legacy chat surface is temporarily restored for operational safety. Canonical
+              runtime state still belongs on the learning-runtime session and workspace routes.
+            </p>
+          </div>
 
           {/* Features Grid */}
           <div className="grid md:grid-cols-3 gap-6 mb-12">

--- a/src/pages/LearningPath.jsx
+++ b/src/pages/LearningPath.jsx
@@ -36,7 +36,7 @@ export default function LearningPath() {
                   Compatibility Surface
                 </p>
                 <h1 className="mt-3 text-4xl font-semibold tracking-tight text-slate-950">
-                  Learning Path is no longer canonical runtime truth
+                  Learning Path is now a compatibility handoff into runtime workspaces
                 </h1>
                 <p className="mt-2 max-w-3xl text-base leading-7 text-slate-600">
                   Topic-level path views remain available for compatibility, but stable slots,
@@ -63,8 +63,8 @@ export default function LearningPath() {
             </div>
 
             <p className="mt-8 text-sm text-slate-500">
-              {subject.fullName} remains available only as a compatibility handoff while the runtime
-              pilot rolls out behind the feature flag.
+              {subject.fullName} remains available only as a compatibility handoff; the legacy path
+              surface returns only if operators trigger explicit rollback.
             </p>
           </div>
         </div>
@@ -75,6 +75,14 @@ export default function LearningPath() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-100">
       <div className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+        <div className="mb-6 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm text-amber-800">
+          <p className="font-semibold uppercase tracking-[0.16em] text-amber-700">Rollback Mode</p>
+          <p className="mt-2">
+            This topic-level path view is temporarily restored for operational safety. Canonical
+            runtime truth still belongs on the learning-runtime workspace routes.
+          </p>
+        </div>
+
         <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
           <div className="flex items-start gap-3">
             <button

--- a/src/pages/StudyHub.jsx
+++ b/src/pages/StudyHub.jsx
@@ -48,11 +48,11 @@ const StudyHub = () => {
                         Compatibility Surface
                     </p>
                     <h1 className="mt-4 text-4xl font-extrabold tracking-tight text-slate-950 sm:text-5xl">
-                        Study Hub now hands off into the learning runtime
+                        Study Hub is now a compatibility shell for the learning runtime
                     </h1>
                     <p className="mt-4 text-base leading-7 text-slate-600">
                         Legacy Study Hub is no longer the canonical home for runtime state. Use the
-                        pilot workspace links below to enter the new workspace shell.
+                        runtime workspace links below to enter the canonical workspace shell.
                     </p>
                 </header>
 
@@ -74,8 +74,8 @@ const StudyHub = () => {
                     </div>
 
                     <div className="mt-6 rounded-3xl border border-dashed border-slate-300 bg-slate-50 p-6 text-sm text-slate-600">
-                        AskAI and Learning Path are retained as compatibility entry points only while
-                        the runtime rollout stays behind the feature flag.
+                        AskAI and Learning Path remain non-canonical compatibility entry points;
+                        the legacy hub returns only if operators trigger an explicit rollback.
                     </div>
                 </main>
             </div>
@@ -85,6 +85,13 @@ const StudyHub = () => {
     return (
         <div className="container mx-auto px-4 py-8">
             <header className="text-center mb-12">
+                <div className="mx-auto mb-6 max-w-3xl rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-left text-sm text-amber-800">
+                    <p className="font-semibold uppercase tracking-[0.16em] text-amber-700">Rollback Mode</p>
+                    <p className="mt-2">
+                        This legacy Study Hub is temporarily restored for operational safety. Treat
+                        learning-runtime workspaces as the canonical home once rollback is cleared.
+                    </p>
+                </div>
                 <h1 className="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-5xl md:text-6xl">
                     Study Hub
                 </h1>

--- a/src/pages/__tests__/legacy-entry-mode.test.js
+++ b/src/pages/__tests__/legacy-entry-mode.test.js
@@ -1,4 +1,5 @@
 import {
+  LEARNING_RUNTIME_LEGACY_ROLLBACK_ENV_FLAG,
   LEARNING_RUNTIME_ROUTE_PATHS,
   LEARNING_RUNTIME_REVIEW_QUEUE_ROUTE_PATH,
   getAskAiEntryMode,
@@ -7,22 +8,36 @@ import {
 } from '../legacy-entry-mode.js';
 
 describe('legacy runtime entry modes', () => {
-  test('legacy entry surfaces stay on their pre-runtime modes when the feature flag is absent', () => {
-    expect(getAskAiEntryMode({ learningRuntimeEnabled: false })).toBe('legacy_chat');
-    expect(getStudyHubSurfaceMode({ learningRuntimeEnabled: false })).toBe('legacy_hub');
-    expect(getLearningPathSurfaceMode({ learningRuntimeEnabled: false })).toBe('legacy_path');
+  test('runtime-first entry is the default posture when no rollback override is active', () => {
+    expect(getAskAiEntryMode()).toBe('learning_runtime');
+    expect(getStudyHubSurfaceMode()).toBe('compatibility_shell');
+    expect(getLearningPathSurfaceMode()).toBe('compatibility_shell');
   });
 
-  test('legacy ask-ai page routes users into the new learning runtime entry under the feature flag', () => {
-    expect(getAskAiEntryMode({ learningRuntimeEnabled: true })).toBe('learning_runtime');
+  test('legacy surfaces only recover their pre-runtime modes when rollback is explicit', () => {
+    expect(getAskAiEntryMode({ learningRuntimeRollback: true })).toBe('legacy_chat');
+    expect(getStudyHubSurfaceMode({ learningRuntimeRollback: true })).toBe('legacy_hub');
+    expect(getLearningPathSurfaceMode({ learningRuntimeRollback: true })).toBe('legacy_path');
   });
 
-  test('legacy study hub stays a compatibility shell under the runtime feature flag', () => {
-    expect(getStudyHubSurfaceMode({ learningRuntimeEnabled: true })).toBe('compatibility_shell');
+  test('rollback env flag restores legacy entry surfaces', () => {
+    const rollbackEnv = {
+      [LEARNING_RUNTIME_LEGACY_ROLLBACK_ENV_FLAG]: 'true',
+    };
+
+    expect(getAskAiEntryMode({}, rollbackEnv)).toBe('legacy_chat');
+    expect(getStudyHubSurfaceMode({}, rollbackEnv)).toBe('legacy_hub');
+    expect(getLearningPathSurfaceMode({}, rollbackEnv)).toBe('legacy_path');
   });
 
-  test('legacy learning path stays a compatibility shell under the runtime feature flag', () => {
-    expect(getLearningPathSurfaceMode({ learningRuntimeEnabled: true })).toBe('compatibility_shell');
+  test('retired frontend pilot flag no longer controls the canonical runtime entry', () => {
+    const retiredFlagEnv = {
+      VITE_LEARNING_RUNTIME_ENABLED: 'false',
+    };
+
+    expect(getAskAiEntryMode({}, retiredFlagEnv)).toBe('learning_runtime');
+    expect(getStudyHubSurfaceMode({}, retiredFlagEnv)).toBe('compatibility_shell');
+    expect(getLearningPathSurfaceMode({}, retiredFlagEnv)).toBe('compatibility_shell');
   });
 
   test('App exposes the learning runtime session and workspace routes', () => {

--- a/src/pages/legacy-entry-mode.js
+++ b/src/pages/legacy-entry-mode.js
@@ -1,5 +1,7 @@
 const META_ENV = typeof import.meta !== 'undefined' ? import.meta.env || {} : {};
 
+export const LEARNING_RUNTIME_LEGACY_ROLLBACK_ENV_FLAG = 'VITE_LEARNING_RUNTIME_ROLLBACK_TO_LEGACY';
+
 export const LEARNING_RUNTIME_SESSION_ROUTE_PATH = '/learn/session/:sessionId';
 export const LEARNING_RUNTIME_WORKSPACE_ROUTE_PATH = '/learn/workspace/:topicId';
 export const LEARNING_RUNTIME_REVIEW_QUEUE_ROUTE_PATH = '/learn/review-queue';
@@ -23,26 +25,30 @@ export const LEARNING_RUNTIME_ENTRY_TOPICS = Object.freeze([
   },
 ]);
 
+export function isLearningRuntimeLegacyRollbackActive(options = {}, env = META_ENV) {
+  if (typeof options.learningRuntimeRollback === 'boolean') {
+    return options.learningRuntimeRollback;
+  }
+
+  if (typeof options.featureFlags?.learningRuntimeRollback === 'boolean') {
+    return options.featureFlags.learningRuntimeRollback;
+  }
+
+  return env[LEARNING_RUNTIME_LEGACY_ROLLBACK_ENV_FLAG] === 'true';
+}
+
 export function isLearningRuntimeEnabled(options = {}, env = META_ENV) {
-  if (typeof options.learningRuntimeEnabled === 'boolean') {
-    return options.learningRuntimeEnabled;
-  }
-
-  if (typeof options.featureFlags?.learningRuntimeEnabled === 'boolean') {
-    return options.featureFlags.learningRuntimeEnabled;
-  }
-
-  return env.VITE_LEARNING_RUNTIME_ENABLED === 'true';
+  return !isLearningRuntimeLegacyRollbackActive(options, env);
 }
 
-export function getAskAiEntryMode(options = {}) {
-  return isLearningRuntimeEnabled(options) ? 'learning_runtime' : 'legacy_chat';
+export function getAskAiEntryMode(options = {}, env = META_ENV) {
+  return isLearningRuntimeEnabled(options, env) ? 'learning_runtime' : 'legacy_chat';
 }
 
-export function getStudyHubSurfaceMode(options = {}) {
-  return isLearningRuntimeEnabled(options) ? 'compatibility_shell' : 'legacy_hub';
+export function getStudyHubSurfaceMode(options = {}, env = META_ENV) {
+  return isLearningRuntimeEnabled(options, env) ? 'compatibility_shell' : 'legacy_hub';
 }
 
-export function getLearningPathSurfaceMode(options = {}) {
-  return isLearningRuntimeEnabled(options) ? 'compatibility_shell' : 'legacy_path';
+export function getLearningPathSurfaceMode(options = {}, env = META_ENV) {
+  return isLearningRuntimeEnabled(options, env) ? 'compatibility_shell' : 'legacy_path';
 }


### PR DESCRIPTION
## Summary
- make learning-runtime entry the default canonical posture and replace the old enabled flag gate with an explicit `VITE_LEARNING_RUNTIME_ROLLBACK_TO_LEGACY` rollback switch
- keep AskAI, Study Hub, and Learning Path as clearly non-canonical compatibility surfaces by default, with rollback-only notices on the restored legacy views
- update the rollout runbook for the runtime-first cutover, retired flag cleanup, and explicit rollback guidance

## Verification
- `npm test -- --runInBand src/pages/__tests__/legacy-entry-mode.test.js`
- `npm test -- --runInBand src/api/__tests__/learningRuntimeApi.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/components/learning-runtime/__tests__/view-models.test.js src/pages/__tests__/legacy-entry-mode.test.js`
- `npm run build`

Closes #71