### PR TITLE
feat(ao): add runtime-provider contract and bootstrap preflight

### DIFF
--- a/scripts/ao/lib/controller-loop.js
+++ b/scripts/ao/lib/controller-loop.js
@@ -452,6 +452,10 @@ export async function runControllerLoop({
     repoRoot,
     projectId,
   });
+  repository.ensureRuntimePreflights({
+    cwd,
+    now: timestamp,
+  });
   const resolvedMode = resolveLoopMode(repository, controllerId, mode, timestamp);
   assertNoActiveControllerLease(repository, controllerId);
   const holderId = process.env.AO_SESSION_NAME ?? process.env.AO_SESSION_ID ?? 'controller-loop';

--- a/scripts/ao/lib/doctor-engine.js
+++ b/scripts/ao/lib/doctor-engine.js
@@ -4,6 +4,7 @@ import {
   createDoctorFinding,
   createDoctorSuggestion,
 } from './doctor-contracts.js';
+import { RUNTIME_PREFLIGHT_SCHEMA_VERSION } from './runtime-contracts.js';
 import { CONTROL_PLANE_LATEST_VERSION } from './state-contracts.js';
 import { TASK_SPEC_SCHEMA_VERSION } from './task-spec.js';
 
@@ -263,6 +264,103 @@ function buildTaskSpecFindings({ controlPlaneSnapshot, projectId }) {
   return findings;
 }
 
