### PR TITLE
Strengthen workspace revisitation and continuation

### DIFF
--- a/api/learning/__tests__/workspace-read-service.test.js
+++ b/api/learning/__tests__/workspace-read-service.test.js
@@ -201,6 +201,109 @@ function createLearningDb() {
     },
   ];
 
+  const sessionRows = [
+    {
+      session_id: 'session-topic-2-later',
+      user_id: 'student-1',
+      subject_code: '9709',
+      session_goal: 'Refresh trig identities',
+      mode: 'learn_concept',
+      state: 'active',
+      active_scope_bundle: {
+        primary_topic_id: 'topic-2',
+        primary_topic_path: '9709/trigonometry/identities',
+        mode: 'learn_concept',
+        current_anchor_kind: 'concept',
+        current_anchor_ref: {
+          kind: 'concept',
+          topic_id: 'topic-2',
+          topic_path: '9709/trigonometry/identities',
+        },
+        current_question_ref: null,
+        current_question_type_ref: {
+          kind: 'question_type',
+          question_type_id: '9709.trigonometry.identities',
+        },
+      },
+      current_anchor_kind: 'concept',
+      current_anchor_ref: {
+        kind: 'concept',
+        topic_id: 'topic-2',
+        topic_path: '9709/trigonometry/identities',
+      },
+      current_question_id: null,
+      current_question_type_id: '9709.trigonometry.identities',
+      summary_state: {
+        resume_title: 'Resume identities review',
+        resume_message: 'Return to the concept anchor for identities.',
+        resume_summary: 'Carry the identities recap into the next pass.',
+      },
+      open_questions: [],
+      key_artifact_refs: [],
+      misconceptions_in_focus: [],
+      lineage_ref: {
+        parent_session_id: null,
+        handoff_kind: null,
+      },
+      created_at: '2026-03-22T08:20:00.000Z',
+      updated_at: '2026-03-22T08:30:00.000Z',
+      parent_session_id: null,
+      handoff_kind: null,
+      summary_snapshot: {
+        recap: 'Identity recap.',
+      },
+    },
+    {
+      session_id: 'session-topic-1-current',
+      user_id: 'student-1',
+      subject_code: '9709',
+      session_goal: 'Close the interval misconception',
+      mode: 'post_mortem_review',
+      state: 'active',
+      active_scope_bundle: {
+        primary_topic_id: 'topic-1',
+        primary_topic_path: '9709/trigonometry/equations',
+        mode: 'post_mortem_review',
+        current_anchor_kind: 'artifact',
+        current_anchor_ref: {
+          kind: 'artifact',
+          artifact_id: 'artifact-primary',
+        },
+        current_question_ref: null,
+        current_question_type_ref: {
+          kind: 'question_type',
+          question_type_id: '9709.trigonometry.equations',
+        },
+      },
+      current_anchor_kind: 'artifact',
+      current_anchor_ref: {
+        kind: 'artifact',
+        artifact_id: 'artifact-primary',
+      },
+      current_question_id: null,
+      current_question_type_id: '9709.trigonometry.equations',
+      summary_state: {
+        resume_title: 'Continue interval repair',
+        resume_message: 'Resume from the misconception artifact anchored to this workspace.',
+        resume_summary: 'Carry the misconception recap into the next pass.',
+      },
+      open_questions: [],
+      key_artifact_refs: [],
+      misconceptions_in_focus: ['domain:interval'],
+      lineage_ref: {
+        parent_session_id: 'session-parent-1',
+        handoff_kind: 'explicit_new_session',
+      },
+      created_at: '2026-03-22T07:30:00.000Z',
+      updated_at: '2026-03-22T07:55:00.000Z',
+      parent_session_id: 'session-parent-1',
+      handoff_kind: 'explicit_new_session',
+      summary_snapshot: {
+        recap: 'Prior interval repair recap.',
+      },
+    },
+  ];
+
   class QueryBuilder {
     constructor(table) {
       this.table = table;
@@ -260,6 +363,18 @@ function createLearningDb() {
         orders: [...this.orders],
         single: false,
       });
+
+      if (this.table === 'learning_session_resume_projection') {
+        let rows = [...sessionRows];
+
+        for (const filter of this.filters) {
+          if (filter.type === 'eq') {
+            rows = rows.filter((row) => row[filter.column] === filter.value);
+          }
+        }
+
+        return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+      }
 
       if (this.table !== 'learning_review_queue_projection') {
         return Promise.reject(new Error(`Unexpected list table: ${this.table}`)).then(resolve, reject);
@@ -569,6 +684,10 @@ function createBoundaryLearningDb() {
       return { data: deriveWorkspaceProjection(userId, topicId), error: null };
     }
 
+    if (query.table === 'learning_session_resume_projection' && query.operation === 'select') {
+      return { data: [], error: null };
+    }
+
     throw new Error(`Unhandled learning query: ${query.table}:${query.operation}`);
   }
 
@@ -725,6 +844,44 @@ describe('workspace read service', () => {
     ]);
     expect(payload.review_queue.items).toHaveLength(1);
     expect(payload.review_queue.items[0].review_task_id).toBe('review-queued-1');
+  });
+
+  test('workspace revisit payload keeps last-session continuity separate from slot and queue changes', async () => {
+    const db = createLearningDb();
+
+    const payload = await getWorkspaceView(db, {
+      userId: 'student-1',
+      topicId: 'topic-1',
+    });
+
+    expect(payload.revisit.last_visit_at).toBe('2026-03-22T07:55:00.000Z');
+    expect(payload.revisit.last_session).toMatchObject({
+      session_id: 'session-topic-1-current',
+      mode: 'post_mortem_review',
+      updated_at: '2026-03-22T07:55:00.000Z',
+      resume_guidance: {
+        title: 'Continue interval repair',
+        summary: 'Carry the misconception recap into the next pass.',
+        anchor_kind: 'artifact',
+        anchor_ref: {
+          kind: 'artifact',
+          artifact_id: 'artifact-primary',
+        },
+      },
+    });
+    expect(payload.revisit.changes_since_last_visit.slot_updates).toEqual([
+      {
+        slot_key: 'common_traps',
+        updated_at: '2026-03-22T08:00:00.000Z',
+      },
+    ]);
+    expect(payload.revisit.changes_since_last_visit.review_updates).toEqual([
+      expect.objectContaining({
+        review_task_id: 'review-queued-1',
+        status: 'open',
+        updated_at: '2026-03-22T08:10:00.000Z',
+      }),
+    ]);
   });
 
   test('review queue endpoint returns global truth with optional topic filter', async () => {

--- a/api/learning/lib/workspaces/workspace-read-service.js
+++ b/api/learning/lib/workspaces/workspace-read-service.js
@@ -5,6 +5,10 @@ import {
   deriveReviewQueueProjection,
   summarizeReviewQueueItems,
 } from '../review/review-scheduler-policy.js';
+import {
+  buildSessionResumeGuidance,
+  createSessionHandoff,
+} from '../session-runtime/session-handoff.js';
 
 const ACTIVE_REVIEW_TASK_STATUSES = new Set(['open', 'partial']);
 
@@ -15,6 +19,27 @@ function normalizeString(value) {
 
   const normalized = String(value).trim();
   return normalized || null;
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseTimestamp(value) {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function isAfterTimestamp(value, baseline) {
+  const valueDate = parseTimestamp(value);
+  const baselineDate = parseTimestamp(baseline);
+
+  return Boolean(valueDate && baselineDate && valueDate.getTime() > baselineDate.getTime());
 }
 
 function isTypedRef(value) {
@@ -121,6 +146,147 @@ function buildWorkspaceNotFound(topicId) {
   });
 }
 
+function readTopicFromSession(session = {}) {
+  const bundle = isPlainObject(session?.active_scope_bundle)
+    ? session.active_scope_bundle
+    : isPlainObject(session?.activeScopeBundle)
+      ? session.activeScopeBundle
+      : {};
+
+  return {
+    topicId: normalizeString(bundle.primary_topic_id ?? bundle.primaryTopicId),
+    topicPath: normalizeString(bundle.primary_topic_path ?? bundle.primaryTopicPath),
+  };
+}
+
+function sessionMatchesWorkspaceTopic(session = {}, { topicId = null, topicPath = null } = {}) {
+  const sessionTopic = readTopicFromSession(session);
+
+  if (topicId && sessionTopic.topicId === topicId) {
+    return true;
+  }
+
+  return Boolean(topicPath && sessionTopic.topicPath === topicPath);
+}
+
+function buildRevisitSession(session = null) {
+  if (!session) {
+    return null;
+  }
+
+  return {
+    session_id: session.session_id ?? null,
+    session_goal: session.session_goal ?? null,
+    mode: session.mode ?? null,
+    state: session.state ?? null,
+    updated_at: session.updated_at ?? null,
+    current_anchor_kind: session.current_anchor_kind ?? null,
+    current_anchor_ref: session.current_anchor_ref ?? null,
+    current_question_id: session.current_question_id ?? null,
+    current_question_type_id: session.current_question_type_id ?? null,
+    resume_guidance: buildSessionResumeGuidance(session),
+    handoff: createSessionHandoff(session),
+  };
+}
+
+async function getLatestWorkspaceSession(
+  client,
+  {
+    userId,
+    topicId,
+    topicPath,
+  } = {},
+) {
+  let query = client
+    .from('learning_session_resume_projection')
+    .select('*')
+    .eq('user_id', userId);
+
+  if (typeof query?.order === 'function') {
+    query = query.order('updated_at', { ascending: false });
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(`Failed to load learning session continuity for workspace revisit: ${error.message}`);
+  }
+
+  const rows = Array.isArray(data) ? data : [];
+
+  return rows
+    .filter((session) => sessionMatchesWorkspaceTopic(session, {
+      topicId,
+      topicPath,
+    }))
+    .sort((left, right) => {
+      const leftTime = parseTimestamp(left?.updated_at)?.getTime() ?? 0;
+      const rightTime = parseTimestamp(right?.updated_at)?.getTime() ?? 0;
+      return rightTime - leftTime;
+    })[0] ?? null;
+}
+
+function buildRevisitChanges({
+  lastVisitAt = null,
+  reviewQueueItems = [],
+  workspaceProjection = null,
+} = {}) {
+  if (!lastVisitAt) {
+    return {
+      slot_updates: [],
+      review_updates: [],
+    };
+  }
+
+  const slotUpdates = Object.entries(workspaceProjection?.slots ?? {})
+    .flatMap(([slotKey, slot]) => {
+      if (slotKey === 'review_queue' || !isAfterTimestamp(slot?.updated_at, lastVisitAt)) {
+        return [];
+      }
+
+      return [{
+        slot_key: slotKey,
+        updated_at: slot.updated_at,
+      }];
+    });
+
+  const reviewUpdates = (Array.isArray(reviewQueueItems) ? reviewQueueItems : [])
+    .filter((item) => isAfterTimestamp(item?.updated_at, lastVisitAt))
+    .map((item) => ({
+      review_task_id: item.review_task_id ?? null,
+      target_question_type_title: item.target_question_type_title ?? null,
+      mode: item.mode ?? null,
+      status: item.status ?? null,
+      due_at: item.due_at ?? null,
+      updated_at: item.updated_at ?? null,
+      completion_evidence: item.completion_evidence ?? null,
+      scheduler_state: item.scheduler_state ?? null,
+    }));
+
+  return {
+    slot_updates: slotUpdates,
+    review_updates: reviewUpdates,
+  };
+}
+
+function buildWorkspaceRevisit({
+  lastSession = null,
+  reviewQueueItems = [],
+  workspaceProjection = null,
+} = {}) {
+  const lastVisitAt = normalizeString(lastSession?.updated_at);
+
+  return {
+    last_visit_at: lastVisitAt,
+    last_session: buildRevisitSession(lastSession),
+    changes_since_last_visit: buildRevisitChanges({
+      lastVisitAt,
+      reviewQueueItems,
+      workspaceProjection,
+    }),
+  };
+}
+
 function filterReviewQueueItems(items, {
   topicId = null,
   status = null,
@@ -212,17 +378,28 @@ export async function getWorkspaceView(
     throw buildWorkspaceNotFound(topicId);
   }
 
-  const reviewQueue = await listReviewTasks(client, {
-    userId,
-    topicId,
-    status: reviewStatus,
-    dueBefore: reviewDueBefore,
-  });
-  const reviewQueueSlotItems = (reviewStatus || reviewDueBefore)
-    ? (await listReviewTasks(client, {
+  const shouldLoadUnfilteredTopicQueue = Boolean(reviewStatus || reviewDueBefore);
+  const [reviewQueue, unfilteredTopicReviewQueue, lastSession] = await Promise.all([
+    listReviewTasks(client, {
       userId,
       topicId,
-    })).items
+      status: reviewStatus,
+      dueBefore: reviewDueBefore,
+    }),
+    shouldLoadUnfilteredTopicQueue
+      ? listReviewTasks(client, {
+        userId,
+        topicId,
+      })
+      : Promise.resolve(null),
+    getLatestWorkspaceSession(client, {
+      userId,
+      topicId,
+      topicPath: workspaceProjection.topic_path,
+    }),
+  ]);
+  const reviewQueueSlotItems = shouldLoadUnfilteredTopicQueue
+    ? unfilteredTopicReviewQueue?.items ?? []
     : reviewQueue.items;
 
   return {
@@ -239,5 +416,10 @@ export async function getWorkspaceView(
       }),
     },
     review_queue: reviewQueue,
+    revisit: buildWorkspaceRevisit({
+      lastSession,
+      reviewQueueItems: reviewQueueSlotItems,
+      workspaceProjection,
+    }),
   };
 }

--- a/src/components/learning-runtime/WorkspaceShell.js
+++ b/src/components/learning-runtime/WorkspaceShell.js
@@ -27,8 +27,12 @@ function toneClassName(tone) {
     return 'border-amber-200 bg-amber-50 text-amber-900';
   }
 
-  if (tone === 'error') {
+  if (tone === 'error' || tone === 'danger') {
     return 'border-rose-200 bg-rose-50 text-rose-700';
+  }
+
+  if (tone === 'success') {
+    return 'border-emerald-200 bg-emerald-50 text-emerald-800';
   }
 
   return 'border-slate-200 bg-slate-50 text-slate-700';
@@ -454,6 +458,161 @@ function renderWorkspaceHeader(workspace) {
   ]);
 }
 
+function renderRevisitAction(action, onLaunch, key = 'action') {
+  if (!action?.launchPayload || typeof onLaunch !== 'function') {
+    return null;
+  }
+
+  return h('button', {
+    key,
+    type: 'button',
+    onClick: () => onLaunch(action.launchPayload),
+    className: 'rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-900 hover:text-slate-900',
+  }, action.ctaLabel || 'Continue');
+}
+
+function renderRevisitSection(revisit, onLaunch) {
+  if (!revisit?.available) {
+    return null;
+  }
+
+  return h('section', {
+    key: 'revisit',
+    className: 'rounded-3xl border border-slate-200 bg-white p-6 shadow-sm',
+  }, [
+    h('div', {
+      key: 'header',
+      className: 'flex flex-wrap items-start justify-between gap-4',
+    }, [
+      h('div', { key: 'copy' }, [
+        h('p', {
+          key: 'eyebrow',
+          className: 'text-sm font-medium uppercase tracking-[0.24em] text-slate-500',
+        }, revisit.headline || 'Return with continuity'),
+        revisit.lastVisitLabel
+          ? h('p', {
+            key: 'last-visit',
+            className: 'mt-3 text-sm font-semibold text-slate-900',
+          }, revisit.lastVisitLabel)
+          : null,
+        revisit.progressSummary
+          ? h('p', {
+            key: 'progress',
+            className: 'mt-2 text-sm leading-6 text-slate-600',
+          }, revisit.progressSummary)
+          : null,
+      ].filter(Boolean)),
+      revisit.continuation
+        ? renderRevisitAction(revisit.continuation, onLaunch, 'continuation-action')
+        : null,
+    ].filter(Boolean)),
+    h('div', {
+      key: 'body',
+      className: 'mt-6 grid gap-4 lg:grid-cols-[1.3fr_0.9fr]',
+    }, [
+      h('div', {
+        key: 'continuity-column',
+        className: 'grid gap-4',
+      }, [
+        revisit.continuation
+          ? h('section', {
+            key: 'continuation',
+            className: 'rounded-2xl border border-slate-200 bg-slate-50 p-5',
+          }, [
+            h('p', {
+              key: 'title',
+              className: 'text-base font-semibold text-slate-950',
+            }, revisit.continuation.title),
+            revisit.continuation.summary
+              ? h('p', {
+                key: 'summary',
+                className: 'mt-2 text-sm font-medium text-slate-900',
+              }, revisit.continuation.summary)
+              : null,
+            revisit.continuation.detail
+              ? h('p', {
+                key: 'detail',
+                className: 'mt-2 text-sm leading-6 text-slate-600',
+              }, revisit.continuation.detail)
+              : null,
+          ].filter(Boolean))
+          : null,
+        revisit.changes?.length
+          ? h('section', {
+            key: 'changes',
+            className: 'rounded-2xl border border-slate-200 bg-slate-50 p-5',
+          }, [
+            h('p', {
+              key: 'title',
+              className: 'text-base font-semibold text-slate-950',
+            }, 'What changed'),
+            h('ul', {
+              key: 'items',
+              className: 'mt-4 space-y-3',
+            }, revisit.changes.map((change) => h('li', {
+              key: change.key,
+              className: 'rounded-2xl border border-slate-200 bg-white px-4 py-3',
+            }, [
+              h('p', {
+                key: 'label',
+                className: 'text-sm font-semibold text-slate-900',
+              }, change.label),
+              h('p', {
+                key: 'summary',
+                className: 'mt-1 text-sm leading-6 text-slate-600',
+              }, change.summary),
+            ]))),
+          ])
+          : null,
+      ].filter(Boolean)),
+      h('div', {
+        key: 'actions-column',
+        className: 'grid gap-4',
+      }, [
+        revisit.nextStep
+          ? h('section', {
+            key: 'next-step',
+            className: 'rounded-2xl border border-slate-200 bg-slate-50 p-5',
+          }, [
+            h('p', {
+              key: 'title',
+              className: 'text-base font-semibold text-slate-950',
+            }, revisit.nextStep.title),
+            revisit.nextStep.summary
+              ? h('p', {
+                key: 'summary',
+                className: 'mt-2 text-sm leading-6 text-slate-600',
+              }, revisit.nextStep.summary)
+              : null,
+            renderRevisitAction(revisit.nextStep, onLaunch, 'next-step-action'),
+          ].filter(Boolean))
+          : null,
+        revisit.signals?.length
+          ? h('div', {
+            key: 'signals',
+            className: 'grid gap-3',
+          }, revisit.signals.map((signal) => h('section', {
+            key: signal.key,
+            className: `rounded-2xl border px-4 py-4 ${toneClassName(signal.tone)}`,
+          }, [
+            h('p', {
+              key: 'label',
+              className: 'text-sm font-semibold',
+            }, signal.label),
+            signal.summary
+              ? h('p', {
+                key: 'summary',
+                className: 'mt-2 text-sm leading-6',
+              }, signal.summary)
+              : null,
+            renderRevisitAction(signal, onLaunch, `${signal.key}-action`),
+          ].filter(Boolean))))
+          : null,
+      ].filter(Boolean)),
+    ]),
+  ]);
+}
+
 export default function WorkspaceShell({
   onCompleteReviewTask = () => {},
   onLaunch = () => {},
@@ -581,6 +740,7 @@ export default function WorkspaceShell({
 
   return h('div', { className: 'grid gap-6' }, [
     renderWorkspaceHeader(localViewModel?.workspace || {}),
+    renderRevisitSection(localViewModel?.revisit || null, onLaunch),
     feedback
       ? h('section', {
         key: 'feedback',

--- a/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
+++ b/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
@@ -190,6 +190,46 @@ function createWorkspacePayload() {
         },
       ],
     },
+    revisit: {
+      lastVisitAt: '2026-03-22T07:55:00.000Z',
+      lastSession: {
+        sessionId: 'session-topic-1-current',
+        mode: 'post_mortem_review',
+        state: 'active',
+        updatedAt: '2026-03-22T07:55:00.000Z',
+        resumeGuidance: {
+          title: 'Continue interval repair',
+          message: 'Resume from the misconception artifact anchored to this workspace.',
+          summary: 'Carry the misconception recap into the next pass.',
+          anchorKind: 'artifact',
+          anchorRef: {
+            kind: 'artifact',
+            artifactId: 'artifact-primary',
+          },
+          currentQuestionTypeId: '9709.trigonometry.equations',
+        },
+      },
+      changesSinceLastVisit: {
+        slotUpdates: [
+          {
+            slotKey: 'common_traps',
+            updatedAt: '2026-03-22T08:00:00.000Z',
+          },
+        ],
+        reviewUpdates: [
+          {
+            reviewTaskId: 'review-task-2',
+            status: 'completed',
+            updatedAt: '2026-03-22T08:04:00.000Z',
+            targetQuestionTypeTitle: 'Trigonometric equations',
+            completionEvidence: {
+              summary: 'Closed the interval mistake with a fresh variant.',
+              outcome: 'completed',
+            },
+          },
+        ],
+      },
+    },
   };
 }
 
@@ -215,6 +255,17 @@ describe('WorkspaceShell', () => {
       }),
     );
 
+    expect(html).toContain('Return with continuity');
+    expect(html).toContain('Last runtime visit 2026-03-22T07:55:00.000Z');
+    expect(html).toContain('4 of 5 canonical slots populated and 1 review outcome completed.');
+    expect(html).toContain('Continue interval repair');
+    expect(html).toContain('Carry the misconception recap into the next pass.');
+    expect(html).toContain('Recommended next step');
+    expect(html).toContain('1 escalated review task is ready in the canonical queue.');
+    expect(html).toContain('Common traps slot updated');
+    expect(html).toContain('Review task completed');
+    expect(html).toContain('Open overview map');
+    expect(html).toContain('Open core method derivation');
     expect(html).toContain('Canonical resident');
     expect(html).toContain('Common traps');
     expect(html).toContain('artifact-primary');

--- a/src/components/learning-runtime/__tests__/view-models.test.js
+++ b/src/components/learning-runtime/__tests__/view-models.test.js
@@ -264,6 +264,46 @@ function createWorkspacePayload() {
         },
       ],
     },
+    revisit: {
+      lastVisitAt: '2026-03-22T07:55:00.000Z',
+      lastSession: {
+        sessionId: 'session-topic-1-current',
+        mode: 'post_mortem_review',
+        state: 'active',
+        updatedAt: '2026-03-22T07:55:00.000Z',
+        resumeGuidance: {
+          title: 'Continue interval repair',
+          message: 'Resume from the misconception artifact anchored to this workspace.',
+          summary: 'Carry the misconception recap into the next pass.',
+          anchorKind: 'artifact',
+          anchorRef: {
+            kind: 'artifact',
+            artifactId: 'artifact-primary',
+          },
+          currentQuestionTypeId: '9709.trigonometry.equations',
+        },
+      },
+      changesSinceLastVisit: {
+        slotUpdates: [
+          {
+            slotKey: 'common_traps',
+            updatedAt: '2026-03-22T08:00:00.000Z',
+          },
+        ],
+        reviewUpdates: [
+          {
+            reviewTaskId: 'review-task-3',
+            status: 'completed',
+            updatedAt: '2026-03-22T08:04:00.000Z',
+            targetQuestionTypeTitle: 'Trigonometric equations',
+            completionEvidence: {
+              summary: 'Solved a clean follow-up variant.',
+              outcome: 'completed',
+            },
+          },
+        ],
+      },
+    },
     featureFlags: {
       learningRuntimeEnabled: true,
     },
@@ -830,6 +870,71 @@ describe('learning runtime session view model', () => {
       completed: 1,
       blocked: 0,
     });
+  });
+
+  test('workspace revisit model surfaces continuity, changes, and next-step entry points', () => {
+    const vm = buildWorkspaceViewModel(createWorkspacePayload(), {
+      now: '2026-03-22T12:00:00.000Z',
+    });
+
+    expect(vm.revisit.lastVisitLabel).toBe('Last runtime visit 2026-03-22T07:55:00.000Z');
+    expect(vm.revisit.progressSummary).toBe('4 of 5 canonical slots populated and 1 review outcome completed.');
+    expect(vm.revisit.continuation).toEqual(expect.objectContaining({
+      title: 'Continue interval repair',
+      summary: 'Carry the misconception recap into the next pass.',
+      detail: 'Resume from the misconception artifact anchored to this workspace.',
+      ctaLabel: 'Continue runtime',
+      launchPayload: {
+        anchorKind: 'artifact',
+        artifactId: 'artifact-primary',
+        mode: 'post_mortem_review',
+        topicId: 'topic-trig-equations',
+        topicPath: '9709/trigonometry/equations',
+        currentQuestionTypeId: '9709.trigonometry.equations',
+      },
+    }));
+    expect(vm.revisit.changes).toEqual([
+      {
+        key: 'slot:common_traps',
+        label: 'Common traps slot updated',
+        summary: 'Canonical slot content changed after your previous runtime visit.',
+      },
+      {
+        key: 'review:review-task-3',
+        label: 'Review task completed',
+        summary: 'Solved a clean follow-up variant.',
+      },
+    ]);
+    expect(vm.revisit.nextStep).toEqual(expect.objectContaining({
+      title: 'Recommended next step',
+      summary: '1 escalated review task is ready in the canonical queue.',
+      ctaLabel: 'Start spaced review',
+      launchPayload: {
+        anchorKind: 'review_task',
+        reviewTaskId: 'review-task-1',
+        mode: 'spaced_review',
+        topicId: 'topic-trig-equations',
+        topicPath: '9709/trigonometry/equations',
+        currentQuestionTypeId: '9709.trigonometry.equations',
+      },
+    }));
+    expect(vm.revisit.signals).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: 'review_queue',
+        label: 'Escalated review ready',
+        ctaLabel: 'Start spaced review',
+      }),
+      expect.objectContaining({
+        key: 'overview_map',
+        label: 'Stale slot',
+        ctaLabel: 'Open overview map',
+      }),
+      expect.objectContaining({
+        key: 'core_method_derivation',
+        label: 'Missing content',
+        ctaLabel: 'Open core method derivation',
+      }),
+    ]));
   });
 
   test('launcher view-model includes custom workspace topics that are outside the entry whitelist', () => {

--- a/src/components/learning-runtime/view-models/workspace-view-model.js
+++ b/src/components/learning-runtime/view-models/workspace-view-model.js
@@ -181,6 +181,10 @@ function buildUpdatedAtLabel(updatedAt) {
   return normalizeString(updatedAt) ? `Updated ${updatedAt}` : null;
 }
 
+function buildVisitLabel(updatedAt) {
+  return normalizeString(updatedAt) ? `Last runtime visit ${updatedAt}` : null;
+}
+
 function buildSlotLaunch(workspace, slotKey) {
   if (!workspace?.workspaceId || !slotKey) {
     return null;
@@ -536,6 +540,249 @@ function buildArtifactInboxViewModel(workspace, slotList) {
   };
 }
 
+function buildLaunchPayloadFromAnchor({
+  anchorKind,
+  anchorRef,
+  currentQuestionTypeId = null,
+  mode = 'learn_concept',
+  workspace,
+} = {}) {
+  const resolvedAnchorKind = normalizeString(anchorKind ?? anchorRef?.kind);
+  if (!resolvedAnchorKind) {
+    return null;
+  }
+
+  const launchPayload = {
+    anchorKind: resolvedAnchorKind,
+    mode: normalizeString(mode, 'learn_concept'),
+    topicId: workspace?.topicId || '',
+    topicPath: workspace?.topicPath || '',
+  };
+
+  if (currentQuestionTypeId) {
+    launchPayload.currentQuestionTypeId = currentQuestionTypeId;
+  }
+
+  switch (resolvedAnchorKind) {
+    case 'artifact': {
+      const artifactId = normalizeString(anchorRef?.artifactId ?? anchorRef?.artifact_id);
+      return artifactId
+        ? {
+          ...launchPayload,
+          artifactId,
+        }
+        : null;
+    }
+    case 'review_task': {
+      const reviewTaskId = normalizeString(anchorRef?.reviewTaskId ?? anchorRef?.review_task_id);
+      return reviewTaskId
+        ? {
+          ...launchPayload,
+          reviewTaskId,
+        }
+        : null;
+    }
+    case 'workspace_slot': {
+      const workspaceId = normalizeString(anchorRef?.workspaceId ?? anchorRef?.workspace_id, workspace?.workspaceId || '');
+      const slotKey = normalizeString(anchorRef?.slotKey ?? anchorRef?.slot_key);
+      return workspaceId && slotKey
+        ? {
+          ...launchPayload,
+          workspaceId,
+          slotKey,
+        }
+        : null;
+    }
+    case 'concept': {
+      return {
+        ...launchPayload,
+        topicId: normalizeString(anchorRef?.topicId ?? anchorRef?.topic_id, workspace?.topicId || ''),
+        topicPath: normalizeString(anchorRef?.topicPath ?? anchorRef?.topic_path, workspace?.topicPath || ''),
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function buildReviewQueueSignal(reviewQueue) {
+  const escalatedCount = reviewQueue?.summary?.escalated ?? 0;
+  const leadItem = (Array.isArray(reviewQueue?.items) ? reviewQueue.items : [])
+    .find((item) => item?.queueState?.value === 'escalated' && item?.canLaunch);
+
+  if (!escalatedCount || !leadItem?.launchPayload) {
+    return null;
+  }
+
+  return {
+    key: 'review_queue',
+    label: 'Escalated review ready',
+    summary: `${escalatedCount} escalated review task${escalatedCount === 1 ? ' is' : 's are'} ready in the canonical queue.`,
+    ctaLabel: 'Start spaced review',
+    launchPayload: leadItem.launchPayload,
+    tone: 'danger',
+  };
+}
+
+function buildSlotSignal(slot, {
+  label,
+  summary,
+} = {}) {
+  if (!slot?.slotLaunch?.launchPayload) {
+    return null;
+  }
+
+  return {
+    key: slot.slotKey,
+    label,
+    summary,
+    ctaLabel: `Open ${slot.title.toLowerCase()}`,
+    launchPayload: slot.slotLaunch.launchPayload,
+    tone: 'warning',
+  };
+}
+
+function buildRevisitSignals(slotList, reviewQueue) {
+  const signals = [];
+  const reviewSignal = buildReviewQueueSignal(reviewQueue);
+  if (reviewSignal) {
+    signals.push(reviewSignal);
+  }
+
+  const staleSlot = slotList.find((slot) => slot?.surfaceState?.value === 'stale');
+  if (staleSlot) {
+    signals.push(buildSlotSignal(staleSlot, {
+      label: 'Stale slot',
+      summary: staleSlot.surfaceState?.message,
+    }));
+  }
+
+  const missingContentSlot = slotList.find((slot) => slot?.contentState?.value === 'missing_content');
+  if (missingContentSlot) {
+    signals.push(buildSlotSignal(missingContentSlot, {
+      label: 'Missing content',
+      summary: missingContentSlot.contentState?.message,
+    }));
+  }
+
+  return signals.filter(Boolean);
+}
+
+function buildRevisitContinuation(revisit, workspace) {
+  const lastSession = revisit?.lastSession || revisit?.last_session || {};
+  const resumeGuidance = lastSession?.resumeGuidance || lastSession?.resume_guidance || null;
+
+  if (!resumeGuidance) {
+    return null;
+  }
+
+  const launchPayload = buildLaunchPayloadFromAnchor({
+    anchorKind: resumeGuidance.anchorKind ?? resumeGuidance.anchor_kind,
+    anchorRef: resumeGuidance.anchorRef ?? resumeGuidance.anchor_ref,
+    currentQuestionTypeId:
+      normalizeString(resumeGuidance.currentQuestionTypeId ?? resumeGuidance.current_question_type_id),
+    mode: normalizeString(lastSession.mode, 'learn_concept'),
+    workspace,
+  });
+
+  if (!launchPayload) {
+    return null;
+  }
+
+  return {
+    title: normalizeString(resumeGuidance.title, 'Continue runtime'),
+    summary: normalizeString(resumeGuidance.summary, ''),
+    detail: normalizeString(resumeGuidance.message, ''),
+    ctaLabel: 'Continue runtime',
+    launchPayload,
+  };
+}
+
+function buildRevisitChanges(revisit = {}) {
+  const changesSinceLastVisit = revisit?.changesSinceLastVisit || revisit?.changes_since_last_visit || {};
+  const slotUpdates = Array.isArray(changesSinceLastVisit.slotUpdates ?? changesSinceLastVisit.slot_updates)
+    ? (changesSinceLastVisit.slotUpdates ?? changesSinceLastVisit.slot_updates)
+    : [];
+  const reviewUpdates = Array.isArray(changesSinceLastVisit.reviewUpdates ?? changesSinceLastVisit.review_updates)
+    ? (changesSinceLastVisit.reviewUpdates ?? changesSinceLastVisit.review_updates)
+    : [];
+
+  return [
+    ...slotUpdates.map((entry) => {
+      const slotKey = normalizeString(entry?.slotKey ?? entry?.slot_key, 'slot');
+      const slotTitle = SLOT_DEFINITION_BY_KEY[slotKey]?.title || labelFromToken(slotKey, 'slot');
+      return {
+        key: `slot:${slotKey}`,
+        label: `${slotTitle} slot updated`,
+        summary: 'Canonical slot content changed after your previous runtime visit.',
+      };
+    }),
+    ...reviewUpdates.map((entry) => {
+      const status = normalizeString(entry?.status, 'updated');
+      const completionEvidence = entry?.completionEvidence ?? entry?.completion_evidence ?? {};
+      return {
+        key: `review:${normalizeString(entry?.reviewTaskId ?? entry?.review_task_id, 'unknown')}`,
+        label: status === 'completed'
+          ? 'Review task completed'
+          : status === 'partial'
+            ? 'Review task partially completed'
+            : 'Review task updated',
+        summary:
+          normalizeString(completionEvidence?.summary)
+          || `${normalizeString(entry?.targetQuestionTypeTitle ?? entry?.target_question_type_title, 'Review task')} changed after your previous runtime visit.`,
+      };
+    }),
+  ];
+}
+
+function buildRevisitNextStep(slotList, reviewQueue) {
+  const recommendedReview = (Array.isArray(reviewQueue?.items) ? reviewQueue.items : [])
+    .find((item) => item?.queueState?.value === 'escalated' && item?.canLaunch);
+
+  if (recommendedReview?.launchPayload) {
+    const escalatedCount = reviewQueue?.summary?.escalated ?? 0;
+    return {
+      title: 'Recommended next step',
+      summary: `${escalatedCount} escalated review task${escalatedCount === 1 ? ' is' : 's are'} ready in the canonical queue.`,
+      ctaLabel: 'Start spaced review',
+      launchPayload: recommendedReview.launchPayload,
+    };
+  }
+
+  const staleSlot = slotList.find((slot) => slot?.surfaceState?.value === 'stale' && slot?.slotLaunch?.launchPayload);
+  if (staleSlot) {
+    return {
+      title: 'Recommended next step',
+      summary: staleSlot.surfaceState?.message,
+      ctaLabel: `Open ${staleSlot.title.toLowerCase()}`,
+      launchPayload: staleSlot.slotLaunch.launchPayload,
+    };
+  }
+
+  return null;
+}
+
+function buildRevisitViewModel(revisit = {}, workspace, slotList, reviewQueue) {
+  const progressSummary = `${slotList.filter((slot) => slot?.primaryArtifact).length} of ${slotList.length} canonical slots populated and ${(reviewQueue?.summary?.completed ?? 0)} review outcome${(reviewQueue?.summary?.completed ?? 0) === 1 ? '' : 's'} completed.`;
+  const changes = buildRevisitChanges(revisit);
+  const continuation = buildRevisitContinuation(revisit, workspace);
+  const nextStep = buildRevisitNextStep(slotList, reviewQueue);
+  const signals = buildRevisitSignals(slotList, reviewQueue);
+  const lastVisitAt = normalizeString(revisit?.lastVisitAt ?? revisit?.last_visit_at);
+  const available = Boolean(lastVisitAt || continuation || nextStep || changes.length > 0 || signals.length > 0);
+
+  return {
+    available,
+    headline: 'Return with continuity',
+    lastVisitLabel: buildVisitLabel(lastVisitAt),
+    progressSummary,
+    continuation,
+    changes,
+    nextStep,
+    signals,
+  };
+}
+
 export function buildWorkspaceViewModel(payload = {}, options = {}) {
   const workspace = payload.workspace || {};
   const slotState = workspace.slotState || workspace.slot_state || {};
@@ -549,16 +796,18 @@ export function buildWorkspaceViewModel(payload = {}, options = {}) {
   const slotList = SLOT_DEFINITIONS
     .filter((definition) => definition.key !== 'review_queue')
     .map((definition) => stableSlots[definition.key]);
+  const reviewQueue = buildReviewQueueViewModel(payload.reviewQueue || payload.review_queue || {}, {
+    now: options.now,
+  });
 
   return {
     workspace: workspaceSummary,
     slots: stableSlots,
     slotList,
     artifactInbox: buildArtifactInboxViewModel(workspace, slotList),
-    reviewQueue: buildReviewQueueViewModel(payload.reviewQueue || payload.review_queue || {}, {
-      now: options.now,
-    }),
+    reviewQueue,
     featureFlags: payload.featureFlags || payload.feature_flags || {},
+    revisit: buildRevisitViewModel(payload.revisit || {}, workspaceSummary, slotList, reviewQueue),
   };
 }
 


### PR DESCRIPTION
## Summary
- add server-backed workspace revisit context using the latest topic-aligned session plus runtime changes since the previous visit
- derive continuity, what-changed, recommended next-step, and actionable stale/review signals in the workspace view model
- render the revisit layer above canonical slots and the topic-filtered review queue without collapsing their separation

## Testing
- `git diff --check` (pass)
- `npm test -- --runInBand api/learning/__tests__/workspace-read-service.test.js src/components/learning-runtime/__tests__/view-models.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js --verbose` (pass, 28 tests)

Closes #73