### PR TITLE
feat(ao): add assist-mode executor and override controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ao:state:json": "node scripts/ao-state.js --json",
     "ao:manage": "node scripts/ao-manage.js",
     "ao:manage:json": "node scripts/ao-manage.js --json",
+    "ao:override": "node scripts/ao-override.js",
     "ao:controller": "node scripts/ao-controller.js",
     "ao:controller:json": "node scripts/ao-controller.js --json",
     "ao:test:acceptance": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand tests/ao/ao-lifecycle-acceptance.test.js",

--- a/scripts/ao-controller.js
+++ b/scripts/ao-controller.js
@@ -64,7 +64,7 @@ function parseArgs(argv) {
     };
   }
 
-  if (options.mode != null && !['observe', 'shadow'].includes(options.mode)) {
+  if (options.mode != null && !['observe', 'shadow', 'assist'].includes(options.mode)) {
     return {
       ok: false,
       error: 'Invalid value for --mode',
@@ -91,7 +91,7 @@ function renderHelp() {
     'Options:',
     '  --project <project_id>      AO project id. Default: ciecopilot-home',
     '  --controller <id>           Controller id. Default: default',
-    '  --mode <observe|shadow>     Override the durable controller mode',
+    '  --mode <observe|shadow|assist> Override the durable controller mode',
     '  --issue <number>            Limit one loop to a specific issue-backed task',
     '  --json                      Print machine-readable JSON output',
     '  -h, --help                  Show help',
@@ -107,6 +107,8 @@ function renderHumanSummary(result) {
     `processed_tasks: ${result.processed_task_count}`,
     `ingested_observations: ${result.ingested_observation_count}`,
     `proposed_actions: ${result.proposed_action_count}`,
+    `executed_actions: ${result.executed_action_count ?? 0}`,
+    `blocked_actions: ${result.blocked_action_count ?? 0}`,
     `task_results: ${taskSummaries.length ? taskSummaries.join(', ') : 'none'}`,
   ].join('\n');
 }

--- a/scripts/ao-override.js
+++ b/scripts/ao-override.js
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_PROJECT_ID,
+  runOverrideCommand,
+} from './ao/lib/override-runner.js';
+import { findRepoRoot } from './ao/lib/repo-root.js';
+
+function createDefaultIo() {
+  return {
+    writeStdout: (text) => process.stdout.write(text),
+    writeStderr: (text) => process.stderr.write(text),
+  };
+}
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1] ?? null;
+  if (value == null || value.startsWith('-')) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+
+  return value;
+}
+
+function parseJsonValue(rawValue) {
+  try {
+    return JSON.parse(rawValue);
+  } catch {
+    throw new Error('Invalid JSON for --value');
+  }
+}
+
+function parseArgs(argv) {
+  const options = {
+    command: null,
+    projectId: DEFAULT_PROJECT_ID,
+    overrideId: null,
+    scopeKind: null,
+    scopeId: null,
+    overrideKind: null,
+    value: {},
+    status: null,
+    expiresAt: null,
+    createdBy: process.env.AO_SESSION_NAME ?? 'operator',
+    reason: null,
+    json: false,
+    help: false,
+  };
+
+  try {
+    for (let index = 0; index < argv.length; index += 1) {
+      const arg = argv[index];
+      if (options.command == null && !arg.startsWith('-')) {
+        options.command = arg;
+        continue;
+      }
+
+      if (arg === '--project') {
+        options.projectId = readOptionValue(argv, index, '--project');
+        index += 1;
+      } else if (arg === '--override') {
+        options.overrideId = readOptionValue(argv, index, '--override');
+        index += 1;
+      } else if (arg === '--scope-kind') {
+        options.scopeKind = readOptionValue(argv, index, '--scope-kind');
+        index += 1;
+      } else if (arg === '--scope-id') {
+        options.scopeId = readOptionValue(argv, index, '--scope-id');
+        index += 1;
+      } else if (arg === '--kind') {
+        options.overrideKind = readOptionValue(argv, index, '--kind');
+        index += 1;
+      } else if (arg === '--value') {
+        options.value = parseJsonValue(readOptionValue(argv, index, '--value'));
+        index += 1;
+      } else if (arg === '--status') {
+        options.status = readOptionValue(argv, index, '--status');
+        index += 1;
+      } else if (arg === '--expires-at') {
+        options.expiresAt = readOptionValue(argv, index, '--expires-at');
+        index += 1;
+      } else if (arg === '--created-by') {
+        options.createdBy = readOptionValue(argv, index, '--created-by');
+        index += 1;
+      } else if (arg === '--reason') {
+        options.reason = readOptionValue(argv, index, '--reason');
+        index += 1;
+      } else if (arg === '--json') {
+        options.json = true;
+      } else if (arg === '--help' || arg === '-h') {
+        options.help = true;
+      } else {
+        return {
+          ok: false,
+          error: `Unknown argument: ${arg}`,
+        };
+      }
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error.message,
+    };
+  }
+
+  if (options.help) {
+    return {
+      ok: true,
+      options,
+    };
+  }
+
+  if (!['create', 'list', 'clear'].includes(options.command)) {
+    return {
+      ok: false,
+      error: `Unsupported command: ${options.command ?? 'none'}`,
+    };
+  }
+
+  if (options.command === 'create' && (!options.scopeKind || !options.scopeId || !options.overrideKind)) {
+    return {
+      ok: false,
+      error: 'create requires --scope-kind, --scope-id, and --kind',
+    };
+  }
+
+  if (options.command === 'clear' && !options.overrideId) {
+    return {
+      ok: false,
+      error: 'clear requires --override',
+    };
+  }
+
+  return {
+    ok: true,
+    options,
+  };
+}
+
+function renderHelp() {
+  return [
+    'Usage: node scripts/ao-override.js <command> [options]',
+    '',
+    'Commands:',
+    '  create      Create a durable AO override',
+    '  list        List durable AO overrides',
+    '  clear       Clear one durable AO override',
+    '',
+    'Options:',
+    '  --project <project_id>      AO project id. Default: ciecopilot-home',
+    '  --override <override_id>    Override id for clear operations',
+    '  --scope-kind <kind>         Override scope kind: global|task|pr|controller',
+    '  --scope-id <id>             Override scope identifier',
+    '  --kind <override_kind>      Override kind, for example hold_autonomy',
+    '  --value <json>              JSON payload for override value',
+    '  --status <status>           Filter list results by status',
+    '  --expires-at <iso>          Optional override expiry timestamp',
+    '  --created-by <actor>        Actor recorded for create/clear audit entries',
+    '  --reason <text>             Clear reason',
+    '  --json                      Print machine-readable JSON output',
+    '  -h, --help                  Show help',
+  ].join('\n');
+}
+
+function renderHumanSummary(result) {
+  const overrides = result.overrides ?? [];
+  if (result.command === 'list') {
+    return [
+      `command: ${result.command}`,
+      `override_count: ${overrides.length}`,
+      `overrides: ${overrides.length ? overrides.map((override) => `${override.override_id}:${override.status}`).join(', ') : 'none'}`,
+    ].join('\n');
+  }
+
+  return [
+    `command: ${result.command}`,
+    `override: ${result.override ? `${result.override.override_id}:${result.override.status}` : 'none'}`,
+  ].join('\n');
+}
+
+export async function runCli(argv, io = createDefaultIo()) {
+  const parsed = parseArgs(argv);
+  if (!parsed.ok) {
+    io.writeStderr(`${parsed.error}\n`);
+    return {
+      exitCode: 4,
+      result: null,
+    };
+  }
+
+  const { options } = parsed;
+  if (options.help) {
+    io.writeStdout(`${renderHelp()}\n`);
+    return {
+      exitCode: 0,
+      result: null,
+    };
+  }
+
+  const repoRoot = findRepoRoot(process.cwd());
+  if (!repoRoot) {
+    io.writeStderr(`Could not locate repo root from ${process.cwd()}\n`);
+    return {
+      exitCode: 3,
+      result: null,
+    };
+  }
+
+  try {
+    const result = await runOverrideCommand({
+      repoRoot,
+      cwd: process.cwd(),
+      projectId: options.projectId,
+      command: options.command,
+      overrideId: options.overrideId,
+      scopeKind: options.scopeKind,
+      scopeId: options.scopeId,
+      overrideKind: options.overrideKind,
+      value: options.value,
+      status: options.status,
+      expiresAt: options.expiresAt,
+      createdBy: options.createdBy,
+      reason: options.reason,
+    });
+
+    if (options.json) {
+      io.writeStdout(JSON.stringify(result, null, 2));
+    } else {
+      io.writeStdout(`${renderHumanSummary(result)}\n`);
+    }
+
+    return {
+      exitCode: 0,
+      result,
+    };
+  } catch (error) {
+    io.writeStderr(`${error.message}\n`);
+    return {
+      exitCode: 3,
+      result: null,
+    };
+  }
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+const executedFile = process.argv[1] ? path.resolve(process.argv[1]) : null;
+
+if (executedFile && executedFile === currentFile) {
+  const { exitCode } = await runCli(process.argv.slice(2));
+  process.exitCode = exitCode;
+}

--- a/scripts/ao/lib/action-executor.js
+++ b/scripts/ao/lib/action-executor.js
@@ -1,0 +1,437 @@
+import { createActionRecord } from './state-contracts.js';
+
+export const ASSIST_ACTION_MODEL_SCHEMA_VERSION = 'ao.control-plane.action-model.v1alpha1';
+export const ASSIST_ACTION_MODEL_FORMAT = 'ao_control_plane_action_model';
+export const ACTION_RISK_CLASSES = ['class_a', 'class_b', 'class_c'];
+
+function resolveNow(now) {
+  if (typeof now === 'function') return resolveNow(now());
+  if (typeof now === 'string' && now.trim() !== '') return now.trim();
+  return new Date().toISOString();
+}
+
+function isPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneJsonValue(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function toStringArray(values) {
+  return (values ?? []).map((value) => String(value));
+}
+
+function toNullablePositiveInteger(value) {
+  if (value == null) return null;
+  const normalized = Number(value);
+  if (!Number.isInteger(normalized) || normalized <= 0) return null;
+  return normalized;
+}
+
+function buildTaskActivePrecondition(task) {
+  return {
+    code: 'task_active',
+    description: 'Managed task must remain active.',
+    satisfied: task?.status === 'active',
+  };
+}
+
+function buildPrScopePrecondition(prNumber) {
+  return {
+    code: 'pr_scope_required',
+    description: 'Action requires one bound PR scope.',
+    satisfied: Number.isInteger(toNullablePositiveInteger(prNumber)),
+  };
+}
+
+const ACTION_POLICIES = {
+  continue_worker: {
+    riskClass: 'class_a',
+    phase4AssistExecutable: true,
+    nonExecutableReason: 'class_a_allowlist',
+    buildPreconditions: ({ task }) => [
+      buildTaskActivePrecondition(task),
+    ],
+  },
+  notify_human_ready: {
+    riskClass: 'class_a',
+    phase4AssistExecutable: true,
+    nonExecutableReason: 'class_a_allowlist',
+    buildPreconditions: ({ task, prNumber }) => [
+      buildTaskActivePrecondition(task),
+      buildPrScopePrecondition(prNumber),
+    ],
+  },
+  hold_ci: {
+    riskClass: 'class_b',
+    phase4AssistExecutable: false,
+    nonExecutableReason: 'advisory_hold_non_executable',
+    buildPreconditions: ({ task, prNumber }) => [
+      buildTaskActivePrecondition(task),
+      buildPrScopePrecondition(prNumber),
+    ],
+  },
+  hold_review: {
+    riskClass: 'class_b',
+    phase4AssistExecutable: false,
+    nonExecutableReason: 'advisory_hold_non_executable',
+    buildPreconditions: ({ task, prNumber }) => [
+      buildTaskActivePrecondition(task),
+      buildPrScopePrecondition(prNumber),
+    ],
+  },
+  hold_mergeability: {
+    riskClass: 'class_b',
+    phase4AssistExecutable: false,
+    nonExecutableReason: 'advisory_hold_non_executable',
+    buildPreconditions: ({ task, prNumber }) => [
+      buildTaskActivePrecondition(task),
+      buildPrScopePrecondition(prNumber),
+    ],
+  },
+  hold_local_control: {
+    riskClass: 'class_b',
+    phase4AssistExecutable: false,
+    nonExecutableReason: 'advisory_hold_non_executable',
+    buildPreconditions: ({ task }) => [
+      buildTaskActivePrecondition(task),
+    ],
+  },
+  human_gate: {
+    riskClass: 'class_b',
+    phase4AssistExecutable: false,
+    nonExecutableReason: 'explicit_human_gate_required',
+    buildPreconditions: ({ task }) => [
+      buildTaskActivePrecondition(task),
+    ],
+  },
+  restore_worker: {
+    riskClass: 'class_c',
+    phase4AssistExecutable: false,
+    nonExecutableReason: 'runtime_ownership_change_forbidden',
+    buildPreconditions: ({ task, prNumber }) => [
+      buildTaskActivePrecondition(task),
+      buildPrScopePrecondition(prNumber),
+    ],
+  },
+  handoff_worker: {
+    riskClass: 'class_c',
+    phase4AssistExecutable: false,
+    nonExecutableReason: 'runtime_ownership_change_forbidden',
+    buildPreconditions: ({ task, prNumber }) => [
+      buildTaskActivePrecondition(task),
+      buildPrScopePrecondition(prNumber),
+    ],
+  },
+};
+
+function resolveActionPolicy(actionKind) {
+  return ACTION_POLICIES[actionKind] ?? {
+    riskClass: 'class_c',
+    phase4AssistExecutable: false,
+    nonExecutableReason: 'unclassified_action_forbidden',
+    buildPreconditions: ({ task }) => [
+      buildTaskActivePrecondition(task),
+    ],
+  };
+}
+
+function buildExecutionDecision({
+  phase4AssistExecutable,
+  preconditions,
+  nonExecutableReason,
+} = {}) {
+  const preconditionsSatisfied = preconditions.every((item) => item.satisfied === true);
+  if (!phase4AssistExecutable) {
+    return {
+      executable: false,
+      reason: nonExecutableReason,
+    };
+  }
+
+  return {
+    executable: preconditionsSatisfied,
+    reason: preconditionsSatisfied ? 'class_a_allowlist' : 'preconditions_unsatisfied',
+  };
+}
+
+export function buildAssistActionModel({
+  controllerId,
+  task,
+  prNumber = null,
+  derivedTrigger = 'manual',
+  lifecycleTopStatus = null,
+  action,
+} = {}) {
+  const policy = resolveActionPolicy(action?.id);
+  const normalizedPrNumber = toNullablePositiveInteger(prNumber);
+  const preconditions = policy.buildPreconditions({
+    controllerId,
+    task,
+    prNumber: normalizedPrNumber,
+    action,
+  });
+  const phase4Assist = buildExecutionDecision({
+    phase4AssistExecutable: policy.phase4AssistExecutable,
+    preconditions,
+    nonExecutableReason: policy.nonExecutableReason,
+  });
+
+  return {
+    schema_version: ASSIST_ACTION_MODEL_SCHEMA_VERSION,
+    format: ASSIST_ACTION_MODEL_FORMAT,
+    controller_id: controllerId == null ? null : String(controllerId),
+    task_id: task?.task_id ?? null,
+    pr_number: normalizedPrNumber,
+    action_kind: String(action?.id),
+    action_class: String(action?.action_class ?? action?.id ?? 'unknown'),
+    summary: String(action?.summary ?? ''),
+    commands: toStringArray(action?.commands),
+    rationale: String(action?.rationale ?? ''),
+    derived_trigger: String(derivedTrigger ?? 'manual'),
+    lifecycle_top_status: lifecycleTopStatus == null ? null : String(lifecycleTopStatus),
+    risk_class: policy.riskClass,
+    preconditions,
+    phase4_assist: phase4Assist,
+  };
+}
+
+function buildFallbackActionModel(record, controllerId, task) {
+  return buildAssistActionModel({
+    controllerId,
+    task,
+    prNumber: record?.payload?.pr_number ?? null,
+    derivedTrigger: record?.payload?.derived_trigger ?? 'manual',
+    lifecycleTopStatus: record?.payload?.top_status ?? null,
+    action: {
+      id: record?.action_kind,
+      action_class: record?.payload?.action_class ?? record?.action_kind,
+      summary: record?.reason ?? `Action ${record?.action_kind ?? 'unknown'}`,
+      commands: record?.payload?.commands ?? [],
+      rationale: record?.payload?.rationale ?? '',
+    },
+  });
+}
+
+function isExpiredOverride(override, timestamp) {
+  if (override?.status !== 'active' || !override?.expires_at) return false;
+  const expiresAt = new Date(override.expires_at);
+  const now = new Date(timestamp);
+  if (Number.isNaN(expiresAt.getTime()) || Number.isNaN(now.getTime())) return false;
+  return expiresAt.getTime() <= now.getTime();
+}
+
+function matchesOverrideScope(override, { controllerId, taskId, prNumber } = {}) {
+  switch (override?.scope_kind) {
+    case 'global':
+      return true;
+    case 'task':
+      return override.scope_id === taskId;
+    case 'controller':
+      return override.scope_id === controllerId;
+    case 'pr':
+      return override.scope_id === (prNumber == null ? null : String(prNumber));
+    default:
+      return false;
+  }
+}
+
+function normalizeActionKindsFromOverride(value) {
+  if (typeof value === 'string' && value.trim() !== '') return [value.trim()];
+  if (Array.isArray(value)) return value.map((item) => String(item));
+  if (!isPlainObject(value)) return [];
+
+  const explicitKind = typeof value.action_kind === 'string' ? [value.action_kind] : [];
+  const explicitKinds = Array.isArray(value.action_kinds)
+    ? value.action_kinds.map((item) => String(item))
+    : [];
+  return [...explicitKind, ...explicitKinds];
+}
+
+function resolveOverrideBlockReason(override, actionKind) {
+  if (override?.override_kind === 'hold_autonomy') {
+    const enabled = !isPlainObject(override.value) || override.value.enabled !== false;
+    return enabled ? 'override_hold_autonomy' : null;
+  }
+
+  if (override?.override_kind === 'block_action_kind') {
+    const actionKinds = normalizeActionKindsFromOverride(override.value);
+    return actionKinds.includes(actionKind) ? 'override_block_action_kind' : null;
+  }
+
+  return null;
+}
+
+function resolveBlockingOverrides(repository, {
+  controllerId,
+  task,
+  actionKind,
+  prNumber,
+  timestamp,
+} = {}) {
+  const snapshot = repository.getSnapshot();
+
+  return snapshot.state.overrides
+    .filter((override) => override.status === 'active')
+    .filter((override) => !isExpiredOverride(override, timestamp))
+    .filter((override) => matchesOverrideScope(override, {
+      controllerId,
+      taskId: task?.task_id ?? null,
+      prNumber,
+    }))
+    .map((override) => ({
+      override,
+      reason: resolveOverrideBlockReason(override, actionKind),
+    }))
+    .filter((entry) => entry.reason != null);
+}
+
+function buildBlockedActionRecord(record, model, timestamp, {
+  reason,
+  matchedOverrideIds = [],
+  structural = false,
+} = {}) {
+  return createActionRecord({
+    ...record,
+    status: structural ? 'blocked' : record.status,
+    updated_at: timestamp,
+    payload: {
+      ...(isPlainObject(record?.payload) ? record.payload : {}),
+      action_model: cloneJsonValue(model),
+      execution: {
+        outcome: 'blocked',
+        reason,
+        blocked_at: timestamp,
+        executor: 'assist_controller',
+        matched_override_ids: matchedOverrideIds,
+      },
+    },
+  });
+}
+
+function buildExecutedActionRecord(record, model, timestamp) {
+  return createActionRecord({
+    ...record,
+    status: 'executed',
+    updated_at: timestamp,
+    payload: {
+      ...(isPlainObject(record?.payload) ? record.payload : {}),
+      action_model: cloneJsonValue(model),
+      execution: {
+        outcome: 'executed',
+        reason: 'class_a_assist_execution',
+        executed_at: timestamp,
+        executor: 'assist_controller',
+      },
+    },
+  });
+}
+
+export async function executeAssistActions({
+  repository,
+  controllerId,
+  task,
+  actionIds = [],
+  now = new Date().toISOString(),
+} = {}) {
+  const timestamp = resolveNow(now);
+  const uniqueActionIds = [...new Set((actionIds ?? []).map((value) => String(value)))];
+  const executedActionIds = [];
+  const blockedActionIds = [];
+
+  for (const actionId of uniqueActionIds) {
+    const record = repository.getSnapshot().state.actions.find((item) => item.action_id === actionId);
+    if (!record || record.status !== 'proposed') {
+      continue;
+    }
+
+    const model = isPlainObject(record.payload?.action_model)
+      ? cloneJsonValue(record.payload.action_model)
+      : buildFallbackActionModel(record, controllerId, task);
+
+    const blockingOverrides = resolveBlockingOverrides(repository, {
+      controllerId,
+      task,
+      actionKind: record.action_kind,
+      prNumber: toNullablePositiveInteger(model.pr_number),
+      timestamp,
+    });
+
+    if (blockingOverrides.length > 0) {
+      const blockedRecord = buildBlockedActionRecord(record, model, timestamp, {
+        reason: blockingOverrides[0].reason,
+        matchedOverrideIds: blockingOverrides.map((entry) => entry.override.override_id),
+        structural: false,
+      });
+      repository.upsertAction(blockedRecord);
+      repository.appendAuditEntry({
+        entityKind: 'action',
+        entityId: record.action_id,
+        operation: 'execution_blocked',
+        actor: 'assist_controller',
+        summary: `Blocked assist execution for ${record.action_id}.`,
+        details: {
+          action_id: record.action_id,
+          action_kind: record.action_kind,
+          reason: blockingOverrides[0].reason,
+          matched_override_ids: blockingOverrides.map((entry) => entry.override.override_id),
+        },
+        recordedAt: timestamp,
+      });
+      blockedActionIds.push(record.action_id);
+      continue;
+    }
+
+    if (model.phase4_assist?.executable !== true) {
+      const blockedRecord = buildBlockedActionRecord(record, model, timestamp, {
+        reason: model.phase4_assist?.reason ?? 'phase4_assist_not_executable',
+        matchedOverrideIds: [],
+        structural: true,
+      });
+      repository.upsertAction(blockedRecord);
+      repository.appendAuditEntry({
+        entityKind: 'action',
+        entityId: record.action_id,
+        operation: 'execution_blocked',
+        actor: 'assist_controller',
+        summary: `Blocked assist execution for ${record.action_id}.`,
+        details: {
+          action_id: record.action_id,
+          action_kind: record.action_kind,
+          reason: model.phase4_assist?.reason ?? 'phase4_assist_not_executable',
+          risk_class: model.risk_class,
+        },
+        recordedAt: timestamp,
+      });
+      blockedActionIds.push(record.action_id);
+      continue;
+    }
+
+    const executedRecord = buildExecutedActionRecord(record, model, timestamp);
+    repository.upsertAction(executedRecord);
+    repository.appendAuditEntry({
+      entityKind: 'action',
+      entityId: record.action_id,
+      operation: 'executed',
+      actor: 'assist_controller',
+      summary: `Executed assist action ${record.action_id}.`,
+      details: {
+        action_id: record.action_id,
+        action_kind: record.action_kind,
+        risk_class: model.risk_class,
+        task_id: task?.task_id ?? null,
+        controller_id: controllerId,
+        pr_number: model.pr_number ?? null,
+      },
+      recordedAt: timestamp,
+    });
+    executedActionIds.push(record.action_id);
+  }
+
+  return {
+    executedActionIds,
+    blockedActionIds,
+  };
+}

--- a/scripts/ao/lib/controller-loop.js
+++ b/scripts/ao/lib/controller-loop.js
@@ -24,13 +24,17 @@ import {
 } from './lifecycle-contracts.js';
 import { buildLifecycleReport as buildLifecycleReportModel } from './lifecycle-engine.js';
 import {
+  buildAssistActionModel,
+  executeAssistActions,
+} from './action-executor.js';
+import {
   createPrScope,
   createProjectScope,
 } from './reconciliation-contracts.js';
 import { reconcileObservations as reconcileObservationModels } from './reconciliation-engine.js';
 
 export const DEFAULT_PROJECT_ID = 'ciecopilot-home';
-export const CONTROLLER_MUTATION_MODES = ['observe', 'shadow'];
+export const CONTROLLER_MUTATION_MODES = ['observe', 'shadow', 'assist'];
 
 function resolveNow(now) {
   if (typeof now === 'function') return resolveNow(now());
@@ -106,6 +110,7 @@ async function persistShadowActions({
   repository,
   task,
   controllerId,
+  mode = 'shadow',
   derivedTrigger,
   lifecycleReport,
   prNumber,
@@ -126,21 +131,34 @@ async function persistShadowActions({
     })),
   });
   const fingerprint = await hashText(signature);
-  const snapshot = repository.getSnapshot();
+  const knownActionIds = new Set(repository.getSnapshot().state.actions.map((record) => record.action_id));
   const createdActionIds = [];
+  const actionIds = [];
+  const requestedBy = mode === 'assist' ? 'assist_controller' : 'shadow_controller';
 
   for (const action of lifecycleReport.actions) {
     const actionId = `proposal-${task.task_id}-${action.id}-${fingerprint.slice(0, 12)}`;
-    if (snapshot.state.actions.some((record) => record.action_id === actionId)) {
+    actionIds.push(actionId);
+    if (knownActionIds.has(actionId)) {
       continue;
     }
+    knownActionIds.add(actionId);
+
+    const actionModel = buildAssistActionModel({
+      controllerId,
+      task,
+      prNumber,
+      derivedTrigger,
+      lifecycleTopStatus: lifecycleReport.top_status ?? null,
+      action,
+    });
 
     repository.upsertAction(createActionRecord({
       action_id: actionId,
       task_id: task.task_id,
       action_kind: action.id,
       status: 'proposed',
-      requested_by: 'shadow_controller',
+      requested_by: requestedBy,
       reason: action.summary,
       created_at: now,
       updated_at: now,
@@ -155,14 +173,32 @@ async function persistShadowActions({
         action_class: action.action_class,
         commands: action.commands,
         rationale: action.rationale,
+        action_model: actionModel,
       },
     }));
+    repository.appendAuditEntry({
+      entityKind: 'action',
+      entityId: actionId,
+      operation: 'proposed',
+      actor: requestedBy,
+      summary: `Recorded proposed action ${actionId}.`,
+      details: {
+        action_id: actionId,
+        action_kind: action.id,
+        task_id: task.task_id,
+        controller_id: controllerId,
+        pr_number: prNumber,
+        risk_class: actionModel.risk_class,
+      },
+      recordedAt: now,
+    });
     createdActionIds.push(actionId);
   }
 
   return {
     count: createdActionIds.length,
-    actionIds: createdActionIds,
+    actionIds,
+    createdActionIds,
   };
 }
 
@@ -231,7 +267,7 @@ function resolveLoopMode(repository, controllerId, mode, now) {
   const snapshot = repository.getSnapshot();
   const currentMode = snapshot.state.controller_modes.find((record) => record.controller_id === controllerId)?.mode ?? 'off';
   if (!CONTROLLER_MUTATION_MODES.includes(currentMode)) {
-    throw new Error(`Controller ${controllerId} must be set to observe or shadow`);
+    throw new Error(`Controller ${controllerId} must be set to observe, shadow, or assist`);
   }
 
   return currentMode;
@@ -306,6 +342,8 @@ export async function runControllerLoop({
   const taskResults = [];
   let ingestedObservationCount = 0;
   let proposedActionCount = 0;
+  let executedActionCount = 0;
+  let blockedActionCount = 0;
 
   try {
     for (const task of activeTasks) {
@@ -332,8 +370,10 @@ export async function runControllerLoop({
 
       let lifecycleTopStatus = null;
       let proposedActionIds = [];
+      let executedActionIds = [];
+      let blockedActionIds = [];
 
-      if (resolvedMode === 'shadow') {
+      if (resolvedMode === 'shadow' || resolvedMode === 'assist') {
         const prNumber = resolveLifecyclePrNumber(prBindings, ingestResult.matchedPrs);
         const resolvedLifecycle = services.resolveLifecycleReport
           ? await services.resolveLifecycleReport({
@@ -361,6 +401,7 @@ export async function runControllerLoop({
           repository,
           task,
           controllerId,
+          mode: resolvedMode,
           derivedTrigger,
           lifecycleReport,
           prNumber,
@@ -368,6 +409,20 @@ export async function runControllerLoop({
         });
         proposedActionIds = proposalResult.actionIds;
         proposedActionCount += proposalResult.count;
+
+        if (resolvedMode === 'assist') {
+          const executionResult = await executeAssistActions({
+            repository,
+            controllerId,
+            task,
+            actionIds: proposalResult.actionIds,
+            now: timestamp,
+          });
+          executedActionIds = executionResult.executedActionIds;
+          blockedActionIds = executionResult.blockedActionIds;
+          executedActionCount += executedActionIds.length;
+          blockedActionCount += blockedActionIds.length;
+        }
       }
 
       taskResults.push({
@@ -377,6 +432,10 @@ export async function runControllerLoop({
         new_observation_count: ingestResult.ingested_count,
         proposed_action_count: proposedActionIds.length,
         proposed_action_ids: proposedActionIds,
+        executed_action_count: executedActionIds.length,
+        executed_action_ids: executedActionIds,
+        blocked_action_count: blockedActionIds.length,
+        blocked_action_ids: blockedActionIds,
         lifecycle_top_status: lifecycleTopStatus,
       });
     }
@@ -401,6 +460,8 @@ export async function runControllerLoop({
     processed_task_count: taskResults.length,
     ingested_observation_count: ingestedObservationCount,
     proposed_action_count: proposedActionCount,
+    executed_action_count: executedActionCount,
+    blocked_action_count: blockedActionCount,
     task_results: taskResults,
   };
 }

--- a/scripts/ao/lib/override-runner.js
+++ b/scripts/ao/lib/override-runner.js
@@ -1,0 +1,153 @@
+import { randomUUID } from 'node:crypto';
+
+import { createOverrideRecord } from './state-contracts.js';
+import { createStateRepository } from './state-repository.js';
+
+export const DEFAULT_PROJECT_ID = 'ciecopilot-home';
+
+function resolveNow(now) {
+  if (typeof now === 'function') return resolveNow(now());
+  if (typeof now === 'string' && now.trim() !== '') return now.trim();
+  return new Date().toISOString();
+}
+
+function isExpiredOverride(override, timestamp) {
+  if (override?.status !== 'active' || !override?.expires_at) return false;
+  const expiresAt = new Date(override.expires_at);
+  const now = new Date(timestamp);
+  if (Number.isNaN(expiresAt.getTime()) || Number.isNaN(now.getTime())) return false;
+  return expiresAt.getTime() <= now.getTime();
+}
+
+function matchesOverrideFilters(override, {
+  status = null,
+  scopeKind = null,
+  scopeId = null,
+  overrideKind = null,
+  now,
+} = {}) {
+  if (status === 'active') {
+    if (override.status !== 'active') return false;
+    if (isExpiredOverride(override, now)) return false;
+  } else if (status != null && override.status !== status) {
+    return false;
+  }
+
+  if (scopeKind != null && override.scope_kind !== scopeKind) return false;
+  if (scopeId != null && override.scope_id !== scopeId) return false;
+  if (overrideKind != null && override.override_kind !== overrideKind) return false;
+  return true;
+}
+
+export async function runOverrideCommand({
+  repoRoot,
+  cwd = repoRoot,
+  projectId = DEFAULT_PROJECT_ID,
+  command,
+  overrideId = null,
+  scopeKind = null,
+  scopeId = null,
+  overrideKind = null,
+  value = {},
+  status = null,
+  expiresAt = null,
+  createdBy = 'operator',
+  reason = null,
+  now = new Date().toISOString(),
+  overrideIdGenerator = randomUUID,
+} = {}) {
+  const timestamp = resolveNow(now);
+  const repository = createStateRepository({
+    repoRoot,
+    projectId,
+  });
+
+  switch (command) {
+    case 'create': {
+      const override = createOverrideRecord({
+        override_id: overrideId ?? overrideIdGenerator(),
+        scope_kind: scopeKind,
+        scope_id: scopeId,
+        override_kind: overrideKind,
+        value,
+        status: 'active',
+        created_at: timestamp,
+        expires_at: expiresAt,
+        cleared_at: null,
+        cleared_reason: null,
+        created_by: createdBy,
+      });
+      repository.upsertOverride(override);
+      repository.appendAuditEntry({
+        entityKind: 'override',
+        entityId: override.override_id,
+        operation: 'created',
+        actor: createdBy ?? 'operator',
+        summary: `Created override ${override.override_id}.`,
+        details: override,
+        recordedAt: timestamp,
+      });
+      return {
+        project_id: projectId,
+        cwd,
+        command,
+        override,
+        overrides: [override],
+      };
+    }
+    case 'list': {
+      const overrides = repository.getSnapshot().state.overrides.filter((override) => matchesOverrideFilters(override, {
+        status,
+        scopeKind,
+        scopeId,
+        overrideKind,
+        now: timestamp,
+      }));
+      return {
+        project_id: projectId,
+        cwd,
+        command,
+        override: null,
+        overrides,
+      };
+    }
+    case 'clear': {
+      const existingOverride = repository.getSnapshot().state.overrides.find((override) => override.override_id === overrideId) ?? null;
+      if (!existingOverride) {
+        throw new Error(`Override not found: ${overrideId}`);
+      }
+
+      const override = existingOverride.status === 'active'
+        ? createOverrideRecord({
+            ...existingOverride,
+            status: 'cleared',
+            cleared_at: timestamp,
+            cleared_reason: reason ?? 'operator_cleared',
+          })
+        : existingOverride;
+
+      if (override !== existingOverride) {
+        repository.upsertOverride(override);
+        repository.appendAuditEntry({
+          entityKind: 'override',
+          entityId: override.override_id,
+          operation: 'cleared',
+          actor: createdBy ?? 'operator',
+          summary: `Cleared override ${override.override_id}.`,
+          details: override,
+          recordedAt: timestamp,
+        });
+      }
+
+      return {
+        project_id: projectId,
+        cwd,
+        command,
+        override,
+        overrides: [override],
+      };
+    }
+    default:
+      throw new Error(`Unsupported override command: ${command}`);
+  }
+}

--- a/scripts/ao/lib/state-repository.js
+++ b/scripts/ao/lib/state-repository.js
@@ -174,6 +174,32 @@ export function createStateRepository({
       return readSnapshot();
     },
 
+    appendAuditEntry({
+      entityKind,
+      entityId,
+      operation,
+      actor,
+      summary,
+      details = {},
+      recordedAt = null,
+    } = {}) {
+      ensureBootstrapped();
+      appendControlPlaneAuditEntry({
+        auditPath: paths.auditPath,
+        entry: createControlPlaneAuditEntry({
+          audit_id: auditIdGenerator(),
+          project_id: projectId,
+          recorded_at: resolveNow(recordedAt ?? clock),
+          entity_kind: entityKind,
+          entity_id: entityId,
+          operation,
+          actor,
+          summary,
+          details,
+        }),
+      });
+    },
+
     listAuditEntries({ limit = null } = {}) {
       return readControlPlaneAuditEntries({
         auditPath: paths.auditPath,

--- a/tests/ao/action-executor.test.js
+++ b/tests/ao/action-executor.test.js
@@ -1,0 +1,282 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+import {
+  buildAssistActionModel,
+  executeAssistActions,
+} from '../../scripts/ao/lib/action-executor.js';
+import {
+  createActionRecord,
+  createManagedTask,
+  createOverrideRecord,
+} from '../../scripts/ao/lib/state-contracts.js';
+import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
+
+const PROJECT_ID = 'ciecopilot-home';
+const tempDirs = [];
+
+function createTempRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-action-executor-'));
+  tempDirs.push(repoRoot);
+  return repoRoot;
+}
+
+function createIdGenerator(prefix) {
+  let index = 0;
+  return () => {
+    index += 1;
+    return `${prefix}-${index}`;
+  };
+}
+
+function seedActiveTask(repository) {
+  repository.upsertManagedTask(createManagedTask({
+    task_id: 'issue-90',
+    issue_number: 90,
+    title: 'Assist-mode Class A executor and override controls',
+    branch_name: 'feat/90',
+    worktree_path: '/tmp/cie-90',
+    status: 'active',
+    created_at: '2026-03-29T07:10:00.000Z',
+    updated_at: '2026-03-29T07:10:00.000Z',
+  }));
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('ao action executor', () => {
+  it('builds typed assist action models with risk classes and preconditions', () => {
+    const notifyModel = buildAssistActionModel({
+      controllerId: 'default',
+      task: {
+        task_id: 'issue-90',
+        status: 'active',
+      },
+      prNumber: 101,
+      derivedTrigger: 'approved_and_green',
+      lifecycleTopStatus: 'continue',
+      action: {
+        id: 'notify_human_ready',
+        action_class: 'notify_human',
+        summary: 'Notify the human that the PR appears ready.',
+        commands: ['gh pr view 101 --json mergeable,reviewDecision,isDraft,url'],
+        rationale: 'Human approval remains required even when the PR appears ready.',
+      },
+    });
+
+    expect(notifyModel).toMatchObject({
+      action_kind: 'notify_human_ready',
+      action_class: 'notify_human',
+      risk_class: 'class_a',
+      phase4_assist: {
+        executable: true,
+        reason: 'class_a_allowlist',
+      },
+    });
+    expect(notifyModel.preconditions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'task_active',
+        satisfied: true,
+      }),
+      expect.objectContaining({
+        code: 'pr_scope_required',
+        satisfied: true,
+      }),
+    ]));
+
+    const restoreModel = buildAssistActionModel({
+      controllerId: 'default',
+      task: {
+        task_id: 'issue-90',
+        status: 'active',
+      },
+      prNumber: 101,
+      derivedTrigger: 'agent_exited',
+      lifecycleTopStatus: 'human_gate',
+      action: {
+        id: 'restore_worker',
+        action_class: 'restore_worker',
+        summary: 'Restore the previously identified worker.',
+        commands: ['ao status -p ciecopilot-home --json'],
+        rationale: 'The prior owner is still identifiable, but continuity is stale.',
+      },
+    });
+
+    expect(restoreModel).toMatchObject({
+      action_kind: 'restore_worker',
+      risk_class: 'class_c',
+      phase4_assist: {
+        executable: false,
+        reason: 'runtime_ownership_change_forbidden',
+      },
+    });
+  });
+
+  it('executes only class A actions and writes explicit execution audit entries', async () => {
+    const repository = createStateRepository({
+      repoRoot: createTempRepo(),
+      projectId: PROJECT_ID,
+      auditIdGenerator: createIdGenerator('audit'),
+    });
+    seedActiveTask(repository);
+
+    const actionModel = buildAssistActionModel({
+      controllerId: 'default',
+      task: repository.getSnapshot().state.managed_tasks[0],
+      prNumber: 101,
+      derivedTrigger: 'manual',
+      lifecycleTopStatus: 'continue',
+      action: {
+        id: 'continue_worker',
+        action_class: 'continue_worker',
+        summary: 'Continue the current worker owner.',
+        commands: ['ao status -p ciecopilot-home --json'],
+        rationale: 'Ownership continuity is clear enough to continue the current worker.',
+      },
+    });
+
+    repository.upsertAction(createActionRecord({
+      action_id: 'action-1',
+      task_id: 'issue-90',
+      action_kind: 'continue_worker',
+      status: 'proposed',
+      requested_by: 'shadow_controller',
+      reason: 'Continue the current worker owner.',
+      created_at: '2026-03-29T07:11:00.000Z',
+      updated_at: '2026-03-29T07:11:00.000Z',
+      payload: {
+        action_model: actionModel,
+      },
+    }));
+
+    const result = await executeAssistActions({
+      repository,
+      controllerId: 'default',
+      task: repository.getSnapshot().state.managed_tasks[0],
+      actionIds: ['action-1'],
+      now: '2026-03-29T07:12:00.000Z',
+    });
+
+    expect(result).toEqual({
+      executedActionIds: ['action-1'],
+      blockedActionIds: [],
+    });
+
+    expect(repository.getSnapshot().state.actions).toEqual([
+      expect.objectContaining({
+        action_id: 'action-1',
+        status: 'executed',
+        payload: expect.objectContaining({
+          execution: expect.objectContaining({
+            outcome: 'executed',
+            executed_at: '2026-03-29T07:12:00.000Z',
+            executor: 'assist_controller',
+          }),
+        }),
+      }),
+    ]);
+
+    expect(repository.listAuditEntries().filter((entry) => (
+      entry.entity_kind === 'action' && entry.entity_id === 'action-1'
+    ))).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        operation: 'executed',
+        actor: 'assist_controller',
+      }),
+    ]));
+  });
+
+  it('honors active autonomy-hold overrides without executing class A actions', async () => {
+    const repository = createStateRepository({
+      repoRoot: createTempRepo(),
+      projectId: PROJECT_ID,
+      auditIdGenerator: createIdGenerator('audit'),
+    });
+    seedActiveTask(repository);
+
+    repository.upsertOverride(createOverrideRecord({
+      override_id: 'override-1',
+      scope_kind: 'task',
+      scope_id: 'issue-90',
+      override_kind: 'hold_autonomy',
+      value: { enabled: true },
+      status: 'active',
+      created_at: '2026-03-29T07:11:00.000Z',
+      expires_at: null,
+      cleared_at: null,
+      cleared_reason: null,
+      created_by: 'operator',
+    }));
+
+    const actionModel = buildAssistActionModel({
+      controllerId: 'default',
+      task: repository.getSnapshot().state.managed_tasks[0],
+      prNumber: 101,
+      derivedTrigger: 'approved_and_green',
+      lifecycleTopStatus: 'continue',
+      action: {
+        id: 'notify_human_ready',
+        action_class: 'notify_human',
+        summary: 'Notify the human that the PR appears ready.',
+        commands: ['gh pr view 101 --json mergeable,reviewDecision,isDraft,url'],
+        rationale: 'Human approval remains required even when the PR appears ready.',
+      },
+    });
+
+    repository.upsertAction(createActionRecord({
+      action_id: 'action-1',
+      task_id: 'issue-90',
+      action_kind: 'notify_human_ready',
+      status: 'proposed',
+      requested_by: 'shadow_controller',
+      reason: 'Notify the human that the PR appears ready.',
+      created_at: '2026-03-29T07:11:00.000Z',
+      updated_at: '2026-03-29T07:11:00.000Z',
+      payload: {
+        action_model: actionModel,
+      },
+    }));
+
+    const result = await executeAssistActions({
+      repository,
+      controllerId: 'default',
+      task: repository.getSnapshot().state.managed_tasks[0],
+      actionIds: ['action-1'],
+      now: '2026-03-29T07:12:00.000Z',
+    });
+
+    expect(result).toEqual({
+      executedActionIds: [],
+      blockedActionIds: ['action-1'],
+    });
+
+    expect(repository.getSnapshot().state.actions).toEqual([
+      expect.objectContaining({
+        action_id: 'action-1',
+        status: 'proposed',
+        payload: expect.objectContaining({
+          execution: expect.objectContaining({
+            outcome: 'blocked',
+            reason: 'override_hold_autonomy',
+          }),
+        }),
+      }),
+    ]);
+
+    expect(repository.listAuditEntries().filter((entry) => (
+      entry.entity_kind === 'action' && entry.entity_id === 'action-1'
+    ))).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        operation: 'execution_blocked',
+        actor: 'assist_controller',
+      }),
+    ]));
+  });
+});

--- a/tests/ao/ao-controller-cli.test.js
+++ b/tests/ao/ao-controller-cli.test.js
@@ -13,10 +13,11 @@ describe('ao controller cli', () => {
     mockRunControllerLoop.mockReset();
     mockRunControllerLoop.mockResolvedValue({
       controller_id: 'default',
-      mode: 'shadow',
+      mode: 'assist',
       processed_task_count: 1,
       ingested_observation_count: 2,
       proposed_action_count: 2,
+      executed_action_count: 1,
       task_results: [],
     });
   });
@@ -24,7 +25,7 @@ describe('ao controller cli', () => {
   it('parses controller mode and scope arguments', async () => {
     const stdout = [];
 
-    const result = await runCli(['--mode', 'shadow', '--issue', '89', '--json'], {
+    const result = await runCli(['--mode', 'assist', '--issue', '89', '--json'], {
       writeStdout: (text) => stdout.push(text),
       writeStderr: () => {},
     });
@@ -32,20 +33,21 @@ describe('ao controller cli', () => {
     expect(result.exitCode).toBe(0);
     expect(mockRunControllerLoop).toHaveBeenCalledWith(expect.objectContaining({
       projectId: 'ciecopilot-home',
-      mode: 'shadow',
+      mode: 'assist',
       issueNumber: 89,
       cwd: process.cwd(),
     }));
     expect(JSON.parse(stdout.join(''))).toMatchObject({
-      mode: 'shadow',
+      mode: 'assist',
       proposed_action_count: 2,
+      executed_action_count: 1,
     });
   });
 
   it('rejects invalid controller modes and invalid issue filters', async () => {
     const stderr = [];
 
-    const invalidMode = await runCli(['--mode', 'assist'], {
+    const invalidMode = await runCli(['--mode', 'launch'], {
       writeStdout: () => {},
       writeStderr: (text) => stderr.push(text),
     });

--- a/tests/ao/ao-override-cli.test.js
+++ b/tests/ao/ao-override-cli.test.js
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockRunOverrideCommand = jest.fn();
+
+jest.unstable_mockModule('../../scripts/ao/lib/override-runner.js', () => ({
+  DEFAULT_PROJECT_ID: 'ciecopilot-home',
+  runOverrideCommand: mockRunOverrideCommand,
+}));
+
+const { runCli } = await import('../../scripts/ao-override.js');
+
+describe('ao override cli', () => {
+  beforeEach(() => {
+    mockRunOverrideCommand.mockReset();
+    mockRunOverrideCommand.mockResolvedValue({
+      command: 'create',
+      override: {
+        override_id: 'override-1',
+        status: 'active',
+      },
+      overrides: [],
+    });
+  });
+
+  it('parses create arguments and forwards JSON values to the override runner', async () => {
+    const stdout = [];
+
+    const result = await runCli([
+      'create',
+      '--scope-kind',
+      'task',
+      '--scope-id',
+      'issue-90',
+      '--kind',
+      'hold_autonomy',
+      '--value',
+      '{"enabled":true}',
+      '--json',
+    ], {
+      writeStdout: (text) => stdout.push(text),
+      writeStderr: () => {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockRunOverrideCommand).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: process.cwd(),
+      projectId: 'ciecopilot-home',
+      command: 'create',
+      scopeKind: 'task',
+      scopeId: 'issue-90',
+      overrideKind: 'hold_autonomy',
+      value: { enabled: true },
+    }));
+    expect(JSON.parse(stdout.join(''))).toMatchObject({
+      override: {
+        override_id: 'override-1',
+      },
+    });
+  });
+
+  it('parses clear requests and rejects invalid commands or malformed JSON', async () => {
+    const stderr = [];
+
+    const cleared = await runCli([
+      'clear',
+      '--override',
+      'override-1',
+      '--reason',
+      'resume_assist_mode',
+    ], {
+      writeStdout: () => {},
+      writeStderr: (text) => stderr.push(text),
+    });
+    const invalidCommand = await runCli(['pause'], {
+      writeStdout: () => {},
+      writeStderr: (text) => stderr.push(text),
+    });
+    const invalidJson = await runCli([
+      'create',
+      '--scope-kind',
+      'task',
+      '--scope-id',
+      'issue-90',
+      '--kind',
+      'hold_autonomy',
+      '--value',
+      '{oops',
+    ], {
+      writeStdout: () => {},
+      writeStderr: (text) => stderr.push(text),
+    });
+
+    expect(cleared.exitCode).toBe(0);
+    expect(invalidCommand.exitCode).toBe(4);
+    expect(invalidJson.exitCode).toBe(4);
+    expect(stderr.join('')).toContain('Unsupported command');
+    expect(stderr.join('')).toContain('Invalid JSON for --value');
+  });
+});

--- a/tests/ao/controller-loop.test.js
+++ b/tests/ao/controller-loop.test.js
@@ -252,6 +252,147 @@ describe('ao controller loop', () => {
         }),
       }),
     ]));
+    expect(repository.listAuditEntries().filter((entry) => entry.entity_kind === 'action')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: 'proposed',
+          actor: 'shadow_controller',
+        }),
+      ]),
+    );
+  });
+
+  it('assist mode executes only explicit class A actions and keeps higher-risk actions gated', async () => {
+    const repository = createStateRepository({
+      repoRoot: createTempRepo(),
+      projectId: PROJECT_ID,
+    });
+    seedActiveTask(repository, 'assist');
+
+    const lifecycleReport = {
+      top_status: 'continue',
+      routing_decision: {
+        action: 'continue_current_worker',
+      },
+      release_decision: {
+        disposition: 'notify_human_ready',
+      },
+      actions: [
+        {
+          id: 'continue_worker',
+          action_class: 'continue_worker',
+          summary: 'Continue the current worker owner.',
+          commands: ['ao status -p ciecopilot-home --json'],
+          rationale: 'Ownership continuity is clear enough to continue the current worker.',
+        },
+        {
+          id: 'restore_worker',
+          action_class: 'restore_worker',
+          summary: 'Restore the previously identified worker.',
+          commands: ['ao status -p ciecopilot-home --json', 'node scripts/ao-reconcile.js --pr 92 --json --strict'],
+          rationale: 'The prior owner is still identifiable, but continuity is stale.',
+        },
+        {
+          id: 'hold_ci',
+          action_class: 'hold',
+          summary: 'Hold until CI is green.',
+          commands: ['gh pr checks 92'],
+          rationale: 'Required CI state is not yet ready.',
+        },
+      ],
+    };
+
+    const result = await runControllerLoop({
+      repoRoot: repository.getSnapshot().paths.repoRoot,
+      cwd: repository.getSnapshot().paths.repoRoot,
+      projectId: PROJECT_ID,
+      controllerId: 'default',
+      now: '2026-03-29T06:41:00.000Z',
+      deps: {
+        loadAoProjectObservation: async () => ({
+          observed_at: '2026-03-29T06:41:00.000Z',
+          workers: [
+            {
+              session_name: 'cie-92',
+              session_runtime_id: 'cie-92',
+              issue_number: 92,
+              branch_name: 'feat/issue-92',
+              pr_number: 92,
+              lifecycle_state: 'idle',
+              last_seen_at: '2026-03-29T06:40:45.000Z',
+              freshness: { status: 'fresh' },
+            },
+          ],
+        }),
+        loadGitHubObservationSet: async () => ({
+          observed_at: '2026-03-29T06:41:00.000Z',
+          prs: [
+            {
+              pr_number: 92,
+              state: 'OPEN',
+              head_branch: 'feat/issue-92',
+              head_sha: 'abc123',
+              review_status: 'approved',
+              ci_status: 'passing',
+              mergeability: 'mergeable',
+              is_draft: false,
+              url: 'https://example.test/pr/92',
+            },
+          ],
+        }),
+        resolveLifecycleReport: async () => lifecycleReport,
+      },
+    });
+
+    expect(result).toMatchObject({
+      mode: 'assist',
+      proposed_action_count: 3,
+      executed_action_count: 1,
+      blocked_action_count: 2,
+      task_results: [
+        expect.objectContaining({
+          proposed_action_count: 3,
+          executed_action_count: 1,
+          blocked_action_count: 2,
+        }),
+      ],
+    });
+
+    expect(repository.getSnapshot().state.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        action_kind: 'continue_worker',
+        status: 'executed',
+        payload: expect.objectContaining({
+          action_model: expect.objectContaining({
+            risk_class: 'class_a',
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        action_kind: 'restore_worker',
+        status: 'blocked',
+        payload: expect.objectContaining({
+          action_model: expect.objectContaining({
+            risk_class: 'class_c',
+          }),
+          execution: expect.objectContaining({
+            outcome: 'blocked',
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        action_kind: 'hold_ci',
+        status: 'blocked',
+        payload: expect.objectContaining({
+          action_model: expect.objectContaining({
+            risk_class: 'class_b',
+          }),
+          execution: expect.objectContaining({
+            outcome: 'blocked',
+          }),
+        }),
+      }),
+    ]));
   });
 
   it('blocks when another active lease already exists for the same controller', async () => {

--- a/tests/ao/override-runner.test.js
+++ b/tests/ao/override-runner.test.js
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+import { runOverrideCommand } from '../../scripts/ao/lib/override-runner.js';
+
+const PROJECT_ID = 'ciecopilot-home';
+const tempDirs = [];
+
+function createTempRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-override-runner-'));
+  tempDirs.push(repoRoot);
+  return repoRoot;
+}
+
+function createIdGenerator(prefix) {
+  let index = 0;
+  return () => {
+    index += 1;
+    return `${prefix}-${index}`;
+  };
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('ao override runner', () => {
+  it('creates, lists, and clears durable overrides', async () => {
+    const repoRoot = createTempRepo();
+
+    const created = await runOverrideCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'create',
+      scopeKind: 'task',
+      scopeId: 'issue-90',
+      overrideKind: 'hold_autonomy',
+      value: { enabled: true },
+      createdBy: 'operator',
+      now: '2026-03-29T07:20:00.000Z',
+      overrideIdGenerator: createIdGenerator('override'),
+    });
+
+    expect(created.override).toMatchObject({
+      override_id: 'override-1',
+      scope_kind: 'task',
+      scope_id: 'issue-90',
+      override_kind: 'hold_autonomy',
+      status: 'active',
+      created_by: 'operator',
+    });
+
+    const listed = await runOverrideCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'list',
+      status: 'active',
+      scopeKind: 'task',
+      scopeId: 'issue-90',
+    });
+
+    expect(listed.overrides).toEqual([
+      expect.objectContaining({
+        override_id: 'override-1',
+        status: 'active',
+      }),
+    ]);
+
+    const cleared = await runOverrideCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'clear',
+      overrideId: 'override-1',
+      reason: 'resume_assist_mode',
+      now: '2026-03-29T07:21:00.000Z',
+    });
+
+    expect(cleared.override).toMatchObject({
+      override_id: 'override-1',
+      status: 'cleared',
+      cleared_at: '2026-03-29T07:21:00.000Z',
+      cleared_reason: 'resume_assist_mode',
+    });
+  });
+
+  it('rejects clearing unknown overrides', async () => {
+    await expect(runOverrideCommand({
+      repoRoot: createTempRepo(),
+      projectId: PROJECT_ID,
+      command: 'clear',
+      overrideId: 'missing-override',
+      reason: 'resume_assist_mode',
+      now: '2026-03-29T07:21:00.000Z',
+    })).rejects.toThrow(/override not found/i);
+  });
+});


### PR DESCRIPTION
Closes #90

## Summary
- add typed assist action models with risk classes and preconditions, and execute only the explicit Phase 4 Class A allowlist
- add `ao-override` create/list/clear workflows plus durable override handling that can pause assist execution with `hold_autonomy`
- wire assist mode through the controller loop and audit proposed, executed, and blocked action outcomes

## Test Plan
- `npm test -- --runInBand tests/ao/action-executor.test.js tests/ao/override-runner.test.js tests/ao/ao-override-cli.test.js tests/ao/ao-controller-cli.test.js tests/ao/controller-loop.test.js`
- `npm test -- --runInBand tests/ao`
- `node scripts/ao-override.js --help`
- `node scripts/ao-controller.js --help`
