### PR TITLE
feat(ao): add policy engine v1 plus tool and credential allowlist

### DIFF
--- a/scripts/ao/lib/controller-loop.js
+++ b/scripts/ao/lib/controller-loop.js
@@ -4,6 +4,7 @@ import {
   CONTROL_PLANE_DEFAULT_CONTROLLER_ID,
   createActionRecord,
   createControllerModeRecord,
+  createPolicyDecisionRecord,
 } from './state-contracts.js';
 import { createStateRepository } from './state-repository.js';
 import {
@@ -28,6 +29,10 @@ import {
   buildAssistActionModel,
   executeAssistActions,
 } from './action-executor.js';
+import {
+  buildPolicyInputForAction,
+  evaluatePolicyDecision,
+} from './policy-engine.js';
 import {
   createPrScope,
   createProjectScope,
@@ -181,34 +186,18 @@ async function persistShadowActions({
   prNumber,
   now,
 } = {}) {
-  const signature = JSON.stringify({
-    controllerId,
-    derivedTrigger,
-    prNumber,
-    top_status: lifecycleReport.top_status,
-    routing_decision: lifecycleReport.routing_decision,
-    release_decision: lifecycleReport.release_decision,
-    actions: lifecycleReport.actions.map((action) => ({
-      id: action.id,
-      action_class: action.action_class,
-      commands: action.commands,
-      rationale: action.rationale,
-    })),
-  });
-  const fingerprint = await hashText(signature);
-  const knownActionIds = new Set(repository.getSnapshot().state.actions.map((record) => record.action_id));
-  const createdActionIds = [];
+  const snapshot = repository.getSnapshot().state;
+  const knownActionIds = new Set(snapshot.actions.map((record) => record.action_id));
+  const knownPolicyDecisionIds = new Set(snapshot.policy_decisions.map((record) => record.decision_id));
   const actionIds = [];
+  const policyDecisionIds = [];
+  const blockedActionIds = [];
+  const deniedActionIds = [];
+  const downgradedActionIds = [];
   const requestedBy = mode === 'assist' ? 'assist_controller' : 'shadow_controller';
+  const credentialProvenances = snapshot.credential_provenances ?? [];
 
   for (const action of lifecycleReport.actions) {
-    const actionId = `proposal-${task.task_id}-${action.id}-${fingerprint.slice(0, 12)}`;
-    actionIds.push(actionId);
-    if (knownActionIds.has(actionId)) {
-      continue;
-    }
-    knownActionIds.add(actionId);
-
     const actionModel = buildAssistActionModel({
       controllerId,
       task,
@@ -217,12 +206,82 @@ async function persistShadowActions({
       lifecycleTopStatus: lifecycleReport.top_status ?? null,
       action,
     });
+    const policyInput = buildPolicyInputForAction({
+      task,
+      prNumber,
+      action,
+    });
+    const policyResult = evaluatePolicyDecision({
+      input: policyInput,
+      credentialProvenances,
+    });
+    const policyFingerprint = hashText(JSON.stringify({
+      policy_version: policyResult.policy_version,
+      input: policyResult.input,
+      decision: policyResult.decision,
+      findings: policyResult.findings,
+    }));
+    const policyDecisionId = `policy-${task.task_id}-${action.id}-${policyFingerprint.slice(0, 12)}`;
+    const actionFingerprint = hashText(JSON.stringify({
+      controllerId,
+      derivedTrigger,
+      prNumber,
+      top_status: lifecycleReport.top_status,
+      routing_decision: lifecycleReport.routing_decision,
+      release_decision: lifecycleReport.release_decision,
+      action: {
+        id: action.id,
+        action_class: action.action_class,
+        commands: action.commands,
+        rationale: action.rationale,
+        policy_inputs: policyResult.input,
+      },
+      policy_decision: policyResult.decision,
+      policy_fingerprint: policyFingerprint,
+    }));
+    const actionId = `proposal-${task.task_id}-${action.id}-${actionFingerprint.slice(0, 12)}`;
+    const actionStatus = policyResult.decision === 'allow' ? 'proposed' : 'blocked';
+
+    actionIds.push(actionId);
+    policyDecisionIds.push(policyDecisionId);
+    if (policyResult.decision !== 'allow') {
+      blockedActionIds.push(actionId);
+      if (policyResult.decision === 'deny') {
+        deniedActionIds.push(actionId);
+      } else if (policyResult.decision === 'downgrade') {
+        downgradedActionIds.push(actionId);
+      }
+    }
+
+    if (!knownPolicyDecisionIds.has(policyDecisionId)) {
+      repository.upsertPolicyDecision(createPolicyDecisionRecord({
+        decision_id: policyDecisionId,
+        task_id: task.task_id,
+        action_id: actionId,
+        action_kind: action.id,
+        subject_kind: 'action',
+        decision: policyResult.decision,
+        policy_version: policyResult.policy_version,
+        input_fingerprint: policyFingerprint,
+        recorded_at: now,
+        summary: policyResult.summary,
+        findings: policyResult.findings,
+        input: policyResult.input,
+        result: policyResult,
+      }));
+      knownPolicyDecisionIds.add(policyDecisionId);
+    }
+
+    if (knownActionIds.has(actionId)) {
+      continue;
+    }
+    knownActionIds.add(actionId);
 
     repository.upsertAction(createActionRecord({
       action_id: actionId,
       task_id: task.task_id,
       action_kind: action.id,
-      status: 'proposed',
+      status: actionStatus,
       requested_by: requestedBy,
       reason: action.summary,
       created_at: now,
@@ -230,7 +289,7 @@ async function persistShadowActions({
       payload: {
         controller_id: controllerId,
         derived_trigger: derivedTrigger,
-        fingerprint,
+        fingerprint: actionFingerprint,
         pr_number: prNumber,
         top_status: lifecycleReport.top_status,
         routing_decision: lifecycleReport.routing_decision,
@@ -239,14 +298,24 @@ async function persistShadowActions({
         commands: action.commands,
         rationale: action.rationale,
         action_model: actionModel,
+        policy_decision_id: policyDecisionId,
+        policy: {
+          decision: policyResult.decision,
+          policy_version: policyResult.policy_version,
+          summary: policyResult.summary,
+          findings: policyResult.findings,
+          input: policyResult.input,
+        },
       },
     }));
     repository.appendAuditEntry({
       entityKind: 'action',
       entityId: actionId,
-      operation: 'proposed',
+      operation: policyResult.decision === 'allow' ? 'proposed' : 'policy_blocked',
       actor: requestedBy,
-      summary: `Recorded proposed action ${actionId}.`,
+      summary: policyResult.decision === 'allow'
+        ? `Recorded proposed action ${actionId}.`
+        : `Policy blocked action ${actionId}.`,
       details: {
         action_id: actionId,
         action_kind: action.id,
@@ -254,16 +323,24 @@ async function persistShadowActions({
         controller_id: controllerId,
         pr_number: prNumber,
         risk_class: actionModel.risk_class,
+        policy_decision: policyResult.decision,
+        policy_decision_id: policyDecisionId,
       },
       recordedAt: now,
     });
-    createdActionIds.push(actionId);
   }
 
   return {
-    count: createdActionIds.length,
+    count: actionIds.length,
     actionIds,
-    createdActionIds,
+    policyDecisionIds,
+    policyDecisionCount: policyDecisionIds.length,
+    policyBlockedActionIds: blockedActionIds,
+    policyBlockedActionCount: blockedActionIds.length,
+    deniedActionIds,
+    deniedActionCount: deniedActionIds.length,
+    downgradedActionIds,
+    downgradedActionCount: downgradedActionIds.length,
   };
 }
 
@@ -410,6 +487,10 @@ export async function runControllerLoop({
   let proposedActionCount = 0;
   let executedActionCount = 0;
   let blockedActionCount = 0;
+  let policyDecisionCount = 0;
+  let policyBlockedActionCount = 0;
+  let deniedActionCount = 0;
+  let downgradedActionCount = 0;
 
   try {
     for (const task of activeTasks) {
@@ -440,6 +521,10 @@ export async function runControllerLoop({
       let proposedActionIds = [];
       let executedActionIds = [];
       let blockedActionIds = [];
+      let policyDecisionIds = [];
+      let policyBlockedActionIds = [];
+      let deniedActionIds = [];
+      let downgradedActionIds = [];
 
       if (resolvedMode === 'shadow' || resolvedMode === 'assist') {
         const prNumber = resolveLifecyclePrNumber(prBindings, ingestResult.matchedPrs);
@@ -477,6 +562,14 @@ export async function runControllerLoop({
         });
         proposedActionIds = proposalResult.actionIds;
         proposedActionCount += proposalResult.count;
+        policyDecisionIds = proposalResult.policyDecisionIds;
+        policyDecisionCount += proposalResult.policyDecisionCount;
+        policyBlockedActionIds = proposalResult.policyBlockedActionIds;
+        policyBlockedActionCount += proposalResult.policyBlockedActionCount;
+        deniedActionIds = proposalResult.deniedActionIds;
+        deniedActionCount += proposalResult.deniedActionCount;
+        downgradedActionIds = proposalResult.downgradedActionIds;
+        downgradedActionCount += proposalResult.downgradedActionCount;
 
         if (resolvedMode === 'assist') {
           const executionResult = await executeAssistActions({
@@ -505,6 +598,14 @@ export async function runControllerLoop({
         executed_action_ids: executedActionIds,
         blocked_action_count: blockedActionIds.length,
         blocked_action_ids: blockedActionIds,
+        policy_decision_count: policyDecisionIds.length,
+        policy_decision_ids: policyDecisionIds,
+        policy_blocked_action_count: policyBlockedActionIds.length,
+        policy_blocked_action_ids: policyBlockedActionIds,
+        denied_action_count: deniedActionIds.length,
+        denied_action_ids: deniedActionIds,
+        downgraded_action_count: downgradedActionIds.length,
+        downgraded_action_ids: downgradedActionIds,
         lifecycle_top_status: lifecycleTopStatus,
       });
     }
@@ -532,6 +633,10 @@ export async function runControllerLoop({
     proposed_action_count: proposedActionCount,
     executed_action_count: executedActionCount,
     blocked_action_count: blockedActionCount,
+    policy_decision_count: policyDecisionCount,
+    policy_blocked_action_count: policyBlockedActionCount,
+    denied_action_count: deniedActionCount,
+    downgraded_action_count: downgradedActionCount,
     task_results: taskResults,
   };
 }

--- a/scripts/ao/lib/policy-engine.js
+++ b/scripts/ao/lib/policy-engine.js
@@ -1,0 +1,383 @@
+import { createDefaultPolicyRules } from './policy-rules.js';
+
+export const POLICY_DECISION_SCHEMA_VERSION = 'ao.policy-decision.v1alpha1';
+export const POLICY_DECISION_FORMAT = 'ao_control_plane_policy_decision_result';
+
+function isPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneJsonValue(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function normalizeOptionalString(value) {
+  if (value == null) return null;
+  const normalized = String(value).trim();
+  return normalized === '' ? null : normalized;
+}
+
+function normalizeFilePath(value) {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) return null;
+  return normalized.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function normalizeToolName(value) {
+  const normalized = normalizeOptionalString(value);
+  return normalized == null ? null : normalized.toLowerCase();
+}
+
+function normalizeMcpServerName(value) {
+  const normalized = normalizeOptionalString(value);
+  return normalized == null ? null : normalized.toLowerCase();
+}
+
+function normalizeNetworkTarget(value) {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) return null;
+
+  try {
+    if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(normalized)) {
+      return new URL(normalized).hostname.toLowerCase();
+    }
+  } catch {
+    return normalized.toLowerCase();
+  }
+
+  return normalized
+    .replace(/^[^@]+@/, '')
+    .split(/[/?#:]/)[0]
+    .toLowerCase();
+}
+
+function normalizeSecretNeed(need) {
+  if (!isPlainObject(need)) return null;
+
+  const credentialKind = normalizeOptionalString(need.credential_kind);
+  const provenanceId = normalizeOptionalString(need.provenance_id);
+  if (!credentialKind || !provenanceId) return null;
+
+  return {
+    credential_kind: credentialKind,
+    provenance_id: provenanceId,
+  };
+}
+
+function uniqueSortedStrings(values, normalizer) {
+  return [...new Set((values ?? [])
+    .map((value) => normalizer(value))
+    .filter((value) => value != null))]
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function uniqueSortedSecretNeeds(values) {
+  const items = (values ?? [])
+    .map((value) => normalizeSecretNeed(value))
+    .filter((value) => value != null);
+  const deduped = new Map();
+  for (const item of items) {
+    deduped.set(`${item.credential_kind}:${item.provenance_id}`, item);
+  }
+  return [...deduped.values()].sort((left, right) => {
+    const leftKey = `${left.credential_kind}:${left.provenance_id}`;
+    const rightKey = `${right.credential_kind}:${right.provenance_id}`;
+    return leftKey.localeCompare(rightKey);
+  });
+}
+
+function normalizePositiveInteger(value) {
+  if (value == null) return null;
+  const normalized = Number(value);
+  return Number.isInteger(normalized) && normalized > 0 ? normalized : null;
+}
+
+function tokenizeCommand(command) {
+  return String(command ?? '')
+    .match(/"[^"]*"|'[^']*'|[^\s]+/g) ?? [];
+}
+
+function stripQuotes(token) {
+  return String(token).replace(/^['"]|['"]$/g, '');
+}
+
+function extractPrimaryTool(command) {
+  const tokens = tokenizeCommand(command).map((token) => stripQuotes(token));
+  while (tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(tokens[0])) {
+    tokens.shift();
+  }
+
+  if (tokens[0] === 'env') {
+    tokens.shift();
+    while (tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(tokens[0])) {
+      tokens.shift();
+    }
+  }
+
+  return normalizeToolName(tokens[0]);
+}
+
+function extractNodeScriptPath(command) {
+  const tokens = tokenizeCommand(command).map((token) => stripQuotes(token));
+  if (normalizeToolName(tokens[0]) !== 'node') return null;
+  if (tokens[1] == null || tokens[1].startsWith('-')) return null;
+  return normalizeFilePath(tokens[1]);
+}
+
+function extractUrlHosts(command) {
+  return uniqueSortedStrings(
+    [...String(command ?? '').matchAll(/https?:\/\/[^\s'"]+/g)].map((match) => match[0]),
+    normalizeNetworkTarget,
+  );
+}
+
+function buildFinding(code, severity, surface, value, detail = null) {
+  return {
+    code,
+    severity,
+    surface,
+    value,
+    detail: normalizeOptionalString(detail),
+  };
+}
+
+function classifyFilePath(filePath, rules) {
+  const normalized = normalizeFilePath(filePath);
+  if (!normalized) return 'ordinary';
+
+  if ((rules.workflow_prefixes ?? []).some((prefix) => normalized.startsWith(prefix))) {
+    return 'workflow';
+  }
+
+  if (
+    (rules.infra_prefixes ?? []).some((prefix) => normalized.startsWith(prefix))
+    || (rules.infra_suffixes ?? []).some((suffix) => normalized.endsWith(suffix))
+  ) {
+    return 'infra';
+  }
+
+  if (
+    (rules.secret_prefixes ?? []).some((prefix) => normalized.startsWith(prefix))
+    || (rules.secret_suffixes ?? []).some((suffix) => normalized.endsWith(suffix))
+  ) {
+    return 'secret';
+  }
+
+  return 'ordinary';
+}
+
+function buildDecisionSummary(decision, findings) {
+  if (decision === 'allow') {
+    return 'Allow seeded policy action.';
+  }
+
+  if (findings.length === 1) {
+    return `${decision[0].toUpperCase()}${decision.slice(1)} action due to ${findings[0].code}.`;
+  }
+
+  return `${decision[0].toUpperCase()}${decision.slice(1)} action due to ${findings.length} policy findings.`;
+}
+
+export function normalizePolicyInput(input = {}) {
+  const workflowPaths = uniqueSortedStrings(input.workflow_paths, normalizeFilePath);
+  const filePaths = uniqueSortedStrings(
+    [...(input.file_paths ?? []), ...workflowPaths],
+    normalizeFilePath,
+  );
+
+  return {
+    task_id: normalizeOptionalString(input.task_id),
+    pr_number: normalizePositiveInteger(input.pr_number),
+    action_kind: normalizeOptionalString(input.action_kind) ?? 'unknown_action',
+    action_class: normalizeOptionalString(input.action_class) ?? 'unknown',
+    task_risk: normalizeOptionalString(input.task_risk) ?? 'medium',
+    tools: uniqueSortedStrings(input.tools, normalizeToolName),
+    mcp_servers: uniqueSortedStrings(input.mcp_servers, normalizeMcpServerName),
+    file_paths: filePaths,
+    workflow_paths: workflowPaths,
+    network_targets: uniqueSortedStrings(input.network_targets, normalizeNetworkTarget),
+    secret_needs: uniqueSortedSecretNeeds(input.secret_needs),
+  };
+}
+
+export function buildPolicyInputForAction({
+  task,
+  prNumber = null,
+  action,
+} = {}) {
+  const explicitInputs = isPlainObject(action?.policy_inputs) ? action.policy_inputs : {};
+  const toolSet = new Set(uniqueSortedStrings(explicitInputs.tools, normalizeToolName));
+  const mcpServerSet = new Set(uniqueSortedStrings(explicitInputs.mcp_servers, normalizeMcpServerName));
+  const filePathSet = new Set(uniqueSortedStrings(explicitInputs.file_paths, normalizeFilePath));
+  const workflowPathSet = new Set(uniqueSortedStrings(explicitInputs.workflow_paths, normalizeFilePath));
+  const networkTargetSet = new Set(uniqueSortedStrings(explicitInputs.network_targets, normalizeNetworkTarget));
+
+  for (const command of action?.commands ?? []) {
+    const tool = extractPrimaryTool(command);
+    if (tool) {
+      toolSet.add(tool);
+      if (tool === 'gh') {
+        networkTargetSet.add('api.github.com');
+        networkTargetSet.add('github.com');
+      }
+    }
+
+    const nodeScriptPath = extractNodeScriptPath(command);
+    if (nodeScriptPath) {
+      filePathSet.add(nodeScriptPath);
+    }
+
+    for (const host of extractUrlHosts(command)) {
+      networkTargetSet.add(host);
+    }
+  }
+
+  return normalizePolicyInput({
+    ...explicitInputs,
+    task_id: task?.task_id ?? explicitInputs.task_id ?? null,
+    pr_number: prNumber ?? explicitInputs.pr_number ?? null,
+    action_kind: action?.id ?? explicitInputs.action_kind ?? null,
+    action_class: action?.action_class ?? explicitInputs.action_class ?? null,
+    task_risk: task?.metadata?.task_risk ?? explicitInputs.task_risk ?? 'medium',
+    tools: [...toolSet],
+    mcp_servers: [...mcpServerSet],
+    file_paths: [...filePathSet],
+    workflow_paths: [...workflowPathSet],
+    network_targets: [...networkTargetSet],
+    secret_needs: explicitInputs.secret_needs ?? [],
+  });
+}
+
+export function evaluatePolicyDecision({
+  input,
+  credentialProvenances = [],
+  rules = createDefaultPolicyRules(),
+} = {}) {
+  const normalizedInput = normalizePolicyInput(input);
+  const activeRules = createDefaultPolicyRules();
+  const providedRules = isPlainObject(rules) ? rules : {};
+  Object.assign(activeRules, cloneJsonValue(providedRules));
+
+  const allowedTools = new Set((activeRules.allowed_tools ?? []).map((value) => String(value).toLowerCase()));
+  const allowedMcpServers = new Set((activeRules.allowed_mcp_servers ?? []).map((value) => String(value).toLowerCase()));
+  const allowedNetworkTargets = new Set((activeRules.allowed_network_targets ?? []).map((value) => String(value).toLowerCase()));
+  const credentialProvenanceMap = new Map((credentialProvenances ?? [])
+    .filter((record) => record?.provenance_id != null)
+    .map((record) => [String(record.provenance_id), record]));
+  const findings = [];
+
+  for (const tool of normalizedInput.tools) {
+    if (!allowedTools.has(tool)) {
+      findings.push(buildFinding('unknown_tool', 'deny', 'tool', tool));
+    }
+  }
+
+  for (const server of normalizedInput.mcp_servers) {
+    if (!allowedMcpServers.has(server)) {
+      findings.push(buildFinding('unknown_mcp_server', 'deny', 'mcp_server', server));
+    }
+  }
+
+  for (const secretNeed of normalizedInput.secret_needs) {
+    const provenance = credentialProvenanceMap.get(secretNeed.provenance_id) ?? null;
+    if (!provenance) {
+      findings.push(buildFinding(
+        'unknown_credential_provenance',
+        'deny',
+        'secret',
+        `${secretNeed.credential_kind}:${secretNeed.provenance_id}`,
+      ));
+      continue;
+    }
+
+    if (provenance.trust_decision !== 'trusted') {
+      findings.push(buildFinding(
+        'untrusted_credential_provenance',
+        'deny',
+        'secret',
+        `${secretNeed.credential_kind}:${secretNeed.provenance_id}`,
+      ));
+      continue;
+    }
+
+    if (provenance.credential_kind !== secretNeed.credential_kind) {
+      findings.push(buildFinding(
+        'credential_kind_mismatch',
+        'deny',
+        'secret',
+        `${secretNeed.credential_kind}:${secretNeed.provenance_id}`,
+      ));
+      continue;
+    }
+
+    const allowedSources = activeRules.credential_source_allowlist?.[secretNeed.credential_kind] ?? [];
+    if (!allowedSources.includes(provenance.source_kind)) {
+      findings.push(buildFinding(
+        'credential_provenance_not_allowlisted',
+        'deny',
+        'secret',
+        `${secretNeed.credential_kind}:${secretNeed.provenance_id}`,
+      ));
+    }
+  }
+
+  for (const target of normalizedInput.network_targets) {
+    if (!allowedNetworkTargets.has(target)) {
+      findings.push(buildFinding(
+        'network_target_requires_review',
+        'downgrade',
+        'network',
+        target,
+      ));
+    }
+  }
+
+  for (const filePath of normalizedInput.file_paths) {
+    const classification = classifyFilePath(filePath, activeRules);
+    if (classification === 'workflow') {
+      findings.push(buildFinding(
+        'workflow_mutation_requires_review',
+        'downgrade',
+        'file',
+        filePath,
+      ));
+      continue;
+    }
+
+    if (classification === 'infra') {
+      findings.push(buildFinding(
+        'infra_mutation_requires_review',
+        'downgrade',
+        'file',
+        filePath,
+      ));
+      continue;
+    }
+
+    if (classification === 'secret') {
+      findings.push(buildFinding(
+        'secret_file_requires_review',
+        'downgrade',
+        'file',
+        filePath,
+      ));
+    }
+  }
+
+  const decision = findings.some((finding) => finding.severity === 'deny')
+    ? 'deny'
+    : findings.some((finding) => finding.severity === 'downgrade')
+      ? 'downgrade'
+      : 'allow';
+
+  return {
+    schema_version: POLICY_DECISION_SCHEMA_VERSION,
+    format: POLICY_DECISION_FORMAT,
+    policy_version: activeRules.policy_version,
+    decision,
+    summary: buildDecisionSummary(decision, findings),
+    input: cloneJsonValue(normalizedInput),
+    findings,
+  };
+}

--- a/scripts/ao/lib/policy-rules.js
+++ b/scripts/ao/lib/policy-rules.js
@@ -1,0 +1,57 @@
+export const AO_POLICY_VERSION = 'ao.policy.v1';
+
+function cloneJsonValue(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function createDefaultPolicyRules() {
+  return cloneJsonValue({
+    policy_version: AO_POLICY_VERSION,
+    allowed_tools: [
+      'ao',
+      'bash',
+      'gh',
+      'git',
+      'jest',
+      'node',
+      'npm',
+      'npx',
+      'sh',
+    ],
+    allowed_mcp_servers: [
+      'github',
+    ],
+    allowed_network_targets: [
+      'api.github.com',
+      'github.com',
+    ],
+    credential_source_allowlist: {
+      github_token: ['ao_managed', 'gh_cli_auth', 'operator_env'],
+      openai_api_key: ['ao_managed', 'operator_env'],
+    },
+    workflow_prefixes: [
+      '.github/workflows/',
+    ],
+    infra_prefixes: [
+      '.github/actions/',
+      'infra/',
+      'pulumi/',
+      'terraform/',
+    ],
+    infra_suffixes: [
+      '.tf',
+      '.tfvars',
+    ],
+    secret_prefixes: [
+      '.env',
+      '.env.',
+    ],
+    secret_suffixes: [
+      '.pem',
+      '.p12',
+      '.pfx',
+      '.key',
+    ],
+  });
+}

--- a/scripts/ao/lib/state-contracts.js
+++ b/scripts/ao/lib/state-contracts.js
@@ -6,7 +6,7 @@ export const CONTROL_PLANE_STATE_SCHEMA_VERSION = 'ao.control-plane.state.v1alph
 export const CONTROL_PLANE_STATE_FORMAT = 'ao_control_plane_state';
 export const CONTROL_PLANE_AUDIT_SCHEMA_VERSION = 'ao.control-plane.audit.v1alpha1';
 export const CONTROL_PLANE_AUDIT_FORMAT = 'ao_control_plane_audit_entry';
-export const CONTROL_PLANE_LATEST_VERSION = 3;
+export const CONTROL_PLANE_LATEST_VERSION = 4;
 export const CONTROL_PLANE_DEFAULT_CONTROLLER_ID = 'default';
 
 export const MANAGED_TASK_STATUSES = ['active', 'paused', 'retired'];
@@ -20,6 +20,8 @@ export const CONTROLLER_MODES = ['off', 'observe', 'shadow', 'assist'];
 export const OBSERVATION_SOURCE_KINDS = ['ao_poll', 'github_poll'];
 export const TASK_SPEC_RECORD_STATES = ['valid', 'invalid'];
 export const DELIVERY_EVENT_FAMILIES = ['pr', 'check', 'review', 'review_comment'];
+export const POLICY_DECISIONS = ['allow', 'deny', 'downgrade'];
+export const CREDENTIAL_PROVENANCE_TRUST_DECISIONS = ['trusted', 'untrusted'];
 
 function isPlainObject(value) {
   return value != null && typeof value === 'object' && !Array.isArray(value);
@@ -160,6 +162,8 @@ export function createEmptyControlPlaneState({
     observations: [],
     delivery_events: [],
     controller_cursors: [],
+    policy_decisions: [],
+    credential_provenances: [],
     task_specs: [],
   };
 }
@@ -403,6 +407,78 @@ export function createControllerCursorRecord({
     last_cursor: normalizeRequiredString(last_cursor, 'last_cursor'),
     observed_at: normalizeIsoTimestamp(observed_at, 'observed_at'),
     updated_at: normalizeIsoTimestamp(updated_at, 'updated_at'),
+  };
+}
+
+function normalizePolicyFindings(findings = []) {
+  if (!Array.isArray(findings)) {
+    throw new Error('Invalid findings');
+  }
+
+  return findings.map((finding) => ({
+    code: normalizeRequiredString(finding?.code, 'finding.code'),
+    severity: normalizeEnum(finding?.severity, 'finding.severity', POLICY_DECISIONS),
+    surface: normalizeRequiredString(finding?.surface, 'finding.surface'),
+    value: normalizeRequiredString(finding?.value, 'finding.value'),
+    detail: normalizeOptionalString(finding?.detail),
+  }));
+}
+
+export function createCredentialProvenanceRecord({
+  provenance_id,
+  credential_kind,
+  source_kind,
+  trust_decision = 'trusted',
+  scope = null,
+  created_at,
+  updated_at,
+  metadata = {},
+} = {}) {
+  return {
+    provenance_id: normalizeRequiredString(provenance_id, 'provenance_id'),
+    credential_kind: normalizeRequiredString(credential_kind, 'credential_kind'),
+    source_kind: normalizeRequiredString(source_kind, 'source_kind'),
+    trust_decision: normalizeEnum(
+      trust_decision,
+      'trust_decision',
+      CREDENTIAL_PROVENANCE_TRUST_DECISIONS,
+    ),
+    scope: normalizeOptionalString(scope),
+    created_at: normalizeIsoTimestamp(created_at, 'created_at'),
+    updated_at: normalizeIsoTimestamp(updated_at, 'updated_at'),
+    metadata: normalizeMetadata(metadata),
+  };
+}
+
+export function createPolicyDecisionRecord({
+  decision_id,
+  task_id,
+  action_id = null,
+  action_kind = null,
+  subject_kind,
+  decision,
+  policy_version,
+  input_fingerprint,
+  recorded_at,
+  summary = null,
+  findings = [],
+  input = {},
+  result = {},
+} = {}) {
+  return {
+    decision_id: normalizeRequiredString(decision_id, 'decision_id'),
+    task_id: normalizeRequiredString(task_id, 'task_id'),
+    action_id: normalizeOptionalString(action_id),
+    action_kind: normalizeOptionalString(action_kind),
+    subject_kind: normalizeRequiredString(subject_kind, 'subject_kind'),
+    decision: normalizeEnum(decision, 'decision', POLICY_DECISIONS),
+    policy_version: normalizeRequiredString(policy_version, 'policy_version'),
+    input_fingerprint: normalizeRequiredString(input_fingerprint, 'input_fingerprint'),
+    recorded_at: normalizeIsoTimestamp(recorded_at, 'recorded_at'),
+    summary: normalizeOptionalString(summary),
+    findings: normalizePolicyFindings(findings),
+    input: cloneJsonValue(input ?? {}),
+    result: cloneJsonValue(result ?? {}),
   };
 }
 

--- a/scripts/ao/lib/state-migrations.js
+++ b/scripts/ao/lib/state-migrations.js
@@ -32,10 +32,16 @@ export const CONTROL_PLANE_DELIVERY_EVENTS_MIGRATION = {
   key: '0003_delivery_events_v1',
 };
 
+export const CONTROL_PLANE_POLICY_ENGINE_MIGRATION = {
+  version: 4,
+  key: '0004_policy_engine_v1',
+};
+
 const CONTROL_PLANE_MIGRATIONS = [
   CONTROL_PLANE_BOOTSTRAP_MIGRATION,
   CONTROL_PLANE_TASK_SPEC_MIGRATION,
   CONTROL_PLANE_DELIVERY_EVENTS_MIGRATION,
+  CONTROL_PLANE_POLICY_ENGINE_MIGRATION,
 ];
 
 function resolveNow(now) {
@@ -94,6 +100,8 @@ function buildBootstrapState({
     'observations',
     'delivery_events',
     'controller_cursors',
+    'policy_decisions',
+    'credential_provenances',
     'task_specs',
   ]) {
     if (Array.isArray(existingState?.[collectionKey])) {
@@ -175,6 +183,14 @@ function applyMigration({
     });
   }
 
+  if (migration.version === CONTROL_PLANE_POLICY_ENGINE_MIGRATION.version) {
+    return buildBootstrapState({
+      projectId,
+      now,
+      existingState: state,
+    });
+  }
+
   throw new Error(`Unsupported migration version ${migration.version}`);
 }
 
@@ -190,6 +206,13 @@ function buildAuditSummary(migration) {
     return {
       operation: 'migrate',
       summary: 'Applied control-plane delivery-event migration.',
+    };
+  }
+
+  if (migration.version === CONTROL_PLANE_POLICY_ENGINE_MIGRATION.version) {
+    return {
+      operation: 'migrate',
+      summary: 'Applied control-plane policy-engine migration.',
     };
   }
 

--- a/scripts/ao/lib/state-repository.js
+++ b/scripts/ao/lib/state-repository.js
@@ -8,12 +8,14 @@ import {
   createControllerLease,
   createControllerModeRecord,
   createControllerCursorRecord,
+  createCredentialProvenanceRecord,
   createDeliveryEventRecord,
   createEmptyControlPlaneState,
   createManagedTask,
   createObservationRecord,
   createOverrideRecord,
   createOwnershipLease,
+  createPolicyDecisionRecord,
   createPrBinding,
   createTaskSpecRecord,
 } from './state-contracts.js';
@@ -95,6 +97,8 @@ export function createStateRepository({
     nextState.observations = sortCollectionByKey(nextState.observations, 'observation_id');
     nextState.delivery_events = sortCollectionByKey(nextState.delivery_events, 'event_id');
     nextState.controller_cursors = sortCollectionByKey(nextState.controller_cursors, 'cursor_id');
+    nextState.policy_decisions = sortCollectionByKey(nextState.policy_decisions, 'decision_id');
+    nextState.credential_provenances = sortCollectionByKey(nextState.credential_provenances, 'provenance_id');
     nextState.task_specs = sortCollectionByKey(nextState.task_specs, 'task_id');
 
     return {
@@ -307,6 +311,28 @@ export function createStateRepository({
         record,
         normalize: createDeliveryEventRecord,
         summary: `Persisted delivery event ${record?.event_id}.`,
+      });
+    },
+
+    upsertCredentialProvenance(record) {
+      return upsertCollectionRecord({
+        collectionKey: 'credential_provenances',
+        identityKey: 'provenance_id',
+        entityKind: 'credential_provenance',
+        record,
+        normalize: createCredentialProvenanceRecord,
+        summary: `Persisted credential provenance ${record?.provenance_id}.`,
+      });
+    },
+
+    upsertPolicyDecision(record) {
+      return upsertCollectionRecord({
+        collectionKey: 'policy_decisions',
+        identityKey: 'decision_id',
+        entityKind: 'policy_decision',
+        record,
+        normalize: createPolicyDecisionRecord,
+        summary: `Persisted policy decision ${record?.decision_id}.`,
       });
     },
 

--- a/tests/ao/controller-policy-gating.test.js
+++ b/tests/ao/controller-policy-gating.test.js
@@ -1,0 +1,372 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+import {
+  createControllerModeRecord,
+  createCredentialProvenanceRecord,
+  createManagedTask,
+  createPrBinding,
+} from '../../scripts/ao/lib/state-contracts.js';
+import { runControllerLoop } from '../../scripts/ao/lib/controller-loop.js';
+import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
+
+const PROJECT_ID = 'ciecopilot-home';
+const tempDirs = [];
+
+function createTempRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-controller-policy-'));
+  tempDirs.push(repoRoot);
+  return repoRoot;
+}
+
+function seedActiveTask(repository, mode) {
+  repository.upsertManagedTask(createManagedTask({
+    task_id: 'issue-107',
+    issue_number: 107,
+    title: 'Policy engine v1',
+    branch_name: 'feat/107',
+    worktree_path: '/tmp/cie-54',
+    status: 'active',
+    created_at: '2026-03-30T10:10:00.000Z',
+    updated_at: '2026-03-30T10:10:00.000Z',
+  }));
+  repository.upsertPrBinding(createPrBinding({
+    binding_id: 'binding-issue-107-pr-107',
+    task_id: 'issue-107',
+    pr_number: 107,
+    branch_name: 'feat/107',
+    base_branch: 'main',
+    status: 'bound',
+    created_at: '2026-03-30T10:10:00.000Z',
+    updated_at: '2026-03-30T10:10:00.000Z',
+  }));
+  repository.upsertControllerMode(createControllerModeRecord({
+    controller_id: 'default',
+    mode,
+    updated_at: '2026-03-30T10:10:00.000Z',
+    updated_by: 'operator',
+    reason: 'Issue #107 policy gating test setup',
+  }));
+}
+
+function seedGitHubCredential(repository) {
+  repository.upsertCredentialProvenance(createCredentialProvenanceRecord({
+    provenance_id: 'cred-gh-cli',
+    credential_kind: 'github_token',
+    source_kind: 'gh_cli_auth',
+    scope: 'github.com',
+    created_at: '2026-03-30T10:10:00.000Z',
+    updated_at: '2026-03-30T10:10:00.000Z',
+  }));
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('ao controller policy gating', () => {
+  it('records inspectable allow, deny, and downgrade policy decisions in shadow mode', async () => {
+    const repository = createStateRepository({
+      repoRoot: createTempRepo(),
+      projectId: PROJECT_ID,
+    });
+    seedActiveTask(repository, 'shadow');
+    seedGitHubCredential(repository);
+
+    const result = await runControllerLoop({
+      repoRoot: repository.getSnapshot().paths.repoRoot,
+      cwd: repository.getSnapshot().paths.repoRoot,
+      projectId: PROJECT_ID,
+      controllerId: 'default',
+      now: '2026-03-30T10:11:00.000Z',
+      deps: {
+        loadAoProjectObservation: async () => ({
+          observed_at: '2026-03-30T10:11:00.000Z',
+          workers: [
+            {
+              session_name: 'cie-54',
+              session_runtime_id: 'cie-54',
+              issue_number: 107,
+              branch_name: 'feat/107',
+              pr_number: 107,
+              lifecycle_state: 'idle',
+              last_seen_at: '2026-03-30T10:10:45.000Z',
+              freshness: { status: 'fresh' },
+            },
+          ],
+        }),
+        loadGitHubObservationSet: async () => ({
+          observed_at: '2026-03-30T10:11:00.000Z',
+          prs: [
+            {
+              pr_number: 107,
+              state: 'OPEN',
+              head_branch: 'feat/107',
+              head_sha: 'abc107',
+              review_status: 'pending',
+              ci_status: 'pending',
+              mergeability: 'mergeable',
+              is_draft: false,
+              url: 'https://example.test/pr/107',
+            },
+          ],
+        }),
+        resolveLifecycleReport: async () => ({
+          top_status: 'hold',
+          routing_decision: {
+            action: 'continue_current_worker',
+          },
+          release_decision: {
+            disposition: 'await_review',
+          },
+          actions: [
+            {
+              id: 'continue_worker',
+              action_class: 'continue_worker',
+              summary: 'Continue the current worker owner.',
+              commands: ['ao status -p ciecopilot-home --json'],
+              rationale: 'Ownership continuity is clear enough to continue the current worker.',
+            },
+            {
+              id: 'workflow_gate',
+              action_class: 'hold',
+              summary: 'Hold workflow mutation for review.',
+              commands: ['git status --short'],
+              rationale: 'Workflow mutations require a policy downgrade.',
+              policy_inputs: {
+                file_paths: ['.github/workflows/release.yml'],
+              },
+            },
+            {
+              id: 'unknown_tool',
+              action_class: 'hold',
+              summary: 'Unknown tool should fail closed.',
+              commands: ['terraform plan'],
+              rationale: 'Unknown tools must be denied.',
+            },
+            {
+              id: 'gh_review',
+              action_class: 'notify_human',
+              summary: 'Review the current PR state.',
+              commands: ['gh pr view 107 --json reviewDecision,url'],
+              rationale: 'Known GH credential provenance should pass.',
+              policy_inputs: {
+                tools: ['gh'],
+                network_targets: ['api.github.com'],
+                secret_needs: [
+                  {
+                    credential_kind: 'github_token',
+                    provenance_id: 'cred-gh-cli',
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      },
+    });
+
+    expect(result).toMatchObject({
+      mode: 'shadow',
+      proposed_action_count: 4,
+      policy_decision_count: 4,
+      policy_blocked_action_count: 2,
+      task_results: [
+        expect.objectContaining({
+          task_id: 'issue-107',
+          policy_decision_count: 4,
+          policy_blocked_action_count: 2,
+          denied_action_count: 1,
+          downgraded_action_count: 1,
+        }),
+      ],
+    });
+
+    expect(repository.getSnapshot().state.policy_decisions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        task_id: 'issue-107',
+        action_kind: 'continue_worker',
+        decision: 'allow',
+      }),
+      expect.objectContaining({
+        task_id: 'issue-107',
+        action_kind: 'workflow_gate',
+        decision: 'downgrade',
+      }),
+      expect.objectContaining({
+        task_id: 'issue-107',
+        action_kind: 'unknown_tool',
+        decision: 'deny',
+      }),
+      expect.objectContaining({
+        task_id: 'issue-107',
+        action_kind: 'gh_review',
+        decision: 'allow',
+      }),
+    ]));
+
+    expect(repository.getSnapshot().state.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        action_kind: 'continue_worker',
+        status: 'proposed',
+        payload: expect.objectContaining({
+          policy: expect.objectContaining({
+            decision: 'allow',
+          }),
+          policy_decision_id: expect.any(String),
+        }),
+      }),
+      expect.objectContaining({
+        action_kind: 'workflow_gate',
+        status: 'blocked',
+        payload: expect.objectContaining({
+          policy: expect.objectContaining({
+            decision: 'downgrade',
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        action_kind: 'unknown_tool',
+        status: 'blocked',
+        payload: expect.objectContaining({
+          policy: expect.objectContaining({
+            decision: 'deny',
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        action_kind: 'gh_review',
+        status: 'proposed',
+        payload: expect.objectContaining({
+          policy: expect.objectContaining({
+            decision: 'allow',
+          }),
+        }),
+      }),
+    ]));
+
+    expect(repository.listAuditEntries()).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        entity_kind: 'policy_decision',
+        operation: 'upsert',
+      }),
+      expect.objectContaining({
+        entity_kind: 'action',
+        operation: 'policy_blocked',
+      }),
+    ]));
+  });
+
+  it('keeps policy-blocked actions out of assist execution', async () => {
+    const repository = createStateRepository({
+      repoRoot: createTempRepo(),
+      projectId: PROJECT_ID,
+    });
+    seedActiveTask(repository, 'assist');
+
+    const result = await runControllerLoop({
+      repoRoot: repository.getSnapshot().paths.repoRoot,
+      cwd: repository.getSnapshot().paths.repoRoot,
+      projectId: PROJECT_ID,
+      controllerId: 'default',
+      now: '2026-03-30T10:12:00.000Z',
+      deps: {
+        loadAoProjectObservation: async () => ({
+          observed_at: '2026-03-30T10:12:00.000Z',
+          workers: [
+            {
+              session_name: 'cie-54',
+              session_runtime_id: 'cie-54',
+              issue_number: 107,
+              branch_name: 'feat/107',
+              pr_number: 107,
+              lifecycle_state: 'idle',
+              last_seen_at: '2026-03-30T10:11:45.000Z',
+              freshness: { status: 'fresh' },
+            },
+          ],
+        }),
+        loadGitHubObservationSet: async () => ({
+          observed_at: '2026-03-30T10:12:00.000Z',
+          prs: [
+            {
+              pr_number: 107,
+              state: 'OPEN',
+              head_branch: 'feat/107',
+              head_sha: 'abc107',
+              review_status: 'approved',
+              ci_status: 'passing',
+              mergeability: 'mergeable',
+              is_draft: false,
+              url: 'https://example.test/pr/107',
+            },
+          ],
+        }),
+        resolveLifecycleReport: async () => ({
+          top_status: 'continue',
+          routing_decision: {
+            action: 'continue_current_worker',
+          },
+          release_decision: {
+            disposition: 'notify_human_ready',
+          },
+          actions: [
+            {
+              id: 'continue_worker',
+              action_class: 'continue_worker',
+              summary: 'Continue the current worker owner.',
+              commands: ['ao status -p ciecopilot-home --json'],
+              rationale: 'Ownership continuity is clear enough to continue the current worker.',
+            },
+            {
+              id: 'workflow_gate',
+              action_class: 'hold',
+              summary: 'Workflow mutation should not execute.',
+              commands: ['git status --short'],
+              rationale: 'Policy downgrade should block assist execution.',
+              policy_inputs: {
+                file_paths: ['.github/workflows/release.yml'],
+              },
+            },
+          ],
+        }),
+      },
+    });
+
+    expect(result).toMatchObject({
+      mode: 'assist',
+      proposed_action_count: 2,
+      executed_action_count: 1,
+      blocked_action_count: 0,
+      policy_blocked_action_count: 1,
+      task_results: [
+        expect.objectContaining({
+          executed_action_count: 1,
+          blocked_action_count: 0,
+          policy_blocked_action_count: 1,
+        }),
+      ],
+    });
+
+    expect(repository.getSnapshot().state.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        action_kind: 'continue_worker',
+        status: 'executed',
+      }),
+      expect.objectContaining({
+        action_kind: 'workflow_gate',
+        status: 'blocked',
+        payload: expect.objectContaining({
+          policy: expect.objectContaining({
+            decision: 'downgrade',
+          }),
+        }),
+      }),
+    ]));
+  });
+});

--- a/tests/ao/policy-engine.test.js
+++ b/tests/ao/policy-engine.test.js
@@ -1,0 +1,201 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { evaluatePolicyDecision } from '../../scripts/ao/lib/policy-engine.js';
+import { createDefaultPolicyRules } from '../../scripts/ao/lib/policy-rules.js';
+import { createCredentialProvenanceRecord } from '../../scripts/ao/lib/state-contracts.js';
+
+const NOW = '2026-03-30T10:00:00.000Z';
+
+function createGitHubCredentialProvenance() {
+  return createCredentialProvenanceRecord({
+    provenance_id: 'cred-gh-cli',
+    credential_kind: 'github_token',
+    source_kind: 'gh_cli_auth',
+    scope: 'github.com',
+    created_at: NOW,
+    updated_at: NOW,
+  });
+}
+
+describe('ao policy engine', () => {
+  it('allows known low-risk tool and network inputs', () => {
+    const decision = evaluatePolicyDecision({
+      input: {
+        task_id: 'issue-107',
+        action_kind: 'continue_worker',
+        action_class: 'continue_worker',
+        task_risk: 'low',
+        tools: ['gh', 'ao'],
+        network_targets: ['github.com', 'api.github.com'],
+      },
+      rules: createDefaultPolicyRules(),
+    });
+
+    expect(decision).toMatchObject({
+      decision: 'allow',
+      policy_version: 'ao.policy.v1',
+      input: {
+        tools: ['ao', 'gh'],
+        network_targets: ['api.github.com', 'github.com'],
+        file_paths: [],
+        mcp_servers: [],
+        secret_needs: [],
+      },
+    });
+    expect(decision.findings).toEqual([]);
+  });
+
+  it('fails closed on unknown tool and unknown MCP server', () => {
+    const decision = evaluatePolicyDecision({
+      input: {
+        task_id: 'issue-107',
+        action_kind: 'unknown-tool',
+        action_class: 'hold',
+        tools: ['terraform'],
+        mcp_servers: ['filesystem'],
+      },
+      rules: createDefaultPolicyRules(),
+    });
+
+    expect(decision.decision).toBe('deny');
+    expect(decision.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'unknown_tool',
+        severity: 'deny',
+        surface: 'tool',
+        value: 'terraform',
+      }),
+      expect.objectContaining({
+        code: 'unknown_mcp_server',
+        severity: 'deny',
+        surface: 'mcp_server',
+        value: 'filesystem',
+      }),
+    ]));
+  });
+
+  it('fails closed on unknown credential provenance for secret-bearing actions', () => {
+    const decision = evaluatePolicyDecision({
+      input: {
+        task_id: 'issue-107',
+        action_kind: 'review-secret',
+        action_class: 'notify_human',
+        tools: ['gh'],
+        network_targets: ['api.github.com'],
+        secret_needs: [
+          {
+            credential_kind: 'github_token',
+            provenance_id: 'cred-missing',
+          },
+        ],
+      },
+      credentialProvenances: [],
+      rules: createDefaultPolicyRules(),
+    });
+
+    expect(decision.decision).toBe('deny');
+    expect(decision.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'unknown_credential_provenance',
+        severity: 'deny',
+        surface: 'secret',
+        value: 'github_token:cred-missing',
+      }),
+    ]));
+  });
+
+  it('allows secret-bearing actions when credential provenance is allowlisted', () => {
+    const decision = evaluatePolicyDecision({
+      input: {
+        task_id: 'issue-107',
+        action_kind: 'review-secret',
+        action_class: 'notify_human',
+        tools: ['gh'],
+        network_targets: ['api.github.com'],
+        secret_needs: [
+          {
+            credential_kind: 'github_token',
+            provenance_id: 'cred-gh-cli',
+          },
+        ],
+      },
+      credentialProvenances: [createGitHubCredentialProvenance()],
+      rules: createDefaultPolicyRules(),
+    });
+
+    expect(decision).toMatchObject({
+      decision: 'allow',
+      findings: [],
+    });
+  });
+
+  it('downgrades workflow, infra, and unallowlisted network surfaces', () => {
+    const decision = evaluatePolicyDecision({
+      input: {
+        task_id: 'issue-107',
+        action_kind: 'mutate-risky-surfaces',
+        action_class: 'hold',
+        tools: ['git'],
+        file_paths: ['infra/main.tf', '.github/workflows/release.yml'],
+        network_targets: ['registry.npmjs.org'],
+      },
+      rules: createDefaultPolicyRules(),
+    });
+
+    expect(decision.decision).toBe('downgrade');
+    expect(decision.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'workflow_mutation_requires_review',
+        severity: 'downgrade',
+        surface: 'file',
+        value: '.github/workflows/release.yml',
+      }),
+      expect.objectContaining({
+        code: 'infra_mutation_requires_review',
+        severity: 'downgrade',
+        surface: 'file',
+        value: 'infra/main.tf',
+      }),
+      expect.objectContaining({
+        code: 'network_target_requires_review',
+        severity: 'downgrade',
+        surface: 'network',
+        value: 'registry.npmjs.org',
+      }),
+    ]));
+  });
+
+  it('is stable under replay for the same seeded state', () => {
+    const input = {
+      task_id: 'issue-107',
+      action_kind: 'stable-replay',
+      action_class: 'notify_human',
+      task_risk: 'medium',
+      tools: ['gh', 'ao', 'gh'],
+      network_targets: ['github.com', 'api.github.com', 'github.com'],
+      secret_needs: [
+        {
+          credential_kind: 'github_token',
+          provenance_id: 'cred-gh-cli',
+        },
+      ],
+    };
+
+    const left = evaluatePolicyDecision({
+      input,
+      credentialProvenances: [createGitHubCredentialProvenance()],
+      rules: createDefaultPolicyRules(),
+    });
+    const right = evaluatePolicyDecision({
+      input: {
+        ...input,
+        tools: ['ao', 'gh'],
+        network_targets: ['api.github.com', 'github.com'],
+      },
+      credentialProvenances: [createGitHubCredentialProvenance()],
+      rules: createDefaultPolicyRules(),
+    });
+
+    expect(left).toEqual(right);
+  });
+});

--- a/tests/ao/state-contracts.test.js
+++ b/tests/ao/state-contracts.test.js
@@ -4,10 +4,13 @@ import {
   ACTION_STATUSES,
   CONTROLLER_LEASE_STATUSES,
   CONTROLLER_MODES,
+  CONTROL_PLANE_LATEST_VERSION,
+  CREDENTIAL_PROVENANCE_TRUST_DECISIONS,
   DELIVERY_EVENT_FAMILIES,
   MANAGED_TASK_STATUSES,
   OVERRIDE_SCOPE_KINDS,
   OVERRIDE_STATUSES,
+  POLICY_DECISIONS,
   PR_BINDING_STATUSES,
   OWNERSHIP_LEASE_STATUSES,
   createActionRecord,
@@ -15,11 +18,13 @@ import {
   createControlPlaneSchema,
   createControllerLease,
   createControllerModeRecord,
+  createCredentialProvenanceRecord,
   createDeliveryEventRecord,
   createEmptyControlPlaneState,
   createManagedTask,
   createOverrideRecord,
   createOwnershipLease,
+  createPolicyDecisionRecord,
   createPrBinding,
   createTaskSpecRecord,
 } from '../../scripts/ao/lib/state-contracts.js';
@@ -37,6 +42,9 @@ describe('ao state contracts', () => {
     expect(OVERRIDE_SCOPE_KINDS).toEqual(['global', 'task', 'pr', 'controller']);
     expect(OVERRIDE_STATUSES).toEqual(['active', 'cleared', 'expired']);
     expect(CONTROLLER_MODES).toEqual(['off', 'observe', 'shadow', 'assist']);
+    expect(POLICY_DECISIONS).toEqual(['allow', 'deny', 'downgrade']);
+    expect(CREDENTIAL_PROVENANCE_TRUST_DECISIONS).toEqual(['trusted', 'untrusted']);
+    expect(CONTROL_PLANE_LATEST_VERSION).toBe(4);
   });
 
   it('creates durable managed-task, binding, lease, action, override, and controller-mode records', () => {
@@ -225,6 +233,62 @@ describe('ao state contracts', () => {
       },
     });
 
+    expect(createCredentialProvenanceRecord({
+      provenance_id: 'cred-gh-cli',
+      credential_kind: 'github_token',
+      source_kind: 'gh_cli_auth',
+      scope: 'github.com',
+      created_at: NOW,
+      updated_at: NOW,
+    })).toEqual({
+      provenance_id: 'cred-gh-cli',
+      credential_kind: 'github_token',
+      source_kind: 'gh_cli_auth',
+      trust_decision: 'trusted',
+      scope: 'github.com',
+      created_at: NOW,
+      updated_at: NOW,
+      metadata: {},
+    });
+
+    expect(createPolicyDecisionRecord({
+      decision_id: 'policy-1',
+      task_id: 'task-1',
+      action_id: 'action-1',
+      action_kind: 'notify_human_ready',
+      subject_kind: 'action',
+      decision: 'allow',
+      policy_version: 'ao.policy.v1',
+      input_fingerprint: 'fingerprint-1',
+      recorded_at: NOW,
+      summary: 'Allow low-risk GitHub inspection.',
+      findings: [],
+      input: {
+        tools: ['gh'],
+      },
+      result: {
+        decision: 'allow',
+      },
+    })).toEqual({
+      decision_id: 'policy-1',
+      task_id: 'task-1',
+      action_id: 'action-1',
+      action_kind: 'notify_human_ready',
+      subject_kind: 'action',
+      decision: 'allow',
+      policy_version: 'ao.policy.v1',
+      input_fingerprint: 'fingerprint-1',
+      recorded_at: NOW,
+      summary: 'Allow low-risk GitHub inspection.',
+      findings: [],
+      input: {
+        tools: ['gh'],
+      },
+      result: {
+        decision: 'allow',
+      },
+    });
+
     expect(createDeliveryEventRecord({
       event_id: 'delivery-1',
       task_id: 'task-1',
@@ -323,6 +387,8 @@ describe('ao state contracts', () => {
       observations: [],
       delivery_events: [],
       controller_cursors: [],
+      policy_decisions: [],
+      credential_provenances: [],
       task_specs: [],
     });
 

--- a/tests/ao/state-migrations.test.js
+++ b/tests/ao/state-migrations.test.js
@@ -73,8 +73,8 @@ describe('ao state migrations', () => {
 
     expect(readJson(paths.schemaPath)).toMatchObject({
       project_id: PROJECT_ID,
-      current_version: 3,
-      latest_version: 3,
+      current_version: 4,
+      latest_version: 4,
       applied_migrations: [
         {
           version: 1,
@@ -91,11 +91,18 @@ describe('ao state migrations', () => {
           key: '0003_delivery_events_v1',
           applied_at: FIXED_NOW,
         },
+        {
+          version: 4,
+          key: '0004_policy_engine_v1',
+          applied_at: FIXED_NOW,
+        },
       ],
     });
     expect(readJson(paths.statePath)).toMatchObject({
       project_id: PROJECT_ID,
       delivery_events: [],
+      policy_decisions: [],
+      credential_provenances: [],
       task_specs: [],
       controller_modes: [
         {
@@ -125,6 +132,12 @@ describe('ao state migrations', () => {
         operation: 'migrate',
         summary: 'Applied control-plane delivery-event migration.',
       }),
+      expect.objectContaining({
+        entity_kind: 'schema',
+        entity_id: 'v4',
+        operation: 'migrate',
+        summary: 'Applied control-plane policy-engine migration.',
+      }),
     ]);
   });
 
@@ -151,7 +164,7 @@ describe('ao state migrations', () => {
       migrated: false,
     });
     expect(readJson(paths.schemaPath).updated_at).toBe(FIXED_NOW);
-    expect(readAuditEntries(paths.auditPath)).toHaveLength(3);
+    expect(readAuditEntries(paths.auditPath)).toHaveLength(4);
   });
 
   it('upgrades a stale schema version and backfills invalid task specs for enrolled tasks', () => {
@@ -167,7 +180,7 @@ describe('ao state migrations', () => {
       format: 'ao_control_plane_schema',
       project_id: PROJECT_ID,
       current_version: 1,
-      latest_version: 3,
+      latest_version: 4,
       created_at: '2026-03-29T03:00:00.000Z',
       updated_at: '2026-03-29T03:00:00.000Z',
       applied_migrations: [
@@ -227,7 +240,7 @@ describe('ao state migrations', () => {
       migrated: true,
     });
     expect(readJson(paths.schemaPath)).toMatchObject({
-      current_version: 3,
+      current_version: 4,
       applied_migrations: [
         {
           version: 1,
@@ -241,10 +254,16 @@ describe('ao state migrations', () => {
           version: 3,
           key: '0003_delivery_events_v1',
         },
+        {
+          version: 4,
+          key: '0004_policy_engine_v1',
+        },
       ],
     });
     expect(readJson(paths.statePath)).toMatchObject({
       delivery_events: [],
+      policy_decisions: [],
+      credential_provenances: [],
       task_specs: [
         {
           task_id: 'issue-105',

--- a/tests/ao/state-repository.test.js
+++ b/tests/ao/state-repository.test.js
@@ -8,10 +8,12 @@ import {
   createActionRecord,
   createControllerLease,
   createControllerModeRecord,
+  createCredentialProvenanceRecord,
   createDeliveryEventRecord,
   createManagedTask,
   createOverrideRecord,
   createOwnershipLease,
+  createPolicyDecisionRecord,
   createPrBinding,
   createTaskSpecRecord,
 } from '../../scripts/ao/lib/state-contracts.js';
@@ -71,6 +73,8 @@ describe('ao state repository', () => {
       overrides: [],
       controller_modes: [],
       delivery_events: [],
+      policy_decisions: [],
+      credential_provenances: [],
       task_specs: [],
     });
     expect(repository.listAuditEntries()).toEqual([]);
@@ -92,6 +96,8 @@ describe('ao state repository', () => {
         '2026-03-29T04:57:00.000Z',
         '2026-03-29T04:58:00.000Z',
         '2026-03-29T04:59:00.000Z',
+        '2026-03-29T05:00:00.000Z',
+        '2026-03-29T05:01:00.000Z',
       ),
       auditIdGenerator: createIdGenerator('audit'),
     });
@@ -205,6 +211,33 @@ describe('ao state repository', () => {
         review_id: 'review-1',
       },
     }));
+    repository.upsertCredentialProvenance(createCredentialProvenanceRecord({
+      provenance_id: 'cred-gh-cli',
+      credential_kind: 'github_token',
+      source_kind: 'gh_cli_auth',
+      scope: 'github.com',
+      created_at: '2026-03-29T04:59:00.000Z',
+      updated_at: '2026-03-29T04:59:00.000Z',
+    }));
+    repository.upsertPolicyDecision(createPolicyDecisionRecord({
+      decision_id: 'policy-1',
+      task_id: 'task-1',
+      action_id: 'action-1',
+      action_kind: 'notify_human_ready',
+      subject_kind: 'action',
+      decision: 'allow',
+      policy_version: 'ao.policy.v1',
+      input_fingerprint: 'fingerprint-1',
+      recorded_at: '2026-03-29T05:00:00.000Z',
+      summary: 'Allow low-risk GitHub inspection.',
+      findings: [],
+      input: {
+        tools: ['gh'],
+      },
+      result: {
+        decision: 'allow',
+      },
+    }));
 
     const snapshot = repository.getSnapshot();
     const auditEntries = repository.listAuditEntries();
@@ -219,12 +252,15 @@ describe('ao state repository', () => {
       overrides: [expect.objectContaining({ override_id: 'override-1', override_kind: 'hold_autonomy' })],
       controller_modes: [expect.objectContaining({ controller_id: 'default', mode: 'observe' })],
       delivery_events: [expect.objectContaining({ event_id: 'delivery-1', event_family: 'review_comment' })],
+      credential_provenances: [expect.objectContaining({ provenance_id: 'cred-gh-cli', credential_kind: 'github_token' })],
+      policy_decisions: [expect.objectContaining({ decision_id: 'policy-1', decision: 'allow' })],
       task_specs: [expect.objectContaining({ task_id: 'task-1', state: 'valid' })],
     });
     expect(auditEntries.map((entry) => `${entry.entity_kind}:${entry.operation}:${entry.entity_id}`)).toEqual([
       'schema:bootstrap:v1',
       'schema:migrate:v2',
       'schema:migrate:v3',
+      'schema:migrate:v4',
       'managed_task:upsert:task-1',
       'pr_binding:upsert:binding-1',
       'ownership_lease:upsert:ownership-1',
@@ -234,6 +270,8 @@ describe('ao state repository', () => {
       'controller_mode:upsert:default',
       'task_spec:upsert:task-1',
       'delivery_event:upsert:delivery-1',
+      'credential_provenance:upsert:cred-gh-cli',
+      'policy_decision:upsert:policy-1',
     ]);
   });
 

--- a/tests/ao/state-runner.test.js
+++ b/tests/ao/state-runner.test.js
@@ -136,7 +136,7 @@ describe('ao state runner', () => {
       active_override_count: 1,
       controller_mode_count: 1,
       controller_modes: ['default=observe'],
-      audit_entry_count: 6,
+      audit_entry_count: 7,
     });
     expect(report.audit.recent_entries).toEqual([
       expect.objectContaining({


### PR DESCRIPTION
Closes #107

## Summary
- add a deterministic AO policy engine plus seeded tool, MCP, network, and credential provenance rules
- persist durable `policy_decisions` and `credential_provenances` in control-plane state with a schema v4 migration
- gate controller proposals before assist execution so denied or downgraded actions are recorded inspectably and fail closed

## Acceptance Mapping
- AO can produce allow, deny, or downgrade decisions for file, network, secret, and tool actions.
  - Implemented in `scripts/ao/lib/policy-engine.js` and `scripts/ao/lib/policy-rules.js`.
  - Covered by `tests/ao/policy-engine.test.js` and `tests/ao/controller-policy-gating.test.js`.
- Unknown tool or unknown credential provenance fails closed.
  - Unknown tools and unknown MCP servers return `deny`.
  - Secret-bearing actions without an allowlisted credential provenance return `deny`.
  - Covered by `tests/ao/policy-engine.test.js` and controller gating assertions in `tests/ao/controller-policy-gating.test.js`.
- Workflow and infra mutations are never treated as ordinary low-risk edits.
  - `.github/workflows/**`, infra paths, and secret-bearing file patterns downgrade proposals before execution.
  - Covered by `tests/ao/policy-engine.test.js` and `tests/ao/controller-policy-gating.test.js`.
- Policy output is stable under replay for the same seeded state.
  - Policy input normalization and deterministic hashes keep replay output stable.
  - Covered by `tests/ao/policy-engine.test.js` and existing controller replay coverage in `tests/ao/controller-loop.test.js`.
- Policy decisions are inspectable through AO state or audit surfaces.
  - Added durable `policy_decisions` and `credential_provenances` collections plus action payload links and audit entries.
  - Covered by `tests/ao/state-contracts.test.js`, `tests/ao/state-migrations.test.js`, `tests/ao/state-repository.test.js`, `tests/ao/state-runner.test.js`, and `tests/ao/controller-policy-gating.test.js`.

## Verification
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/policy-engine.test.js tests/ao/controller-policy-gating.test.js tests/ao/controller-loop.test.js`
  - PASS (3 suites, 15 tests)
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/ao-controller-cli.test.js tests/ao/ao-doctor-cli.test.js tests/ao/ao-lifecycle-acceptance.test.js tests/ao/ao-lifecycle-cli.test.js tests/ao/ao-manage-cli.test.js tests/ao/ao-observation-source.test.js tests/ao/ao-reconcile-cli.test.js tests/ao/ao-state-cli.test.js tests/ao/controller-loop.test.js tests/ao/controller-shadow-parity.test.js tests/ao/controller-state-contracts.test.js tests/ao/doctor-contracts.test.js tests/ao/doctor-engine.test.js tests/ao/doctor-local-state-source.test.js tests/ao/doctor-report.test.js tests/ao/doctor-runner.test.js tests/ao/event-ingest.test.js tests/ao/gate-model.test.js tests/ao/github-observation-source.test.js tests/ao/lifecycle-contracts.test.js tests/ao/lifecycle-engine.test.js tests/ao/lifecycle-report.test.js tests/ao/manage-runner.test.js tests/ao/reconciliation-contracts.test.js tests/ao/reconciliation-engine.test.js tests/ao/reconciliation-report.test.js tests/ao/reconciliation-runner.test.js tests/ao/state-contracts.test.js tests/ao/state-migrations.test.js tests/ao/state-repository.test.js tests/ao/state-runner.test.js tests/ao/transition-engine.test.js`
  - PASS (32 suites, 148 tests)

## Out Of Scope Preserved
- no runtime bootstrap implementation
- no org-level RBAC or SaaS policy management
- no repo-knowledge linting
- no expansion into assist executor overrides or later issue work
