### PR TITLE
fix(ao): enforce assist preflight gating

### DIFF
--- a/scripts/ao/lib/action-executor.js
+++ b/scripts/ao/lib/action-executor.js
@@ -46,6 +46,25 @@ function buildPrScopePrecondition(prNumber) {
   };
 }
 
+function normalizeRuntimePreflight(runtimeRef, runtimePreflight) {
+  const normalizedRuntimeRef = runtimeRef == null ? null : String(runtimeRef);
+  const normalizedRecord = isPlainObject(runtimePreflight) ? runtimePreflight : null;
+  return {
+    runtime_ref: normalizedRuntimeRef ?? normalizedRecord?.runtime_ref ?? null,
+    status: normalizedRecord?.status == null ? 'missing' : String(normalizedRecord.status),
+    replay_key: normalizedRecord?.replay_key == null ? null : String(normalizedRecord.replay_key),
+  };
+}
+
+function buildRuntimePreflightPrecondition(runtimeRef, runtimePreflight) {
+  const normalizedRuntimePreflight = normalizeRuntimePreflight(runtimeRef, runtimePreflight);
+  return {
+    code: 'runtime_preflight_clean',
+    description: 'Assist execution requires a clean runtime preflight for the bound runtime.',
+    satisfied: normalizedRuntimePreflight.runtime_ref != null && normalizedRuntimePreflight.status === 'clean',
+  };
+}
+
 const ACTION_POLICIES = {
   continue_worker: {
     riskClass: 'class_a',
@@ -153,7 +172,9 @@ function buildExecutionDecision({
 
   return {
     executable: preconditionsSatisfied,
-    reason: preconditionsSatisfied ? 'class_a_allowlist' : 'preconditions_unsatisfied',
+    reason: preconditionsSatisfied
+      ? 'class_a_allowlist'
+      : (preconditions.find((item) => item.satisfied !== true)?.code ?? 'preconditions_unsatisfied'),
   };
 }
 
@@ -163,16 +184,22 @@ export function buildAssistActionModel({
   prNumber = null,
   derivedTrigger = 'manual',
   lifecycleTopStatus = null,
+  runtimeRef = null,
+  runtimePreflight = null,
   action,
 } = {}) {
   const policy = resolveActionPolicy(action?.id);
   const normalizedPrNumber = toNullablePositiveInteger(prNumber);
-  const preconditions = policy.buildPreconditions({
-    controllerId,
-    task,
-    prNumber: normalizedPrNumber,
-    action,
-  });
+  const runtimePreflightRecord = normalizeRuntimePreflight(runtimeRef, runtimePreflight);
+  const preconditions = [
+    ...policy.buildPreconditions({
+      controllerId,
+      task,
+      prNumber: normalizedPrNumber,
+      action,
+    }),
+    buildRuntimePreflightPrecondition(runtimeRef, runtimePreflight),
+  ];
   const phase4Assist = buildExecutionDecision({
     phase4AssistExecutable: policy.phase4AssistExecutable,
     preconditions,
@@ -193,6 +220,7 @@ export function buildAssistActionModel({
     derived_trigger: String(derivedTrigger ?? 'manual'),
     lifecycle_top_status: lifecycleTopStatus == null ? null : String(lifecycleTopStatus),
     risk_class: policy.riskClass,
+    runtime_preflight: runtimePreflightRecord,
     preconditions,
     phase4_assist: phase4Assist,
   };
@@ -205,6 +233,12 @@ function buildFallbackActionModel(record, controllerId, task) {
     prNumber: record?.payload?.pr_number ?? null,
     derivedTrigger: record?.payload?.derived_trigger ?? 'manual',
     lifecycleTopStatus: record?.payload?.top_status ?? null,
+    runtimeRef: record?.payload?.runtime_preflight?.runtime_ref
+      ?? record?.payload?.action_model?.runtime_preflight?.runtime_ref
+      ?? null,
+    runtimePreflight: record?.payload?.runtime_preflight
+      ?? record?.payload?.action_model?.runtime_preflight
+      ?? null,
     action: {
       id: record?.action_kind,
       action_class: record?.payload?.action_class ?? record?.action_kind,
@@ -329,6 +363,13 @@ function buildExecutedActionRecord(record, model, timestamp) {
   });
 }
 
+function hasDurableAllowPolicy(record) {
+  const policyDecisionId = typeof record?.payload?.policy_decision_id === 'string'
+    ? record.payload.policy_decision_id.trim()
+    : '';
+  return policyDecisionId !== '' && record?.payload?.policy?.decision === 'allow';
+}
+
 export async function executeAssistActions({
   repository,
   controllerId,
@@ -350,6 +391,31 @@ export async function executeAssistActions({
     const model = isPlainObject(record.payload?.action_model)
       ? cloneJsonValue(record.payload.action_model)
       : buildFallbackActionModel(record, controllerId, task);
+
+    if (!hasDurableAllowPolicy(record)) {
+      const blockedRecord = buildBlockedActionRecord(record, model, timestamp, {
+        reason: 'policy_allow_required',
+        matchedOverrideIds: [],
+        structural: true,
+      });
+      repository.upsertAction(blockedRecord);
+      repository.appendAuditEntry({
+        entityKind: 'action',
+        entityId: record.action_id,
+        operation: 'execution_blocked',
+        actor: 'assist_controller',
+        summary: `Blocked assist execution for ${record.action_id}.`,
+        details: {
+          action_id: record.action_id,
+          action_kind: record.action_kind,
+          reason: 'policy_allow_required',
+          policy_decision_id: record?.payload?.policy_decision_id ?? null,
+        },
+        recordedAt: timestamp,
+      });
+      blockedActionIds.push(record.action_id);
+      continue;
+    }
 
     const blockingOverrides = resolveBlockingOverrides(repository, {
       controllerId,
@@ -402,6 +468,7 @@ export async function executeAssistActions({
           action_kind: record.action_kind,
           reason: model.phase4_assist?.reason ?? 'phase4_assist_not_executable',
           risk_class: model.risk_class,
+          runtime_preflight: cloneJsonValue(model.runtime_preflight ?? null),
         },
         recordedAt: timestamp,
       });
@@ -424,6 +491,8 @@ export async function executeAssistActions({
         task_id: task?.task_id ?? null,
         controller_id: controllerId,
         pr_number: model.pr_number ?? null,
+        runtime_preflight: cloneJsonValue(model.runtime_preflight ?? null),
+        policy_decision_id: record?.payload?.policy_decision_id ?? null,
       },
       recordedAt: timestamp,
     });

--- a/scripts/ao/lib/controller-loop.js
+++ b/scripts/ao/lib/controller-loop.js
@@ -72,6 +72,19 @@ function buildGitHubScope(task, prBindings = []) {
   });
 }
 
+function resolveTaskRuntimePreflight(snapshot, task) {
+  const taskSpec = snapshot.state.task_specs.find((record) => record.task_id === task.task_id) ?? null;
+  const runtimeRef = taskSpec?.snapshot?.spec?.runtime_ref ?? null;
+  const runtimePreflight = runtimeRef == null
+    ? null
+    : (snapshot.state.runtime_preflights.find((record) => record.runtime_ref === runtimeRef) ?? null);
+  return {
+    taskSpec,
+    runtimeRef,
+    runtimePreflight,
+  };
+}
+
 function resolveLifecyclePrNumber(prBindings = [], matchedPrs = []) {
   const prNumbers = uniquePrNumbers(prBindings, matchedPrs);
   return prNumbers.length === 1 ? prNumbers[0] : null;
@@ -196,6 +209,7 @@ async function persistShadowActions({
   const downgradedActionIds = [];
   const requestedBy = mode === 'assist' ? 'assist_controller' : 'shadow_controller';
   const credentialProvenances = snapshot.credential_provenances ?? [];
+  const { runtimeRef, runtimePreflight } = resolveTaskRuntimePreflight({ state: snapshot }, task);
 
   for (const action of lifecycleReport.actions) {
     const actionModel = buildAssistActionModel({
@@ -204,6 +218,8 @@ async function persistShadowActions({
       prNumber,
       derivedTrigger,
       lifecycleTopStatus: lifecycleReport.top_status ?? null,
+      runtimeRef,
+      runtimePreflight,
       action,
     });
     const policyInput = buildPolicyInputForAction({
@@ -298,6 +314,7 @@ async function persistShadowActions({
         commands: action.commands,
         rationale: action.rationale,
         action_model: actionModel,
+        runtime_preflight: actionModel.runtime_preflight,
         policy_decision_id: policyDecisionId,
         policy: {
           decision: policyResult.decision,
@@ -445,6 +462,10 @@ export async function runControllerLoop({
     buildDoctorReport: buildDoctorReportModel,
     buildLifecycleReport: buildLifecycleReportModel,
     resolveLifecycleReport: null,
+    ensureRuntimePreflights: ({ repository: activeRepository, cwd: activeCwd, now: activeNow }) => activeRepository.ensureRuntimePreflights({
+      cwd: activeCwd,
+      now: activeNow,
+    }),
     ...deps,
   };
   const timestamp = resolveNow(now);
@@ -452,7 +473,8 @@ export async function runControllerLoop({
     repoRoot,
     projectId,
   });
-  repository.ensureRuntimePreflights({
+  await services.ensureRuntimePreflights({
+    repository,
     cwd,
     now: timestamp,
   });

--- a/tests/ao/action-executor.test.js
+++ b/tests/ao/action-executor.test.js
@@ -62,6 +62,12 @@ describe('ao action executor', () => {
       prNumber: 101,
       derivedTrigger: 'approved_and_green',
       lifecycleTopStatus: 'continue',
+      runtimeRef: 'runtime.github_local',
+      runtimePreflight: {
+        runtime_ref: 'runtime.github_local',
+        status: 'clean',
+        replay_key: 'runtime_preflight:clean',
+      },
       action: {
         id: 'notify_human_ready',
         action_class: 'notify_human',
@@ -75,6 +81,10 @@ describe('ao action executor', () => {
       action_kind: 'notify_human_ready',
       action_class: 'notify_human',
       risk_class: 'class_a',
+      runtime_preflight: {
+        runtime_ref: 'runtime.github_local',
+        status: 'clean',
+      },
       phase4_assist: {
         executable: true,
         reason: 'class_a_allowlist',
@@ -88,6 +98,47 @@ describe('ao action executor', () => {
       expect.objectContaining({
         code: 'pr_scope_required',
         satisfied: true,
+      }),
+    ]));
+
+    const missingPreflightModel = buildAssistActionModel({
+      controllerId: 'default',
+      task: {
+        task_id: 'issue-90',
+        status: 'active',
+      },
+      derivedTrigger: 'manual',
+      lifecycleTopStatus: 'continue',
+      runtimeRef: 'runtime.github_local',
+      runtimePreflight: {
+        runtime_ref: 'runtime.github_local',
+        status: 'missing_dependency',
+        replay_key: 'runtime_preflight:missing',
+      },
+      action: {
+        id: 'continue_worker',
+        action_class: 'continue_worker',
+        summary: 'Continue the current worker owner.',
+        commands: ['ao status -p ciecopilot-home --json'],
+        rationale: 'Ownership continuity is clear enough to continue the current worker.',
+      },
+    });
+
+    expect(missingPreflightModel).toMatchObject({
+      action_kind: 'continue_worker',
+      runtime_preflight: {
+        runtime_ref: 'runtime.github_local',
+        status: 'missing_dependency',
+      },
+      phase4_assist: {
+        executable: false,
+        reason: 'runtime_preflight_clean',
+      },
+    });
+    expect(missingPreflightModel.preconditions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'runtime_preflight_clean',
+        satisfied: false,
       }),
     ]));
 
@@ -133,6 +184,12 @@ describe('ao action executor', () => {
       prNumber: 101,
       derivedTrigger: 'manual',
       lifecycleTopStatus: 'continue',
+      runtimeRef: 'runtime.github_local',
+      runtimePreflight: {
+        runtime_ref: 'runtime.github_local',
+        status: 'clean',
+        replay_key: 'runtime_preflight:clean',
+      },
       action: {
         id: 'continue_worker',
         action_class: 'continue_worker',
@@ -153,6 +210,11 @@ describe('ao action executor', () => {
       updated_at: '2026-03-29T07:11:00.000Z',
       payload: {
         action_model: actionModel,
+        policy_decision_id: 'policy-1',
+        policy: {
+          decision: 'allow',
+          policy_version: 'ao.policy.v1',
+        },
       },
     }));
 
@@ -193,6 +255,76 @@ describe('ao action executor', () => {
     ]));
   });
 
+  it('blocks assist execution when durable policy attribution is missing', async () => {
+    const repository = createStateRepository({
+      repoRoot: createTempRepo(),
+      projectId: PROJECT_ID,
+      auditIdGenerator: createIdGenerator('audit'),
+    });
+    seedActiveTask(repository);
+
+    const actionModel = buildAssistActionModel({
+      controllerId: 'default',
+      task: repository.getSnapshot().state.managed_tasks[0],
+      prNumber: 101,
+      derivedTrigger: 'manual',
+      lifecycleTopStatus: 'continue',
+      runtimeRef: 'runtime.github_local',
+      runtimePreflight: {
+        runtime_ref: 'runtime.github_local',
+        status: 'clean',
+        replay_key: 'runtime_preflight:clean',
+      },
+      action: {
+        id: 'continue_worker',
+        action_class: 'continue_worker',
+        summary: 'Continue the current worker owner.',
+        commands: ['ao status -p ciecopilot-home --json'],
+        rationale: 'Ownership continuity is clear enough to continue the current worker.',
+      },
+    });
+
+    repository.upsertAction(createActionRecord({
+      action_id: 'action-1',
+      task_id: 'issue-90',
+      action_kind: 'continue_worker',
+      status: 'proposed',
+      requested_by: 'shadow_controller',
+      reason: 'Continue the current worker owner.',
+      created_at: '2026-03-29T07:11:00.000Z',
+      updated_at: '2026-03-29T07:11:00.000Z',
+      payload: {
+        action_model: actionModel,
+      },
+    }));
+
+    const result = await executeAssistActions({
+      repository,
+      controllerId: 'default',
+      task: repository.getSnapshot().state.managed_tasks[0],
+      actionIds: ['action-1'],
+      now: '2026-03-29T07:12:00.000Z',
+    });
+
+    expect(result).toEqual({
+      executedActionIds: [],
+      blockedActionIds: ['action-1'],
+    });
+
+    expect(repository.getSnapshot().state.actions).toEqual([
+      expect.objectContaining({
+        action_id: 'action-1',
+        status: 'blocked',
+        payload: expect.objectContaining({
+          execution: expect.objectContaining({
+            outcome: 'blocked',
+            reason: 'policy_allow_required',
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it('honors active autonomy-hold overrides without executing class A actions', async () => {
     const repository = createStateRepository({
       repoRoot: createTempRepo(),
@@ -221,6 +353,12 @@ describe('ao action executor', () => {
       prNumber: 101,
       derivedTrigger: 'approved_and_green',
       lifecycleTopStatus: 'continue',
+      runtimeRef: 'runtime.github_local',
+      runtimePreflight: {
+        runtime_ref: 'runtime.github_local',
+        status: 'clean',
+        replay_key: 'runtime_preflight:clean',
+      },
       action: {
         id: 'notify_human_ready',
         action_class: 'notify_human',
@@ -241,6 +379,11 @@ describe('ao action executor', () => {
       updated_at: '2026-03-29T07:11:00.000Z',
       payload: {
         action_model: actionModel,
+        policy_decision_id: 'policy-1',
+        policy: {
+          decision: 'allow',
+          policy_version: 'ao.policy.v1',
+        },
       },
     }));
 

--- a/tests/ao/ao-override-cli.test.js
+++ b/tests/ao/ao-override-cli.test.js
@@ -35,6 +35,10 @@ describe('ao override cli', () => {
       'hold_autonomy',
       '--value',
       '{"enabled":true}',
+      '--expires-at',
+      '2026-03-30T12:00:00.000Z',
+      '--created-by',
+      'ao-operator',
       '--json',
     ], {
       writeStdout: (text) => stdout.push(text),
@@ -50,6 +54,8 @@ describe('ao override cli', () => {
       scopeId: 'issue-90',
       overrideKind: 'hold_autonomy',
       value: { enabled: true },
+      expiresAt: '2026-03-30T12:00:00.000Z',
+      createdBy: 'ao-operator',
     }));
     expect(JSON.parse(stdout.join(''))).toMatchObject({
       override: {

--- a/tests/ao/controller-loop.test.js
+++ b/tests/ao/controller-loop.test.js
@@ -9,8 +9,11 @@ import {
   createControllerModeRecord,
   createManagedTask,
   createPrBinding,
+  createRuntimePreflightRecord,
+  createTaskSpecRecord,
 } from '../../scripts/ao/lib/state-contracts.js';
 import { runControllerLoop } from '../../scripts/ao/lib/controller-loop.js';
+import { runRuntimeBootstrapPreflight } from '../../scripts/ao/lib/runtime-preflight.js';
 import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
 
 const PROJECT_ID = 'ciecopilot-home';
@@ -49,6 +52,44 @@ function seedActiveTask(repository, mode) {
     updated_at: '2026-03-29T06:40:00.000Z',
     updated_by: 'operator',
     reason: 'Issue #89 test setup',
+  }));
+}
+
+function seedCleanRuntimePreflight(repository, {
+  taskId = 'issue-92',
+  issueNumber = 92,
+  runtimeRef = 'runtime.github_local',
+} = {}) {
+  repository.upsertTaskSpec(createTaskSpecRecord({
+    task_id: taskId,
+    source_kind: 'github_issue',
+    source_issue_number: issueNumber,
+    created_at: '2026-03-29T06:40:00.000Z',
+    updated_at: '2026-03-29T06:40:00.000Z',
+    snapshot: {
+      schema_version: 'ao.task-spec.v1alpha1',
+      spec: {
+        problem_type: 'issue_delivery',
+        acceptance_contract: ['Assist only executes after clean runtime preflight.'],
+        runtime_ref: runtimeRef,
+        policy_ref: 'policy.operator_gated',
+        human_gates: ['operator_review'],
+      },
+    },
+  }));
+
+  repository.upsertRuntimePreflight(createRuntimePreflightRecord({
+    recorded_at: '2026-03-29T06:40:00.000Z',
+    snapshot: runRuntimeBootstrapPreflight({
+      runtimeRef,
+      cwd: repository.getSnapshot().paths.repoRoot,
+      now: '2026-03-29T06:40:00.000Z',
+      probes: {
+        commandExists: () => true,
+        pathExists: () => true,
+        capability: () => true,
+      },
+    }),
   }));
 }
 
@@ -555,6 +596,7 @@ describe('ao controller loop', () => {
       projectId: PROJECT_ID,
     });
     seedActiveTask(repository, 'assist');
+    seedCleanRuntimePreflight(repository);
 
     const lifecycleReport = {
       top_status: 'continue',
@@ -585,6 +627,13 @@ describe('ao controller loop', () => {
           summary: 'Hold until CI is green.',
           commands: ['gh pr checks 92'],
           rationale: 'Required CI state is not yet ready.',
+        },
+        {
+          id: 'notify_human_ready',
+          action_class: 'notify_human',
+          summary: 'Notify the human that the PR appears ready.',
+          commands: ['terraform plan'],
+          rationale: 'This should be blocked by policy because terraform is not an allowlisted tool.',
         },
       ],
     };
@@ -628,19 +677,22 @@ describe('ao controller loop', () => {
           ],
         }),
         resolveLifecycleReport: async () => lifecycleReport,
+        ensureRuntimePreflights: () => repository.getSnapshot().state.runtime_preflights,
       },
     });
 
     expect(result).toMatchObject({
       mode: 'assist',
-      proposed_action_count: 3,
+      proposed_action_count: 4,
       executed_action_count: 1,
       blocked_action_count: 2,
+      policy_blocked_action_count: 1,
       task_results: [
         expect.objectContaining({
-          proposed_action_count: 3,
+          proposed_action_count: 4,
           executed_action_count: 1,
           blocked_action_count: 2,
+          policy_blocked_action_count: 1,
         }),
       ],
     });
@@ -679,7 +731,116 @@ describe('ao controller loop', () => {
           }),
         }),
       }),
+      expect.objectContaining({
+        action_kind: 'notify_human_ready',
+        status: 'blocked',
+        payload: expect.objectContaining({
+          policy: expect.objectContaining({
+            decision: 'deny',
+          }),
+        }),
+      }),
     ]));
+  });
+
+  it('assist mode blocks class A actions until runtime preflight has passed', async () => {
+    const repository = createStateRepository({
+      repoRoot: createTempRepo(),
+      projectId: PROJECT_ID,
+    });
+    seedActiveTask(repository, 'assist');
+
+    const result = await runControllerLoop({
+      repoRoot: repository.getSnapshot().paths.repoRoot,
+      cwd: repository.getSnapshot().paths.repoRoot,
+      projectId: PROJECT_ID,
+      controllerId: 'default',
+      now: '2026-03-29T06:41:00.000Z',
+      deps: {
+        loadAoProjectObservation: async () => ({
+          observed_at: '2026-03-29T06:41:00.000Z',
+          workers: [
+            {
+              session_name: 'cie-92',
+              session_runtime_id: 'cie-92',
+              issue_number: 92,
+              branch_name: 'feat/issue-92',
+              pr_number: 92,
+              lifecycle_state: 'idle',
+              last_seen_at: '2026-03-29T06:40:45.000Z',
+              freshness: { status: 'fresh' },
+            },
+          ],
+        }),
+        loadGitHubObservationSet: async () => ({
+          observed_at: '2026-03-29T06:41:00.000Z',
+          prs: [
+            {
+              pr_number: 92,
+              state: 'OPEN',
+              head_branch: 'feat/issue-92',
+              head_sha: 'abc123',
+              review_status: 'approved',
+              ci_status: 'passing',
+              mergeability: 'mergeable',
+              is_draft: false,
+              url: 'https://example.test/pr/92',
+            },
+          ],
+        }),
+        resolveLifecycleReport: async () => ({
+          top_status: 'continue',
+          routing_decision: {
+            action: 'continue_current_worker',
+          },
+          release_decision: {
+            disposition: 'continue_current_worker',
+          },
+          actions: [
+            {
+              id: 'continue_worker',
+              action_class: 'continue_worker',
+              summary: 'Continue the current worker owner.',
+              commands: ['ao status -p ciecopilot-home --json'],
+              rationale: 'Ownership continuity is clear enough to continue the current worker.',
+            },
+          ],
+        }),
+      },
+    });
+
+    expect(result).toMatchObject({
+      mode: 'assist',
+      proposed_action_count: 1,
+      executed_action_count: 0,
+      blocked_action_count: 1,
+      task_results: [
+        expect.objectContaining({
+          proposed_action_count: 1,
+          executed_action_count: 0,
+          blocked_action_count: 1,
+        }),
+      ],
+    });
+
+    expect(repository.getSnapshot().state.actions).toEqual([
+      expect.objectContaining({
+        action_kind: 'continue_worker',
+        status: 'blocked',
+        payload: expect.objectContaining({
+          action_model: expect.objectContaining({
+            phase4_assist: expect.objectContaining({
+              executable: false,
+              reason: 'runtime_preflight_clean',
+            }),
+          }),
+          execution: expect.objectContaining({
+            outcome: 'blocked',
+            reason: 'runtime_preflight_clean',
+          }),
+        }),
+      }),
+    ]);
   });
 
   it('blocks when another active lease already exists for the same controller', async () => {

--- a/tests/ao/controller-policy-gating.test.js
+++ b/tests/ao/controller-policy-gating.test.js
@@ -9,8 +9,11 @@ import {
   createCredentialProvenanceRecord,
   createManagedTask,
   createPrBinding,
+  createRuntimePreflightRecord,
+  createTaskSpecRecord,
 } from '../../scripts/ao/lib/state-contracts.js';
 import { runControllerLoop } from '../../scripts/ao/lib/controller-loop.js';
+import { runRuntimeBootstrapPreflight } from '../../scripts/ao/lib/runtime-preflight.js';
 import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
 
 const PROJECT_ID = 'ciecopilot-home';
@@ -60,6 +63,44 @@ function seedGitHubCredential(repository) {
     scope: 'github.com',
     created_at: '2026-03-30T10:10:00.000Z',
     updated_at: '2026-03-30T10:10:00.000Z',
+  }));
+}
+
+function seedCleanRuntimePreflight(repository, {
+  taskId = 'issue-107',
+  issueNumber = 107,
+  runtimeRef = 'runtime.github_local',
+} = {}) {
+  repository.upsertTaskSpec(createTaskSpecRecord({
+    task_id: taskId,
+    source_kind: 'github_issue',
+    source_issue_number: issueNumber,
+    created_at: '2026-03-30T10:10:00.000Z',
+    updated_at: '2026-03-30T10:10:00.000Z',
+    snapshot: {
+      schema_version: 'ao.task-spec.v1alpha1',
+      spec: {
+        problem_type: 'issue_delivery',
+        acceptance_contract: ['Assist only executes after clean runtime preflight.'],
+        runtime_ref: runtimeRef,
+        policy_ref: 'policy.operator_gated',
+        human_gates: ['operator_review'],
+      },
+    },
+  }));
+
+  repository.upsertRuntimePreflight(createRuntimePreflightRecord({
+    recorded_at: '2026-03-30T10:10:00.000Z',
+    snapshot: runRuntimeBootstrapPreflight({
+      runtimeRef,
+      cwd: repository.getSnapshot().paths.repoRoot,
+      now: '2026-03-30T10:10:00.000Z',
+      probes: {
+        commandExists: () => true,
+        pathExists: () => true,
+        capability: () => true,
+      },
+    }),
   }));
 }
 
@@ -268,6 +309,7 @@ describe('ao controller policy gating', () => {
       projectId: PROJECT_ID,
     });
     seedActiveTask(repository, 'assist');
+    seedCleanRuntimePreflight(repository);
 
     const result = await runControllerLoop({
       repoRoot: repository.getSnapshot().paths.repoRoot,
@@ -335,6 +377,7 @@ describe('ao controller policy gating', () => {
             },
           ],
         }),
+        ensureRuntimePreflights: () => repository.getSnapshot().state.runtime_preflights,
       },
     });
 

--- a/tests/ao/override-runner.test.js
+++ b/tests/ao/override-runner.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from '@jest/globals';
 
 import { runOverrideCommand } from '../../scripts/ao/lib/override-runner.js';
+import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
 
 const PROJECT_ID = 'ciecopilot-home';
 const tempDirs = [];
@@ -85,6 +86,69 @@ describe('ao override runner', () => {
       status: 'cleared',
       cleared_at: '2026-03-29T07:21:00.000Z',
       cleared_reason: 'resume_assist_mode',
+    });
+
+    const repository = createStateRepository({
+      repoRoot,
+      projectId: PROJECT_ID,
+    });
+
+    expect(repository.getSnapshot().state.overrides).toEqual([
+      expect.objectContaining({
+        override_id: 'override-1',
+        scope_kind: 'task',
+        scope_id: 'issue-90',
+        status: 'cleared',
+        expires_at: null,
+        created_by: 'operator',
+      }),
+    ]);
+    expect(repository.listAuditEntries().filter((entry) => entry.entity_kind === 'override')).toEqual([
+      expect.objectContaining({
+        entity_id: 'override-1',
+        operation: 'upsert',
+      }),
+      expect.objectContaining({
+        entity_id: 'override-1',
+        operation: 'created',
+        actor: 'operator',
+      }),
+      expect.objectContaining({
+        entity_id: 'override-1',
+        operation: 'upsert',
+      }),
+      expect.objectContaining({
+        entity_id: 'override-1',
+        operation: 'cleared',
+        actor: 'operator',
+      }),
+    ]);
+  });
+
+  it('preserves expiry attribution on created overrides', async () => {
+    const repoRoot = createTempRepo();
+
+    const created = await runOverrideCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'create',
+      scopeKind: 'pr',
+      scopeId: '109',
+      overrideKind: 'block_action_kind',
+      value: { action_kinds: ['notify_human_ready'] },
+      expiresAt: '2026-03-29T08:00:00.000Z',
+      createdBy: 'ao-operator',
+      now: '2026-03-29T07:30:00.000Z',
+      overrideIdGenerator: createIdGenerator('override'),
+    });
+
+    expect(created.override).toMatchObject({
+      override_id: 'override-1',
+      scope_kind: 'pr',
+      scope_id: '109',
+      override_kind: 'block_action_kind',
+      expires_at: '2026-03-29T08:00:00.000Z',
+      created_by: 'ao-operator',
     });
   });
 


### PR DESCRIPTION
## Summary
- require assist action models to carry runtime preflight state and fail closed unless the bound runtime preflight is clean
- require durable allow-policy attribution before assist execution and preserve runtime/policy details in action audit payloads
- extend controller and override coverage for clean preflight seeding, policy-blocked assist paths, override expiry forwarding, and override audit persistence

## Acceptance Mapping
- `assist` runs only when runtime preflight passed and policy/tool checks allow the action class.
  Evidence: `buildAssistActionModel` now records `runtime_preflight` and enforces a `runtime_preflight_clean` precondition; `executeAssistActions` now refuses proposed actions that lack durable allow-policy attribution. Covered by `tests/ao/action-executor.test.js`, `tests/ao/controller-loop.test.js`, and `tests/ao/controller-policy-gating.test.js`.
- override records include actor, scope, expiry, and audit attribution.
  Evidence: `ao-override` now has explicit CLI coverage for `--created-by` and `--expires-at`, and the runner tests assert persisted override state plus created/cleared audit entries. Covered by `tests/ao/ao-override-cli.test.js` and `tests/ao/override-runner.test.js`.
- forbidden actions remain blocked even in `assist`.
  Evidence: class B/C and policy-blocked actions stay out of assist execution, while missing runtime preflight blocks even class A execution. Covered by `tests/ao/action-executor.test.js`, `tests/ao/controller-loop.test.js`, and `tests/ao/controller-policy-gating.test.js`.
- every executed action creates durable action, policy, and audit records.
  Evidence: assist execution still requires persisted `policy_decision_id` + allow decision and records execution audit details with runtime preflight attribution. Covered by `tests/ao/action-executor.test.js` and `tests/ao/controller-loop.test.js`.
- `assist` remains bounded to approved low-risk action classes.
  Evidence: class A allowlist remains the only executable surface; higher-risk and unapproved actions are structurally blocked. Covered by `tests/ao/action-executor.test.js` and `tests/ao/controller-loop.test.js`.

## Verification
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/action-executor.test.js tests/ao/ao-controller-cli.test.js tests/ao/ao-override-cli.test.js tests/ao/controller-loop.test.js`
  Result: PASS (4 suites, 17 tests)
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand tests/ao`
  Result: PASS (41 suites, 183 tests)

## Out Of Scope Preserved
- no auto-merge
- no privileged workflow reruns
- no destructive cleanup
- no same-branch parallel writers

Closes #109
