### PR TITLE
feat(learning): freeze subject adapter foundation

### DIFF
--- a/api/learning/__tests__/question-import-service.test.js
+++ b/api/learning/__tests__/question-import-service.test.js
@@ -1074,6 +1074,30 @@ describe('learning question import api', () => {
     expect(second.body.error.code).toBe('idempotency_conflict');
   });
 
+  test('POST /api/learning/questions/import rejects subjects without a runtime-enabled adapter', async () => {
+    const res = await harness.request
+      .post('/api/learning/questions/import')
+      .set('Origin', 'http://localhost:3000')
+      .set('Authorization', 'Bearer test-user:student-1:student')
+      .send({
+        subject_code: '9702',
+        prompt_representation: {
+          type: 'text',
+          value: 'A car accelerates uniformly from rest along a straight road.',
+        },
+        provenance_summary: {
+          import_source: 'manual_paste',
+        },
+        classification: {
+          primary_question_type_id: '9702.mechanics.force_balance',
+          classification_confidence: 0.61,
+        },
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('subject_adapter_not_enabled');
+  });
+
   test('POST /api/learning/questions/import replays the canonical durable response on same-payload retry after completion', async () => {
     const first = await harness.request
       .post('/api/learning/questions/import')
@@ -1259,12 +1283,21 @@ describe('learning question import api', () => {
       linked_references: [],
       updated_at: '2026-03-22T09:00:00.000Z',
     });
-    expect(workspaceRes.body.review_queue).toEqual({
+    expect(workspaceRes.body.review_queue).toMatchObject({
       scope: 'global_queue_projection',
       topic_id: 'topic-integration-1',
       status: null,
       due_before: null,
       items: [],
+      policy: {
+        daily_recommendation_cap: 3,
+        max_high_priority_open_per_type: 1,
+        immediate_repair_max_deferral_hours: 12,
+      },
+      summary: {
+        total: 0,
+        open: 0,
+      },
     });
   });
 });

--- a/api/learning/__tests__/review-task-service.test.js
+++ b/api/learning/__tests__/review-task-service.test.js
@@ -246,6 +246,43 @@ describe('learning orchestration', () => {
     expect(reconciliationService.calls).toHaveLength(1);
   });
 
+  test('learning effects reject subjects without a runtime-enabled adapter', async () => {
+    const reviewTaskService = createSpyService('generateTasksFromOutcome', async () => []);
+    const artifactService = createSpyService('buildArtifactCandidates', async () => []);
+    const reconciliationService = createSpyService('reconcileDerivedState', async ({ derivedState }) => ({
+      reconciliation_run_id: 'recon-unsupported',
+      status: 'completed',
+      derived_state: derivedState,
+    }));
+
+    await expect(applyLearningEffects(
+      {
+        user_id: 'student-1',
+        subject_code: '9702',
+        question_id: 'question-physics-1',
+        question_context: {
+          family_id: '9702.mechanics_dynamics',
+          question_type_id: '9702.mechanics.force_balance',
+          classification_confidence: 0.74,
+        },
+        source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-physics-1' },
+        source_mark_run_ref: { kind: 'mark_run', mark_run_id: 'mark-run-physics-1' },
+        uncertainty_validated: false,
+      },
+      {
+        reviewTaskService,
+        artifactService,
+        reconciliationService,
+      },
+    )).rejects.toMatchObject({
+      code: 'subject_adapter_not_enabled',
+    });
+
+    expect(reviewTaskService.calls).toHaveLength(0);
+    expect(artifactService.calls).toHaveLength(0);
+    expect(reconciliationService.calls).toHaveLength(0);
+  });
+
   test('weak-evidence promoted integration creates review tasks without authoritative score effects', async () => {
     const reviewTaskService = createSpyService('generateTasksFromOutcome', async (input) => [
       {

--- a/api/learning/__tests__/subject-adapter-registry.test.js
+++ b/api/learning/__tests__/subject-adapter-registry.test.js
@@ -1,0 +1,63 @@
+import {
+  RUNTIME_CORE_OWNERSHIP,
+  SUBJECT_ADAPTER_OWNERSHIP,
+} from '../lib/subjects/subject-adapter-contract.js';
+import {
+  SUBJECT_ADAPTER_DECISION,
+  getSubjectAdapter,
+} from '../lib/subjects/subject-adapter-registry.js';
+
+describe('subject adapter registry', () => {
+  test('freezes runtime-core-owned versus adapter-owned responsibilities', () => {
+    expect(RUNTIME_CORE_OWNERSHIP).toEqual(
+      expect.arrayContaining([
+        'study-session lifecycle and typed active_scope_bundle persistence',
+        'workspace, artifact, and review-task repositories plus immutable lineage',
+        'reconciliation, idempotency, and generic learning HTTP/error envelopes',
+      ]),
+    );
+
+    expect(SUBJECT_ADAPTER_OWNERSHIP).toMatchObject({
+      classification: expect.arrayContaining([
+        'question family/type semantics and canonical import normalization',
+      ]),
+      marking: expect.arrayContaining([
+        'released scoring posture interpretation for subject question types',
+      ]),
+      mastery: expect.arrayContaining([
+        'mastery signal allocation and type-versus-family promotion semantics',
+      ]),
+      review: expect.arrayContaining([
+        'review trigger routing and subject-specific scheduling semantics',
+      ]),
+    });
+  });
+
+  test('9709 is runtime-enabled and 9702 is the selected next subject', () => {
+    const currentAdapter = getSubjectAdapter('9709');
+    const selectedNextAdapter = getSubjectAdapter('9702', { allowDisabled: true });
+
+    expect(currentAdapter.meta).toMatchObject({
+      subject_code: '9709',
+      runtime_enabled: true,
+    });
+    expect(currentAdapter.classification.mergeCanonicalClassification).toEqual(expect.any(Function));
+    expect(currentAdapter.marking.resolveReleasedScoringPosture).toEqual(expect.any(Function));
+    expect(currentAdapter.mastery.buildMasteryProjection).toEqual(expect.any(Function));
+    expect(currentAdapter.review.buildSchedulerSeed).toEqual(expect.any(Function));
+
+    expect(SUBJECT_ADAPTER_DECISION).toMatchObject({
+      current_runtime_subject: '9709',
+      selected_next_subject: '9702',
+    });
+    expect(selectedNextAdapter.meta).toMatchObject({
+      subject_code: '9702',
+      runtime_enabled: false,
+      selection_state: 'selected_next',
+    });
+  });
+
+  test('disabled next-subject adapters fail explicitly instead of falling back to math defaults', () => {
+    expect(() => getSubjectAdapter('9702')).toThrow(/not enabled/i);
+  });
+});

--- a/api/learning/lib/contracts/error-contract.js
+++ b/api/learning/lib/contracts/error-contract.js
@@ -14,6 +14,7 @@ export const LEARNING_ERROR_CODES = Object.freeze({
   REVIEW_TASK_STATE_CONFLICT: 'review_task_state_conflict',
   ARTIFACT_NOT_FOUND: 'artifact_not_found',
   ARTIFACT_STATE_CONFLICT: 'artifact_state_conflict',
+  SUBJECT_ADAPTER_NOT_ENABLED: 'subject_adapter_not_enabled',
   IDEMPOTENCY_CONFLICT: 'idempotency_conflict',
 });
 
@@ -97,6 +98,11 @@ const LEARNING_ERROR_DEFINITIONS = Object.freeze({
   [LEARNING_ERROR_CODES.ARTIFACT_STATE_CONFLICT]: Object.freeze({
     status: 409,
     message: 'The artifact state conflicts with this request.',
+    retryable: false,
+  }),
+  [LEARNING_ERROR_CODES.SUBJECT_ADAPTER_NOT_ENABLED]: Object.freeze({
+    status: 409,
+    message: 'The requested subject adapter is not enabled for the learning runtime.',
     retryable: false,
   }),
   [LEARNING_ERROR_CODES.IDEMPOTENCY_CONFLICT]: Object.freeze({

--- a/api/learning/lib/import/question-import-service.js
+++ b/api/learning/lib/import/question-import-service.js
@@ -1,12 +1,14 @@
 import { randomUUID } from 'node:crypto';
 import { LEARNING_ERROR_CODES } from '../contracts/error-contract.js';
-import { resolveReleasedScoringPosture } from '../contracts/released-scope.js';
 import { LearningHttpError } from '../http/learning-http.js';
 import {
   getCanonicalQuestionType,
   getQuestionById,
   insertImportedQuestion,
 } from '../repositories/question-registry-repository.js';
+import {
+  getSubjectAdapter,
+} from '../subjects/subject-adapter-registry.js';
 import {
   deleteLearningRequestIdempotencyReservation,
   finalizeLearningRequestIdempotency,
@@ -121,15 +123,6 @@ function normalizeQuestionImportBody(body = {}) {
   };
 }
 
-function mergeCanonicalClassification(classification, canonicalQuestionType) {
-  return {
-    ...classification,
-    family_id: canonicalQuestionType?.family_id ?? classification.family_id,
-    primary_question_type_id:
-      canonicalQuestionType?.question_type_id ?? classification.primary_question_type_id,
-  };
-}
-
 function createIdempotencyConflictError() {
   return new LearningHttpError(
     LEARNING_ERROR_CODES.IDEMPOTENCY_CONFLICT,
@@ -161,16 +154,19 @@ async function buildQuestionImportResponse(client, {
   const requestClassification = isPlainObject(requestPayload?.classification)
     ? requestPayload.classification
     : {};
+  const adapter = getSubjectAdapter(
+    question?.subject_code ?? requestPayload?.subject_code ?? null,
+  );
   const canonicalQuestionType = await getCanonicalQuestionType(client, {
     subjectCode: question?.subject_code ?? requestPayload?.subject_code ?? null,
     questionTypeId:
       question?.primary_question_type_id ?? requestClassification.primary_question_type_id ?? null,
   });
-  const classification = mergeCanonicalClassification(
-    requestClassification,
+  const classification = adapter.classification.mergeCanonicalClassification({
+    classification: requestClassification,
     canonicalQuestionType,
-  );
-  const scoringScopePosture = resolveReleasedScoringPosture({
+  });
+  const scoringScopePosture = adapter.marking.resolveReleasedScoringPosture({
     questionTypeId:
       question?.primary_question_type_id ?? classification.primary_question_type_id ?? null,
     questionTypeReleaseState: canonicalQuestionType?.release_state ?? null,
@@ -277,15 +273,16 @@ async function performQuestionImport(client, {
   normalizedInput,
   questionId = null,
 } = {}) {
+  const adapter = getSubjectAdapter(normalizedInput.subject_code);
   const canonicalQuestionType = await getCanonicalQuestionType(client, {
     subjectCode: normalizedInput.subject_code,
     questionTypeId: normalizedInput.classification.primary_question_type_id,
   });
-  const classification = mergeCanonicalClassification(
-    normalizedInput.classification,
+  const classification = adapter.classification.mergeCanonicalClassification({
+    classification: normalizedInput.classification,
     canonicalQuestionType,
-  );
-  const scoringScopePosture = resolveReleasedScoringPosture({
+  });
+  const scoringScopePosture = adapter.marking.resolveReleasedScoringPosture({
     questionTypeId: classification.primary_question_type_id,
     questionTypeReleaseState: canonicalQuestionType?.release_state ?? null,
     candidateRubricRefs: classification.candidate_rubric_refs,

--- a/api/learning/lib/mastery/mastery-orchestrator.js
+++ b/api/learning/lib/mastery/mastery-orchestrator.js
@@ -1,4 +1,3 @@
-import { resolveReleasedScoringPosture } from '../contracts/released-scope.js';
 import { buildAttemptRef, buildMarkRunRef } from '../contracts/runtime-contract.js';
 import { createReviewTaskService } from '../review/review-task-service.js';
 import { createDefaultReviewTaskService } from '../review/review-task-service.js';
@@ -6,6 +5,10 @@ import { createArtifactService } from '../artifacts/artifact-service.js';
 import { createArtifactRepository } from '../repositories/artifact-repository.js';
 import { createReconciliationService } from '../reconciliation/reconciliation-service.js';
 import { createDefaultReconciliationService } from '../reconciliation/reconciliation-service.js';
+import {
+  getSubjectAdapter,
+  resolveSubjectCodeFromRuntimeInput,
+} from '../subjects/subject-adapter-registry.js';
 import { buildLearningRuntimeAutoEntryPayload } from '../../../error-book/lib/error-book-service.js';
 
 function normalizeArray(value) {
@@ -16,116 +19,9 @@ function getQuestionContext(input = {}) {
   return input.question_context || {};
 }
 
-function buildReleaseScopePosture(input = {}) {
-  const questionContext = getQuestionContext(input);
-
-  return input.release_scope_posture || resolveReleasedScoringPosture({
-    questionTypeId: questionContext.question_type_id,
-    questionTypeReleaseState:
-      questionContext.question_type_release_state
-      ?? questionContext.primary_question_type_release_state
-      ?? null,
-    candidateRubricRefs: questionContext.candidate_rubric_refs,
-    classificationConfidence: questionContext.classification_confidence,
-    uncertaintyValidated: input.uncertainty_validated ?? false,
-  });
-}
-
-function getMarkingResult(input = {}) {
-  return input.marking_result && typeof input.marking_result === 'object'
-    ? input.marking_result
-    : null;
-}
-
-function hasPositiveAuthoritativeSignal(decisions = []) {
-  return decisions.some((decision) =>
-    decision?.awarded === true && Number(decision?.awarded_marks ?? 0) > 0);
-}
-
-function hasConservativePartMapping(markingResult = null) {
-  return Boolean(
-    markingResult?.marking_summary?.conservative_part_mapping
-    || Number(markingResult?.marking_summary?.ambiguous_rubric_point_result_count ?? 0) > 0,
-  );
-}
-
-function buildLocalSignals(input = {}, releaseScopePosture = {}) {
-  const questionContext = getQuestionContext(input);
-  const repairTopicId =
-    input.repair_target_topic_id
-    || questionContext.primary_topic_id
-    || input.source_attempt_context?.topic_id
-    || null;
-  const questionTypeId = questionContext.question_type_id ?? null;
-  const familyId = questionContext.family_id ?? null;
-
-  return normalizeArray(getMarkingResult(input)?.part_results)
-    .filter((partResult) => Number(partResult?.score_awarded ?? 0) > 0)
-    .map((partResult) => ({
-      scope_kind: partResult?.subpart_id ? 'subpart' : 'part',
-      topic_id: repairTopicId,
-      family_id: familyId,
-      question_type_id: questionTypeId,
-      part_id: partResult?.part_id ?? null,
-      subpart_id: partResult?.subpart_id ?? null,
-      signal_direction: 'positive',
-      signal_weight: releaseScopePosture.authoritative_scoring_allowed
-        ? 'authoritative_local'
-        : 'conservative_local',
-      release_scope_status: releaseScopePosture.release_scope_status,
-      score_awarded: Number(partResult?.score_awarded ?? 0),
-      score_max: Number(partResult?.score_max ?? 0),
-    }));
-}
-
-function shouldPromoteQuestionType(input = {}, releaseScopePosture = {}) {
-  const markingResult = getMarkingResult(input);
-  return Boolean(
-    releaseScopePosture.authoritative_scoring_allowed
-    && hasPositiveAuthoritativeSignal(input.decisions)
-    && !markingResult?.marking_summary?.local_signal_only
-    && !hasConservativePartMapping(markingResult),
-  );
-}
-
-function buildMasteryUpdates(input = {}, releaseScopePosture = {}, { localSignals = [] } = {}) {
-  const questionContext = getQuestionContext(input);
-  const questionTypeId = questionContext.question_type_id ?? null;
-  const familyId = questionContext.family_id ?? null;
-  const repairTopicId =
-    input.repair_target_topic_id
-    || questionContext.primary_topic_id
-    || input.source_attempt_context?.topic_id
-    || null;
-  const updates = [];
-
-  if (shouldPromoteQuestionType(input, releaseScopePosture)) {
-    updates.push({
-      level: 'question_type',
-      topic_id: repairTopicId,
-      family_id: familyId,
-      question_type_id: questionTypeId,
-      signal_direction: 'positive',
-      signal_weight: 'authoritative',
-      release_scope_status: releaseScopePosture.release_scope_status,
-    });
-  } else if (localSignals.length === 0 && familyId && releaseScopePosture.classification_confidence !== null) {
-    updates.push({
-      level: 'family',
-      topic_id: repairTopicId,
-      family_id: familyId,
-      question_type_id: null,
-      signal_direction: 'diagnostic',
-      signal_weight: 'conservative',
-      release_scope_status: releaseScopePosture.release_scope_status,
-    });
-  }
-
-  return updates;
-}
-
 function buildErrorBookHooks({
   input,
+  subjectCode,
   artifactCandidates,
   repairTopicId,
   repairTopicPath,
@@ -139,7 +35,7 @@ function buildErrorBookHooks({
     .map((candidate) =>
       buildLearningRuntimeAutoEntryPayload({
         userId: input.user_id,
-        subjectCode: input.subject_code ?? null,
+        subjectCode,
         question: input.error_book_question || 'Auto-generated learning-runtime misconception note.',
         explanation: input.error_book_explanation ?? null,
         repairTopicRef: {
@@ -181,7 +77,18 @@ export function createMasteryOrchestrator({
   return {
     async applyLearningEffects(input = {}) {
       const questionContext = getQuestionContext(input);
-      const releaseScopePosture = buildReleaseScopePosture(input);
+      const subjectCode = resolveSubjectCodeFromRuntimeInput(input, questionContext);
+      const adapter = getSubjectAdapter(subjectCode);
+      const releaseScopePosture = input.release_scope_posture || adapter.marking.resolveReleasedScoringPosture({
+        questionTypeId: questionContext.question_type_id,
+        questionTypeReleaseState:
+          questionContext.question_type_release_state
+          ?? questionContext.primary_question_type_release_state
+          ?? null,
+        candidateRubricRefs: questionContext.candidate_rubric_refs,
+        classificationConfidence: questionContext.classification_confidence,
+        uncertaintyValidated: input.uncertainty_validated ?? false,
+      });
       const sourceAttemptRef = input.source_attempt_ref
         || (input.attempt_id ? buildAttemptRef(input.attempt_id) : null);
       const sourceMarkRunRef = input.source_mark_run_ref
@@ -198,6 +105,7 @@ export function createMasteryOrchestrator({
         || null;
       const reviewTaskInput = {
         ...input,
+        subject_code: subjectCode,
         authoritative_scoring_allowed: releaseScopePosture.authoritative_scoring_allowed,
         fallback_reason_code: releaseScopePosture.fallback_reason_code,
         repair_target_topic_id: repairTopicId,
@@ -222,16 +130,20 @@ export function createMasteryOrchestrator({
         source_mark_run_ref: sourceMarkRunRef,
         source_session_id: input.source_session_id ?? null,
       };
-      const localSignals = buildLocalSignals(input, releaseScopePosture);
-      const masteryUpdates = buildMasteryUpdates(input, releaseScopePosture, {
-        localSignals,
+      const masteryProjection = adapter.mastery.buildMasteryProjection({
+        input,
+        questionContext,
+        releaseScopePosture,
       });
+      const localSignals = masteryProjection.localSignals;
+      const masteryUpdates = masteryProjection.masteryUpdates;
       const reviewTasks = releaseScopePosture.authoritative_scoring_allowed
         ? []
         : await reviewTaskService.generateTasksFromOutcome(reviewTaskInput);
       const artifactCandidates = await artifactService.buildArtifactCandidates(artifactInput);
       const errorBookHooks = buildErrorBookHooks({
         input,
+        subjectCode,
         artifactCandidates,
         repairTopicId,
         repairTopicPath,

--- a/api/learning/lib/review/review-task-service.js
+++ b/api/learning/lib/review/review-task-service.js
@@ -2,10 +2,13 @@ import { createReviewTaskRepository } from '../repositories/review-task-reposito
 import { LEARNING_ERROR_CODES } from '../contracts/error-contract.js';
 import { LearningHttpError } from '../http/learning-http.js';
 import {
-  buildReviewTaskSchedulerSeed,
   mergeReviewTaskPayload,
   pickReviewTaskMergeCandidate,
 } from './review-scheduler-policy.js';
+import {
+  getSubjectAdapter,
+  resolveSubjectCodeFromRuntimeInput,
+} from '../subjects/subject-adapter-registry.js';
 
 const REVIEW_TASK_INTENTS = new Set(['complete', 'reschedule', 'snooze', 'reopen']);
 const REVIEW_TASK_COMPLETION_OUTCOMES = new Set(['completed', 'partial']);
@@ -281,7 +284,9 @@ function buildReviewTaskPayload(input = {}, now = new Date()) {
     input.repair_target_question_type_id
     || input.question_context?.question_type_id
     || null;
-  const scheduler = buildReviewTaskSchedulerSeed({
+  const subjectCode = resolveSubjectCodeFromRuntimeInput(input, input.question_context);
+  const adapter = getSubjectAdapter(subjectCode);
+  const scheduler = adapter.review.buildSchedulerSeed({
     now,
     misconceptionTags: input.misconception_tags,
     triggerType: input.trigger_type,

--- a/api/learning/lib/subjects/subject-adapter-contract.js
+++ b/api/learning/lib/subjects/subject-adapter-contract.js
@@ -1,0 +1,75 @@
+function freezeList(values) {
+  return Object.freeze([...values]);
+}
+
+function freezeArea(area = {}) {
+  return Object.freeze({ ...area });
+}
+
+function assertFunction(path, value) {
+  if (typeof value !== 'function') {
+    throw new TypeError(`${path} must be a function.`);
+  }
+}
+
+function assertMeta(meta = {}) {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+    throw new TypeError('meta must be an object.');
+  }
+
+  if (typeof meta.subject_code !== 'string' || !meta.subject_code.trim()) {
+    throw new TypeError('meta.subject_code is required.');
+  }
+
+  if (typeof meta.runtime_enabled !== 'boolean') {
+    throw new TypeError('meta.runtime_enabled must be a boolean.');
+  }
+}
+
+export const RUNTIME_CORE_OWNERSHIP = freezeList([
+  'study-session lifecycle and typed active_scope_bundle persistence',
+  'workspace, artifact, and review-task repositories plus immutable lineage',
+  'reconciliation, idempotency, and generic learning HTTP/error envelopes',
+  'generic released-family evidence gates and conservative fallback invariants',
+]);
+
+export const SUBJECT_ADAPTER_OWNERSHIP = Object.freeze({
+  classification: freezeList([
+    'question family/type semantics and canonical import normalization',
+    'subject-owned runtime context defaults and import-time taxonomy mapping',
+  ]),
+  marking: freezeList([
+    'released scoring posture interpretation for subject question types',
+    'subject-specific rubric and uncertainty semantics above core invariants',
+  ]),
+  mastery: freezeList([
+    'mastery signal allocation and type-versus-family promotion semantics',
+    'subject-specific local signal weighting and conservative fallback behavior',
+  ]),
+  review: freezeList([
+    'review trigger routing and subject-specific scheduling semantics',
+    'subject-owned review posture for misconception-heavy or non-math flows',
+  ]),
+});
+
+export function createSubjectAdapter(definition = {}) {
+  const meta = definition.meta ?? {};
+  const classification = definition.classification ?? {};
+  const marking = definition.marking ?? {};
+  const mastery = definition.mastery ?? {};
+  const review = definition.review ?? {};
+
+  assertMeta(meta);
+  assertFunction('classification.mergeCanonicalClassification', classification.mergeCanonicalClassification);
+  assertFunction('marking.resolveReleasedScoringPosture', marking.resolveReleasedScoringPosture);
+  assertFunction('mastery.buildMasteryProjection', mastery.buildMasteryProjection);
+  assertFunction('review.buildSchedulerSeed', review.buildSchedulerSeed);
+
+  return Object.freeze({
+    meta: Object.freeze({ ...meta }),
+    classification: freezeArea(classification),
+    marking: freezeArea(marking),
+    mastery: freezeArea(mastery),
+    review: freezeArea(review),
+  });
+}

--- a/api/learning/lib/subjects/subject-adapter-registry.js
+++ b/api/learning/lib/subjects/subject-adapter-registry.js
@@ -1,0 +1,242 @@
+import { LEARNING_ERROR_CODES } from '../contracts/error-contract.js';
+import { resolveReleasedScoringPosture as resolveCoreReleasedScoringPosture } from '../contracts/released-scope.js';
+import { LearningHttpError } from '../http/learning-http.js';
+import { buildReviewTaskSchedulerSeed } from '../review/review-scheduler-policy.js';
+import { createSubjectAdapter } from './subject-adapter-contract.js';
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeSubjectCode(value) {
+  const normalized = normalizeString(value);
+  return /^\d{4}$/.test(normalized) ? normalized : null;
+}
+
+function deriveSubjectCodeFromStructuredId(value) {
+  const normalized = normalizeString(value);
+  const match = normalized.match(/^(\d{4})(?:[./]|$)/);
+  return match ? match[1] : null;
+}
+
+function getQuestionContext(input = {}) {
+  return input.question_context && typeof input.question_context === 'object'
+    ? input.question_context
+    : {};
+}
+
+function createSubjectAdapterNotEnabledError(subjectCode, selectionState = 'unregistered') {
+  const normalizedSubjectCode = normalizeSubjectCode(subjectCode) || normalizeString(subjectCode) || 'unknown';
+  return new LearningHttpError(
+    LEARNING_ERROR_CODES.SUBJECT_ADAPTER_NOT_ENABLED,
+    `Subject adapter ${normalizedSubjectCode} is not enabled for the learning runtime.`,
+    {
+      status: 409,
+      details: {
+        subject_code: normalizedSubjectCode,
+        selection_state: selectionState,
+      },
+    },
+  );
+}
+
+function createDisabledArea(subjectCode, selectionState) {
+  return () => {
+    throw createSubjectAdapterNotEnabledError(subjectCode, selectionState);
+  };
+}
+
+function mergeCanonicalClassification({ classification = {}, canonicalQuestionType = null } = {}) {
+  return {
+    ...classification,
+    family_id: canonicalQuestionType?.family_id ?? classification.family_id ?? null,
+    primary_question_type_id:
+      canonicalQuestionType?.question_type_id ?? classification.primary_question_type_id ?? null,
+  };
+}
+
+function hasPositiveAuthoritativeSignal(decisions = []) {
+  return decisions.some((decision) =>
+    decision?.awarded === true && Number(decision?.awarded_marks ?? 0) > 0);
+}
+
+function hasConservativePartMapping(markingResult = null) {
+  return Boolean(
+    markingResult?.marking_summary?.conservative_part_mapping
+    || Number(markingResult?.marking_summary?.ambiguous_rubric_point_result_count ?? 0) > 0,
+  );
+}
+
+function build9709LocalSignals(input = {}, questionContext = {}, releaseScopePosture = {}) {
+  const repairTopicId =
+    input.repair_target_topic_id
+    || questionContext.primary_topic_id
+    || input.source_attempt_context?.topic_id
+    || null;
+  const questionTypeId = questionContext.question_type_id ?? null;
+  const familyId = questionContext.family_id ?? null;
+
+  return normalizeArray(input.marking_result?.part_results)
+    .filter((partResult) => Number(partResult?.score_awarded ?? 0) > 0)
+    .map((partResult) => ({
+      scope_kind: partResult?.subpart_id ? 'subpart' : 'part',
+      topic_id: repairTopicId,
+      family_id: familyId,
+      question_type_id: questionTypeId,
+      part_id: partResult?.part_id ?? null,
+      subpart_id: partResult?.subpart_id ?? null,
+      signal_direction: 'positive',
+      signal_weight: releaseScopePosture.authoritative_scoring_allowed
+        ? 'authoritative_local'
+        : 'conservative_local',
+      release_scope_status: releaseScopePosture.release_scope_status,
+      score_awarded: Number(partResult?.score_awarded ?? 0),
+      score_max: Number(partResult?.score_max ?? 0),
+    }));
+}
+
+function shouldPromote9709QuestionType(input = {}, releaseScopePosture = {}) {
+  const markingResult = input.marking_result && typeof input.marking_result === 'object'
+    ? input.marking_result
+    : null;
+
+  return Boolean(
+    releaseScopePosture.authoritative_scoring_allowed
+    && hasPositiveAuthoritativeSignal(input.decisions)
+    && !markingResult?.marking_summary?.local_signal_only
+    && !hasConservativePartMapping(markingResult),
+  );
+}
+
+function build9709MasteryProjection({ input = {}, questionContext = {}, releaseScopePosture = {} } = {}) {
+  const questionTypeId = questionContext.question_type_id ?? null;
+  const familyId = questionContext.family_id ?? null;
+  const repairTopicId =
+    input.repair_target_topic_id
+    || questionContext.primary_topic_id
+    || input.source_attempt_context?.topic_id
+    || null;
+  const localSignals = build9709LocalSignals(input, questionContext, releaseScopePosture);
+  const masteryUpdates = [];
+
+  if (shouldPromote9709QuestionType(input, releaseScopePosture)) {
+    masteryUpdates.push({
+      level: 'question_type',
+      topic_id: repairTopicId,
+      family_id: familyId,
+      question_type_id: questionTypeId,
+      signal_direction: 'positive',
+      signal_weight: 'authoritative',
+      release_scope_status: releaseScopePosture.release_scope_status,
+    });
+  } else if (localSignals.length === 0 && familyId && releaseScopePosture.classification_confidence !== null) {
+    masteryUpdates.push({
+      level: 'family',
+      topic_id: repairTopicId,
+      family_id: familyId,
+      question_type_id: null,
+      signal_direction: 'diagnostic',
+      signal_weight: 'conservative',
+      release_scope_status: releaseScopePosture.release_scope_status,
+    });
+  }
+
+  return {
+    localSignals,
+    masteryUpdates,
+  };
+}
+
+export const SUBJECT_ADAPTER_DECISION = Object.freeze({
+  current_runtime_subject: '9709',
+  selected_next_subject: '9702',
+  decided_on: '2026-03-25',
+  evidence_report_path: 'docs/reports/learning_runtime_second_subject_decision_2026-03-25.md',
+});
+
+const SUBJECT_ADAPTERS = new Map([
+  [
+    '9709',
+    createSubjectAdapter({
+      meta: {
+        subject_code: '9709',
+        display_name: 'Mathematics',
+        runtime_enabled: true,
+        selection_state: 'current_runtime',
+      },
+      classification: {
+        mergeCanonicalClassification,
+      },
+      marking: {
+        resolveReleasedScoringPosture: (input = {}) => resolveCoreReleasedScoringPosture(input),
+      },
+      mastery: {
+        buildMasteryProjection: (input = {}) => build9709MasteryProjection(input),
+      },
+      review: {
+        buildSchedulerSeed: (input = {}) => buildReviewTaskSchedulerSeed(input),
+      },
+    }),
+  ],
+  [
+    '9702',
+    createSubjectAdapter({
+      meta: {
+        subject_code: '9702',
+        display_name: 'Physics',
+        runtime_enabled: false,
+        selection_state: 'selected_next',
+      },
+      classification: {
+        mergeCanonicalClassification: createDisabledArea('9702', 'selected_next'),
+      },
+      marking: {
+        resolveReleasedScoringPosture: createDisabledArea('9702', 'selected_next'),
+      },
+      mastery: {
+        buildMasteryProjection: createDisabledArea('9702', 'selected_next'),
+      },
+      review: {
+        buildSchedulerSeed: createDisabledArea('9702', 'selected_next'),
+      },
+    }),
+  ],
+]);
+
+export function resolveSubjectCodeFromRuntimeInput(input = {}, questionContext = getQuestionContext(input)) {
+  return (
+    normalizeSubjectCode(input.subject_code)
+    || normalizeSubjectCode(questionContext.subject_code)
+    || deriveSubjectCodeFromStructuredId(
+      questionContext.question_type_id
+      || input.repair_target_question_type_id
+      || questionContext.family_id
+      || questionContext.primary_topic_path
+      || input.repair_target_topic_path
+      || input.source_attempt_context?.topic_path
+      || null,
+    )
+  );
+}
+
+export function getSubjectAdapter(subjectCode, { allowDisabled = false } = {}) {
+  const normalizedSubjectCode = normalizeSubjectCode(subjectCode);
+  const adapter = normalizedSubjectCode ? SUBJECT_ADAPTERS.get(normalizedSubjectCode) : null;
+
+  if (!adapter) {
+    throw createSubjectAdapterNotEnabledError(normalizedSubjectCode, 'unregistered');
+  }
+
+  if (!allowDisabled && !adapter.meta.runtime_enabled) {
+    throw createSubjectAdapterNotEnabledError(
+      adapter.meta.subject_code,
+      adapter.meta.selection_state,
+    );
+  }
+
+  return adapter;
+}

--- a/docs/reports/learning_runtime_second_subject_decision_2026-03-25.md
+++ b/docs/reports/learning_runtime_second_subject_decision_2026-03-25.md
@@ -1,0 +1,80 @@
+# Learning Runtime Second Subject Decision
+
+**Date:** 2026-03-25  
+**Decision:** choose `9702` (Physics) as the second subject after `9709`  
+**Status:** selected next, not runtime-enabled yet
+
+## Decision Criteria
+
+- Use live repo evidence, not aspirational product language alone.
+- Prefer a subject that already has meaningful content and retrieval surfaces in the repo.
+- Avoid a path that can look successful by silently reusing `9709` heuristics.
+- Choose a subject that forces the adapter contract to prove itself in classification, marking, mastery, and review semantics.
+
+## Evidence Snapshot
+
+### 1. The shipped runtime is still overwhelmingly `9709`-specific
+
+Repo counts captured from the current branch:
+
+- `api/learning src/components/learning-runtime src/pages/learning-runtime`
+  - `9709`: `360`
+  - `9231`: `1`
+  - `9702`: `0`
+- `api/marking tests/marking`
+  - `9709`: `29`
+  - `9231`: `0`
+  - `9702`: `0`
+
+This confirms the issue premise: the current runtime is not a landed multi-subject runtime.
+
+Additional repo evidence:
+
+- `api/rag/lib/ask-service.js` contains a `9709`-specific cross-topic planning heuristic.
+- `src/components/learning-runtime/ImportedQuestionIntake.js` and `src/components/learning-runtime/view-models/session-live-state.js` still default to `9709`.
+
+### 2. The repo already has real multi-subject content surfaces
+
+Past-paper files:
+
+- `data/past-papers/9702Physics`: `316`
+- `data/past-papers/9231Further-Mathematics`: `156`
+
+Mark-scheme files:
+
+- `data/mark-schemes/9702Physics`: `344`
+- `data/mark-schemes/9231Further-Mathematics`: `163`
+
+Topic-note files:
+
+- `src/data/data-notes/9702as+a2`: `43`
+- `src/data/data-notes/9231FP4data-notes`: `33`
+
+This shows that the repo already has stronger raw content coverage for `9702` than for `9231`.
+
+### 3. `9702` creates a better adapter test than `9231`
+
+The misconception taxonomy already shows subject-specific behavior:
+
+- `supabase/migrations/20260217100003_create_misconception_tables.sql` gives `9702` a unique `unit_error` tag.
+- `9231` mostly shares the existing math-oriented misconception set with `9709`.
+
+That difference matters for this issue. The goal is not to find the closest math neighbor; it is to freeze an adapter boundary that survives a genuinely different subject.
+
+## Why `9702` Wins
+
+- `9702` has better live repo evidence than `9231` across papers, mark schemes, and topic notes.
+- `9702` forces the system to acknowledge non-math semantics early instead of pretending math defaults generalize.
+- `9702` is closer to the PRD’s open expansion question, which explicitly asks about Physics vs Chemistry rather than about another math syllabus.
+
+## Why `9231` Was Not Chosen First
+
+- It is too easy to treat `9231` as “more math” and accidentally copy `9709` assumptions forward.
+- The current repo evidence shows less raw content coverage than `9702`.
+- For this foundation issue, similarity is a risk: it can hide a weak adapter boundary instead of validating it.
+
+## Resulting Runtime Rule
+
+- `9709` stays runtime-enabled.
+- `9702` is recorded as the next adapter target.
+- Any attempt to use `9702` in the learning runtime before rollout must fail explicitly with `subject_adapter_not_enabled`, not silently inherit `9709` behavior.

--- a/docs/superpowers/plans/2026-03-25-subject-adapter-foundation.md
+++ b/docs/superpowers/plans/2026-03-25-subject-adapter-foundation.md
@@ -1,0 +1,72 @@
+# Subject Adapter Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Freeze a runtime subject-adapter contract, route current `9709` behavior through it, and record an evidence-based second-subject decision without rolling out that second subject yet.
+
+**Architecture:** Add a thin adapter registry above the frozen runtime/session contract and below subject-sensitive runtime behaviors. Keep session persistence, typed refs, reconciliation, artifact lifecycle, and queue state in runtime core; move classification, marking posture, mastery semantics, and review scheduling semantics behind per-subject adapters. Use a runtime-enabled `9709` adapter and a selected-but-disabled `9702` stub to make the boundary explicit.
+
+**Tech Stack:** Node API handlers, Jest, existing learning-runtime/marking/review modules, Markdown docs.
+
+---
+
+## Chunk 1: Contract And Tests
+
+### Task 1: Add failing tests for the adapter boundary and second-subject decision
+
+**Files:**
+- Create: `api/learning/__tests__/subject-adapter-registry.test.js`
+- Modify: `api/learning/__tests__/question-import-service.test.js`
+- Modify: `api/learning/__tests__/review-task-service.test.js`
+
+- [ ] **Step 1: Write a failing registry test**
+- [ ] **Step 2: Write failing service tests proving unsupported subjects do not silently reuse `9709` logic**
+- [ ] **Step 3: Run focused Jest suites and confirm failure**
+
+## Chunk 2: Adapter Registry Integration
+
+### Task 2: Implement the subject-adapter contract and `9709`/`9702` registry entries
+
+**Files:**
+- Create: `api/learning/lib/subjects/subject-adapter-contract.js`
+- Create: `api/learning/lib/subjects/subject-adapter-registry.js`
+
+- [ ] **Step 1: Define adapter-owned vs runtime-core-owned responsibilities**
+- [ ] **Step 2: Implement a runtime-enabled `9709` adapter using existing semantics**
+- [ ] **Step 3: Implement a selected-next `9702` stub that fails explicitly instead of falling back to math defaults**
+
+### Task 3: Route live runtime behavior through the adapter seam
+
+**Files:**
+- Modify: `api/learning/lib/import/question-import-service.js`
+- Modify: `api/learning/lib/mastery/mastery-orchestrator.js`
+- Modify: `api/learning/lib/review/review-task-service.js`
+
+- [ ] **Step 1: Use adapter classification/marking in imported-question intake**
+- [ ] **Step 2: Use adapter marking/mastery in learning effects orchestration**
+- [ ] **Step 3: Use adapter review semantics when building review tasks**
+- [ ] **Step 4: Run focused Jest suites and confirm green**
+
+## Chunk 3: Evidence Artifact
+
+### Task 4: Record the frozen contract and second-subject decision
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-03-25-subject-adapter-foundation.md`
+- Create: `docs/reports/learning_runtime_second_subject_decision_2026-03-25.md`
+
+- [ ] **Step 1: Document core-owned vs adapter-owned runtime responsibilities**
+- [ ] **Step 2: Summarize live repo evidence for `9702` and `9231`**
+- [ ] **Step 3: Record the chosen subject and why the alternative was not chosen**
+
+## Chunk 4: Verification And Delivery
+
+### Task 5: Verify, commit, and open the PR
+
+**Files:**
+- Modify: current branch only
+
+- [ ] **Step 1: Run focused verification commands and capture exact results**
+- [ ] **Step 2: Rename branch to `feat/72`**
+- [ ] **Step 3: Commit with a conventional message**
+- [ ] **Step 4: Push and create a PR that closes #72**

--- a/docs/superpowers/specs/2026-03-25-subject-adapter-foundation.md
+++ b/docs/superpowers/specs/2026-03-25-subject-adapter-foundation.md
@@ -1,0 +1,98 @@
+# Subject Adapter Foundation
+
+**Date:** 2026-03-25  
+**Status:** frozen for issue #72  
+**Depends on:** `核心项目文档/PRD.md`, `docs/superpowers/specs/2026-03-20-prd-learning-runtime-contract-design.md`
+
+## Goal
+
+Freeze the runtime subject-adapter boundary before any second-subject rollout so the next subject does not inherit `9709` semantics by accident.
+
+This issue does **not** ship a second subject. It freezes the contract and records which subject should be next.
+
+## Runtime-Core-Owned Responsibilities
+
+These remain in runtime core and must not move into subject adapters:
+
+- Study-session lifecycle and typed `active_scope_bundle` persistence
+- Workspace, artifact, and review-task repositories plus immutable lineage
+- Reconciliation, idempotency, and generic learning HTTP/error envelopes
+- Generic released-family evidence gates and conservative fallback invariants
+
+The executable source of truth for this split lives in `api/learning/lib/subjects/subject-adapter-contract.js`.
+
+## Adapter-Owned Responsibilities
+
+Each subject adapter owns exactly four behavior surfaces:
+
+### 1. Classification
+
+- question family / question type semantics
+- canonical import normalization
+- subject-owned runtime context defaults
+
+Executable hook:
+
+- `classification.mergeCanonicalClassification(...)`
+
+### 2. Marking
+
+- subject interpretation of released scoring posture
+- subject-specific rubric / uncertainty semantics above the core invariant
+
+Executable hook:
+
+- `marking.resolveReleasedScoringPosture(...)`
+
+### 3. Mastery
+
+- mastery signal allocation
+- question-type vs family promotion semantics
+- subject-specific conservative fallback behavior
+
+Executable hook:
+
+- `mastery.buildMasteryProjection(...)`
+
+### 4. Review
+
+- review trigger routing
+- subject-specific scheduler semantics
+
+Executable hook:
+
+- `review.buildSchedulerSeed(...)`
+
+## Frozen Runtime Posture
+
+- `9709` is the only runtime-enabled adapter in this issue.
+- `9702` is recorded as the selected next subject but remains disabled.
+- Disabled adapters must fail explicitly instead of falling back to `9709` behavior.
+
+This is enforced in `api/learning/lib/subjects/subject-adapter-registry.js` and covered by `api/learning/__tests__/subject-adapter-registry.test.js`.
+
+## Integration Points Landed In This Issue
+
+The subject adapter seam is now exercised in live runtime paths:
+
+- imported-question intake uses adapter classification + marking posture
+- learning effects use adapter marking + mastery semantics
+- review-task generation uses adapter review scheduling semantics
+
+The relevant tests are:
+
+- `api/learning/__tests__/subject-adapter-registry.test.js`
+- `api/learning/__tests__/question-import-service.test.js`
+- `api/learning/__tests__/review-task-service.test.js`
+
+## Second-Subject Decision
+
+The selected next subject after `9709` is `9702` (Physics).
+
+Rationale:
+
+- it already has meaningful repo evidence across past papers, mark schemes, notes, and subject pages
+- it exercises subject-specific semantics that math does not, which makes it a better test of the adapter contract
+- choosing `9231` first would create a stronger temptation to copy math heuristics forward instead of proving the boundary
+
+The evidence record is frozen in `docs/reports/learning_runtime_second_subject_decision_2026-03-25.md`.


### PR DESCRIPTION
## Summary
- freeze a subject-adapter contract and registry for learning-runtime classification, marking, mastery, and review semantics
- route imported-question intake, learning effects, and review-task scheduling through the adapter boundary so non-enabled subjects fail explicitly instead of reusing `9709` defaults
- record the second-subject decision with live repo evidence and select `9702` as the next adapter target after `9709`

## Why
- the PRD requires subject-specific adapters for post-math expansion
- the runtime was still implicitly math-first in live code
- this issue needed a frozen contract and an evidence-based second-subject choice before any rollout work

## Artifacts
- `api/learning/lib/subjects/subject-adapter-contract.js`
- `api/learning/lib/subjects/subject-adapter-registry.js`
- `docs/superpowers/specs/2026-03-25-subject-adapter-foundation.md`
- `docs/reports/learning_runtime_second_subject_decision_2026-03-25.md`

## Verification
- `npm test -- --runInBand api/learning/__tests__/subject-adapter-registry.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/review-task-service.test.js --verbose`

Closes #72
