### PR TITLE
feat(learning): expose mastery and review explainability

### DIFF
--- a/api/learning/__tests__/released-scope.test.js
+++ b/api/learning/__tests__/released-scope.test.js
@@ -49,7 +49,7 @@ test('pilot type membership alone does not unlock authoritative scoring', () => 
       uncertaintyValidated: false,
       classificationConfidence: 0.81,
     }),
-  ).toEqual({
+  ).toMatchObject({
     release_scope_status: RELEASE_SCOPE_STATUSES.NON_RELEASED_FALLBACK,
     authoritative_scoring_allowed: false,
     fallback_mode: LEARNING_FALLBACK_MODES.NON_RELEASED_FALLBACK,
@@ -76,7 +76,7 @@ test('promoted differential equations separable can unlock authoritative scoring
       uncertaintyValidated: true,
       classificationConfidence: 0.92,
     }),
-  ).toEqual({
+  ).toMatchObject({
     release_scope_status: RELEASE_SCOPE_STATUSES.RELEASED_SCORING,
     authoritative_scoring_allowed: true,
     fallback_mode: null,
@@ -103,7 +103,7 @@ test('pilot type with a released rubric and validated uncertainty unlocks author
       uncertaintyValidated: true,
       classificationConfidence: 0.94,
     }),
-  ).toEqual({
+  ).toMatchObject({
     release_scope_status: RELEASE_SCOPE_STATUSES.RELEASED_SCORING,
     authoritative_scoring_allowed: true,
     fallback_mode: null,
@@ -129,7 +129,7 @@ test('pilot type with released rubric still falls back when classification confi
       ],
       uncertaintyValidated: true,
     }),
-  ).toEqual({
+  ).toMatchObject({
     release_scope_status: RELEASE_SCOPE_STATUSES.NON_RELEASED_FALLBACK,
     authoritative_scoring_allowed: false,
     fallback_mode: LEARNING_FALLBACK_MODES.NON_RELEASED_FALLBACK,
@@ -156,7 +156,7 @@ test('promoted integration application can unlock authoritative scoring once all
       uncertaintyValidated: true,
       classificationConfidence: 0.89,
     }),
-  ).toEqual({
+  ).toMatchObject({
     release_scope_status: RELEASE_SCOPE_STATUSES.RELEASED_SCORING,
     authoritative_scoring_allowed: true,
     fallback_mode: null,
@@ -183,7 +183,7 @@ test('non-promoted integration question types remain fallback only even with a r
       uncertaintyValidated: true,
       classificationConfidence: 0.77,
     }),
-  ).toEqual({
+  ).toMatchObject({
     release_scope_status: RELEASE_SCOPE_STATUSES.NON_RELEASED_FALLBACK,
     authoritative_scoring_allowed: false,
     fallback_mode: LEARNING_FALLBACK_MODES.NON_RELEASED_FALLBACK,
@@ -210,12 +210,89 @@ test('non-promoted differential equations question types remain fallback only ev
       uncertaintyValidated: true,
       classificationConfidence: 0.78,
     }),
-  ).toEqual({
+  ).toMatchObject({
     release_scope_status: RELEASE_SCOPE_STATUSES.NON_RELEASED_FALLBACK,
     authoritative_scoring_allowed: false,
     fallback_mode: LEARNING_FALLBACK_MODES.NON_RELEASED_FALLBACK,
     fallback_reason_code: FALLBACK_REASON_CODES.NON_PILOT_QUESTION_TYPE,
     classification_confidence: 0.78,
     learning_signal_posture: LEARNING_SIGNAL_POSTURES.CONSERVATIVE_FALLBACK,
+  });
+});
+
+test('released-scope posture exposes factorized explainability for fallback and authoritative states', () => {
+  const fallback = resolveReleasedScoringPosture({
+    questionTypeId: '9709.integration.application',
+    questionTypeReleaseState: 'released',
+    candidateRubricRefs: [
+      {
+        kind: 'rubric_release',
+        rubric_set_id: '9709.integration.application',
+        rubric_version_id: 'integration-application-v1',
+        scope_level: 'question_type',
+        release_state: 'released',
+      },
+    ],
+    uncertaintyValidated: false,
+    classificationConfidence: 0.78,
+  });
+  const authoritative = resolveReleasedScoringPosture({
+    questionTypeId: '9709.integration.application',
+    questionTypeReleaseState: 'released',
+    candidateRubricRefs: [
+      {
+        kind: 'rubric_release',
+        rubric_set_id: '9709.integration.application',
+        rubric_version_id: 'integration-application-v1',
+        scope_level: 'question_type',
+        release_state: 'released',
+      },
+    ],
+    uncertaintyValidated: true,
+    classificationConfidence: 0.89,
+  });
+
+  expect(fallback).toMatchObject({
+    fallback_reason_code: 'unvalidated_uncertainty_posture',
+    explanation: {
+      posture: 'conservative_fallback',
+      summary: expect.stringContaining('uncertainty'),
+      factors: expect.arrayContaining([
+        expect.objectContaining({
+          code: 'released_question_type',
+          status: 'met',
+        }),
+        expect.objectContaining({
+          code: 'released_family_evidence',
+          status: 'met',
+        }),
+        expect.objectContaining({
+          code: 'released_rubric',
+          status: 'met',
+        }),
+        expect.objectContaining({
+          code: 'classification_confidence',
+          status: 'met',
+          value: 0.78,
+        }),
+        expect.objectContaining({
+          code: 'uncertainty_validation',
+          status: 'missing',
+        }),
+      ]),
+    },
+  });
+  expect(authoritative).toMatchObject({
+    authoritative_scoring_allowed: true,
+    explanation: {
+      posture: 'released_authoritative',
+      summary: expect.stringContaining('authoritative'),
+      factors: expect.arrayContaining([
+        expect.objectContaining({
+          code: 'uncertainty_validation',
+          status: 'met',
+        }),
+      ]),
+    },
   });
 });

--- a/api/learning/__tests__/review-task-service.test.js
+++ b/api/learning/__tests__/review-task-service.test.js
@@ -395,6 +395,7 @@ describe('review task service generation', () => {
       fallback_reason_code: 'non_released_fallback',
       repair_target_topic_id: 'topic-1',
       repair_target_topic_path: '9709/trigonometry/equations',
+      source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
       misconception_tags: ['domain:interval'],
       question_context: {
         family_id: '9709.trigonometry_manipulation_equations',
@@ -421,6 +422,23 @@ describe('review task service generation', () => {
           immediate_repair_max_deferral_at: '2026-03-24T22:00:00.000Z',
         }),
       },
+      explanation: {
+        posture: 'conservative_fallback',
+        summary: 'Queued from interval-repair evidence while authoritative mastery stays conservative.',
+        freshness: {
+          bucket: 'fresh',
+          route: 'immediate_repair',
+        },
+        attempt_history: {
+          attempt_count: 1,
+          latest_source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
+        },
+        evidence: {
+          source_question_id: 'question-1',
+          source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
+          misconception_tags: ['domain:interval'],
+        },
+      },
     });
   });
 
@@ -437,6 +455,14 @@ describe('review task service generation', () => {
           route: 'immediate_repair',
           freshness_bucket: 'fresh',
           immediate_repair_max_deferral_at: '2026-03-24T22:00:00.000Z',
+        },
+        explainability: {
+          attempt_history: {
+            attempt_count: 1,
+            latest_source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-existing' },
+            source_attempt_refs: [{ kind: 'attempt', attempt_id: 'attempt-existing' }],
+            source_question_ids: ['question-existing'],
+          },
         },
       },
     });
@@ -471,6 +497,7 @@ describe('review task service generation', () => {
       fallback_reason_code: 'non_released_fallback',
       repair_target_topic_id: 'topic-1',
       repair_target_topic_path: '9709/trigonometry/equations',
+      source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
       misconception_tags: ['domain:interval', 'identity:rewrite'],
       question_context: {
         family_id: '9709.trigonometry_manipulation_equations',
@@ -487,6 +514,21 @@ describe('review task service generation', () => {
         scheduler_policy: expect.objectContaining({
           route: 'immediate_repair',
         }),
+        explainability: {
+          attempt_history: {
+            attempt_count: 2,
+            latest_source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
+            source_attempt_refs: expect.arrayContaining([
+              { kind: 'attempt', attempt_id: 'attempt-existing' },
+              { kind: 'attempt', attempt_id: 'attempt-1' },
+            ]),
+          },
+        },
+      },
+      explanation: {
+        attempt_history: {
+          attempt_count: 2,
+        },
       },
     });
   });