+function buildRuntimePreflightFindings({ controlPlaneSnapshot, projectId }) {
+  const findings = [];
+  if (!controlPlaneSnapshot?.bootstrapped) return findings;
+
+  const taskSpecsByTaskId = new Map(
+    (controlPlaneSnapshot?.state?.task_specs ?? []).map((record) => [record?.task_id, record]),
+  );
+  const runtimePreflightsByRef = new Map(
+    (controlPlaneSnapshot?.state?.runtime_preflights ?? []).map((record) => [record?.runtime_ref, record]),
+  );
+
+  for (const task of controlPlaneSnapshot?.state?.managed_tasks ?? []) {
+    const taskSpecRecord = taskSpecsByTaskId.get(task?.task_id);
+    if (
+      !taskSpecRecord
+      || taskSpecRecord?.state !== 'valid'
+      || taskSpecRecord?.snapshot?.schema_version !== TASK_SPEC_SCHEMA_VERSION
+    ) {
+      continue;
+    }
+
+    const runtimeRef = taskSpecRecord?.snapshot?.spec?.runtime_ref ?? null;
+    if (!runtimeRef) continue;
+
+    const runtimePreflightRecord = runtimePreflightsByRef.get(runtimeRef);
+    if (!runtimePreflightRecord) {
+      findings.push(createDoctorFinding({
+        code: 'runtime_preflight_missing',
+        severity: 'blocker',
+        origin: 'doctor',
+        source_area: 'control_plane',
+        subject_type: 'task',
+        subject_id: task?.task_id ?? projectId,
+        summary: 'Managed task is missing durable runtime preflight state.',
+        details: [`runtime_ref: ${runtimeRef}`],
+        evidence_refs: [],
+        suggestion_ids: ['human_review'],
+      }));
+      continue;
+    }
+
+    if (runtimePreflightRecord?.snapshot?.schema_version !== RUNTIME_PREFLIGHT_SCHEMA_VERSION) {
+      findings.push(createDoctorFinding({
+        code: 'runtime_preflight_mixed_version',
+        severity: 'blocker',
+        origin: 'doctor',
+        source_area: 'control_plane',
+        subject_type: 'task',
+        subject_id: task?.task_id ?? projectId,
+        summary: 'Managed task has a mixed-version runtime preflight snapshot.',
+        details: [
+          `snapshot_schema_version: ${runtimePreflightRecord?.snapshot?.schema_version ?? 'missing'}`,
+          `expected_schema_version: ${RUNTIME_PREFLIGHT_SCHEMA_VERSION}`,
+        ],
+        evidence_refs: [],
+        suggestion_ids: ['human_review'],
+      }));
+      continue;
+    }
+
+    if (runtimePreflightRecord.status === 'unsupported_provider') {
+      findings.push(createDoctorFinding({
+        code: 'runtime_preflight_unsupported_provider',
+        severity: 'blocker',
+        origin: 'doctor',
+        source_area: 'control_plane',
+        subject_type: 'task',
+        subject_id: task?.task_id ?? projectId,
+        summary: 'Managed task runtime preflight resolved to an unsupported provider.',
+        details: [`runtime_ref: ${runtimeRef}`],
+        evidence_refs: [],
+        suggestion_ids: ['human_review'],
+      }));
+      continue;
+    }
+
+    if (runtimePreflightRecord.status === 'missing_dependency') {
+      findings.push(createDoctorFinding({
+        code: 'runtime_preflight_missing_dependency',
+        severity: 'blocker',
+        origin: 'doctor',
+        source_area: 'control_plane',
+        subject_type: 'task',
+        subject_id: task?.task_id ?? projectId,
+        summary: 'Managed task runtime preflight is blocked by missing bootstrap requirements.',
+        details: (runtimePreflightRecord?.snapshot?.checks ?? [])
+          .filter((item) => item?.status === 'missing')
+          .map((item) => item.requirement_id),
+        evidence_refs: [],
+        suggestion_ids: ['human_review'],
+      }));
+    }
+  }
+
+  return findings;
+}
+
 function buildDoctorOnlyFindings({
   scope,
   reconciliationReport,
@@ -464,6 +562,10 @@ function buildDoctorOnlyFindings({
   return [
     ...findings,
     ...buildTaskSpecFindings({
+      controlPlaneSnapshot,
+      projectId,
+    }),
+    ...buildRuntimePreflightFindings({
       controlPlaneSnapshot,
       projectId,
     }),

--- a/scripts/ao/lib/doctor-runner.js
+++ b/scripts/ao/lib/doctor-runner.js
@@ -20,10 +20,14 @@ function loadControlPlaneSnapshot({
   const repoRoot = findRepoRoot(cwd);
   if (!repoRoot) return null;
 
-  return createStateRepository({
+  const repository = createStateRepository({
     repoRoot,
     projectId,
-  }).getSnapshot();
+  });
+  repository.ensureRuntimePreflights({
+    cwd,
+  });
+  return repository.getSnapshot();
 }
 
 export async function runDoctor({

--- a/scripts/ao/lib/runtime-contracts.js
+++ b/scripts/ao/lib/runtime-contracts.js
@@ -1,0 +1,207 @@
+import { createHash } from 'node:crypto';
+
+export const RUNTIME_PROVIDER_SCHEMA_VERSION = 'ao.runtime-provider.v1alpha1';
+export const RUNTIME_PREFLIGHT_SCHEMA_VERSION = 'ao.runtime-preflight.v1alpha1';
+export const RUNTIME_PREFLIGHT_FORMAT = 'ao_runtime_preflight';
+
+export const RUNTIME_PROVIDER_KINDS = ['github_local'];
+export const BOOTSTRAP_REQUIREMENT_KINDS = [
+  'language_runtime',
+  'package_manager',
+  'setup_step',
+  'network_posture',
+  'filesystem_posture',
+  'secret_posture',
+];
+export const BOOTSTRAP_PROBE_KINDS = ['command', 'path', 'capability'];
+export const RUNTIME_PREFLIGHT_CHECK_STATUSES = ['satisfied', 'missing', 'unsupported'];
+export const RUNTIME_PREFLIGHT_STATUSES = ['clean', 'missing_dependency', 'unsupported_provider'];
+
+function isPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneJsonValue(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function normalizeRequiredString(value, fieldName) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+
+  return value.trim();
+}
+
+function normalizeOptionalString(value, fieldName) {
+  if (value == null) return null;
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+
+  const normalized = value.trim();
+  return normalized === '' ? null : normalized;
+}
+
+function normalizeIsoTimestamp(value, fieldName) {
+  const normalized = normalizeRequiredString(value, fieldName);
+  const date = new Date(normalized);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+
+  return normalized;
+}
+
+function normalizeEnum(value, fieldName, allowedValues) {
+  const normalized = normalizeRequiredString(value, fieldName);
+  if (!allowedValues.includes(normalized)) {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+
+  return normalized;
+}
+
+function normalizeStringArray(values, fieldName) {
+  if (!Array.isArray(values)) {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+
+  return values.map((value, index) => normalizeRequiredString(value, `${fieldName}[${index}]`));
+}
+
+function normalizeMetadata(value = {}) {
+  if (value == null) return {};
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid metadata');
+  }
+
+  return cloneJsonValue(value);
+}
+
+function normalizeProbe(probe) {
+  if (!isPlainObject(probe)) {
+    throw new Error('Invalid probe');
+  }
+
+  const kind = normalizeEnum(probe.kind, 'probe.kind', BOOTSTRAP_PROBE_KINDS);
+  if (kind === 'command') {
+    return {
+      kind,
+      command: normalizeRequiredString(probe.command, 'probe.command'),
+    };
+  }
+
+  if (kind === 'path') {
+    return {
+      kind,
+      path: normalizeRequiredString(probe.path, 'probe.path'),
+    };
+  }
+
+  return {
+    kind,
+    capability: normalizeRequiredString(probe.capability, 'probe.capability'),
+  };
+}
+
+function buildRuntimePreflightReplayKey(snapshot) {
+  const digest = createHash('sha1')
+    .update(JSON.stringify({
+      runtime_ref: snapshot.runtime_ref,
+      provider_id: snapshot.provider_id,
+      status: snapshot.status,
+      contract: snapshot.contract,
+      checks: snapshot.checks,
+    }))
+    .digest('hex');
+
+  return `runtime_preflight:${digest}`;
+}
+
+export function createBootstrapRequirement({
+  requirement_id,
+  requirement_kind,
+  summary,
+  probe,
+  setup_steps = [],
+  metadata = {},
+} = {}) {
+  return {
+    requirement_id: normalizeRequiredString(requirement_id, 'requirement_id'),
+    requirement_kind: normalizeEnum(
+      requirement_kind,
+      'requirement_kind',
+      BOOTSTRAP_REQUIREMENT_KINDS,
+    ),
+    summary: normalizeRequiredString(summary, 'summary'),
+    probe: normalizeProbe(probe),
+    setup_steps: normalizeStringArray(setup_steps, 'setup_steps'),
+    metadata: normalizeMetadata(metadata),
+  };
+}
+
+export function createRuntimeProviderContract({
+  runtime_ref,
+  provider_id,
+  provider_kind,
+  display_name,
+  bootstrap_requirements = [],
+  metadata = {},
+} = {}) {
+  return {
+    schema_version: RUNTIME_PROVIDER_SCHEMA_VERSION,
+    runtime_ref: normalizeRequiredString(runtime_ref, 'runtime_ref'),
+    provider_id: normalizeRequiredString(provider_id, 'provider_id'),
+    provider_kind: normalizeEnum(provider_kind, 'provider_kind', RUNTIME_PROVIDER_KINDS),
+    display_name: normalizeRequiredString(display_name, 'display_name'),
+    bootstrap_requirements: (bootstrap_requirements ?? []).map((item) => createBootstrapRequirement(item)),
+    metadata: normalizeMetadata(metadata),
+  };
+}
+
+export function createRuntimePreflightCheck({
+  requirement_id,
+  requirement_kind,
+  status,
+  summary,
+  details = [],
+  setup_steps = [],
+} = {}) {
+  return {
+    requirement_id: normalizeRequiredString(requirement_id, 'requirement_id'),
+    requirement_kind: normalizeRequiredString(requirement_kind, 'requirement_kind'),
+    status: normalizeEnum(status, 'status', RUNTIME_PREFLIGHT_CHECK_STATUSES),
+    summary: normalizeRequiredString(summary, 'summary'),
+    details: normalizeStringArray(details, 'details'),
+    setup_steps: normalizeStringArray(setup_steps, 'setup_steps'),
+  };
+}
+
+export function createRuntimePreflightSnapshot({
+  runtime_ref,
+  provider_id = null,
+  observed_at,
+  status,
+  contract = null,
+  checks = [],
+} = {}) {
+  const normalizedContract = contract == null ? null : createRuntimeProviderContract(contract);
+  const normalizedProviderId = normalizedContract?.provider_id ?? normalizeOptionalString(provider_id, 'provider_id');
+  const normalizedSnapshot = {
+    schema_version: RUNTIME_PREFLIGHT_SCHEMA_VERSION,
+    format: RUNTIME_PREFLIGHT_FORMAT,
+    runtime_ref: normalizeRequiredString(runtime_ref, 'runtime_ref'),
+    provider_id: normalizedProviderId,
+    status: normalizeEnum(status, 'status', RUNTIME_PREFLIGHT_STATUSES),
+    observed_at: normalizeIsoTimestamp(observed_at, 'observed_at'),
+    contract: normalizedContract,
+    checks: (checks ?? []).map((item) => createRuntimePreflightCheck(item)),
+  };
+
+  return {
+    ...normalizedSnapshot,
+    replay_key: buildRuntimePreflightReplayKey(normalizedSnapshot),
+  };
+}

--- a/scripts/ao/lib/runtime-preflight.js
+++ b/scripts/ao/lib/runtime-preflight.js
@@ -1,0 +1,206 @@
+import * as fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import {
+  createRuntimePreflightCheck,
+  createRuntimePreflightSnapshot,
+} from './runtime-contracts.js';
+import { getRuntimeProviderContract } from './runtime-providers/index.js';
+
+function resolveNow(now) {
+  if (typeof now === 'function') return resolveNow(now());
+  if (typeof now === 'string' && now.trim() !== '') return now.trim();
+  return new Date().toISOString();
+}
+
+function defaultCommandExists(command) {
+  const result = spawnSync('bash', ['-lc', `command -v ${JSON.stringify(String(command))}`], {
+    stdio: 'ignore',
+  });
+  return result.status === 0;
+}
+
+function defaultPathExists(targetPath) {
+  return fs.existsSync(targetPath);
+}
+
+function hasWritableAccess(cwd) {
+  try {
+    fs.accessSync(cwd, fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasGitHubAuth(env) {
+  if (env.GITHUB_TOKEN || env.GH_TOKEN || env.GITHUB_AUTH_TOKEN) return true;
+  const result = spawnSync('gh', ['auth', 'status'], {
+    stdio: 'ignore',
+    env,
+  });
+  return result.status === 0;
+}
+
+function defaultCapability(capability, context) {
+  const env = context?.env ?? process.env;
+
+  switch (capability) {
+    case 'network.github_api':
+      return env.AO_RUNTIME_NETWORK_POSTURE !== 'offline' && env.AO_NETWORK_DISABLED !== '1';
+    case 'filesystem.workspace_write':
+      return hasWritableAccess(context?.cwd ?? process.cwd());
+    case 'secret.github_auth':
+      return hasGitHubAuth(env);
+    default:
+      return false;
+  }
+}
+
+function normalizeCapabilityProbeResult(result) {
+  if (result === true) {
+    return {
+      status: 'satisfied',
+      details: [],
+    };
+  }
+
+  if (result === false || result == null) {
+    return {
+      status: 'missing',
+      details: [],
+    };
+  }
+
+  if (typeof result === 'string' && result.trim() === 'unsupported') {
+    return {
+      status: 'unsupported',
+      details: [],
+    };
+  }
+
+  if (result != null && typeof result === 'object') {
+    const status = result.status === 'unsupported' ? 'unsupported' : (
+      result.status === 'missing' ? 'missing' : 'satisfied'
+    );
+    return {
+      status,
+      details: Array.isArray(result.details) ? result.details.map((value) => String(value)) : [],
+    };
+  }
+
+  return {
+    status: 'missing',
+    details: [],
+  };
+}
+
+function evaluateRequirement(requirement, context, probes) {
+  if (requirement.probe.kind === 'command') {
+    const commandExists = probes.commandExists(requirement.probe.command, context);
+    return createRuntimePreflightCheck({
+      requirement_id: requirement.requirement_id,
+      requirement_kind: requirement.requirement_kind,
+      status: commandExists ? 'satisfied' : 'missing',
+      summary: requirement.summary,
+      details: [`command: ${requirement.probe.command}`],
+      setup_steps: requirement.setup_steps,
+    });
+  }
+
+  if (requirement.probe.kind === 'path') {
+    const targetPath = path.resolve(context.cwd, requirement.probe.path);
+    const pathExists = probes.pathExists(targetPath, context);
+    return createRuntimePreflightCheck({
+      requirement_id: requirement.requirement_id,
+      requirement_kind: requirement.requirement_kind,
+      status: pathExists ? 'satisfied' : 'missing',
+      summary: requirement.summary,
+      details: [`path: ${targetPath}`],
+      setup_steps: requirement.setup_steps,
+    });
+  }
+
+  const capabilityResult = normalizeCapabilityProbeResult(
+    probes.capability(requirement.probe.capability, context),
+  );
+  return createRuntimePreflightCheck({
+    requirement_id: requirement.requirement_id,
+    requirement_kind: requirement.requirement_kind,
+    status: capabilityResult.status,
+    summary: requirement.summary,
+    details: [
+      `capability: ${requirement.probe.capability}`,
+      ...capabilityResult.details,
+    ],
+    setup_steps: requirement.setup_steps,
+  });
+}
+
+function deriveOverallStatus(checks) {
+  if (checks.some((item) => item.status === 'unsupported')) {
+    return 'unsupported_provider';
+  }
+
+  if (checks.some((item) => item.status === 'missing')) {
+    return 'missing_dependency';
+  }
+
+  return 'clean';
+}
+
+export function runRuntimeBootstrapPreflight({
+  runtimeRef,
+  cwd = process.cwd(),
+  now = new Date().toISOString(),
+  resolveRuntimeProvider = getRuntimeProviderContract,
+  probes = {},
+  env = process.env,
+} = {}) {
+  const timestamp = resolveNow(now);
+  const runtimeProvider = resolveRuntimeProvider(runtimeRef);
+  if (!runtimeProvider) {
+    return createRuntimePreflightSnapshot({
+      runtime_ref: String(runtimeRef),
+      provider_id: null,
+      observed_at: timestamp,
+      status: 'unsupported_provider',
+      contract: null,
+      checks: [
+        {
+          requirement_id: `provider.${String(runtimeRef)}`,
+          requirement_kind: 'runtime_provider',
+          status: 'unsupported',
+          summary: 'Runtime provider is not supported by the current AO runtime registry.',
+          details: [`runtime_ref: ${String(runtimeRef)}`],
+          setup_steps: [],
+        },
+      ],
+    });
+  }
+
+  const context = {
+    cwd,
+    env,
+    runtime_ref: runtimeProvider.runtime_ref,
+    provider_id: runtimeProvider.provider_id,
+  };
+  const effectiveProbes = {
+    commandExists: probes.commandExists ?? defaultCommandExists,
+    pathExists: probes.pathExists ?? defaultPathExists,
+    capability: probes.capability ?? defaultCapability,
+  };
+  const checks = runtimeProvider.bootstrap_requirements.map((requirement) => (
+    evaluateRequirement(requirement, context, effectiveProbes)
+  ));
+
+  return createRuntimePreflightSnapshot({
+    runtime_ref: runtimeProvider.runtime_ref,
+    provider_id: runtimeProvider.provider_id,
+    observed_at: timestamp,
+    status: deriveOverallStatus(checks),
+    contract: runtimeProvider,
+    checks,
+  });
+}

--- a/scripts/ao/lib/runtime-providers/github-local.js
+++ b/scripts/ao/lib/runtime-providers/github-local.js
@@ -1,0 +1,73 @@
+import { createRuntimeProviderContract } from '../runtime-contracts.js';
+
+export const GITHUB_LOCAL_RUNTIME_PROVIDER = createRuntimeProviderContract({
+  runtime_ref: 'runtime.github_local',
+  provider_id: 'github_local',
+  provider_kind: 'github_local',
+  display_name: 'GitHub local workspace',
+  bootstrap_requirements: [
+    {
+      requirement_id: 'language_runtime.node',
+      requirement_kind: 'language_runtime',
+      summary: 'Node.js runtime is available for AO scripts.',
+      probe: {
+        kind: 'command',
+        command: 'node',
+      },
+      setup_steps: ['Install Node.js.'],
+    },
+    {
+      requirement_id: 'package_manager.npm',
+      requirement_kind: 'package_manager',
+      summary: 'npm is available to bootstrap the repo-local workspace.',
+      probe: {
+        kind: 'command',
+        command: 'npm',
+      },
+      setup_steps: ['Install npm.'],
+    },
+    {
+      requirement_id: 'setup_step.install_dependencies',
+      requirement_kind: 'setup_step',
+      summary: 'Repo dependencies are installed in node_modules.',
+      probe: {
+        kind: 'path',
+        path: 'node_modules',
+      },
+      setup_steps: ['Run npm install.'],
+    },
+    {
+      requirement_id: 'network_posture.github_api',
+      requirement_kind: 'network_posture',
+      summary: 'GitHub API network access is available for AO coordination.',
+      probe: {
+        kind: 'capability',
+        capability: 'network.github_api',
+      },
+      setup_steps: ['Allow outbound access to github.com and api.github.com.'],
+    },
+    {
+      requirement_id: 'filesystem_posture.workspace_write',
+      requirement_kind: 'filesystem_posture',
+      summary: 'The repository worktree is writable for AO-managed edits.',
+      probe: {
+        kind: 'capability',
+        capability: 'filesystem.workspace_write',
+      },
+      setup_steps: ['Grant write access to the repository worktree.'],
+    },
+    {
+      requirement_id: 'secret_posture.github_auth',
+      requirement_kind: 'secret_posture',
+      summary: 'GitHub authentication is available for AO GitHub operations.',
+      probe: {
+        kind: 'capability',
+        capability: 'secret.github_auth',
+      },
+      setup_steps: ['Authenticate gh CLI or export GITHUB_TOKEN.'],
+    },
+  ],
+  metadata: {
+    executor: 'local_workspace',
+  },
+});

--- a/scripts/ao/lib/runtime-providers/index.js
+++ b/scripts/ao/lib/runtime-providers/index.js
@@ -1,0 +1,22 @@
+import { GITHUB_LOCAL_RUNTIME_PROVIDER } from './github-local.js';
+
+function cloneJsonValue(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+const PROVIDERS_BY_RUNTIME_REF = new Map([
+  [GITHUB_LOCAL_RUNTIME_PROVIDER.runtime_ref, GITHUB_LOCAL_RUNTIME_PROVIDER],
+]);
+
+export function listRuntimeProviderContracts() {
+  return [...PROVIDERS_BY_RUNTIME_REF.values()].map((provider) => cloneJsonValue(provider));
+}
+
+export function getRuntimeProviderContract(runtimeRef) {
+  const normalizedRuntimeRef = typeof runtimeRef === 'string' ? runtimeRef.trim() : '';
+  if (!normalizedRuntimeRef) return null;
+
+  const provider = PROVIDERS_BY_RUNTIME_REF.get(normalizedRuntimeRef);
+  return provider == null ? null : cloneJsonValue(provider);
+}

--- a/scripts/ao/lib/state-contracts.js
+++ b/scripts/ao/lib/state-contracts.js
@@ -1,3 +1,4 @@
+import { createRuntimePreflightSnapshot } from './runtime-contracts.js';
 import { createTaskSpecSnapshot } from './task-spec.js';
 
 export const CONTROL_PLANE_SCHEMA_VERSION = 'ao.control-plane.schema.v1alpha1';
@@ -6,7 +7,7 @@ export const CONTROL_PLANE_STATE_SCHEMA_VERSION = 'ao.control-plane.state.v1alph
 export const CONTROL_PLANE_STATE_FORMAT = 'ao_control_plane_state';
 export const CONTROL_PLANE_AUDIT_SCHEMA_VERSION = 'ao.control-plane.audit.v1alpha1';
 export const CONTROL_PLANE_AUDIT_FORMAT = 'ao_control_plane_audit_entry';
-export const CONTROL_PLANE_LATEST_VERSION = 4;
+export const CONTROL_PLANE_LATEST_VERSION = 5;
 export const CONTROL_PLANE_DEFAULT_CONTROLLER_ID = 'default';
 
 export const MANAGED_TASK_STATUSES = ['active', 'paused', 'retired'];
@@ -165,6 +166,7 @@ export function createEmptyControlPlaneState({
     policy_decisions: [],
     credential_provenances: [],
     task_specs: [],
+    runtime_preflights: [],
   };
 }
 
@@ -508,6 +510,30 @@ export function createTaskSpecRecord({
     state: normalizedSnapshot.valid ? 'valid' : 'invalid',
     created_at: normalizeIsoTimestamp(created_at, 'created_at'),
     updated_at: normalizeIsoTimestamp(updated_at, 'updated_at'),
+    snapshot: normalizedSnapshot,
+  };
+}
+
+export function createRuntimePreflightRecord({
+  recorded_at,
+  snapshot,
+} = {}) {
+  const normalizedSnapshot = createRuntimePreflightSnapshot({
+    runtime_ref: snapshot?.runtime_ref,
+    provider_id: snapshot?.provider_id ?? null,
+    observed_at: snapshot?.observed_at,
+    status: snapshot?.status,
+    contract: snapshot?.contract ?? null,
+    checks: snapshot?.checks ?? [],
+  });
+
+  return {
+    runtime_ref: normalizeRequiredString(normalizedSnapshot.runtime_ref, 'runtime_ref'),
+    provider_id: normalizeOptionalString(normalizedSnapshot.provider_id),
+    status: normalizeRequiredString(normalizedSnapshot.status, 'status'),
+    observed_at: normalizeIsoTimestamp(normalizedSnapshot.observed_at, 'observed_at'),
+    recorded_at: normalizeIsoTimestamp(recorded_at, 'recorded_at'),
+    replay_key: normalizeRequiredString(normalizedSnapshot.replay_key, 'replay_key'),
     snapshot: normalizedSnapshot,
   };
 }

--- a/scripts/ao/lib/state-migrations.js
+++ b/scripts/ao/lib/state-migrations.js
@@ -37,11 +37,17 @@ export const CONTROL_PLANE_POLICY_ENGINE_MIGRATION = {
   key: '0004_policy_engine_v1',
 };
 
+export const CONTROL_PLANE_RUNTIME_PREFLIGHT_MIGRATION = {
+  version: 5,
+  key: '0005_runtime_preflight_v1',
+};
+
 const CONTROL_PLANE_MIGRATIONS = [
   CONTROL_PLANE_BOOTSTRAP_MIGRATION,
   CONTROL_PLANE_TASK_SPEC_MIGRATION,
   CONTROL_PLANE_DELIVERY_EVENTS_MIGRATION,
   CONTROL_PLANE_POLICY_ENGINE_MIGRATION,
+  CONTROL_PLANE_RUNTIME_PREFLIGHT_MIGRATION,
 ];
 
 function resolveNow(now) {
@@ -103,6 +109,7 @@ function buildBootstrapState({
     'policy_decisions',
     'credential_provenances',
     'task_specs',
+    'runtime_preflights',
   ]) {
     if (Array.isArray(existingState?.[collectionKey])) {
       state[collectionKey] = cloneJsonValue(existingState[collectionKey]);
@@ -191,6 +198,14 @@ function applyMigration({
     });
   }
 
+  if (migration.version === CONTROL_PLANE_RUNTIME_PREFLIGHT_MIGRATION.version) {
+    return buildBootstrapState({
+      projectId,
+      now,
+      existingState: state,
+    });
+  }
+
   throw new Error(`Unsupported migration version ${migration.version}`);
 }
 
@@ -213,6 +228,13 @@ function buildAuditSummary(migration) {
     return {
       operation: 'migrate',
       summary: 'Applied control-plane policy-engine migration.',
+    };
+  }
+
+  if (migration.version === CONTROL_PLANE_RUNTIME_PREFLIGHT_MIGRATION.version) {
+    return {
+      operation: 'migrate',
+      summary: 'Applied control-plane runtime-preflight migration.',
     };
   }
 

--- a/scripts/ao/lib/state-repository.js
+++ b/scripts/ao/lib/state-repository.js
@@ -17,8 +17,10 @@ import {
   createOwnershipLease,
   createPolicyDecisionRecord,
   createPrBinding,
+  createRuntimePreflightRecord,
   createTaskSpecRecord,
 } from './state-contracts.js';
+import { runRuntimeBootstrapPreflight } from './runtime-preflight.js';
 import { appendControlPlaneAuditEntry, readControlPlaneAuditEntries } from './state-audit.js';
 import {
   bootstrapControlPlaneState,
@@ -62,6 +64,20 @@ function sortCollectionByKey(items, key) {
   return [...(items ?? [])].sort((left, right) => String(left?.[key] ?? '').localeCompare(String(right?.[key] ?? '')));
 }
 
+function normalizeRuntimeRefs(runtimeRefs) {
+  if (!Array.isArray(runtimeRefs)) return [];
+  return [...new Set(runtimeRefs
+    .filter((value) => typeof value === 'string')
+    .map((value) => value.trim())
+    .filter(Boolean))].sort((left, right) => left.localeCompare(right));
+}
+
+function extractRuntimeRefsFromState(state) {
+  return normalizeRuntimeRefs(
+    (state?.task_specs ?? []).map((record) => record?.snapshot?.spec?.runtime_ref ?? null),
+  );
+}
+
 export function createStateRepository({
   repoRoot,
   projectId,
@@ -100,6 +116,7 @@ export function createStateRepository({
     nextState.policy_decisions = sortCollectionByKey(nextState.policy_decisions, 'decision_id');
     nextState.credential_provenances = sortCollectionByKey(nextState.credential_provenances, 'provenance_id');
     nextState.task_specs = sortCollectionByKey(nextState.task_specs, 'task_id');
+    nextState.runtime_preflights = sortCollectionByKey(nextState.runtime_preflights, 'runtime_ref');
 
     return {
       bootstrapped: true,
@@ -356,6 +373,78 @@ export function createStateRepository({
         normalize: createTaskSpecRecord,
         summary: `Persisted task spec ${record?.task_id}.`,
       });
+    },
+
+    upsertRuntimePreflight(record) {
+      return upsertCollectionRecord({
+        collectionKey: 'runtime_preflights',
+        identityKey: 'runtime_ref',
+        entityKind: 'runtime_preflight',
+        record,
+        normalize: createRuntimePreflightRecord,
+        summary: `Persisted runtime preflight ${record?.runtime_ref ?? record?.snapshot?.runtime_ref}.`,
+      });
+    },
+
+    ensureRuntimePreflights({
+      cwd = repoRoot,
+      now = clock,
+      runtimeRefs = null,
+      probes = {},
+    } = {}) {
+      ensureBootstrapped();
+      const timestamp = resolveNow(now);
+      let snapshot = readSnapshot();
+      const requestedRuntimeRefs = runtimeRefs == null
+        ? extractRuntimeRefsFromState(snapshot.state)
+        : normalizeRuntimeRefs(runtimeRefs);
+      const ensuredRecords = [];
+
+      for (const runtimeRef of requestedRuntimeRefs) {
+        const preflightSnapshot = runRuntimeBootstrapPreflight({
+          runtimeRef,
+          cwd,
+          now: timestamp,
+          probes,
+        });
+        const normalizedRecord = createRuntimePreflightRecord({
+          recorded_at: timestamp,
+          snapshot: preflightSnapshot,
+        });
+        const existingRecord = (snapshot.state.runtime_preflights ?? []).find(
+          (record) => record?.runtime_ref === normalizedRecord.runtime_ref,
+        );
+
+        if (existingRecord?.replay_key === normalizedRecord.replay_key) {
+          ensuredRecords.push(existingRecord);
+          continue;
+        }
+
+        const nextState = cloneJsonValue(snapshot.state);
+        const existingIndex = nextState.runtime_preflights.findIndex(
+          (record) => record?.runtime_ref === normalizedRecord.runtime_ref,
+        );
+        if (existingIndex >= 0) {
+          nextState.runtime_preflights[existingIndex] = normalizedRecord;
+        } else {
+          nextState.runtime_preflights.push(normalizedRecord);
+        }
+
+        persistState({
+          state: nextState,
+          entityKind: 'runtime_preflight',
+          entityId: normalizedRecord.runtime_ref,
+          summary: `Persisted runtime preflight ${normalizedRecord.runtime_ref}.`,
+          details: normalizedRecord,
+        });
+        snapshot = {
+          ...snapshot,
+          state: nextState,
+        };
+        ensuredRecords.push(normalizedRecord);
+      }
+
+      return sortCollectionByKey(ensuredRecords, 'runtime_ref');
     },
   };
 }

--- a/tests/ao/controller-shadow-parity.test.js
+++ b/tests/ao/controller-shadow-parity.test.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from '@jest/globals';
 
@@ -22,7 +23,8 @@ import {
 import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
 
 const PROJECT_ID = 'ciecopilot-home';
-const FIXTURE_ROOT = path.join(process.cwd(), 'tests', 'ao', 'fixtures', 'acceptance');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = path.join(__dirname, 'fixtures', 'acceptance');
 const ORIGINAL_FIXTURE_ROOT = process.env.AO_FIXTURE_ROOT;
 const tempDirs = [];
 

--- a/tests/ao/controller-state-contracts.test.js
+++ b/tests/ao/controller-state-contracts.test.js
@@ -97,6 +97,7 @@ describe('ao controller state contracts', () => {
       observations: [],
       delivery_events: [],
       controller_cursors: [],
+      runtime_preflights: [],
     });
   });
 });

--- a/tests/ao/doctor-engine.test.js
+++ b/tests/ao/doctor-engine.test.js
@@ -71,6 +71,7 @@ function buildControlPlaneSnapshot(overrides = {}) {
     state: {
       managed_tasks: [],
       task_specs: [],
+      runtime_preflights: [],
     },
     ...overrides,
   };
@@ -296,6 +297,107 @@ describe('doctor engine', () => {
     expect(report.findings).toEqual(expect.arrayContaining([
       expect.objectContaining({
         code: 'task_spec_state_schema_stale',
+        origin: 'doctor',
+      }),
+    ]));
+  });
+
+  it('blocks when a managed task runtime ref has no durable preflight state', () => {
+    const report = buildDoctorReport({
+      scope: createDoctorProjectScope({ projectId: 'ciecopilot-home' }),
+      reconciliationReport: buildReconciliationReport(),
+      localState: buildLocalState(),
+      controlPlaneSnapshot: buildControlPlaneSnapshot({
+        state: {
+          managed_tasks: [
+            {
+              task_id: 'issue-108',
+              issue_number: 108,
+              title: 'feat(ao): add runtime-provider contract and bootstrap preflight',
+            },
+          ],
+          task_specs: [
+            {
+              task_id: 'issue-108',
+              state: 'valid',
+              snapshot: {
+                schema_version: 'ao.task-spec.v1alpha1',
+                valid: true,
+                findings: [],
+                spec: {
+                  problem_type: 'issue_delivery',
+                  acceptance_contract: ['runtime preflight is durable'],
+                  runtime_ref: 'runtime.github_local',
+                  policy_ref: 'policy.operator_gated',
+                  human_gates: ['operator_enroll'],
+                },
+              },
+            },
+          ],
+          runtime_preflights: [],
+        },
+      }),
+    });
+
+    expect(report.top_status).toBe('blocked');
+    expect(report.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'runtime_preflight_missing',
+        severity: 'blocker',
+        origin: 'doctor',
+      }),
+    ]));
+  });
+
+  it('surfaces mixed-version runtime preflight snapshots as explicit findings', () => {
+    const report = buildDoctorReport({
+      scope: createDoctorProjectScope({ projectId: 'ciecopilot-home' }),
+      reconciliationReport: buildReconciliationReport(),
+      localState: buildLocalState(),
+      controlPlaneSnapshot: buildControlPlaneSnapshot({
+        state: {
+          managed_tasks: [
+            {
+              task_id: 'issue-108',
+              issue_number: 108,
+              title: 'feat(ao): add runtime-provider contract and bootstrap preflight',
+            },
+          ],
+          task_specs: [
+            {
+              task_id: 'issue-108',
+              state: 'valid',
+              snapshot: {
+                schema_version: 'ao.task-spec.v1alpha1',
+                valid: true,
+                findings: [],
+                spec: {
+                  problem_type: 'issue_delivery',
+                  acceptance_contract: ['runtime preflight is durable'],
+                  runtime_ref: 'runtime.github_local',
+                  policy_ref: 'policy.operator_gated',
+                  human_gates: ['operator_enroll'],
+                },
+              },
+            },
+          ],
+          runtime_preflights: [
+            {
+              runtime_ref: 'runtime.github_local',
+              status: 'clean',
+              snapshot: {
+                schema_version: 'ao.runtime-preflight.v0',
+                runtime_ref: 'runtime.github_local',
+              },
+            },
+          ],
+        },
+      }),
+    });
+
+    expect(report.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'runtime_preflight_mixed_version',
         origin: 'doctor',
       }),
     ]));

--- a/tests/ao/doctor-runner.test.js
+++ b/tests/ao/doctor-runner.test.js
@@ -5,6 +5,7 @@ const mockLoadDoctorLocalState = jest.fn();
 const mockBuildDoctorReport = jest.fn();
 const mockFindRepoRoot = jest.fn();
 const mockCreateStateRepository = jest.fn();
+const mockEnsureRuntimePreflights = jest.fn();
 
 jest.unstable_mockModule('../../scripts/ao/lib/reconciliation-runner.js', () => ({
   DEFAULT_PROJECT_ID: 'ciecopilot-home',
@@ -36,17 +37,20 @@ describe('doctor runner', () => {
     mockBuildDoctorReport.mockReset();
     mockFindRepoRoot.mockReset();
     mockCreateStateRepository.mockReset();
+    mockEnsureRuntimePreflights.mockReset();
     mockFindRepoRoot.mockReturnValue('/home/samsen/code/ciecopilot-home');
     mockCreateStateRepository.mockReturnValue({
+      ensureRuntimePreflights: mockEnsureRuntimePreflights,
       getSnapshot: () => ({
         bootstrapped: true,
         schema: {
-          current_version: 2,
-          latest_version: 2,
+          current_version: 5,
+          latest_version: 5,
         },
         state: {
           managed_tasks: [],
           task_specs: [],
+          runtime_preflights: [],
         },
       }),
     });
@@ -79,6 +83,9 @@ describe('doctor runner', () => {
       projectId: 'ciecopilot-home',
       prNumber: null,
     });
+    expect(mockEnsureRuntimePreflights).toHaveBeenCalledWith({
+      cwd: '/home/samsen/code/ciecopilot-home',
+    });
     expect(mockLoadDoctorLocalState).toHaveBeenCalledWith({
       cwd: '/home/samsen/code/ciecopilot-home',
     });
@@ -101,12 +108,13 @@ describe('doctor runner', () => {
       controlPlaneSnapshot: {
         bootstrapped: true,
         schema: {
-          current_version: 2,
-          latest_version: 2,
+          current_version: 5,
+          latest_version: 5,
         },
         state: {
           managed_tasks: [],
           task_specs: [],
+          runtime_preflights: [],
         },
       },
     });
@@ -129,12 +137,13 @@ describe('doctor runner', () => {
       controlPlaneSnapshot: {
         bootstrapped: true,
         schema: {
-          current_version: 2,
-          latest_version: 2,
+          current_version: 5,
+          latest_version: 5,
         },
         state: {
           managed_tasks: [],
           task_specs: [],
+          runtime_preflights: [],
         },
       },
       report: {
@@ -178,6 +187,9 @@ describe('doctor runner', () => {
       pr_number: 44,
       authoritative_for_release: false,
       diagnose_only: true,
+    });
+    expect(mockEnsureRuntimePreflights).toHaveBeenCalledWith({
+      cwd: '/home/samsen/code/ciecopilot-home',
     });
     expect(result.report.top_status).toBe('healthy');
   });

--- a/tests/ao/runtime-contracts.test.js
+++ b/tests/ao/runtime-contracts.test.js
@@ -1,0 +1,250 @@
+import { describe, expect, it } from '@jest/globals';
+
+const {
+  BOOTSTRAP_PROBE_KINDS,
+  BOOTSTRAP_REQUIREMENT_KINDS,
+  RUNTIME_PREFLIGHT_CHECK_STATUSES,
+  RUNTIME_PREFLIGHT_FORMAT,
+  RUNTIME_PREFLIGHT_SCHEMA_VERSION,
+  RUNTIME_PREFLIGHT_STATUSES,
+  RUNTIME_PROVIDER_KINDS,
+  RUNTIME_PROVIDER_SCHEMA_VERSION,
+  createBootstrapRequirement,
+  createRuntimePreflightSnapshot,
+  createRuntimeProviderContract,
+} = await import('../../scripts/ao/lib/runtime-contracts.js');
+const {
+  getRuntimeProviderContract,
+} = await import('../../scripts/ao/lib/runtime-providers/index.js');
+
+const NOW = '2026-03-30T10:00:00.000Z';
+
+describe('runtime contracts', () => {
+  it('freezes typed runtime-provider bootstrap enums', () => {
+    expect(RUNTIME_PROVIDER_SCHEMA_VERSION).toBe('ao.runtime-provider.v1alpha1');
+    expect(RUNTIME_PROVIDER_KINDS).toEqual(['github_local']);
+    expect(BOOTSTRAP_REQUIREMENT_KINDS).toEqual([
+      'language_runtime',
+      'package_manager',
+      'setup_step',
+      'network_posture',
+      'filesystem_posture',
+      'secret_posture',
+    ]);
+    expect(BOOTSTRAP_PROBE_KINDS).toEqual(['command', 'path', 'capability']);
+    expect(RUNTIME_PREFLIGHT_SCHEMA_VERSION).toBe('ao.runtime-preflight.v1alpha1');
+    expect(RUNTIME_PREFLIGHT_FORMAT).toBe('ao_runtime_preflight');
+    expect(RUNTIME_PREFLIGHT_CHECK_STATUSES).toEqual(['satisfied', 'missing', 'unsupported']);
+    expect(RUNTIME_PREFLIGHT_STATUSES).toEqual([
+      'clean',
+      'missing_dependency',
+      'unsupported_provider',
+    ]);
+  });
+
+  it('normalizes bootstrap requirements and provider contracts', () => {
+    expect(createBootstrapRequirement({
+      requirement_id: 'language_runtime.node',
+      requirement_kind: 'language_runtime',
+      summary: 'Node.js runtime is available for AO scripts.',
+      probe: {
+        kind: 'command',
+        command: 'node',
+      },
+      setup_steps: [
+        'Install a supported Node.js runtime.',
+      ],
+      metadata: {
+        minimum_major: 20,
+      },
+    })).toEqual({
+      requirement_id: 'language_runtime.node',
+      requirement_kind: 'language_runtime',
+      summary: 'Node.js runtime is available for AO scripts.',
+      probe: {
+        kind: 'command',
+        command: 'node',
+      },
+      setup_steps: [
+        'Install a supported Node.js runtime.',
+      ],
+      metadata: {
+        minimum_major: 20,
+      },
+    });
+
+    expect(createRuntimeProviderContract({
+      runtime_ref: 'runtime.github_local',
+      provider_id: 'github_local',
+      provider_kind: 'github_local',
+      display_name: 'GitHub local workspace',
+      bootstrap_requirements: [
+        {
+          requirement_id: 'language_runtime.node',
+          requirement_kind: 'language_runtime',
+          summary: 'Node.js runtime is available for AO scripts.',
+          probe: {
+            kind: 'command',
+            command: 'node',
+          },
+          setup_steps: ['Install Node.js.'],
+        },
+      ],
+      metadata: {
+        executor: 'local_workspace',
+      },
+    })).toEqual({
+      schema_version: RUNTIME_PROVIDER_SCHEMA_VERSION,
+      runtime_ref: 'runtime.github_local',
+      provider_id: 'github_local',
+      provider_kind: 'github_local',
+      display_name: 'GitHub local workspace',
+      bootstrap_requirements: [
+        {
+          requirement_id: 'language_runtime.node',
+          requirement_kind: 'language_runtime',
+          summary: 'Node.js runtime is available for AO scripts.',
+          probe: {
+            kind: 'command',
+            command: 'node',
+          },
+          setup_steps: ['Install Node.js.'],
+          metadata: {},
+        },
+      ],
+      metadata: {
+        executor: 'local_workspace',
+      },
+    });
+  });
+
+  it('defines the GitHub local runtime contract with explicit bootstrap requirements', () => {
+    const contract = getRuntimeProviderContract('runtime.github_local');
+
+    expect(contract).toMatchObject({
+      schema_version: RUNTIME_PROVIDER_SCHEMA_VERSION,
+      runtime_ref: 'runtime.github_local',
+      provider_id: 'github_local',
+      provider_kind: 'github_local',
+      display_name: 'GitHub local workspace',
+    });
+    expect(contract.bootstrap_requirements.map((item) => item.requirement_kind)).toEqual([
+      'language_runtime',
+      'package_manager',
+      'setup_step',
+      'network_posture',
+      'filesystem_posture',
+      'secret_posture',
+    ]);
+    expect(contract.bootstrap_requirements).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        requirement_id: 'language_runtime.node',
+        requirement_kind: 'language_runtime',
+        probe: {
+          kind: 'command',
+          command: 'node',
+        },
+      }),
+      expect.objectContaining({
+        requirement_id: 'package_manager.npm',
+        requirement_kind: 'package_manager',
+        probe: {
+          kind: 'command',
+          command: 'npm',
+        },
+      }),
+      expect.objectContaining({
+        requirement_id: 'setup_step.install_dependencies',
+        requirement_kind: 'setup_step',
+        probe: {
+          kind: 'path',
+          path: 'node_modules',
+        },
+        setup_steps: ['Run npm install.'],
+      }),
+      expect.objectContaining({
+        requirement_id: 'network_posture.github_api',
+        requirement_kind: 'network_posture',
+        probe: {
+          kind: 'capability',
+          capability: 'network.github_api',
+        },
+      }),
+      expect.objectContaining({
+        requirement_id: 'filesystem_posture.workspace_write',
+        requirement_kind: 'filesystem_posture',
+        probe: {
+          kind: 'capability',
+          capability: 'filesystem.workspace_write',
+        },
+      }),
+      expect.objectContaining({
+        requirement_id: 'secret_posture.github_auth',
+        requirement_kind: 'secret_posture',
+        probe: {
+          kind: 'capability',
+          capability: 'secret.github_auth',
+        },
+      }),
+    ]));
+  });
+
+  it('creates versioned runtime preflight snapshots with stable replay keys', () => {
+    const first = createRuntimePreflightSnapshot({
+      runtime_ref: 'runtime.github_local',
+      provider_id: 'github_local',
+      observed_at: NOW,
+      status: 'clean',
+      contract: getRuntimeProviderContract('runtime.github_local'),
+      checks: [
+        {
+          requirement_id: 'language_runtime.node',
+          requirement_kind: 'language_runtime',
+          status: 'satisfied',
+          summary: 'Node.js runtime is available for AO scripts.',
+          details: ['command: node'],
+          setup_steps: ['Install Node.js.'],
+        },
+      ],
+    });
+    const second = createRuntimePreflightSnapshot({
+      runtime_ref: 'runtime.github_local',
+      provider_id: 'github_local',
+      observed_at: NOW,
+      status: 'clean',
+      contract: getRuntimeProviderContract('runtime.github_local'),
+      checks: [
+        {
+          requirement_id: 'language_runtime.node',
+          requirement_kind: 'language_runtime',
+          status: 'satisfied',
+          summary: 'Node.js runtime is available for AO scripts.',
+          details: ['command: node'],
+          setup_steps: ['Install Node.js.'],
+        },
+      ],
+    });
+
+    expect(first).toEqual(second);
+    expect(first).toEqual({
+      schema_version: RUNTIME_PREFLIGHT_SCHEMA_VERSION,
+      format: RUNTIME_PREFLIGHT_FORMAT,
+      runtime_ref: 'runtime.github_local',
+      provider_id: 'github_local',
+      status: 'clean',
+      observed_at: NOW,
+      replay_key: expect.stringMatching(/^runtime_preflight:/),
+      contract: getRuntimeProviderContract('runtime.github_local'),
+      checks: [
+        {
+          requirement_id: 'language_runtime.node',
+          requirement_kind: 'language_runtime',
+          status: 'satisfied',
+          summary: 'Node.js runtime is available for AO scripts.',
+          details: ['command: node'],
+          setup_steps: ['Install Node.js.'],
+        },
+      ],
+    });
+  });
+});

--- a/tests/ao/runtime-preflight.test.js
+++ b/tests/ao/runtime-preflight.test.js
@@ -1,0 +1,219 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+const {
+  runRuntimeBootstrapPreflight,
+} = await import('../../scripts/ao/lib/runtime-preflight.js');
+const {
+  createManagedTask,
+  createTaskSpecRecord,
+} = await import('../../scripts/ao/lib/state-contracts.js');
+const {
+  createStateRepository,
+} = await import('../../scripts/ao/lib/state-repository.js');
+
+const PROJECT_ID = 'ciecopilot-home';
+const NOW = '2026-03-30T10:10:00.000Z';
+const tempDirs = [];
+
+function createTempRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-runtime-preflight-'));
+  tempDirs.push(repoRoot);
+  return repoRoot;
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('runtime preflight', () => {
+  it('classifies the GitHub local runtime as clean when every bootstrap requirement is satisfied', () => {
+    const result = runRuntimeBootstrapPreflight({
+      runtimeRef: 'runtime.github_local',
+      cwd: '/tmp/ciecopilot-home',
+      now: NOW,
+      probes: {
+        commandExists: (command) => ['node', 'npm'].includes(command),
+        pathExists: (filePath) => filePath.endsWith(`${path.sep}node_modules`),
+        capability: (capability) => [
+          'network.github_api',
+          'filesystem.workspace_write',
+          'secret.github_auth',
+        ].includes(capability),
+      },
+    });
+
+    expect(result).toMatchObject({
+      runtime_ref: 'runtime.github_local',
+      provider_id: 'github_local',
+      status: 'clean',
+      observed_at: NOW,
+      checks: [
+        expect.objectContaining({
+          requirement_id: 'language_runtime.node',
+          status: 'satisfied',
+        }),
+        expect.objectContaining({
+          requirement_id: 'package_manager.npm',
+          status: 'satisfied',
+        }),
+        expect.objectContaining({
+          requirement_id: 'setup_step.install_dependencies',
+          status: 'satisfied',
+        }),
+        expect.objectContaining({
+          requirement_id: 'network_posture.github_api',
+          status: 'satisfied',
+        }),
+        expect.objectContaining({
+          requirement_id: 'filesystem_posture.workspace_write',
+          status: 'satisfied',
+        }),
+        expect.objectContaining({
+          requirement_id: 'secret_posture.github_auth',
+          status: 'satisfied',
+        }),
+      ],
+    });
+  });
+
+  it('classifies missing bootstrap dependencies without collapsing them into an unsupported provider result', () => {
+    const result = runRuntimeBootstrapPreflight({
+      runtimeRef: 'runtime.github_local',
+      cwd: '/tmp/ciecopilot-home',
+      now: NOW,
+      probes: {
+        commandExists: (command) => command === 'node',
+        pathExists: () => false,
+        capability: (capability) => capability === 'filesystem.workspace_write',
+      },
+    });
+
+    expect(result.status).toBe('missing_dependency');
+    expect(result.checks).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        requirement_id: 'package_manager.npm',
+        status: 'missing',
+      }),
+      expect.objectContaining({
+        requirement_id: 'setup_step.install_dependencies',
+        status: 'missing',
+      }),
+      expect.objectContaining({
+        requirement_id: 'network_posture.github_api',
+        status: 'missing',
+      }),
+      expect.objectContaining({
+        requirement_id: 'secret_posture.github_auth',
+        status: 'missing',
+      }),
+    ]));
+  });
+
+  it('classifies unknown runtime refs as unsupported providers', () => {
+    const result = runRuntimeBootstrapPreflight({
+      runtimeRef: 'runtime.unsupported_vm',
+      cwd: '/tmp/ciecopilot-home',
+      now: NOW,
+      probes: {
+        commandExists: () => true,
+        pathExists: () => true,
+        capability: () => true,
+      },
+    });
+
+    expect(result).toMatchObject({
+      runtime_ref: 'runtime.unsupported_vm',
+      provider_id: null,
+      status: 'unsupported_provider',
+      checks: [
+        expect.objectContaining({
+          requirement_id: 'provider.runtime.unsupported_vm',
+          status: 'unsupported',
+        }),
+      ],
+    });
+  });
+
+  it('persists runtime preflight state durably and skips replay-identical rewrites', () => {
+    const repoRoot = createTempRepo();
+    const repository = createStateRepository({
+      repoRoot,
+      projectId: PROJECT_ID,
+      clock: () => NOW,
+    });
+
+    repository.upsertManagedTask(createManagedTask({
+      task_id: 'issue-108',
+      issue_number: 108,
+      title: 'feat(ao): add runtime-provider contract and bootstrap preflight',
+      branch_name: 'feat/108',
+      worktree_path: repoRoot,
+      status: 'active',
+      created_at: NOW,
+      updated_at: NOW,
+    }));
+    repository.upsertTaskSpec(createTaskSpecRecord({
+      task_id: 'issue-108',
+      source_kind: 'github_issue',
+      source_issue_number: 108,
+      created_at: NOW,
+      updated_at: NOW,
+      snapshot: {
+        schema_version: 'ao.task-spec.v1alpha1',
+        valid: true,
+        findings: [],
+        spec: {
+          problem_type: 'issue_delivery',
+          acceptance_contract: ['runtime preflight is durable'],
+          runtime_ref: 'runtime.github_local',
+          policy_ref: 'policy.operator_gated',
+          human_gates: ['operator_enroll'],
+        },
+      },
+    }));
+
+    const first = repository.ensureRuntimePreflights({
+      cwd: repoRoot,
+      now: NOW,
+      probes: {
+        commandExists: (command) => ['node', 'npm'].includes(command),
+        pathExists: (filePath) => filePath.endsWith(`${path.sep}node_modules`),
+        capability: () => true,
+      },
+    });
+    const second = repository.ensureRuntimePreflights({
+      cwd: repoRoot,
+      now: NOW,
+      probes: {
+        commandExists: (command) => ['node', 'npm'].includes(command),
+        pathExists: (filePath) => filePath.endsWith(`${path.sep}node_modules`),
+        capability: () => true,
+      },
+    });
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(second[0].replay_key).toBe(first[0].replay_key);
+    expect(repository.getSnapshot().state.runtime_preflights).toEqual([
+      expect.objectContaining({
+        runtime_ref: 'runtime.github_local',
+        provider_id: 'github_local',
+        status: 'clean',
+        replay_key: first[0].replay_key,
+      }),
+    ]);
+    expect(repository.listAuditEntries().filter((entry) => entry.entity_kind === 'runtime_preflight')).toEqual([
+      expect.objectContaining({
+        entity_kind: 'runtime_preflight',
+        entity_id: 'runtime.github_local',
+        operation: 'upsert',
+      }),
+    ]);
+  });
+});

--- a/tests/ao/state-contracts.test.js
+++ b/tests/ao/state-contracts.test.js
@@ -26,6 +26,7 @@ import {
   createOwnershipLease,
   createPolicyDecisionRecord,
   createPrBinding,
+  createRuntimePreflightRecord,
   createTaskSpecRecord,
 } from '../../scripts/ao/lib/state-contracts.js';
 
@@ -44,7 +45,7 @@ describe('ao state contracts', () => {
     expect(CONTROLLER_MODES).toEqual(['off', 'observe', 'shadow', 'assist']);
     expect(POLICY_DECISIONS).toEqual(['allow', 'deny', 'downgrade']);
     expect(CREDENTIAL_PROVENANCE_TRUST_DECISIONS).toEqual(['trusted', 'untrusted']);
-    expect(CONTROL_PLANE_LATEST_VERSION).toBe(4);
+    expect(CONTROL_PLANE_LATEST_VERSION).toBe(5);
   });
 
   it('creates durable managed-task, binding, lease, action, override, and controller-mode records', () => {
@@ -233,6 +234,58 @@ describe('ao state contracts', () => {
       },
     });
 
+    const runtimePreflightRecord = createRuntimePreflightRecord({
+      recorded_at: NOW,
+      snapshot: {
+        schema_version: 'ao.runtime-preflight.v1alpha1',
+        format: 'ao_runtime_preflight',
+        runtime_ref: 'runtime.github_local',
+        provider_id: 'github_local',
+        status: 'clean',
+        observed_at: NOW,
+        replay_key: 'runtime_preflight:abc123',
+        contract: {
+          schema_version: 'ao.runtime-provider.v1alpha1',
+          runtime_ref: 'runtime.github_local',
+          provider_id: 'github_local',
+          provider_kind: 'github_local',
+          display_name: 'GitHub local workspace',
+          bootstrap_requirements: [],
+          metadata: {},
+        },
+        checks: [],
+      },
+    });
+    expect(runtimePreflightRecord.replay_key).toMatch(/^runtime_preflight:/);
+    expect(runtimePreflightRecord.snapshot.replay_key).toBe(runtimePreflightRecord.replay_key);
+    expect(runtimePreflightRecord).toMatchObject({
+      runtime_ref: 'runtime.github_local',
+      provider_id: 'github_local',
+      status: 'clean',
+      observed_at: NOW,
+      recorded_at: NOW,
+      replay_key: expect.stringMatching(/^runtime_preflight:/),
+      snapshot: {
+        schema_version: 'ao.runtime-preflight.v1alpha1',
+        format: 'ao_runtime_preflight',
+        runtime_ref: 'runtime.github_local',
+        provider_id: 'github_local',
+        status: 'clean',
+        observed_at: NOW,
+        replay_key: expect.stringMatching(/^runtime_preflight:/),
+        contract: {
+          schema_version: 'ao.runtime-provider.v1alpha1',
+          runtime_ref: 'runtime.github_local',
+          provider_id: 'github_local',
+          provider_kind: 'github_local',
+          display_name: 'GitHub local workspace',
+          bootstrap_requirements: [],
+          metadata: {},
+        },
+        checks: [],
+      },
+    });
+
     expect(createCredentialProvenanceRecord({
       provenance_id: 'cred-gh-cli',
       credential_kind: 'github_token',
@@ -390,6 +443,7 @@ describe('ao state contracts', () => {
       policy_decisions: [],
       credential_provenances: [],
       task_specs: [],
+      runtime_preflights: [],
     });
 
     expect(createControlPlaneAuditEntry({

--- a/tests/ao/state-migrations.test.js
+++ b/tests/ao/state-migrations.test.js
@@ -73,8 +73,8 @@ describe('ao state migrations', () => {
 
     expect(readJson(paths.schemaPath)).toMatchObject({
       project_id: PROJECT_ID,
-      current_version: 4,
-      latest_version: 4,
+      current_version: 5,
+      latest_version: 5,
       applied_migrations: [
         {
           version: 1,
@@ -96,6 +96,11 @@ describe('ao state migrations', () => {
           key: '0004_policy_engine_v1',
           applied_at: FIXED_NOW,
         },
+        {
+          version: 5,
+          key: '0005_runtime_preflight_v1',
+          applied_at: FIXED_NOW,
+        },
       ],
     });
     expect(readJson(paths.statePath)).toMatchObject({
@@ -104,6 +109,7 @@ describe('ao state migrations', () => {
       policy_decisions: [],
       credential_provenances: [],
       task_specs: [],
+      runtime_preflights: [],
       controller_modes: [
         {
           controller_id: 'default',
@@ -138,6 +144,12 @@ describe('ao state migrations', () => {
         operation: 'migrate',
         summary: 'Applied control-plane policy-engine migration.',
       }),
+      expect.objectContaining({
+        entity_kind: 'schema',
+        entity_id: 'v5',
+        operation: 'migrate',
+        summary: 'Applied control-plane runtime-preflight migration.',
+      }),
     ]);
   });
 
@@ -164,7 +176,7 @@ describe('ao state migrations', () => {
       migrated: false,
     });
     expect(readJson(paths.schemaPath).updated_at).toBe(FIXED_NOW);
-    expect(readAuditEntries(paths.auditPath)).toHaveLength(4);
+    expect(readAuditEntries(paths.auditPath)).toHaveLength(5);
   });
 
   it('upgrades a stale schema version and backfills invalid task specs for enrolled tasks', () => {
@@ -180,7 +192,7 @@ describe('ao state migrations', () => {
       format: 'ao_control_plane_schema',
       project_id: PROJECT_ID,
       current_version: 1,
-      latest_version: 4,
+      latest_version: 5,
       created_at: '2026-03-29T03:00:00.000Z',
       updated_at: '2026-03-29T03:00:00.000Z',
       applied_migrations: [
@@ -240,7 +252,7 @@ describe('ao state migrations', () => {
       migrated: true,
     });
     expect(readJson(paths.schemaPath)).toMatchObject({
-      current_version: 4,
+      current_version: 5,
       applied_migrations: [
         {
           version: 1,
@@ -258,12 +270,17 @@ describe('ao state migrations', () => {
           version: 4,
           key: '0004_policy_engine_v1',
         },
+        {
+          version: 5,
+          key: '0005_runtime_preflight_v1',
+        },
       ],
     });
     expect(readJson(paths.statePath)).toMatchObject({
       delivery_events: [],
       policy_decisions: [],
       credential_provenances: [],
+      runtime_preflights: [],
       task_specs: [
         {
           task_id: 'issue-105',

--- a/tests/ao/state-repository.test.js
+++ b/tests/ao/state-repository.test.js
@@ -76,6 +76,7 @@ describe('ao state repository', () => {
       policy_decisions: [],
       credential_provenances: [],
       task_specs: [],
+      runtime_preflights: [],
     });
     expect(repository.listAuditEntries()).toEqual([]);
     expect(fs.existsSync(path.join(repoRoot, '.ao-control-plane'))).toBe(false);
@@ -261,6 +262,7 @@ describe('ao state repository', () => {
       'schema:migrate:v2',
       'schema:migrate:v3',
       'schema:migrate:v4',
+      'schema:migrate:v5',
       'managed_task:upsert:task-1',
       'pr_binding:upsert:binding-1',
       'ownership_lease:upsert:ownership-1',

--- a/tests/ao/state-runner.test.js
+++ b/tests/ao/state-runner.test.js
@@ -136,7 +136,7 @@ describe('ao state runner', () => {
       active_override_count: 1,
       controller_mode_count: 1,
       controller_modes: ['default=observe'],
-      audit_entry_count: 7,
+      audit_entry_count: 8,
     });
     expect(report.audit.recent_entries).toEqual([
       expect.objectContaining({


### PR DESCRIPTION
Closes #108

## Summary
This change makes AO runtime assumptions explicit before execution by introducing typed runtime-provider contracts, a deterministic bootstrap preflight classifier, durable persisted preflight state, and doctor-visible findings for missing or mixed-version runtime readiness.

The implementation stays inside the #108 boundary:
- adds explicit AO runtime-provider contracts and a minimal `runtime.github_local` provider definition
- classifies bootstrap readiness as `clean`, `missing_dependency`, or `unsupported_provider`
- persists versioned runtime preflight results in repo-local control-plane state with replay-safe deduping
- refreshes preflight state from doctor and controller entry points so failed readiness is surfaced before execution decisions

## Acceptance Mapping
### Runtime requirements are represented through explicit AO runtime contracts
Evidence:
- `scripts/ao/lib/runtime-contracts.js`
- `scripts/ao/lib/runtime-providers/github-local.js`
- `scripts/ao/lib/runtime-providers/index.js`
- `tests/ao/runtime-contracts.test.js`

### Bootstrap preflight classifies clean, missing-dependency, and unsupported-provider paths
Evidence:
- `scripts/ao/lib/runtime-preflight.js`
- `tests/ao/runtime-preflight.test.js`

### Failed preflight is operator-visible before execution
Evidence:
- `scripts/ao/lib/doctor-runner.js` refreshes runtime preflights before building the doctor report
- `scripts/ao/lib/doctor-engine.js` emits blocker findings for missing, mixed-version, unsupported-provider, and missing-dependency preflight state
- `scripts/ao/lib/controller-loop.js` refreshes runtime preflight state before shadow/assist evaluation
- `tests/ao/doctor-runner.test.js`
- `tests/ao/doctor-engine.test.js`

### Preflight results are versioned, durable, and replay-safe
Evidence:
- `scripts/ao/lib/state-contracts.js` adds durable runtime preflight records
- `scripts/ao/lib/state-migrations.js` adds control-plane schema migration `0005_runtime_preflight_v1`
- `scripts/ao/lib/state-repository.js` persists runtime preflights and skips replay-identical rewrites by replay key
- `tests/ao/runtime-preflight.test.js`
- `tests/ao/state-contracts.test.js`
- `tests/ao/state-migrations.test.js`
- `tests/ao/state-repository.test.js`

### Mixed-version preflight state is detectable
Evidence:
- `scripts/ao/lib/doctor-engine.js`
- `tests/ao/doctor-engine.test.js`

## Out Of Scope Preserved
- no custom VM infrastructure was added
- no broad multi-provider sandbox integration was added beyond the minimal `runtime.github_local` contract set
- no `assist` executor semantics were broadened; this change is classification and readiness surfacing only

## Verification
Passed locally:

```bash
node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/runtime-contracts.test.js tests/ao/runtime-preflight.test.js tests/ao/doctor-runner.test.js
```

```bash
node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/ao-controller-cli.test.js tests/ao/ao-doctor-cli.test.js tests/ao/ao-lifecycle-acceptance.test.js tests/ao/ao-lifecycle-cli.test.js tests/ao/ao-manage-cli.test.js tests/ao/ao-observation-source.test.js tests/ao/ao-reconcile-cli.test.js tests/ao/ao-state-cli.test.js tests/ao/controller-loop.test.js tests/ao/controller-shadow-parity.test.js tests/ao/controller-state-contracts.test.js tests/ao/doctor-contracts.test.js tests/ao/doctor-engine.test.js tests/ao/doctor-local-state-source.test.js tests/ao/doctor-report.test.js tests/ao/doctor-runner.test.js tests/ao/event-ingest.test.js tests/ao/gate-model.test.js tests/ao/github-observation-source.test.js tests/ao/lifecycle-contracts.test.js tests/ao/lifecycle-engine.test.js tests/ao/lifecycle-report.test.js tests/ao/manage-runner.test.js tests/ao/reconciliation-contracts.test.js tests/ao/reconciliation-engine.test.js tests/ao/reconciliation-report.test.js tests/ao/reconciliation-runner.test.js tests/ao/state-contracts.test.js tests/ao/state-migrations.test.js tests/ao/state-repository.test.js tests/ao/state-runner.test.js tests/ao/transition-engine.test.js
```