--- a/api/learning/__tests__/subject-adapter-registry.test.js
+++ b/api/learning/__tests__/subject-adapter-registry.test.js
@@ -114,6 +114,32 @@ describe('subject adapter registry', () => {
       learning_signal_posture: 'conservative_fallback',
       supported_capabilities: ['classification'],
       fallback_capabilities: ['marking', 'mastery', 'review'],
+      explanation: {
+        posture: 'read_only_fallback',
+        summary: expect.stringContaining('read-only'),
+        factors: expect.arrayContaining([
+          expect.objectContaining({
+            code: 'selection_state',
+            status: 'selected_next',
+          }),
+          expect.objectContaining({
+            code: 'classification',
+            status: 'supported',
+          }),
+          expect.objectContaining({
+            code: 'marking',
+            status: 'fallback_only',
+          }),
+          expect.objectContaining({
+            code: 'mastery',
+            status: 'fallback_only',
+          }),
+          expect.objectContaining({
+            code: 'review',
+            status: 'fallback_only',
+          }),
+        ]),
+      },
     });
   });
 

--- a/api/learning/__tests__/workspace-read-service.test.js
+++ b/api/learning/__tests__/workspace-read-service.test.js
@@ -73,12 +73,28 @@ function createLearningDb(overrides = {}) {
       related_artifact_refs: [],
       source_question_id: 'question-1',
       source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
-      trigger_type: 'marking_outcome',
-      mode: 'redo_variant',
+      trigger_type: 'immediate_repair',
+      mode: 'trap_fix',
       due_at: '2026-03-23T00:00:00.000Z',
       priority: 'high',
       estimated_minutes: 15,
-      success_criteria: {},
+      success_criteria: {
+        scheduler_policy: {
+          route: 'immediate_repair',
+          freshness_bucket: 'fresh',
+        },
+        explainability: {
+          attempt_history: {
+            attempt_count: 2,
+            latest_source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1b' },
+            source_attempt_refs: [
+              { kind: 'attempt', attempt_id: 'attempt-1' },
+              { kind: 'attempt', attempt_id: 'attempt-1b' },
+            ],
+            source_question_ids: ['question-1', 'question-1b'],
+          },
+        },
+      },
       completion_evidence: {},
       status: 'open',
       created_at: '2026-03-22T08:10:00.000Z',
@@ -903,10 +919,27 @@ describe('workspace read service', () => {
       review_task_id: 'review-queued-1',
       target_topic_id: 'topic-1',
       scheduler_state: {
-        value: 'blocked',
-        label: 'Blocked',
+        value: 'escalated',
+        label: 'Escalated',
         tone: 'danger',
-        reason_code: 'daily_recommendation_cap',
+        reason_code: 'fresh_immediate_repair',
+      },
+      explanation: {
+        posture: 'conservative_fallback',
+        freshness: {
+          bucket: 'fresh',
+          route: 'immediate_repair',
+          scheduler_state: 'escalated',
+        },
+        attempt_history: {
+          attempt_count: 2,
+          latest_source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1b' },
+        },
+        evidence: {
+          source_question_id: 'question-1',
+          source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
+          misconception_tags: ['domain:interval'],
+        },
       },
     });
   });

--- a/api/learning/lib/contracts/released-scope-core.js
+++ b/api/learning/lib/contracts/released-scope-core.js
@@ -62,6 +62,124 @@ function hasValidatedUncertaintyPosture(value) {
   return value.status === 'validated';
 }
 
+function buildExplanationFactor(code, status, summary, value = null) {
+  return {
+    code,
+    status,
+    summary,
+    ...(value !== null && value !== undefined ? { value } : {}),
+  };
+}
+
+function summarizeFallbackReason(fallbackReasonCode) {
+  switch (fallbackReasonCode) {
+    case FALLBACK_REASON_CODES.MISSING_QUESTION_TYPE:
+      return 'the question type is still missing';
+    case FALLBACK_REASON_CODES.NON_PILOT_QUESTION_TYPE:
+      return 'the question type is outside the released authoritative slice';
+    case FALLBACK_REASON_CODES.MISSING_RELEASED_FAMILY_EVIDENCE:
+      return 'released family evidence is still missing';
+    case FALLBACK_REASON_CODES.MISSING_RELEASED_RUBRIC:
+      return 'a released rubric is still missing';
+    case FALLBACK_REASON_CODES.MISSING_CLASSIFICATION_CONFIDENCE:
+      return 'classification confidence is still missing';
+    case FALLBACK_REASON_CODES.UNVALIDATED_UNCERTAINTY_POSTURE:
+      return 'validated uncertainty posture is still missing';
+    case FALLBACK_REASON_CODES.SUBJECT_ADAPTER_CAPABILITY_NOT_ENABLED:
+      return 'the current subject remains in a conservative read-only posture';
+    default:
+      return 'the released-scoring gate is still unresolved';
+  }
+}
+
+function buildReleasedScopeExplanation({
+  posture = {},
+  questionTypeId = null,
+  questionTypeReleaseState = null,
+  candidateRubricRefs = [],
+  classificationConfidence = null,
+  uncertaintyValidated = false,
+  uncertaintyPosture = null,
+  releasedFamilyEvidenceOk = null,
+} = {}) {
+  const normalizedQuestionTypeId = normalizeQuestionTypeId(questionTypeId);
+  const normalizedReleaseState = normalizeQuestionTypeReleaseState(questionTypeReleaseState);
+  const normalizedClassification = normalizeClassificationConfidence(
+    classificationConfidence ?? posture.classification_confidence,
+  );
+  const releasedQuestionTypeMet = Boolean(normalizedQuestionTypeId) && normalizedReleaseState === 'released';
+  const releasedRubricMet = hasReleasedRubricRef(candidateRubricRefs);
+  const uncertaintyValidationMet = hasValidatedUncertaintyPosture(
+    uncertaintyPosture ?? uncertaintyValidated,
+  );
+  const factors = [
+    buildExplanationFactor(
+      'released_question_type',
+      releasedQuestionTypeMet ? 'met' : 'missing',
+      releasedQuestionTypeMet
+        ? `Released question type ${normalizedQuestionTypeId} is available.`
+        : 'A released question type is required before authoritative scoring can apply.',
+      normalizedQuestionTypeId || null,
+    ),
+    releasedFamilyEvidenceOk === null
+      ? null
+      : buildExplanationFactor(
+        'released_family_evidence',
+        releasedFamilyEvidenceOk ? 'met' : 'missing',
+        releasedFamilyEvidenceOk
+          ? 'Released family evidence is available for this question type.'
+          : 'Released family evidence is still missing for this question type.',
+      ),
+    buildExplanationFactor(
+      'released_rubric',
+      releasedRubricMet ? 'met' : 'missing',
+      releasedRubricMet
+        ? 'A released rubric is available for this question type.'
+        : 'A released rubric is required before authoritative scoring can apply.',
+    ),
+    buildExplanationFactor(
+      'classification_confidence',
+      normalizedClassification !== null ? 'met' : 'missing',
+      normalizedClassification !== null
+        ? `Classification confidence ${normalizedClassification} is available.`
+        : 'Classification confidence is still required before authoritative scoring can apply.',
+      normalizedClassification,
+    ),
+    buildExplanationFactor(
+      'uncertainty_validation',
+      uncertaintyValidationMet ? 'met' : 'missing',
+      uncertaintyValidationMet
+        ? 'Validated uncertainty posture is available.'
+        : 'Validated uncertainty posture is still required before authoritative scoring can apply.',
+    ),
+  ].filter(Boolean);
+
+  if (posture.authoritative_scoring_allowed) {
+    return {
+      posture: 'released_authoritative',
+      summary:
+        'Released authoritative scoring is active because the released question-type, family, rubric, confidence, and uncertainty gates are satisfied.',
+      factors,
+    };
+  }
+
+  return {
+    posture: 'conservative_fallback',
+    summary: `Fallback remains active because ${summarizeFallbackReason(posture.fallback_reason_code)}.`,
+    factors,
+  };
+}
+
+export function withReleasedScopeExplanation(posture, context = {}) {
+  return {
+    ...posture,
+    explanation: buildReleasedScopeExplanation({
+      posture,
+      ...context,
+    }),
+  };
+}
+
 export function buildFallbackPosture(fallbackReasonCode, classificationConfidence) {
   return {
     release_scope_status: RELEASE_SCOPE_STATUSES.NON_RELEASED_FALLBACK,
@@ -70,6 +188,11 @@ export function buildFallbackPosture(fallbackReasonCode, classificationConfidenc
     fallback_reason_code: fallbackReasonCode,
     classification_confidence: classificationConfidence,
     learning_signal_posture: LEARNING_SIGNAL_POSTURES.CONSERVATIVE_FALLBACK,
+    explanation: {
+      posture: 'conservative_fallback',
+      summary: `Fallback remains active because ${summarizeFallbackReason(fallbackReasonCode)}.`,
+      factors: [],
+    },
   };
 }
 
@@ -111,46 +234,103 @@ export function resolveInlineReleasedScoringPosture({
     : isSeededPilotQuestionType(normalizedQuestionType, questionTypeReleaseState);
 
   if (!normalizedQuestionType) {
-    return buildFallbackPosture(
-      FALLBACK_REASON_CODES.MISSING_QUESTION_TYPE,
-      normalizedClassification,
+    return withReleasedScopeExplanation(
+      buildFallbackPosture(
+        FALLBACK_REASON_CODES.MISSING_QUESTION_TYPE,
+        normalizedClassification,
+      ),
+      {
+        questionTypeId: normalizedQuestionType,
+        questionTypeReleaseState,
+        candidateRubricRefs,
+        uncertaintyValidated,
+        uncertaintyPosture,
+        classificationConfidence: normalizedClassification,
+      },
     );
   }
 
   if (!pilotQuestionTypeMatch) {
-    return buildFallbackPosture(
-      FALLBACK_REASON_CODES.NON_PILOT_QUESTION_TYPE,
-      normalizedClassification,
+    return withReleasedScopeExplanation(
+      buildFallbackPosture(
+        FALLBACK_REASON_CODES.NON_PILOT_QUESTION_TYPE,
+        normalizedClassification,
+      ),
+      {
+        questionTypeId: normalizedQuestionType,
+        questionTypeReleaseState,
+        candidateRubricRefs,
+        uncertaintyValidated,
+        uncertaintyPosture,
+        classificationConfidence: normalizedClassification,
+      },
     );
   }
 
   if (!hasReleasedRubricRef(candidateRubricRefs)) {
-    return buildFallbackPosture(
-      FALLBACK_REASON_CODES.MISSING_RELEASED_RUBRIC,
-      normalizedClassification,
+    return withReleasedScopeExplanation(
+      buildFallbackPosture(
+        FALLBACK_REASON_CODES.MISSING_RELEASED_RUBRIC,
+        normalizedClassification,
+      ),
+      {
+        questionTypeId: normalizedQuestionType,
+        questionTypeReleaseState,
+        candidateRubricRefs,
+        uncertaintyValidated,
+        uncertaintyPosture,
+        classificationConfidence: normalizedClassification,
+      },
     );
   }
 
   if (normalizedClassification === null) {
-    return buildFallbackPosture(
-      FALLBACK_REASON_CODES.MISSING_CLASSIFICATION_CONFIDENCE,
-      normalizedClassification,
+    return withReleasedScopeExplanation(
+      buildFallbackPosture(
+        FALLBACK_REASON_CODES.MISSING_CLASSIFICATION_CONFIDENCE,
+        normalizedClassification,
+      ),
+      {
+        questionTypeId: normalizedQuestionType,
+        questionTypeReleaseState,
+        candidateRubricRefs,
+        uncertaintyValidated,
+        uncertaintyPosture,
+        classificationConfidence: normalizedClassification,
+      },
     );
   }
 
   if (!validatedUncertainty) {
-    return buildFallbackPosture(
-      FALLBACK_REASON_CODES.UNVALIDATED_UNCERTAINTY_POSTURE,
-      normalizedClassification,
+    return withReleasedScopeExplanation(
+      buildFallbackPosture(
+        FALLBACK_REASON_CODES.UNVALIDATED_UNCERTAINTY_POSTURE,
+        normalizedClassification,
+      ),
+      {
+        questionTypeId: normalizedQuestionType,
+        questionTypeReleaseState,
+        candidateRubricRefs,
+        uncertaintyValidated,
+        uncertaintyPosture,
+        classificationConfidence: normalizedClassification,
+      },
     );
   }
 
-  return {
+  return withReleasedScopeExplanation({
     release_scope_status: RELEASE_SCOPE_STATUSES.RELEASED_SCORING,
     authoritative_scoring_allowed: true,
     fallback_mode: null,
     fallback_reason_code: null,
     classification_confidence: normalizedClassification,
     learning_signal_posture: LEARNING_SIGNAL_POSTURES.AUTHORITATIVE_SCORING,
-  };
+  }, {
+    questionTypeId: normalizedQuestionType,
+    questionTypeReleaseState,
+    candidateRubricRefs,
+    uncertaintyValidated,
+    uncertaintyPosture,
+    classificationConfidence: normalizedClassification,
+  });
 }

--- a/api/learning/lib/contracts/released-scope.js
+++ b/api/learning/lib/contracts/released-scope.js
@@ -9,6 +9,7 @@ import {
   normalizeClassificationConfidence,
   normalizeQuestionTypeId,
   resolveInlineReleasedScoringPosture,
+  withReleasedScopeExplanation,
 } from './released-scope-core.js';
 
 export {
@@ -37,16 +38,36 @@ export function resolveReleasedScoringPosture({
     : isSeededPilotQuestionType(normalizedQuestionTypeId, questionTypeReleaseState);
 
   if (!normalizedQuestionTypeId) {
-    return buildFallbackPosture(
-      FALLBACK_REASON_CODES.MISSING_QUESTION_TYPE,
-      normalizedClassificationConfidence,
+    return withReleasedScopeExplanation(
+      buildFallbackPosture(
+        FALLBACK_REASON_CODES.MISSING_QUESTION_TYPE,
+        normalizedClassificationConfidence,
+      ),
+      {
+        questionTypeId: normalizedQuestionTypeId,
+        questionTypeReleaseState,
+        candidateRubricRefs,
+        uncertaintyValidated,
+        uncertaintyPosture,
+        classificationConfidence: normalizedClassificationConfidence,
+      },
     );
   }
 
   if (!pilotQuestionTypeMatch) {
-    return buildFallbackPosture(
-      FALLBACK_REASON_CODES.NON_PILOT_QUESTION_TYPE,
-      normalizedClassificationConfidence,
+    return withReleasedScopeExplanation(
+      buildFallbackPosture(
+        FALLBACK_REASON_CODES.NON_PILOT_QUESTION_TYPE,
+        normalizedClassificationConfidence,
+      ),
+      {
+        questionTypeId: normalizedQuestionTypeId,
+        questionTypeReleaseState,
+        candidateRubricRefs,
+        uncertaintyValidated,
+        uncertaintyPosture,
+        classificationConfidence: normalizedClassificationConfidence,
+      },
     );
   }
 
@@ -55,13 +76,24 @@ export function resolveReleasedScoringPosture({
   });
 
   if (!releasedFamilyEvidence.ok) {
-    return buildFallbackPosture(
-      FALLBACK_REASON_CODES.MISSING_RELEASED_FAMILY_EVIDENCE,
-      normalizedClassificationConfidence,
+    return withReleasedScopeExplanation(
+      buildFallbackPosture(
+        FALLBACK_REASON_CODES.MISSING_RELEASED_FAMILY_EVIDENCE,
+        normalizedClassificationConfidence,
+      ),
+      {
+        questionTypeId: normalizedQuestionTypeId,
+        questionTypeReleaseState,
+        candidateRubricRefs,
+        uncertaintyValidated,
+        uncertaintyPosture,
+        classificationConfidence: normalizedClassificationConfidence,
+        releasedFamilyEvidenceOk: false,
+      },
     );
   }
 
-  return resolveInlineReleasedScoringPosture({
+  return withReleasedScopeExplanation(resolveInlineReleasedScoringPosture({
     questionTypeId: normalizedQuestionTypeId,
     questionTypeReleaseState,
     candidateRubricRefs,
@@ -69,5 +101,13 @@ export function resolveReleasedScoringPosture({
     uncertaintyPosture,
     classificationConfidence: normalizedClassificationConfidence,
     isPilotQuestionType: pilotQuestionTypeMatch,
+  }), {
+    questionTypeId: normalizedQuestionTypeId,
+    questionTypeReleaseState,
+    candidateRubricRefs,
+    uncertaintyValidated,
+    uncertaintyPosture,
+    classificationConfidence: normalizedClassificationConfidence,
+    releasedFamilyEvidenceOk: true,
   });
 }

--- a/api/learning/lib/review/review-scheduler-policy.js
+++ b/api/learning/lib/review/review-scheduler-policy.js
@@ -166,6 +166,291 @@ function buildStoredPolicy(policy = {}, fallbackReasonCode = null) {
   };
 }
 
+function uniqueStrings(values = []) {
+  const seen = new Set();
+  return normalizeArray(values).filter((value) => {
+    const normalized = normalizeString(value);
+    if (!normalized || seen.has(normalized)) {
+      return false;
+    }
+
+    seen.add(normalized);
+    return true;
+  });
+}
+
+function uniqueTypedRefs(refs = []) {
+  const seen = new Set();
+  return normalizeArray(refs).flatMap((ref) => {
+    const normalized = normalizeObject(ref);
+    const kind = normalizeString(normalized.kind);
+    if (!kind) {
+      return [];
+    }
+
+    const refKey = JSON.stringify(normalized);
+    if (seen.has(refKey)) {
+      return [];
+    }
+
+    seen.add(refKey);
+    return [clone(normalized)];
+  });
+}
+
+function labelFromMisconceptionTag(tag) {
+  const normalized = normalizeString(tag);
+  if (!normalized) {
+    return null;
+  }
+
+  const lastToken = normalized.split(':').pop() || normalized;
+  return lastToken.replace(/_/g, ' ');
+}
+
+function summarizeExplainability(task = {}, explainability = {}) {
+  const misconceptionTags = normalizeArray(
+    explainability?.evidence?.misconception_tags ?? task?.target_misconception_tags,
+  );
+  const misconceptionLabel = labelFromMisconceptionTag(misconceptionTags[0]);
+  const evidenceLabel = misconceptionLabel
+    ? `${misconceptionLabel}-repair`
+    : normalizeString(explainability?.evidence?.coverage_scope)
+      ? `${normalizeString(explainability.evidence.coverage_scope)}-level`
+      : 'runtime';
+
+  return `Queued from ${evidenceLabel} evidence while authoritative mastery stays conservative.`;
+}
+
+export function buildReviewTaskExplainabilitySeed({
+  sourceQuestionId = null,
+  sourceAttemptRef = null,
+  targetMisconceptionTags = [],
+  fallbackReasonCode = null,
+  schedulerPolicy = {},
+  coverageScope = 'question',
+  localSignalOnly = false,
+  partResults = [],
+  ambiguousPartMappingCount = 0,
+} = {}) {
+  const sourceAttemptRefs = uniqueTypedRefs(sourceAttemptRef ? [sourceAttemptRef] : []);
+  const sourceQuestionIds = uniqueStrings(sourceQuestionId ? [sourceQuestionId] : []);
+
+  return {
+    posture: 'conservative_fallback',
+    posture_reason_code: fallbackReasonCode ?? null,
+    creation_reason_codes: uniqueStrings([
+      fallbackReasonCode,
+      normalizeArray(targetMisconceptionTags).length > 0 ? 'misconception_tag_trigger' : null,
+      localSignalOnly ? 'local_signal_only' : null,
+    ]),
+    attempt_history: {
+      attempt_count: Math.max(sourceAttemptRefs.length, sourceQuestionIds.length),
+      latest_source_attempt_ref: sourceAttemptRef ?? null,
+      source_attempt_refs: sourceAttemptRefs,
+      source_question_ids: sourceQuestionIds,
+    },
+    evidence: {
+      source_question_id: sourceQuestionId ?? null,
+      source_attempt_ref: sourceAttemptRef ?? null,
+      misconception_tags: normalizeArray(targetMisconceptionTags),
+      coverage_scope: coverageScope ?? null,
+      local_signal_only: localSignalOnly === true,
+      ambiguous_part_mapping_count: Number(ambiguousPartMappingCount ?? 0),
+      part_results: normalizeArray(partResults),
+    },
+    freshness: {
+      route: normalizeString(schedulerPolicy?.route),
+      bucket: normalizeString(schedulerPolicy?.freshness_bucket),
+    },
+  };
+}
+
+function mergeReviewTaskExplainability(existingTask = {}, candidateTask = {}) {
+  const existingExplainability = normalizeObject(
+    normalizeObject(existingTask?.success_criteria)?.explainability,
+  );
+  const candidateExplainability = normalizeObject(
+    normalizeObject(candidateTask?.success_criteria)?.explainability,
+  );
+  const existingAttemptHistory = normalizeObject(existingExplainability.attempt_history);
+  const candidateAttemptHistory = normalizeObject(candidateExplainability.attempt_history);
+  const existingEvidence = normalizeObject(existingExplainability.evidence);
+  const candidateEvidence = normalizeObject(candidateExplainability.evidence);
+  const existingFreshness = normalizeObject(existingExplainability.freshness);
+  const candidateFreshness = normalizeObject(candidateExplainability.freshness);
+  const sourceAttemptRefs = uniqueTypedRefs([
+    ...normalizeArray(existingAttemptHistory.source_attempt_refs),
+    existingAttemptHistory.latest_source_attempt_ref,
+    existingEvidence.source_attempt_ref,
+    ...normalizeArray(candidateAttemptHistory.source_attempt_refs),
+    candidateAttemptHistory.latest_source_attempt_ref,
+    candidateEvidence.source_attempt_ref,
+  ]);
+  const latestSourceAttemptRef =
+    candidateAttemptHistory.latest_source_attempt_ref
+    ?? candidateEvidence.source_attempt_ref
+    ?? existingAttemptHistory.latest_source_attempt_ref
+    ?? existingEvidence.source_attempt_ref
+    ?? null;
+  const sourceQuestionIds = uniqueStrings([
+    ...normalizeArray(existingAttemptHistory.source_question_ids),
+    existingEvidence.source_question_id,
+    ...normalizeArray(candidateAttemptHistory.source_question_ids),
+    candidateEvidence.source_question_id,
+  ]);
+
+  return {
+    posture: candidateExplainability.posture ?? existingExplainability.posture ?? 'conservative_fallback',
+    posture_reason_code:
+      candidateExplainability.posture_reason_code
+      ?? existingExplainability.posture_reason_code
+      ?? null,
+    creation_reason_codes: uniqueStrings([
+      ...normalizeArray(existingExplainability.creation_reason_codes),
+      ...normalizeArray(candidateExplainability.creation_reason_codes),
+    ]),
+    attempt_history: {
+      attempt_count:
+        Math.max(
+          sourceAttemptRefs.length,
+          sourceQuestionIds.length,
+          Number(existingAttemptHistory.attempt_count ?? 0),
+          Number(candidateAttemptHistory.attempt_count ?? 0),
+        ),
+      latest_source_attempt_ref: latestSourceAttemptRef,
+      source_attempt_refs: sourceAttemptRefs,
+      source_question_ids: sourceQuestionIds,
+    },
+    evidence: {
+      ...existingEvidence,
+      ...candidateEvidence,
+      source_question_id:
+        candidateEvidence.source_question_id ?? existingEvidence.source_question_id ?? null,
+      source_attempt_ref: latestSourceAttemptRef,
+      misconception_tags: uniqueStrings([
+        ...normalizeArray(existingEvidence.misconception_tags),
+        ...normalizeArray(candidateEvidence.misconception_tags),
+      ]),
+      part_results:
+        normalizeArray(candidateEvidence.part_results).length > 0
+          ? normalizeArray(candidateEvidence.part_results)
+          : normalizeArray(existingEvidence.part_results),
+      ambiguous_part_mapping_count:
+        candidateEvidence.ambiguous_part_mapping_count
+        ?? existingEvidence.ambiguous_part_mapping_count
+        ?? 0,
+      coverage_scope: candidateEvidence.coverage_scope ?? existingEvidence.coverage_scope ?? null,
+      local_signal_only:
+        candidateEvidence.local_signal_only
+        ?? existingEvidence.local_signal_only
+        ?? false,
+    },
+    freshness: {
+      ...existingFreshness,
+      ...candidateFreshness,
+      route: candidateFreshness.route ?? existingFreshness.route ?? null,
+      bucket: candidateFreshness.bucket ?? existingFreshness.bucket ?? null,
+    },
+  };
+}
+
+export function buildReviewTaskExplainability(task = {}) {
+  const successCriteria = normalizeObject(task?.success_criteria);
+  const storedExplainability = normalizeObject(successCriteria.explainability);
+  const attemptHistory = normalizeObject(storedExplainability.attempt_history);
+  const evidence = normalizeObject(storedExplainability.evidence);
+  const freshness = normalizeObject(storedExplainability.freshness);
+  const schedulerState = normalizeObject(task?.scheduler_state);
+  const schedulerReasons = normalizeArray(task?.scheduler_reasons);
+  const explanation = {
+    posture: normalizeString(storedExplainability.posture, 'conservative_fallback'),
+    posture_reason_code:
+      normalizeString(
+        storedExplainability.posture_reason_code,
+        successCriteria.fallback_reason_code ?? null,
+      ),
+    creation_reason_codes: uniqueStrings(storedExplainability.creation_reason_codes),
+    attempt_history: {
+      attempt_count:
+        Number(
+          attemptHistory.attempt_count
+          ?? uniqueTypedRefs([
+            ...normalizeArray(attemptHistory.source_attempt_refs),
+            attemptHistory.latest_source_attempt_ref,
+            evidence.source_attempt_ref ?? task?.source_attempt_ref,
+          ]).length,
+        ) || 0,
+      latest_source_attempt_ref:
+        attemptHistory.latest_source_attempt_ref
+        ?? evidence.source_attempt_ref
+        ?? task?.source_attempt_ref
+        ?? null,
+      source_attempt_refs: uniqueTypedRefs([
+        ...normalizeArray(attemptHistory.source_attempt_refs),
+        attemptHistory.latest_source_attempt_ref,
+        evidence.source_attempt_ref,
+        task?.source_attempt_ref,
+      ]),
+      source_question_ids: uniqueStrings([
+        ...normalizeArray(attemptHistory.source_question_ids),
+        evidence.source_question_id,
+        task?.source_question_id,
+      ]),
+    },
+    evidence: {
+      source_question_id: normalizeString(
+        evidence.source_question_id,
+        task?.source_question_id ?? null,
+      ),
+      source_attempt_ref:
+        evidence.source_attempt_ref
+        ?? task?.source_attempt_ref
+        ?? null,
+      misconception_tags: uniqueStrings(
+        evidence.misconception_tags ?? task?.target_misconception_tags,
+      ),
+      coverage_scope: normalizeString(
+        evidence.coverage_scope,
+        successCriteria.coverage_scope ?? null,
+      ),
+      local_signal_only:
+        typeof evidence.local_signal_only === 'boolean'
+          ? evidence.local_signal_only
+          : successCriteria.local_signal_only === true,
+      ambiguous_part_mapping_count:
+        evidence.ambiguous_part_mapping_count
+        ?? successCriteria.ambiguous_part_mapping_count
+        ?? 0,
+      part_results: normalizeArray(
+        evidence.part_results ?? successCriteria.part_results,
+      ),
+    },
+    freshness: {
+      route: normalizeString(
+        freshness.route,
+        task?.scheduler_policy?.route ?? normalizeRoute(task),
+      ),
+      bucket: normalizeString(
+        freshness.bucket,
+        task?.scheduler_policy?.freshness_bucket ?? null,
+      ),
+      due_at: normalizeString(task?.due_at),
+      scheduler_state: normalizeString(task?.scheduler_state?.value),
+      reason_codes: uniqueStrings(
+        schedulerReasons.map((reason) => reason?.code),
+      ),
+    },
+    summary: normalizeString(storedExplainability.summary),
+  };
+
+  if (!explanation.summary) {
+    explanation.summary = summarizeExplainability(task, explanation);
+  }
+
+  return explanation;
+}
+
 export function buildReviewTaskSchedulerSeed({
   now = new Date(),
   misconceptionTags = [],
@@ -334,6 +619,7 @@ export function deriveReviewQueueProjection(tasks = [], options = {}) {
       scheduler_policy: schedulerPolicy,
       scheduler_state: buildSchedulerStateFromTask(task, { now: nowDate.toISOString() }),
       scheduler_reasons: [],
+      explanation: null,
     };
   });
 
@@ -419,6 +705,13 @@ export function deriveReviewQueueProjection(tasks = [], options = {}) {
       ? buildReason(task.scheduler_state.reason_code, task.scheduler_state.reason_summary)
       : null;
     task.scheduler_reasons = reason ? [reason] : [];
+    task.explanation = buildReviewTaskExplainability(task);
+  }
+
+  for (const task of items) {
+    if (!task.explanation) {
+      task.explanation = buildReviewTaskExplainability(task);
+    }
   }
 
   return {
@@ -520,6 +813,7 @@ export function mergeReviewTaskPayload(existingTask = {}, candidateTask = {}, ti
       ...existingSuccessCriteria,
       ...candidateSuccessCriteria,
       scheduler_policy: mergedSchedulerPolicy,
+      explainability: mergeReviewTaskExplainability(existingTask, candidateTask),
     },
     updated_at: timestamp,
   };
@@ -535,5 +829,11 @@ export function normalizeSchedulerProjectionItem(item = {}) {
     scheduler_policy: schedulerPolicy,
     scheduler_state: schedulerState,
     scheduler_reasons: schedulerReasons,
+    explanation: buildReviewTaskExplainability({
+      ...item,
+      scheduler_policy: schedulerPolicy,
+      scheduler_state: schedulerState,
+      scheduler_reasons: schedulerReasons,
+    }),
   };
 }

--- a/api/learning/lib/review/review-task-service.js
+++ b/api/learning/lib/review/review-task-service.js
@@ -2,7 +2,9 @@ import { createReviewTaskRepository } from '../repositories/review-task-reposito
 import { LEARNING_ERROR_CODES } from '../contracts/error-contract.js';
 import { LearningHttpError } from '../http/learning-http.js';
 import {
+  buildReviewTaskExplainabilitySeed,
   mergeReviewTaskPayload,
+  normalizeSchedulerProjectionItem,
   pickReviewTaskMergeCandidate,
 } from './review-scheduler-policy.js';
 import {
@@ -310,6 +312,18 @@ function buildReviewTaskPayload(input = {}, now = new Date()) {
   const ambiguousPartMappingCount = Number(
     input.marking_result?.marking_summary?.ambiguous_rubric_point_result_count ?? 0,
   );
+  const schedulerPolicy = scheduler.policy;
+  const explainability = buildReviewTaskExplainabilitySeed({
+    sourceQuestionId: input.question_id ?? null,
+    sourceAttemptRef: input.source_attempt_ref ?? null,
+    targetMisconceptionTags: input.misconception_tags,
+    fallbackReasonCode: input.fallback_reason_code ?? null,
+    schedulerPolicy,
+    coverageScope: input.marking_result?.marking_summary?.coverage_scope ?? 'question',
+    localSignalOnly: input.marking_result?.marking_summary?.local_signal_only === true,
+    partResults,
+    ambiguousPartMappingCount,
+  });
 
   return {
     user_id: input.user_id,
@@ -334,7 +348,8 @@ function buildReviewTaskPayload(input = {}, now = new Date()) {
       ambiguous_part_mapping_count: ambiguousPartMappingCount,
       part_results: partResults,
       fallback_reason_code: input.fallback_reason_code ?? null,
-      scheduler_policy: scheduler.policy,
+      scheduler_policy: schedulerPolicy,
+      explainability,
     },
     completion_evidence: {},
     status: 'open',
@@ -362,7 +377,7 @@ export function createReviewTaskService({
       }
 
       if (!reviewTaskRepository) {
-        return [payload];
+        return [normalizeSchedulerProjectionItem(payload)];
       }
 
       const activeTasks = await reviewTaskRepository.listReviewTaskProjectionsByUser?.(payload.user_id)
@@ -379,21 +394,21 @@ export function createReviewTaskService({
           mergedPatch,
         );
         return [
-          {
+          normalizeSchedulerProjectionItem({
             ...mergeCandidate,
             ...merged,
             target_topic_path:
               payload.target_topic_path ?? mergeCandidate.target_topic_path ?? null,
-          },
+          }),
         ];
       }
 
       const stored = await reviewTaskRepository.insertReviewTask(payload);
       return [
-        {
+        normalizeSchedulerProjectionItem({
           ...stored,
           target_topic_path: payload.target_topic_path,
-        },
+        }),
       ];
     },
 
@@ -450,7 +465,7 @@ export function createReviewTaskService({
       );
 
       return {
-        review_task: projection || updated,
+        review_task: normalizeSchedulerProjectionItem(projection || updated),
       };
     },
   };

--- a/api/learning/lib/subjects/subject-adapter-registry.js
+++ b/api/learning/lib/subjects/subject-adapter-registry.js
@@ -181,6 +181,42 @@ function buildRuntimePostureSummary(readOnly) {
   return 'Read-only second-subject runtime slice: scoring, mastery, and review automation stay conservative.';
 }
 
+function buildRuntimePostureExplanation({
+  adapter,
+  supportedCapabilities = [],
+  fallbackCapabilities = [],
+} = {}) {
+  const readOnly = Array.isArray(fallbackCapabilities) && fallbackCapabilities.length > 0;
+  if (!readOnly || !adapter) {
+    return null;
+  }
+
+  const displayName = adapter.meta.display_name ?? adapter.meta.subject_code ?? 'This subject';
+  return {
+    posture: 'read_only_fallback',
+    summary:
+      `${displayName} is read-only in the current runtime slice, so mastery and review automation remain conservative.`,
+    factors: [
+      {
+        code: 'selection_state',
+        status: adapter.meta.selection_state ?? 'unknown',
+        summary:
+          `${displayName} is ${String(adapter.meta.selection_state ?? 'unknown').replace(/_/g, ' ')} instead of the current runtime subject.`,
+      },
+      ...supportedCapabilities.map((capability) => ({
+        code: capability,
+        status: 'supported',
+        summary: `${capability.replace(/_/g, ' ')} remains enabled in this slice.`,
+      })),
+      ...fallbackCapabilities.map((capability) => ({
+        code: capability,
+        status: 'fallback_only',
+        summary: `${capability.replace(/_/g, ' ')} remains conservative in this slice.`,
+      })),
+    ],
+  };
+}
+
 export const SUBJECT_ADAPTER_DECISION = Object.freeze({
   current_runtime_subject: '9709',
   selected_next_subject: '9702',
@@ -332,6 +368,11 @@ export function buildSubjectRuntimePosture(subjectCode, { allowDisabled = false 
     supported_capabilities: supportedCapabilities,
     fallback_capabilities: fallbackCapabilities,
     summary: buildRuntimePostureSummary(readOnly),
+    explanation: buildRuntimePostureExplanation({
+      adapter,
+      supportedCapabilities,
+      fallbackCapabilities,
+    }),
   };
 }
 

--- a/src/components/learning-runtime/ImportPostureBanner.js
+++ b/src/components/learning-runtime/ImportPostureBanner.js
@@ -16,6 +16,29 @@ function renderDetail(label, value) {
   ]);
 }
 
+function renderExplanationFactor(factor) {
+  if (!factor) {
+    return null;
+  }
+
+  const code = factor.code || 'factor';
+  const summary = factor.summary || factor.status || code;
+
+  return h('li', {
+    key: code,
+    className: 'rounded-2xl border border-amber-200 bg-white px-4 py-3 text-sm text-amber-950',
+  }, [
+    h('p', {
+      key: 'code',
+      className: 'font-medium text-amber-800',
+    }, code),
+    h('p', {
+      key: 'summary',
+      className: 'mt-1 leading-6',
+    }, summary),
+  ]);
+}
+
 export default function ImportPostureBanner({
   question,
   posture,
@@ -31,6 +54,7 @@ export default function ImportPostureBanner({
   const releaseScopeStatus = posture?.releaseScopeStatus
     ?? question?.releaseScopeStatus
     ?? null;
+  const explanation = posture?.explanation || null;
 
   return h('section', {
     className: 'rounded-3xl border border-amber-200 bg-amber-50 p-6 shadow-sm',
@@ -58,6 +82,27 @@ export default function ImportPostureBanner({
       renderDetail('Learning signal posture', posture?.learningSignalPosture),
       renderDetail('Classification confidence', posture?.classificationConfidence),
     ].filter(Boolean)),
+    explanation?.summary
+      ? h('div', {
+        key: 'explanation',
+        className: 'mt-6 rounded-2xl border border-amber-200 bg-white px-4 py-4 text-sm text-amber-950',
+      }, [
+        h('p', {
+          key: 'title',
+          className: 'font-medium text-amber-800',
+        }, 'Why this posture is active'),
+        h('p', {
+          key: 'summary',
+          className: 'mt-2 leading-6',
+        }, explanation.summary),
+      ])
+      : null,
+    Array.isArray(explanation?.factors) && explanation.factors.length > 0
+      ? h('ul', {
+        key: 'factors',
+        className: 'mt-4 grid gap-3',
+      }, explanation.factors.map(renderExplanationFactor).filter(Boolean))
+      : null,
     handoffError
       ? h('div', {
         key: 'error',

--- a/src/components/learning-runtime/ReviewQueuePanel.js
+++ b/src/components/learning-runtime/ReviewQueuePanel.js
@@ -39,6 +39,15 @@ function renderSummaryChip(key, label, value) {
   ]);
 }
 
+function formatFreshnessLabel(explanation) {
+  const bucket = explanation?.freshness?.bucket;
+  if (!bucket) {
+    return null;
+  }
+
+  return `${bucket.slice(0, 1).toUpperCase()}${bucket.slice(1)} evidence`;
+}
+
 function renderReviewItem(item, {
   drafts = {},
   mutationStateByTaskId = {},
@@ -98,6 +107,62 @@ function renderReviewItem(item, {
         key: 'result-summary',
         className: 'mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800',
       }, item.resultFeedback.summary)
+      : null,
+    item.explanation?.summary
+      ? h('div', {
+        key: 'explanation-summary',
+        className: 'mt-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700',
+      }, [
+        h('p', {
+          key: 'title',
+          className: 'font-semibold text-slate-900',
+        }, 'Why this task exists'),
+        h('p', {
+          key: 'summary',
+          className: 'mt-1 leading-6',
+        }, item.explanation.summary),
+        h('dl', {
+          key: 'meta',
+          className: 'mt-3 grid gap-2 sm:grid-cols-3',
+        }, [
+          item.explanation?.attemptHistory?.attemptCount
+            ? h('div', { key: 'attempts' }, [
+              h('dt', {
+                key: 'label',
+                className: 'text-xs font-semibold uppercase tracking-[0.16em] text-slate-500',
+              }, 'Attempt history'),
+              h('dd', {
+                key: 'value',
+                className: 'mt-1 text-sm font-medium text-slate-900',
+              }, `${item.explanation.attemptHistory.attemptCount} attempts`),
+            ])
+            : null,
+          formatFreshnessLabel(item.explanation)
+            ? h('div', { key: 'freshness' }, [
+              h('dt', {
+                key: 'label',
+                className: 'text-xs font-semibold uppercase tracking-[0.16em] text-slate-500',
+              }, 'Freshness'),
+              h('dd', {
+                key: 'value',
+                className: 'mt-1 text-sm font-medium text-slate-900',
+              }, formatFreshnessLabel(item.explanation)),
+            ])
+            : null,
+          item.explanation?.posture
+            ? h('div', { key: 'posture' }, [
+              h('dt', {
+                key: 'label',
+                className: 'text-xs font-semibold uppercase tracking-[0.16em] text-slate-500',
+              }, 'Posture'),
+              h('dd', {
+                key: 'value',
+                className: 'mt-1 text-sm font-medium text-slate-900',
+              }, item.explanation.posture.replace(/_/g, ' ')),
+            ])
+            : null,
+        ].filter(Boolean)),
+      ])
       : null,
     h(ReviewTaskActionBar, {
       key: 'actions',

--- a/src/components/learning-runtime/SessionHeader.js
+++ b/src/components/learning-runtime/SessionHeader.js
@@ -22,6 +22,12 @@ function renderPill(label, value) {
 
 export default function SessionHeader({ header, session }) {
   const hasSession = Boolean(session?.sessionId);
+  const postureExplanation = header?.postureExplanation || null;
+  const postureBannerVisible = Boolean(
+    header?.fallbackMode
+    || postureExplanation?.summary
+    || header?.authoritativeScoringAllowed === true,
+  );
   const pills = [
     renderPill('Anchor', header?.anchorKind),
     renderPill('Topic', header?.topicPath),
@@ -48,17 +54,30 @@ export default function SessionHeader({ header, session }) {
           : 'Launch the first interactive runtime session from a valid anchor payload, then keep the ask loop inside the same session.'),
       ]),
       h('div', { key: 'pills', className: 'flex flex-wrap gap-3' }, pills),
-      header?.fallbackMode
+      postureBannerVisible
         ? h('div', {
           key: 'fallback-banner',
           className: 'rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900',
         }, [
-          h('p', { key: 'title', className: 'font-semibold' }, 'Runtime fallback is active'),
+          h('p', {
+            key: 'title',
+            className: 'font-semibold',
+          }, header?.fallbackMode ? 'Runtime fallback is active' : 'Runtime posture is explicit'),
           h('p', { key: 'body', className: 'mt-1 leading-6' }, [
-            `Fallback mode: ${header.fallbackMode}.`,
+            header?.fallbackMode
+              ? `Fallback mode: ${header.fallbackMode}.`
+              : header?.authoritativeScoringAllowed === true
+                ? 'Authoritative scoring is enabled for this posture.'
+                : '',
             header?.fallbackReasonCode ? ` Reason: ${header.fallbackReasonCode}.` : '',
             header?.learningSignalPosture ? ` Learning signal posture: ${header.learningSignalPosture}.` : '',
           ].join('')),
+          postureExplanation?.summary
+            ? h('p', {
+              key: 'explanation-summary',
+              className: 'mt-1 leading-6',
+            }, postureExplanation.summary)
+            : null,
           header?.runtimeSummary
             ? h('p', {
               key: 'summary',
@@ -70,6 +89,15 @@ export default function SessionHeader({ header, session }) {
               key: 'capabilities',
               className: 'mt-1 leading-6',
             }, `Conservative capabilities: ${header.fallbackCapabilities.join(', ')}.`)
+            : null,
+          postureExplanation?.factors?.length
+            ? h('ul', {
+              key: 'explanation-factors',
+              className: 'mt-2 list-disc space-y-1 pl-5',
+            }, postureExplanation.factors.map((factor) => h('li', {
+              key: `${factor.code}:${factor.status}`,
+              className: 'leading-6',
+            }, factor.summary || `${factor.code}: ${factor.status}`)))
             : null,
         ])
         : null,

--- a/src/components/learning-runtime/WorkspaceShell.js
+++ b/src/components/learning-runtime/WorkspaceShell.js
@@ -467,6 +467,7 @@ function renderRuntimePosture(runtimePosture = null) {
     && runtimePosture.fallbackCapabilities.length > 0
     ? `Conservative capabilities: ${runtimePosture.fallbackCapabilities.join(', ')}.`
     : null;
+  const explanation = runtimePosture?.explanation || null;
 
   return h('section', {
     key: 'runtime-posture',
@@ -492,11 +493,25 @@ function renderRuntimePosture(runtimePosture = null) {
         ? ` Learning signal posture: ${runtimePosture.learningSignalPosture}.`
         : '',
     ].join('')),
+    explanation?.summary
+      ? h('p', {
+        key: 'explanation-summary',
+        className: 'mt-2 text-sm leading-6 text-amber-900',
+      }, explanation.summary)
+      : null,
     capabilityCopy
       ? h('p', {
         key: 'capabilities',
         className: 'mt-2 text-sm leading-6 text-amber-900',
       }, capabilityCopy)
+      : null,
+    Array.isArray(explanation?.factors) && explanation.factors.length > 0
+      ? h('ul', {
+        key: 'factors',
+        className: 'mt-3 list-disc space-y-1 pl-5 text-sm leading-6 text-amber-900',
+      }, explanation.factors.map((factor) => h('li', {
+        key: `${factor.code}:${factor.status}`,
+      }, factor.summary || `${factor.code}: ${factor.status}`)))
       : null,
   ]);
 }

--- a/src/components/learning-runtime/__tests__/ImportPostureBanner.test.js
+++ b/src/components/learning-runtime/__tests__/ImportPostureBanner.test.js
@@ -18,6 +18,18 @@ describe('ImportPostureBanner', () => {
           fallbackReasonCode: 'non_pilot_question_type',
           classificationConfidence: 0.77,
           learningSignalPosture: 'conservative_fallback',
+          explanation: {
+            posture: 'conservative_fallback',
+            summary:
+              'Fallback remains active because this question type is outside the released authoritative slice.',
+            factors: [
+              {
+                code: 'released_question_type',
+                status: 'missing',
+                summary: 'This question type is not part of the released authoritative runtime slice.',
+              },
+            ],
+          },
         },
         handoffStatus: 'idle',
         onStartSession: () => {},
@@ -28,6 +40,8 @@ describe('ImportPostureBanner', () => {
     expect(html).toContain('non_released_fallback');
     expect(html).toContain('non_pilot_question_type');
     expect(html).toContain('question-import-1');
+    expect(html).toContain('Fallback remains active because this question type is outside the released authoritative slice.');
+    expect(html).toContain('released_question_type');
     expect(html).toContain('Enter runtime session');
   });
 });

--- a/src/components/learning-runtime/__tests__/LearningSessionShell.test.js
+++ b/src/components/learning-runtime/__tests__/LearningSessionShell.test.js
@@ -103,6 +103,28 @@ function createReadOnlyPhysicsSessionPayload() {
       fallbackCapabilities: ['marking', 'mastery', 'review'],
       summary:
         'Read-only second-subject runtime slice: scoring, mastery, and review automation stay conservative.',
+      explanation: {
+        posture: 'read_only_fallback',
+        summary:
+          'Physics stays read-only in the current runtime slice, so mastery and review automation remain conservative.',
+        factors: [
+          {
+            code: 'selection_state',
+            status: 'selected_next',
+            summary: 'Physics is selected next, not the current runtime subject.',
+          },
+          {
+            code: 'marking',
+            status: 'fallback_only',
+            summary: 'Marking remains conservative in this slice.',
+          },
+          {
+            code: 'mastery',
+            status: 'fallback_only',
+            summary: 'Mastery remains conservative in this slice.',
+          },
+        ],
+      },
     },
     featureFlags: {
       learningRuntimeEnabled: true,
@@ -286,6 +308,9 @@ describe('LearningSessionShell', () => {
 
     expect(html).toContain('Runtime fallback is active');
     expect(html).toContain('subject_adapter_capability_not_enabled');
+    expect(html).toContain('Physics stays read-only in the current runtime slice');
+    expect(html).toContain('Physics is selected next, not the current runtime subject.');
+    expect(html).toContain('Marking remains conservative in this slice.');
     expect(html).toContain('9702/mechanics/force-balance');
     expect(html).toContain('Read-only second-subject runtime slice');
   });

--- a/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
+++ b/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
@@ -172,6 +172,17 @@ function createWorkspacePayload() {
               summary: 'Fresh repair evidence should be retried before it is spaced.',
             },
           ],
+          explanation: {
+            summary: 'Queued from interval-repair evidence while authoritative mastery stays conservative.',
+            posture: 'conservative_fallback',
+            freshness: {
+              bucket: 'fresh',
+              route: 'immediate_repair',
+            },
+            attemptHistory: {
+              attemptCount: 2,
+            },
+          },
         },
         {
           reviewTaskId: 'review-task-2',
@@ -362,6 +373,10 @@ describe('WorkspaceShell', () => {
     expect(html).toContain('Escalated');
     expect(html).toContain('Completed');
     expect(html).toContain('Fresh repair evidence should be retried before it is spaced.');
+    expect(html).toContain('Queued from interval-repair evidence while authoritative mastery stays conservative.');
+    expect(html).toContain('Attempt history');
+    expect(html).toContain('2 attempts');
+    expect(html).toContain('Fresh evidence');
     expect(html).toContain('Start spaced review');
     expect(html).toContain('Mark complete');
     expect(html).toContain('Reschedule');
@@ -380,6 +395,10 @@ describe('WorkspaceShell', () => {
 
     expect(html).toContain('Read-only second-subject runtime slice');
     expect(html).toContain('subject_adapter_capability_not_enabled');
+    expect(html).toContain('Read-only');
+    expect(html).toContain('marking');
+    expect(html).toContain('mastery');
+    expect(html).toContain('review');
     expect(html).toContain('9702/mechanics/force-balance');
   });
 

--- a/src/components/learning-runtime/view-models/review-queue-view-model.js
+++ b/src/components/learning-runtime/view-models/review-queue-view-model.js
@@ -142,6 +142,94 @@ function normalizeSchedulerReasons(value) {
   })).filter((reason) => reason.code || reason.summary);
 }
 
+function normalizeExplanationFactors(value) {
+  return (Array.isArray(value) ? value : []).map((factor) => ({
+    code: normalizeString(factor?.code),
+    status: normalizeString(factor?.status),
+    summary: normalizeString(factor?.summary),
+    value: factor?.value ?? null,
+  })).filter((factor) => factor.code || factor.summary);
+}
+
+function normalizeReviewTaskExplanation(value) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const attemptHistory = value.attemptHistory ?? value.attempt_history ?? {};
+  const evidence = value.evidence ?? {};
+  const freshness = value.freshness ?? {};
+
+  return {
+    summary: normalizeString(value.summary),
+    posture: normalizeString(value.posture),
+    postureReasonCode: normalizeString(
+      value.postureReasonCode ?? value.posture_reason_code,
+    ),
+    creationReasonCodes: (Array.isArray(value.creationReasonCodes ?? value.creation_reason_codes)
+      ? (value.creationReasonCodes ?? value.creation_reason_codes)
+      : []).map((code) => normalizeString(code)).filter(Boolean),
+    factors: normalizeExplanationFactors(value.factors),
+    attemptHistory: {
+      attemptCount:
+        attemptHistory.attemptCount
+        ?? attemptHistory.attempt_count
+        ?? 0,
+      latestSourceAttemptRef:
+        attemptHistory.latestSourceAttemptRef
+        ?? attemptHistory.latest_source_attempt_ref
+        ?? null,
+      sourceAttemptRefs:
+        Array.isArray(attemptHistory.sourceAttemptRefs ?? attemptHistory.source_attempt_refs)
+          ? (attemptHistory.sourceAttemptRefs ?? attemptHistory.source_attempt_refs)
+          : [],
+      sourceQuestionIds:
+        Array.isArray(attemptHistory.sourceQuestionIds ?? attemptHistory.source_question_ids)
+          ? (attemptHistory.sourceQuestionIds ?? attemptHistory.source_question_ids)
+          : [],
+    },
+    evidence: {
+      sourceQuestionId: normalizeString(
+        evidence.sourceQuestionId ?? evidence.source_question_id,
+      ),
+      sourceAttemptRef:
+        evidence.sourceAttemptRef
+        ?? evidence.source_attempt_ref
+        ?? null,
+      misconceptionTags: (Array.isArray(
+        evidence.misconceptionTags ?? evidence.misconception_tags,
+      )
+        ? (evidence.misconceptionTags ?? evidence.misconception_tags)
+        : []).map((tag) => normalizeString(tag)).filter(Boolean),
+      coverageScope: normalizeString(
+        evidence.coverageScope ?? evidence.coverage_scope,
+      ),
+      localSignalOnly:
+        typeof evidence.localSignalOnly === 'boolean'
+          ? evidence.localSignalOnly
+          : evidence.local_signal_only === true,
+      ambiguousPartMappingCount:
+        evidence.ambiguousPartMappingCount
+        ?? evidence.ambiguous_part_mapping_count
+        ?? 0,
+      partResults: Array.isArray(evidence.partResults ?? evidence.part_results)
+        ? (evidence.partResults ?? evidence.part_results)
+        : [],
+    },
+    freshness: {
+      bucket: normalizeString(freshness.bucket),
+      route: normalizeString(freshness.route),
+      dueAt: normalizeString(freshness.dueAt ?? freshness.due_at),
+      schedulerState: normalizeString(
+        freshness.schedulerState ?? freshness.scheduler_state,
+      ),
+      reasonCodes: (Array.isArray(freshness.reasonCodes ?? freshness.reason_codes)
+        ? (freshness.reasonCodes ?? freshness.reason_codes)
+        : []).map((code) => normalizeString(code)).filter(Boolean),
+    },
+  };
+}
+
 function buildSchedulerExplanation(schedulerState, schedulerReasons, schedulerPolicy) {
   const primaryReason = schedulerReasons[0] || null;
   if (!schedulerState && !primaryReason && !schedulerPolicy) {
@@ -250,6 +338,7 @@ export function buildReviewQueueViewModel(reviewQueue = {}, options = {}) {
         schedulerReasons,
         schedulerPolicy,
       ),
+      explanation: normalizeReviewTaskExplanation(item.explanation),
       launchPayload: buildLaunchPayload(item),
       workspaceLink: {
         topicId: normalizeString(item.targetTopicId ?? item.target_topic_id, ''),

--- a/src/components/learning-runtime/view-models/session-view-model.js
+++ b/src/components/learning-runtime/view-models/session-view-model.js
@@ -17,6 +17,27 @@ function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
+function normalizeExplanationFactors(value) {
+  return normalizeArray(value).map((factor) => ({
+    code: normalizeText(factor?.code, null),
+    status: normalizeText(factor?.status, null),
+    summary: normalizeText(factor?.summary, null),
+    value: factor?.value ?? null,
+  })).filter((factor) => factor.code || factor.summary);
+}
+
+function buildExplanationViewModel(explanation = null) {
+  if (!explanation || typeof explanation !== 'object') {
+    return null;
+  }
+
+  return {
+    posture: normalizeText(explanation.posture, null),
+    summary: normalizeText(explanation.summary, null),
+    factors: normalizeExplanationFactors(explanation.factors),
+  };
+}
+
 function normalizeRefId(ref, key) {
   if (!ref || typeof ref !== 'object') {
     return null;
@@ -351,6 +372,7 @@ function buildPostMortemViewModel(sessionPayload = {}, session, topicPath) {
             : scoringPosture.authoritative_scoring_allowed ?? null,
         fallbackReasonCode:
           scoringPosture.fallbackReasonCode ?? scoringPosture.fallback_reason_code ?? null,
+        explanation: buildExplanationViewModel(scoringPosture.explanation),
       }
       : null,
     diagnosticFocus: {
@@ -413,6 +435,7 @@ function buildRuntimePostureViewModel(runtimePosture = null) {
       runtimePosture.fallbackCapabilities ?? runtimePosture.fallback_capabilities,
     ).map((capability) => normalizeText(capability, '')).filter(Boolean),
     summary: normalizeText(runtimePosture.summary, null),
+    explanation: buildExplanationViewModel(runtimePosture.explanation),
   };
 }
 
@@ -499,6 +522,10 @@ export function buildSessionViewModel(payload = {}, options = {}) {
         ?? null,
       runtimeSummary: runtimePosture?.summary ?? null,
       fallbackCapabilities: runtimePosture?.fallbackCapabilities ?? [],
+      postureExplanation:
+        latestResponse?.fallbackPosture?.explanation
+        ?? runtimePosture?.explanation
+        ?? null,
       handoffKind:
         continuity?.suggestedHandoff?.handoffKindLabel
         || continuity?.lineage?.handoffKindLabel

--- a/src/components/learning-runtime/view-models/workspace-view-model.js
+++ b/src/components/learning-runtime/view-models/workspace-view-model.js
@@ -95,6 +95,27 @@ function normalizeCapabilityList(values) {
     .filter(Boolean);
 }
 
+function normalizeExplanationFactors(value) {
+  return (Array.isArray(value) ? value : []).map((factor) => ({
+    code: normalizeString(factor?.code),
+    status: normalizeString(factor?.status),
+    summary: normalizeString(factor?.summary),
+    value: factor?.value ?? null,
+  })).filter((factor) => factor.code || factor.summary);
+}
+
+function buildExplanationViewModel(explanation = null) {
+  if (!explanation || typeof explanation !== 'object') {
+    return null;
+  }
+
+  return {
+    posture: normalizeString(explanation.posture),
+    summary: normalizeString(explanation.summary),
+    factors: normalizeExplanationFactors(explanation.factors),
+  };
+}
+
 function buildRuntimePostureViewModel(runtimePosture = null) {
   if (!runtimePosture || typeof runtimePosture !== 'object') {
     return null;
@@ -126,6 +147,7 @@ function buildRuntimePostureViewModel(runtimePosture = null) {
       runtimePosture.fallbackCapabilities ?? runtimePosture.fallback_capabilities,
     ),
     summary: normalizeString(runtimePosture.summary),
+    explanation: buildExplanationViewModel(runtimePosture.explanation),
   };
 }
 


### PR DESCRIPTION
Closes #93

## Summary
This PR exposes machine-readable explainability for the learning runtime surfaces that were still acting like opaque system decisions. Review tasks now carry evidence-backed explanation payloads, released-scope and subject-runtime posture payloads now explain why authoritative scoring is available or why fallback remains active, and the session/workspace UI renders that reasoning directly so users can distinguish released authoritative posture from conservative fallback posture.

The underlying gap was that the runtime already had conservative policy and scheduler mechanics, but the read model mostly surfaced only status flags and fallback codes. That made mastery posture, review-task creation, freshness, and uncertainty hard to interpret even when the system was behaving correctly. This change keeps the frozen runtime contract intact and adds additive explainability fields instead of redesigning the mastery algorithm or widening released scope.

## What changed
Backend contract and projection work now builds explicit explanation objects for released-scope posture, second-subject runtime posture, and review-task scheduling. Review-task explainability includes attempt history, evidence, freshness, posture, and deterministic summary text, and those payloads are preserved when tasks merge or are projected back through the read model.

Frontend view models now normalize those explainability payloads and the learning runtime UI renders them in the import posture banner, session header, workspace posture panel, and review queue panel. Users can now see why fallback is active, what evidence created a review task, how fresh that evidence is, and whether the runtime is operating in released authoritative mode or a conservative fallback posture.

Focused tests were added and updated across the runtime contract, review-task service, workspace read service, and UI rendering to lock the explainability contract into place.

## Verification
- `npm test -- --runInBand api/learning/__tests__/released-scope.test.js api/learning/__tests__/subject-adapter-registry.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/workspace-read-service.test.js src/components/learning-runtime/__tests__/ImportPostureBanner.test.js src/components/learning-runtime/__tests__/LearningSessionShell.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/components/learning-runtime/__tests__/view-models.test.js --verbose`
- `npm run build`
