### PR TITLE
feat(ao): add checkpoint schema and explicit resume

### DIFF
--- a/scripts/ao-manage.js
+++ b/scripts/ao-manage.js
@@ -103,7 +103,7 @@ function parseArgs(argv) {
     };
   }
 
-  if (!['enroll', 'adopt', 'unmanage', 'retire'].includes(options.command)) {
+  if (!['enroll', 'adopt', 'resume', 'unmanage', 'retire'].includes(options.command)) {
     return {
       ok: false,
       error: `Unsupported command: ${options.command ?? 'none'}`,
@@ -144,6 +144,7 @@ function renderHelp() {
     'Commands:',
     '  enroll      Explicitly enroll one managed task',
     '  adopt       Re-activate a paused managed task and refresh bindings',
+    '  resume      Re-activate work from the latest valid checkpoint',
     '  unmanage    Pause active management while preserving bindings',
     '  retire      Retire the managed task and release active bindings',
     '',
@@ -170,6 +171,7 @@ function renderHumanSummary(result) {
     `task: ${result.task.task_id} status=${result.task.status}`,
     `pr_binding: ${result.prBinding ? `${result.prBinding.pr_number}/${result.prBinding.status}` : 'none'}`,
     `ownership_lease: ${result.ownershipLease ? `${result.ownershipLease.owner_session_name}/${result.ownershipLease.status}` : 'none'}`,
+    `resume_checkpoint: ${result.resume ? `${result.resume.checkpoint_id}/${result.resume.state}` : 'none'}`,
     `released_ownership_leases: ${result.releasedOwnershipLeaseIds.length ? result.releasedOwnershipLeaseIds.join(', ') : 'none'}`,
     `released_pr_bindings: ${result.releasedPrBindingIds.length ? result.releasedPrBindingIds.join(', ') : 'none'}`,
   ].join('\n');

--- a/scripts/ao/lib/checkpoint-store.js
+++ b/scripts/ao/lib/checkpoint-store.js
@@ -1,0 +1,367 @@
+import { createHash } from 'node:crypto';
+
+import {
+  CHECKPOINT_FORMAT,
+  CHECKPOINT_SCHEMA_VERSION,
+  createCheckpointRecord,
+} from './state-contracts.js';
+
+const VALID_TASK_SPEC_SCHEMA_VERSION = 'ao.task-spec.v1alpha1';
+const VALID_RUNTIME_PREFLIGHT_SCHEMA_VERSION = 'ao.runtime-preflight.v1alpha1';
+
+function resolveNow(now) {
+  if (typeof now === 'function') return resolveNow(now());
+  if (typeof now === 'string' && now.trim() !== '') return now.trim();
+  return new Date().toISOString();
+}
+
+function compareRecordedAtDescending(left, right) {
+  const leftRecordedAt = String(left?.recorded_at ?? '');
+  const rightRecordedAt = String(right?.recorded_at ?? '');
+  if (leftRecordedAt !== rightRecordedAt) {
+    return rightRecordedAt.localeCompare(leftRecordedAt);
+  }
+
+  return String(right?.checkpoint_id ?? '').localeCompare(String(left?.checkpoint_id ?? ''));
+}
+
+function buildCheckpointId({ taskId, recordedAt }) {
+  const digest = createHash('sha1')
+    .update(JSON.stringify({
+      task_id: taskId,
+      recorded_at: recordedAt,
+    }))
+    .digest('hex')
+    .slice(0, 12);
+  return `checkpoint-${taskId}-${digest}`;
+}
+
+function selectLatestTaskCheckpoint(checkpoints = [], taskId) {
+  return (checkpoints ?? [])
+    .filter((record) => record?.task_id === taskId)
+    .sort(compareRecordedAtDescending)[0] ?? null;
+}
+
+function resolveCheckpointRecord(snapshot, {
+  taskId = null,
+  checkpointId = null,
+} = {}) {
+  if (checkpointId) {
+    return (snapshot?.state?.checkpoints ?? []).find((record) => record?.checkpoint_id === checkpointId) ?? null;
+  }
+
+  if (taskId) {
+    return selectLatestTaskCheckpoint(snapshot?.state?.checkpoints ?? [], taskId);
+  }
+
+  return null;
+}
+
+function buildInspection(record, reasonCodes = []) {
+  let state = 'valid';
+  if (reasonCodes.some((code) => code.startsWith('checkpoint_') || code.endsWith('_mixed_version') || code.endsWith('_not_clean'))) {
+    state = 'invalid';
+  } else if (reasonCodes.length > 0) {
+    state = 'stale';
+  }
+
+  return {
+    checkpoint_id: record?.checkpoint_id ?? null,
+    task_id: record?.task_id ?? null,
+    state,
+    reason_codes: [...new Set(reasonCodes)],
+    record,
+  };
+}
+
+function validateCheckpointRecord(snapshot, record) {
+  if (!record) {
+    return buildInspection(null, ['checkpoint_missing']);
+  }
+
+  const reasonCodes = [];
+  const checkpointSnapshot = record.snapshot ?? {};
+
+  if (checkpointSnapshot.schema_version !== CHECKPOINT_SCHEMA_VERSION) {
+    reasonCodes.push('checkpoint_mixed_version');
+  }
+  if (checkpointSnapshot.format !== CHECKPOINT_FORMAT) {
+    reasonCodes.push('checkpoint_invalid_format');
+  }
+
+  const taskRef = checkpointSnapshot.task_ref ?? {};
+  const currentTask = (snapshot?.state?.managed_tasks ?? []).find((task) => task?.task_id === record.task_id) ?? null;
+  if (!currentTask) {
+    reasonCodes.push('managed_task_missing');
+  } else {
+    if (
+      currentTask.issue_number !== taskRef.issue_number
+      || currentTask.title !== taskRef.title
+      || currentTask.branch_name !== taskRef.branch_name
+      || currentTask.worktree_path !== taskRef.worktree_path
+    ) {
+      reasonCodes.push('managed_task_advanced');
+    }
+    if (currentTask.branch_name !== taskRef.branch_name || currentTask.worktree_path !== taskRef.worktree_path) {
+      reasonCodes.push('managed_task_binding_changed');
+    }
+    if (currentTask.status === 'retired') {
+      reasonCodes.push('managed_task_retired');
+    }
+  }
+
+  const taskSpecRef = checkpointSnapshot.verification_ref?.task_spec ?? null;
+  if (!taskSpecRef) {
+    reasonCodes.push('checkpoint_task_spec_missing');
+  } else {
+    if (taskSpecRef.snapshot_schema_version !== VALID_TASK_SPEC_SCHEMA_VERSION) {
+      reasonCodes.push('task_spec_mixed_version');
+    }
+
+    const currentTaskSpec = (snapshot?.state?.task_specs ?? []).find(
+      (taskSpec) => taskSpec?.task_id === taskSpecRef.task_id,
+    ) ?? null;
+    if (!currentTaskSpec) {
+      reasonCodes.push('task_spec_missing');
+    } else {
+      if (currentTaskSpec.updated_at !== taskSpecRef.updated_at) {
+        reasonCodes.push('task_spec_advanced');
+      }
+      if (currentTaskSpec.snapshot?.schema_version !== VALID_TASK_SPEC_SCHEMA_VERSION) {
+        reasonCodes.push('task_spec_mixed_version');
+      }
+      if (currentTaskSpec.state !== taskSpecRef.state || currentTaskSpec.state !== 'valid') {
+        reasonCodes.push('task_spec_invalid');
+      }
+    }
+  }
+
+  const runtimePreflightRef = checkpointSnapshot.verification_ref?.runtime_preflight ?? null;
+  if (!runtimePreflightRef) {
+    reasonCodes.push('checkpoint_runtime_preflight_missing');
+  } else {
+    if (runtimePreflightRef.snapshot_schema_version !== VALID_RUNTIME_PREFLIGHT_SCHEMA_VERSION) {
+      reasonCodes.push('runtime_preflight_mixed_version');
+    }
+
+    const currentRuntimePreflight = (snapshot?.state?.runtime_preflights ?? []).find(
+      (runtimePreflight) => runtimePreflight?.runtime_ref === runtimePreflightRef.runtime_ref,
+    ) ?? null;
+    if (!currentRuntimePreflight) {
+      reasonCodes.push('runtime_preflight_missing');
+    } else {
+      if (currentRuntimePreflight.snapshot?.schema_version !== VALID_RUNTIME_PREFLIGHT_SCHEMA_VERSION) {
+        reasonCodes.push('runtime_preflight_mixed_version');
+      }
+      if (
+        currentRuntimePreflight.recorded_at !== runtimePreflightRef.recorded_at
+        || currentRuntimePreflight.replay_key !== runtimePreflightRef.replay_key
+      ) {
+        reasonCodes.push('runtime_preflight_advanced');
+      }
+      if (currentRuntimePreflight.status !== 'clean' || runtimePreflightRef.status !== 'clean') {
+        reasonCodes.push('runtime_preflight_not_clean');
+      }
+    }
+  }
+
+  const executionRef = checkpointSnapshot.execution_ref ?? null;
+  if (!executionRef) {
+    reasonCodes.push('checkpoint_execution_ref_missing');
+  } else {
+    const currentControllerMode = (snapshot?.state?.controller_modes ?? []).find(
+      (recordItem) => recordItem?.controller_id === executionRef.controller_id,
+    ) ?? null;
+    if (!currentControllerMode) {
+      reasonCodes.push('controller_mode_missing');
+    } else if (
+      currentControllerMode.mode !== executionRef.controller_mode
+      || currentControllerMode.updated_at !== executionRef.controller_mode_updated_at
+    ) {
+      reasonCodes.push('controller_mode_advanced');
+    }
+  }
+
+  const prBindingRef = checkpointSnapshot.task_ref?.pr_binding ?? null;
+  if (prBindingRef) {
+    const currentBinding = (snapshot?.state?.pr_bindings ?? []).find((binding) => (
+      binding?.task_id === record.task_id
+        && binding?.pr_number === prBindingRef.pr_number
+        && binding?.status === 'bound'
+    )) ?? null;
+    if (!currentBinding) {
+      reasonCodes.push('pr_binding_missing');
+    } else if (
+      currentBinding.updated_at !== prBindingRef.updated_at
+      || currentBinding.branch_name !== prBindingRef.branch_name
+      || currentBinding.base_branch !== prBindingRef.base_branch
+    ) {
+      reasonCodes.push('pr_binding_advanced');
+    }
+  }
+
+  return buildInspection(record, reasonCodes);
+}
+
+function resolveResumeSafeRefs(snapshot, taskId, controllerId) {
+  const task = (snapshot?.state?.managed_tasks ?? []).find((record) => record?.task_id === taskId) ?? null;
+  if (!task) {
+    throw new Error(`Cannot capture checkpoint for missing task ${taskId}`);
+  }
+
+  const taskSpec = (snapshot?.state?.task_specs ?? []).find((record) => record?.task_id === taskId) ?? null;
+  if (!taskSpec || taskSpec.state !== 'valid') {
+    throw new Error(`Cannot capture checkpoint for ${taskId} without a valid task spec`);
+  }
+
+  const runtimeRef = taskSpec.snapshot?.spec?.runtime_ref ?? null;
+  const runtimePreflight = runtimeRef == null
+    ? null
+    : ((snapshot?.state?.runtime_preflights ?? []).find((record) => record?.runtime_ref === runtimeRef) ?? null);
+  if (!runtimePreflight || runtimePreflight.status !== 'clean') {
+    throw new Error(`Cannot capture checkpoint for ${taskId} without a clean runtime preflight`);
+  }
+
+  const controllerMode = (snapshot?.state?.controller_modes ?? []).find(
+    (record) => record?.controller_id === controllerId,
+  ) ?? null;
+  if (!controllerMode) {
+    throw new Error(`Cannot capture checkpoint for ${taskId} without controller mode ${controllerId}`);
+  }
+
+  const prBinding = (snapshot?.state?.pr_bindings ?? []).find((record) => (
+    record?.task_id === taskId && record?.status === 'bound'
+  )) ?? null;
+
+  return {
+    task,
+    taskSpec,
+    runtimePreflight,
+    controllerMode,
+    prBinding,
+  };
+}
+
+export function createCheckpointStore({
+  repository,
+  now = () => new Date().toISOString(),
+} = {}) {
+  return {
+    captureCheckpoint({
+      taskId,
+      controllerId = 'default',
+      derivedTrigger = null,
+      lifecycleTopStatus = null,
+      observedAt = resolveNow(now),
+      actionIds = [],
+      reason = 'controller_checkpoint',
+      createdBy = 'checkpoint_store',
+    } = {}) {
+      const snapshot = repository.getSnapshot();
+      const {
+        task,
+        taskSpec,
+        runtimePreflight,
+        controllerMode,
+        prBinding,
+      } = resolveResumeSafeRefs(snapshot, taskId, controllerId);
+      const recordedAt = resolveNow(now);
+
+      const checkpointRecord = createCheckpointRecord({
+        checkpoint_id: buildCheckpointId({
+          taskId,
+          recordedAt,
+        }),
+        task_id: task.task_id,
+        recorded_at: recordedAt,
+        created_by: createdBy,
+        reason,
+        snapshot: {
+          schema_version: CHECKPOINT_SCHEMA_VERSION,
+          format: CHECKPOINT_FORMAT,
+          task_ref: {
+            task_id: task.task_id,
+            issue_number: task.issue_number ?? null,
+            title: task.title,
+            branch_name: task.branch_name ?? null,
+            worktree_path: task.worktree_path ?? null,
+            updated_at: task.updated_at,
+            pr_binding: prBinding == null ? null : {
+              binding_id: prBinding.binding_id,
+              pr_number: prBinding.pr_number,
+              branch_name: prBinding.branch_name ?? null,
+              base_branch: prBinding.base_branch ?? null,
+              updated_at: prBinding.updated_at,
+              status: prBinding.status,
+            },
+          },
+          verification_ref: {
+            task_spec: {
+              task_id: taskSpec.task_id,
+              updated_at: taskSpec.updated_at,
+              state: taskSpec.state,
+              snapshot_schema_version: taskSpec.snapshot?.schema_version ?? 'missing',
+            },
+            runtime_preflight: {
+              runtime_ref: runtimePreflight.runtime_ref,
+              recorded_at: runtimePreflight.recorded_at,
+              replay_key: runtimePreflight.replay_key,
+              status: runtimePreflight.status,
+              snapshot_schema_version: runtimePreflight.snapshot?.schema_version ?? 'missing',
+            },
+          },
+          execution_ref: {
+            controller_id: controllerMode.controller_id,
+            controller_mode: controllerMode.mode,
+            controller_mode_updated_at: controllerMode.updated_at,
+            derived_trigger: derivedTrigger,
+            lifecycle_top_status: lifecycleTopStatus,
+            observed_at: observedAt,
+            action_ids: actionIds,
+          },
+        },
+      });
+
+      return repository.upsertCheckpoint(checkpointRecord);
+    },
+
+    inspectCheckpoint({
+      taskId = null,
+      checkpointId = null,
+    } = {}) {
+      const snapshot = repository.getSnapshot();
+      const record = resolveCheckpointRecord(snapshot, {
+        taskId,
+        checkpointId,
+      });
+      return validateCheckpointRecord(snapshot, record);
+    },
+
+    inspectAllCheckpoints() {
+      const snapshot = repository.getSnapshot();
+      return [...(snapshot.state.checkpoints ?? [])]
+        .sort(compareRecordedAtDescending)
+        .map((record) => validateCheckpointRecord(snapshot, record));
+    },
+
+    loadCheckpointForResume({
+      taskId = null,
+      checkpointId = null,
+    } = {}) {
+      const inspection = this.inspectCheckpoint({
+        taskId,
+        checkpointId,
+      });
+
+      if (inspection.state === 'valid') {
+        return inspection;
+      }
+
+      if (inspection.state === 'stale') {
+        throw new Error(`Cannot resume from stale checkpoint: ${inspection.reason_codes.join(', ')}`);
+      }
+
+      throw new Error(`Cannot resume from invalid checkpoint: ${inspection.reason_codes.join(', ')}`);
+    },
+  };
+}

--- a/scripts/ao/lib/controller-loop.js
+++ b/scripts/ao/lib/controller-loop.js
@@ -6,6 +6,7 @@ import {
   createControllerModeRecord,
   createPolicyDecisionRecord,
 } from './state-contracts.js';
+import { createCheckpointStore } from './checkpoint-store.js';
 import { createStateRepository } from './state-repository.js';
 import {
   buildControllerLeaseId,
@@ -473,6 +474,10 @@ export async function runControllerLoop({
     repoRoot,
     projectId,
   });
+  const checkpointStore = createCheckpointStore({
+    repository,
+    now: () => timestamp,
+  });
   await services.ensureRuntimePreflights({
     repository,
     cwd,
@@ -610,6 +615,31 @@ export async function runControllerLoop({
           executedActionCount += executedActionIds.length;
           blockedActionCount += blockedActionIds.length;
         }
+      }
+
+      try {
+        checkpointStore.captureCheckpoint({
+          taskId: task.task_id,
+          controllerId,
+          derivedTrigger,
+          lifecycleTopStatus,
+          observedAt: timestamp,
+          actionIds: [...proposedActionIds, ...executedActionIds],
+          reason: 'controller_loop_checkpoint',
+          createdBy: 'ao_controller',
+        });
+      } catch (error) {
+        repository.appendAuditEntry({
+          entityKind: 'checkpoint',
+          entityId: task.task_id,
+          operation: 'skip',
+          actor: 'ao_controller',
+          summary: `Skipped checkpoint for ${task.task_id}.`,
+          details: {
+            error: error.message,
+          },
+          recordedAt: timestamp,
+        });
       }
 
       taskResults.push({

--- a/scripts/ao/lib/manage-runner.js
+++ b/scripts/ao/lib/manage-runner.js
@@ -1,3 +1,4 @@
+import { createCheckpointStore } from './checkpoint-store.js';
 import { normalizeIssueIntake } from './issue-intake.js';
 import { createStateRepository } from './state-repository.js';
 import { createTaskSpecRecord } from './state-contracts.js';
@@ -16,6 +17,10 @@ function resolveNow(now) {
   if (typeof now === 'function') return resolveNow(now());
   if (typeof now === 'string' && now.trim() !== '') return now.trim();
   return new Date().toISOString();
+}
+
+function isPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function matchesTaskIdentity(task, { taskId = null, issueNumber = null } = {}) {
@@ -121,6 +126,10 @@ export async function runManageCommand({
     repoRoot,
     projectId,
   });
+  const checkpointStore = createCheckpointStore({
+    repository,
+    now: () => timestamp,
+  });
   const snapshot = repository.getSnapshot();
   const existingTask = snapshot.state.managed_tasks.find((task) => matchesTaskIdentity(task, {
     taskId,
@@ -130,22 +139,47 @@ export async function runManageCommand({
     taskId,
     issueNumber,
   });
-  const resolvedTitle = title ?? existingTask?.title ?? (issueNumber != null ? `Issue #${issueNumber}` : resolvedTaskId);
+  const resumeCheckpoint = command === 'resume'
+    ? checkpointStore.loadCheckpointForResume({
+        taskId: resolvedTaskId,
+      })
+    : null;
+  const checkpointTaskRef = resumeCheckpoint?.record?.snapshot?.task_ref ?? null;
+  const checkpointPrBinding = checkpointTaskRef?.pr_binding ?? null;
+  const resolvedIssueNumber = issueNumber ?? existingTask?.issue_number ?? checkpointTaskRef?.issue_number ?? null;
+  const resolvedTitle = title ?? checkpointTaskRef?.title ?? existingTask?.title ?? (resolvedIssueNumber != null ? `Issue #${resolvedIssueNumber}` : resolvedTaskId);
+  const resolvedBranchName = branchName ?? checkpointTaskRef?.branch_name ?? existingTask?.branch_name ?? null;
+  const resolvedWorktreePath = worktreePath ?? checkpointTaskRef?.worktree_path ?? existingTask?.worktree_path ?? null;
+  const resolvedPrNumber = prNumber ?? checkpointPrBinding?.pr_number ?? null;
+  const resolvedBaseBranch = baseBranch ?? checkpointPrBinding?.base_branch ?? 'main';
+  const nextMetadata = command === 'resume'
+    ? {
+        ...(isPlainObject(existingTask?.metadata) ? existingTask.metadata : {}),
+        resume: {
+          last_resume_checkpoint_id: resumeCheckpoint?.checkpoint_id ?? null,
+          resume_kind: 'explicit_checkpoint',
+          resumed_at: timestamp,
+          checkpoint_recorded_at: resumeCheckpoint?.record?.recorded_at ?? null,
+          runtime_preflight_replay_key: resumeCheckpoint?.record?.snapshot?.verification_ref?.runtime_preflight?.replay_key ?? null,
+        },
+      }
+    : existingTask?.metadata ?? null;
 
   const task = transitionManagedTask({
-    intent: command,
+    intent: command === 'resume' ? 'adopt' : command,
     existingTask,
     now: timestamp,
     taskId: resolvedTaskId,
-    issueNumber,
+    issueNumber: resolvedIssueNumber,
     title: resolvedTitle,
-    branchName,
-    worktreePath,
+    branchName: resolvedBranchName,
+    worktreePath: resolvedWorktreePath,
+    metadata: nextMetadata,
   });
   repository.upsertManagedTask(task);
 
   let taskSpec = null;
-  if (['enroll', 'adopt'].includes(command)) {
+  if (['enroll', 'adopt', 'resume'].includes(command)) {
     const postTaskSnapshot = repository.getSnapshot();
     const existingTaskSpec = postTaskSnapshot.state.task_specs.find(
       (record) => record.task_id === task.task_id,
@@ -177,7 +211,7 @@ export async function runManageCommand({
   let releasedOwnershipLeaseIds = [];
   let releasedPrBindingIds = [];
 
-  if (ownerSessionName && ['enroll', 'adopt'].includes(command)) {
+  if (ownerSessionName && ['enroll', 'adopt', 'resume'].includes(command)) {
     releasedOwnershipLeaseIds = releaseConflictingOwnershipLeases(repository, task.task_id, ownerSessionName, timestamp);
     const postReleaseSnapshot = repository.getSnapshot();
     const existingOwnershipLease = postReleaseSnapshot.state.ownership_leases.find(
@@ -206,13 +240,13 @@ export async function runManageCommand({
     }
   }
 
-  if (prNumber != null) {
-    releasedPrBindingIds = releaseConflictingPrBindings(repository, task.task_id, prNumber, timestamp);
+  if (resolvedPrNumber != null) {
+    releasedPrBindingIds = releaseConflictingPrBindings(repository, task.task_id, resolvedPrNumber, timestamp);
     const postReleaseSnapshot = repository.getSnapshot();
     const existingBinding = postReleaseSnapshot.state.pr_bindings.find(
       (binding) => binding.binding_id === buildPrBindingId({
         taskId: task.task_id,
-        prNumber,
+        prNumber: resolvedPrNumber,
       }),
     ) ?? null;
 
@@ -222,12 +256,12 @@ export async function runManageCommand({
       now: timestamp,
       bindingId: buildPrBindingId({
         taskId: task.task_id,
-        prNumber,
+        prNumber: resolvedPrNumber,
       }),
       taskId: task.task_id,
-      prNumber,
-      branchName: branchName ?? task.branch_name,
-      baseBranch,
+      prNumber: resolvedPrNumber,
+      branchName: resolvedBranchName ?? task.branch_name,
+      baseBranch: resolvedBaseBranch,
     });
     repository.upsertPrBinding(prBinding);
   }
@@ -257,6 +291,11 @@ export async function runManageCommand({
     taskSpec,
     prBinding,
     ownershipLease,
+    resume: resumeCheckpoint == null ? null : {
+      checkpoint_id: resumeCheckpoint.checkpoint_id,
+      state: resumeCheckpoint.state,
+      reason_codes: resumeCheckpoint.reason_codes,
+    },
     releasedOwnershipLeaseIds,
     releasedPrBindingIds,
   };

--- a/scripts/ao/lib/state-contracts.js
+++ b/scripts/ao/lib/state-contracts.js
@@ -7,8 +7,10 @@ export const CONTROL_PLANE_STATE_SCHEMA_VERSION = 'ao.control-plane.state.v1alph
 export const CONTROL_PLANE_STATE_FORMAT = 'ao_control_plane_state';
 export const CONTROL_PLANE_AUDIT_SCHEMA_VERSION = 'ao.control-plane.audit.v1alpha1';
 export const CONTROL_PLANE_AUDIT_FORMAT = 'ao_control_plane_audit_entry';
-export const CONTROL_PLANE_LATEST_VERSION = 5;
+export const CONTROL_PLANE_LATEST_VERSION = 6;
 export const CONTROL_PLANE_DEFAULT_CONTROLLER_ID = 'default';
+export const CHECKPOINT_SCHEMA_VERSION = 'ao.checkpoint.v1alpha1';
+export const CHECKPOINT_FORMAT = 'ao_checkpoint';
 
 export const MANAGED_TASK_STATUSES = ['active', 'paused', 'retired'];
 export const PR_BINDING_STATUSES = ['bound', 'released', 'closed'];
@@ -92,6 +94,14 @@ function normalizeEnum(value, fieldName, allowedValues) {
   return normalized;
 }
 
+function normalizeStringArray(values, fieldName) {
+  if (!Array.isArray(values)) {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+
+  return values.map((value, index) => normalizeRequiredString(value, `${fieldName}[${index}]`));
+}
+
 function normalizeMetadata(value = {}) {
   if (value == null) return {};
   if (!isPlainObject(value)) {
@@ -167,6 +177,7 @@ export function createEmptyControlPlaneState({
     credential_provenances: [],
     task_specs: [],
     runtime_preflights: [],
+    checkpoints: [],
   };
 }
 
@@ -534,6 +545,163 @@ export function createRuntimePreflightRecord({
     observed_at: normalizeIsoTimestamp(normalizedSnapshot.observed_at, 'observed_at'),
     recorded_at: normalizeIsoTimestamp(recorded_at, 'recorded_at'),
     replay_key: normalizeRequiredString(normalizedSnapshot.replay_key, 'replay_key'),
+    snapshot: normalizedSnapshot,
+  };
+}
+
+function normalizeCheckpointPrBinding(value) {
+  if (value == null) return null;
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid checkpoint pr_binding');
+  }
+
+  return {
+    binding_id: normalizeRequiredString(value.binding_id, 'pr_binding.binding_id'),
+    pr_number: normalizePositiveInteger(value.pr_number, 'pr_binding.pr_number'),
+    branch_name: normalizeOptionalString(value.branch_name),
+    base_branch: normalizeOptionalString(value.base_branch),
+    updated_at: normalizeIsoTimestamp(value.updated_at, 'pr_binding.updated_at'),
+    status: normalizeRequiredString(value.status, 'pr_binding.status'),
+  };
+}
+
+function normalizeCheckpointTaskRef(value = {}) {
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid task_ref');
+  }
+
+  return {
+    task_id: normalizeRequiredString(value.task_id, 'task_ref.task_id'),
+    issue_number: normalizePositiveInteger(value.issue_number, 'task_ref.issue_number', {
+      nullable: true,
+    }),
+    title: normalizeRequiredString(value.title, 'task_ref.title'),
+    branch_name: normalizeOptionalString(value.branch_name),
+    worktree_path: normalizeOptionalString(value.worktree_path),
+    updated_at: normalizeIsoTimestamp(value.updated_at, 'task_ref.updated_at'),
+    pr_binding: normalizeCheckpointPrBinding(value.pr_binding),
+  };
+}
+
+function normalizeCheckpointTaskSpecRef(value) {
+  if (value == null) return null;
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid verification_ref.task_spec');
+  }
+
+  return {
+    task_id: normalizeRequiredString(value.task_id, 'verification_ref.task_spec.task_id'),
+    updated_at: normalizeIsoTimestamp(value.updated_at, 'verification_ref.task_spec.updated_at'),
+    state: normalizeRequiredString(value.state, 'verification_ref.task_spec.state'),
+    snapshot_schema_version: normalizeRequiredString(
+      value.snapshot_schema_version,
+      'verification_ref.task_spec.snapshot_schema_version',
+    ),
+  };
+}
+
+function normalizeCheckpointRuntimePreflightRef(value) {
+  if (value == null) return null;
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid verification_ref.runtime_preflight');
+  }
+
+  return {
+    runtime_ref: normalizeRequiredString(
+      value.runtime_ref,
+      'verification_ref.runtime_preflight.runtime_ref',
+    ),
+    recorded_at: normalizeIsoTimestamp(
+      value.recorded_at,
+      'verification_ref.runtime_preflight.recorded_at',
+    ),
+    replay_key: normalizeRequiredString(
+      value.replay_key,
+      'verification_ref.runtime_preflight.replay_key',
+    ),
+    status: normalizeRequiredString(value.status, 'verification_ref.runtime_preflight.status'),
+    snapshot_schema_version: normalizeRequiredString(
+      value.snapshot_schema_version,
+      'verification_ref.runtime_preflight.snapshot_schema_version',
+    ),
+  };
+}
+
+function normalizeCheckpointVerificationRef(value = {}) {
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid verification_ref');
+  }
+
+  return {
+    task_spec: normalizeCheckpointTaskSpecRef(value.task_spec),
+    runtime_preflight: normalizeCheckpointRuntimePreflightRef(value.runtime_preflight),
+  };
+}
+
+function normalizeCheckpointExecutionRef(value = {}) {
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid execution_ref');
+  }
+
+  return {
+    controller_id: normalizeRequiredString(value.controller_id, 'execution_ref.controller_id'),
+    controller_mode: normalizeEnum(value.controller_mode, 'execution_ref.controller_mode', CONTROLLER_MODES),
+    controller_mode_updated_at: normalizeIsoTimestamp(
+      value.controller_mode_updated_at,
+      'execution_ref.controller_mode_updated_at',
+    ),
+    derived_trigger: normalizeOptionalString(value.derived_trigger),
+    lifecycle_top_status: normalizeOptionalString(value.lifecycle_top_status),
+    observed_at: normalizeIsoTimestamp(value.observed_at, 'execution_ref.observed_at'),
+    action_ids: normalizeStringArray(value.action_ids ?? [], 'execution_ref.action_ids'),
+  };
+}
+
+export function createCheckpointSnapshot({
+  schema_version = CHECKPOINT_SCHEMA_VERSION,
+  format = CHECKPOINT_FORMAT,
+  task_ref,
+  verification_ref,
+  execution_ref,
+} = {}) {
+  return {
+    schema_version: normalizeRequiredString(schema_version, 'schema_version'),
+    format: normalizeRequiredString(format, 'format'),
+    task_ref: normalizeCheckpointTaskRef(task_ref),
+    verification_ref: normalizeCheckpointVerificationRef(verification_ref),
+    execution_ref: normalizeCheckpointExecutionRef(execution_ref),
+  };
+}
+
+export function createCheckpointRecord({
+  checkpoint_id,
+  task_id,
+  recorded_at,
+  snapshot,
+  created_by = null,
+  reason = null,
+  metadata = {},
+} = {}) {
+  const normalizedSnapshot = createCheckpointSnapshot({
+    schema_version: snapshot?.schema_version,
+    format: snapshot?.format,
+    task_ref: snapshot?.task_ref,
+    verification_ref: snapshot?.verification_ref,
+    execution_ref: snapshot?.execution_ref,
+  });
+  const normalizedTaskId = normalizeRequiredString(task_id, 'task_id');
+
+  if (normalizedTaskId !== normalizedSnapshot.task_ref.task_id) {
+    throw new Error('Checkpoint task_id must match snapshot.task_ref.task_id');
+  }
+
+  return {
+    checkpoint_id: normalizeRequiredString(checkpoint_id, 'checkpoint_id'),
+    task_id: normalizedTaskId,
+    recorded_at: normalizeIsoTimestamp(recorded_at, 'recorded_at'),
+    created_by: normalizeOptionalString(created_by),
+    reason: normalizeOptionalString(reason),
+    metadata: normalizeMetadata(metadata),
     snapshot: normalizedSnapshot,
   };
 }

--- a/scripts/ao/lib/state-migrations.js
+++ b/scripts/ao/lib/state-migrations.js
@@ -42,12 +42,18 @@ export const CONTROL_PLANE_RUNTIME_PREFLIGHT_MIGRATION = {
   key: '0005_runtime_preflight_v1',
 };
 
+export const CONTROL_PLANE_CHECKPOINT_MIGRATION = {
+  version: 6,
+  key: '0006_checkpoint_v1',
+};
+
 const CONTROL_PLANE_MIGRATIONS = [
   CONTROL_PLANE_BOOTSTRAP_MIGRATION,
   CONTROL_PLANE_TASK_SPEC_MIGRATION,
   CONTROL_PLANE_DELIVERY_EVENTS_MIGRATION,
   CONTROL_PLANE_POLICY_ENGINE_MIGRATION,
   CONTROL_PLANE_RUNTIME_PREFLIGHT_MIGRATION,
+  CONTROL_PLANE_CHECKPOINT_MIGRATION,
 ];
 
 function resolveNow(now) {
@@ -110,6 +116,7 @@ function buildBootstrapState({
     'credential_provenances',
     'task_specs',
     'runtime_preflights',
+    'checkpoints',
   ]) {
     if (Array.isArray(existingState?.[collectionKey])) {
       state[collectionKey] = cloneJsonValue(existingState[collectionKey]);
@@ -206,6 +213,14 @@ function applyMigration({
     });
   }
 
+  if (migration.version === CONTROL_PLANE_CHECKPOINT_MIGRATION.version) {
+    return buildBootstrapState({
+      projectId,
+      now,
+      existingState: state,
+    });
+  }
+
   throw new Error(`Unsupported migration version ${migration.version}`);
 }
 
@@ -235,6 +250,13 @@ function buildAuditSummary(migration) {
     return {
       operation: 'migrate',
       summary: 'Applied control-plane runtime-preflight migration.',
+    };
+  }
+
+  if (migration.version === CONTROL_PLANE_CHECKPOINT_MIGRATION.version) {
+    return {
+      operation: 'migrate',
+      summary: 'Applied control-plane checkpoint migration.',
     };
   }
 

--- a/scripts/ao/lib/state-report.js
+++ b/scripts/ao/lib/state-report.js
@@ -21,6 +21,7 @@ export function renderAoStateHumanSummary(report) {
     `controller_modes: ${formatList(report.summary.controller_modes)}`,
     `observations: ${report.summary.observation_count}`,
     `controller_cursors: ${report.summary.controller_cursor_count}`,
+    `checkpoints: ${report.summary.checkpoint_count} (valid=${report.summary.valid_checkpoint_count}, stale=${report.summary.stale_checkpoint_count}, invalid=${report.summary.invalid_checkpoint_count})`,
     `audit_entries: ${report.summary.audit_entry_count}`,
     `recent_audit: ${formatList(recentAudit)}`,
   ].join('\n');

--- a/scripts/ao/lib/state-repository.js
+++ b/scripts/ao/lib/state-repository.js
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import {
   CONTROL_PLANE_LATEST_VERSION,
   createActionRecord,
+  createCheckpointRecord,
   createControlPlaneAuditEntry,
   createControlPlaneSchema,
   createControllerLease,
@@ -117,6 +118,7 @@ export function createStateRepository({
     nextState.credential_provenances = sortCollectionByKey(nextState.credential_provenances, 'provenance_id');
     nextState.task_specs = sortCollectionByKey(nextState.task_specs, 'task_id');
     nextState.runtime_preflights = sortCollectionByKey(nextState.runtime_preflights, 'runtime_ref');
+    nextState.checkpoints = sortCollectionByKey(nextState.checkpoints, 'checkpoint_id');
 
     return {
       bootstrapped: true,
@@ -434,7 +436,7 @@ export function createStateRepository({
           state: nextState,
           entityKind: 'runtime_preflight',
           entityId: normalizedRecord.runtime_ref,
-          summary: `Persisted runtime preflight ${normalizedRecord.runtime_ref}.`,
+        summary: `Persisted runtime preflight ${normalizedRecord.runtime_ref}.`,
           details: normalizedRecord,
         });
         snapshot = {
@@ -445,6 +447,17 @@ export function createStateRepository({
       }
 
       return sortCollectionByKey(ensuredRecords, 'runtime_ref');
+    },
+
+    upsertCheckpoint(record) {
+      return upsertCollectionRecord({
+        collectionKey: 'checkpoints',
+        identityKey: 'checkpoint_id',
+        entityKind: 'checkpoint',
+        record,
+        normalize: createCheckpointRecord,
+        summary: `Persisted checkpoint ${record?.checkpoint_id}.`,
+      });
     },
   };
 }

--- a/scripts/ao/lib/state-runner.js
+++ b/scripts/ao/lib/state-runner.js
@@ -1,3 +1,4 @@
+import { createCheckpointStore } from './checkpoint-store.js';
 import * as fs from 'node:fs';
 import path from 'node:path';
 
@@ -45,6 +46,12 @@ export async function loadAoStateReport({
   const snapshot = repository.getSnapshot();
   const auditEntries = repository.listAuditEntries();
   const recentEntries = auditLimit == null ? auditEntries : auditEntries.slice(-auditLimit);
+  const checkpointInspections = createCheckpointStore({
+    repository,
+  }).inspectAllCheckpoints();
+  const validCheckpointCount = checkpointInspections.filter((inspection) => inspection.state === 'valid').length;
+  const staleCheckpointCount = checkpointInspections.filter((inspection) => inspection.state === 'stale').length;
+  const invalidCheckpointCount = checkpointInspections.filter((inspection) => inspection.state === 'invalid').length;
 
   return {
     schema_version: AO_STATE_SCHEMA_VERSION,
@@ -66,7 +73,14 @@ export async function loadAoStateReport({
       controller_modes: summarizeControllerModes(snapshot.state.controller_modes),
       observation_count: snapshot.state.observations.length,
       controller_cursor_count: snapshot.state.controller_cursors.length,
+      checkpoint_count: checkpointInspections.length,
+      valid_checkpoint_count: validCheckpointCount,
+      stale_checkpoint_count: staleCheckpointCount,
+      invalid_checkpoint_count: invalidCheckpointCount,
       audit_entry_count: auditEntries.length,
+    },
+    checkpoints: {
+      inspections: checkpointInspections,
     },
     audit: {
       recent_entries: recentEntries,

--- a/tests/ao/ao-manage-cli.test.js
+++ b/tests/ao/ao-manage-cli.test.js
@@ -83,6 +83,32 @@ describe('ao manage cli', () => {
     });
   });
 
+  it('accepts resume as an explicit command without requiring branch or worktree flags', async () => {
+    const result = await runCli([
+      'resume',
+      '--issue',
+      '110',
+      '--owner-session',
+      'cie-57',
+      '--owner-session-id',
+      'cie-57',
+      '--json',
+    ], {
+      writeStdout: () => {},
+      writeStderr: () => {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockRunManageCommand).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: 'ciecopilot-home',
+      command: 'resume',
+      issueNumber: 110,
+      ownerSessionName: 'cie-57',
+      ownerSessionId: 'cie-57',
+      cwd: process.cwd(),
+    }));
+  });
+
   it('rejects unsupported commands and invalid numeric arguments', async () => {
     const stderr = [];
 

--- a/tests/ao/checkpoint-store.test.js
+++ b/tests/ao/checkpoint-store.test.js
@@ -1,0 +1,253 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+import { createCheckpointStore } from '../../scripts/ao/lib/checkpoint-store.js';
+import {
+  createControllerModeRecord,
+  createManagedTask,
+  createPrBinding,
+  createTaskSpecRecord,
+} from '../../scripts/ao/lib/state-contracts.js';
+import { resolveControlPlanePaths } from '../../scripts/ao/lib/state-migrations.js';
+import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
+
+const PROJECT_ID = 'ciecopilot-home';
+const tempDirs = [];
+
+function createTempRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-checkpoint-store-'));
+  tempDirs.push(repoRoot);
+  return repoRoot;
+}
+
+function createRepository() {
+  return createStateRepository({
+    repoRoot: createTempRepo(),
+    projectId: PROJECT_ID,
+  });
+}
+
+function seedResumeSafeTask(repository, {
+  taskId = 'issue-110',
+  issueNumber = 110,
+  branchName = 'feat/110',
+  worktreePath = '/tmp/cie-57',
+  prNumber = 110,
+  now = '2026-03-30T10:00:00.000Z',
+} = {}) {
+  repository.upsertManagedTask(createManagedTask({
+    task_id: taskId,
+    issue_number: issueNumber,
+    title: 'feat(ao): add checkpoint schema and explicit resume',
+    branch_name: branchName,
+    worktree_path: worktreePath,
+    status: 'active',
+    created_at: now,
+    updated_at: now,
+  }));
+  repository.upsertPrBinding(createPrBinding({
+    binding_id: `binding-${taskId}-pr-${prNumber}`,
+    task_id: taskId,
+    pr_number: prNumber,
+    branch_name: branchName,
+    base_branch: 'main',
+    status: 'bound',
+    created_at: now,
+    updated_at: now,
+  }));
+  repository.upsertControllerMode(createControllerModeRecord({
+    controller_id: 'default',
+    mode: 'observe',
+    updated_at: now,
+    updated_by: 'operator',
+    reason: 'Checkpoint test setup',
+  }));
+  repository.upsertTaskSpec(createTaskSpecRecord({
+    task_id: taskId,
+    source_kind: 'github_issue',
+    source_issue_number: issueNumber,
+    created_at: now,
+    updated_at: now,
+    snapshot: {
+      schema_version: 'ao.task-spec.v1alpha1',
+      spec: {
+        problem_type: 'issue_delivery',
+        acceptance_contract: ['Checkpoint-backed resume exists.'],
+        runtime_ref: 'runtime.github_local',
+        policy_ref: 'policy.operator_gated',
+        human_gates: ['operator_resume'],
+      },
+    },
+  }));
+  repository.ensureRuntimePreflights({
+    cwd: repository.getSnapshot().paths.repoRoot,
+    now,
+    probes: {
+      commandExists: () => true,
+      pathExists: () => true,
+      capability: () => true,
+    },
+  });
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('ao checkpoint store', () => {
+  it('persists a versioned checkpoint with task, verification, and execution references', () => {
+    const repository = createRepository();
+    seedResumeSafeTask(repository);
+    const checkpointStore = createCheckpointStore({
+      repository,
+      now: () => '2026-03-30T10:05:00.000Z',
+    });
+
+    const checkpoint = checkpointStore.captureCheckpoint({
+      taskId: 'issue-110',
+      controllerId: 'default',
+      derivedTrigger: 'manual',
+      lifecycleTopStatus: null,
+      observedAt: '2026-03-30T10:05:00.000Z',
+      actionIds: ['proposal-issue-110-continue'],
+    });
+
+    expect(checkpoint).toMatchObject({
+      task_id: 'issue-110',
+      snapshot: {
+        schema_version: 'ao.checkpoint.v1alpha1',
+        format: 'ao_checkpoint',
+        task_ref: {
+          task_id: 'issue-110',
+          issue_number: 110,
+          branch_name: 'feat/110',
+          worktree_path: '/tmp/cie-57',
+          pr_binding: {
+            pr_number: 110,
+            branch_name: 'feat/110',
+          },
+        },
+        verification_ref: {
+          task_spec: {
+            task_id: 'issue-110',
+            state: 'valid',
+            snapshot_schema_version: 'ao.task-spec.v1alpha1',
+          },
+          runtime_preflight: {
+            runtime_ref: 'runtime.github_local',
+            status: 'clean',
+            snapshot_schema_version: 'ao.runtime-preflight.v1alpha1',
+            replay_key: expect.stringMatching(/^runtime_preflight:/),
+          },
+        },
+        execution_ref: {
+          controller_id: 'default',
+          controller_mode: 'observe',
+          derived_trigger: 'manual',
+          lifecycle_top_status: null,
+          observed_at: '2026-03-30T10:05:00.000Z',
+          action_ids: ['proposal-issue-110-continue'],
+        },
+      },
+    });
+
+    expect(checkpointStore.inspectCheckpoint({
+      taskId: 'issue-110',
+    })).toMatchObject({
+      task_id: 'issue-110',
+      checkpoint_id: checkpoint.checkpoint_id,
+      state: 'valid',
+      reason_codes: [],
+    });
+    expect(checkpointStore.inspectAllCheckpoints()).toEqual([
+      expect.objectContaining({
+        task_id: 'issue-110',
+        state: 'valid',
+      }),
+    ]);
+  });
+
+  it('fails closed when the current durable task state has advanced past the checkpoint', () => {
+    const repository = createRepository();
+    seedResumeSafeTask(repository);
+    const checkpointStore = createCheckpointStore({
+      repository,
+      now: () => '2026-03-30T10:05:00.000Z',
+    });
+
+    checkpointStore.captureCheckpoint({
+      taskId: 'issue-110',
+      controllerId: 'default',
+      derivedTrigger: 'manual',
+      observedAt: '2026-03-30T10:05:00.000Z',
+      actionIds: [],
+    });
+
+    repository.upsertManagedTask(createManagedTask({
+      task_id: 'issue-110',
+      issue_number: 110,
+      title: 'feat(ao): add checkpoint schema and explicit resume',
+      branch_name: 'feat/110',
+      worktree_path: '/tmp/cie-57b',
+      status: 'active',
+      created_at: '2026-03-30T10:00:00.000Z',
+      updated_at: '2026-03-30T10:06:00.000Z',
+    }));
+
+    expect(checkpointStore.inspectCheckpoint({
+      taskId: 'issue-110',
+    })).toMatchObject({
+      state: 'stale',
+      reason_codes: expect.arrayContaining(['managed_task_advanced']),
+    });
+    expect(() => checkpointStore.loadCheckpointForResume({
+      taskId: 'issue-110',
+    })).toThrow(/stale checkpoint/i);
+  });
+
+  it('detects mixed-version checkpoint state during inspection', () => {
+    const repository = createRepository();
+    seedResumeSafeTask(repository);
+    const checkpointStore = createCheckpointStore({
+      repository,
+      now: () => '2026-03-30T10:05:00.000Z',
+    });
+
+    const checkpoint = checkpointStore.captureCheckpoint({
+      taskId: 'issue-110',
+      controllerId: 'default',
+      derivedTrigger: 'manual',
+      observedAt: '2026-03-30T10:05:00.000Z',
+      actionIds: [],
+    });
+    const paths = resolveControlPlanePaths({
+      repoRoot: repository.getSnapshot().paths.repoRoot,
+      projectId: PROJECT_ID,
+    });
+    const state = JSON.parse(fs.readFileSync(paths.statePath, 'utf8'));
+    state.checkpoints = state.checkpoints.map((record) => (
+      record.checkpoint_id === checkpoint.checkpoint_id
+        ? {
+            ...record,
+            snapshot: {
+              ...record.snapshot,
+              schema_version: 'ao.checkpoint.v0alpha9',
+            },
+          }
+        : record
+    ));
+    fs.writeFileSync(paths.statePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+
+    expect(checkpointStore.inspectCheckpoint({
+      taskId: 'issue-110',
+    })).toMatchObject({
+      state: 'invalid',
+      reason_codes: expect.arrayContaining(['checkpoint_mixed_version']),
+    });
+  });
+});

--- a/tests/ao/controller-loop.test.js
+++ b/tests/ao/controller-loop.test.js
@@ -106,6 +106,7 @@ describe('ao controller loop', () => {
       projectId: PROJECT_ID,
     });
     seedActiveTask(repository, 'observe');
+    seedCleanRuntimePreflight(repository);
     const resolveLifecycleReport = jest.fn();
 
     const result = await runControllerLoop({
@@ -115,6 +116,15 @@ describe('ao controller loop', () => {
       controllerId: 'default',
       now: '2026-03-29T06:41:00.000Z',
       deps: {
+        ensureRuntimePreflights: ({ repository: activeRepository, cwd, now }) => activeRepository.ensureRuntimePreflights({
+          cwd,
+          now,
+          probes: {
+            commandExists: () => true,
+            pathExists: () => true,
+            capability: () => true,
+          },
+        }),
         loadAoProjectObservation: async () => ({
           observed_at: '2026-03-29T06:41:00.000Z',
           workers: [
@@ -169,6 +179,29 @@ describe('ao controller loop', () => {
     const snapshot = repository.getSnapshot().state;
     expect(snapshot.observations).toHaveLength(2);
     expect(snapshot.actions).toEqual([]);
+    expect(snapshot.checkpoints).toEqual([
+      expect.objectContaining({
+        task_id: 'issue-92',
+        snapshot: expect.objectContaining({
+          schema_version: 'ao.checkpoint.v1alpha1',
+          verification_ref: expect.objectContaining({
+            task_spec: expect.objectContaining({
+              task_id: 'issue-92',
+              state: 'valid',
+            }),
+            runtime_preflight: expect.objectContaining({
+              runtime_ref: 'runtime.github_local',
+              status: 'clean',
+            }),
+          }),
+          execution_ref: expect.objectContaining({
+            controller_id: 'default',
+            controller_mode: 'observe',
+            derived_trigger: 'manual',
+          }),
+        }),
+      }),
+    ]);
     expect(snapshot.controller_leases).toEqual([
       expect.objectContaining({
         controller_id: 'default',

--- a/tests/ao/controller-state-contracts.test.js
+++ b/tests/ao/controller-state-contracts.test.js
@@ -98,6 +98,7 @@ describe('ao controller state contracts', () => {
       delivery_events: [],
       controller_cursors: [],
       runtime_preflights: [],
+      checkpoints: [],
     });
   });
 });

--- a/tests/ao/doctor-runner.test.js
+++ b/tests/ao/doctor-runner.test.js
@@ -44,13 +44,14 @@ describe('doctor runner', () => {
       getSnapshot: () => ({
         bootstrapped: true,
         schema: {
-          current_version: 5,
-          latest_version: 5,
+          current_version: 6,
+          latest_version: 6,
         },
         state: {
           managed_tasks: [],
           task_specs: [],
           runtime_preflights: [],
+          checkpoints: [],
         },
       }),
     });
@@ -108,13 +109,14 @@ describe('doctor runner', () => {
       controlPlaneSnapshot: {
         bootstrapped: true,
         schema: {
-          current_version: 5,
-          latest_version: 5,
+          current_version: 6,
+          latest_version: 6,
         },
         state: {
           managed_tasks: [],
           task_specs: [],
           runtime_preflights: [],
+          checkpoints: [],
         },
       },
     });
@@ -137,13 +139,14 @@ describe('doctor runner', () => {
       controlPlaneSnapshot: {
         bootstrapped: true,
         schema: {
-          current_version: 5,
-          latest_version: 5,
+          current_version: 6,
+          latest_version: 6,
         },
         state: {
           managed_tasks: [],
           task_specs: [],
           runtime_preflights: [],
+          checkpoints: [],
         },
       },
       report: {

--- a/tests/ao/manage-runner.test.js
+++ b/tests/ao/manage-runner.test.js
@@ -4,8 +4,10 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from '@jest/globals';
 
+import { createCheckpointStore } from '../../scripts/ao/lib/checkpoint-store.js';
 import { resolveControlPlanePaths } from '../../scripts/ao/lib/state-migrations.js';
 import { runManageCommand } from '../../scripts/ao/lib/manage-runner.js';
+import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
 
 const PROJECT_ID = 'ciecopilot-home';
 const tempDirs = [];
@@ -171,6 +173,186 @@ describe('ao manage runner', () => {
       owner_session_name: 'cie-50',
       status: 'active',
     });
+  });
+
+  it('resumes a paused task from an explicit checkpoint instead of treating it as a new enrollment', async () => {
+    const repoRoot = createTempRepo();
+
+    await runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'enroll',
+      issueNumber: 110,
+      title: 'feat(ao): add checkpoint schema and explicit resume',
+      branchName: 'feat/110',
+      worktreePath: '/tmp/cie-57',
+      prNumber: 120,
+      ownerSessionName: 'cie-57',
+      ownerSessionId: 'cie-57',
+      taskSpecBody: [
+        '## Problem Type',
+        'issue_delivery',
+        '',
+        '## Acceptance Contract',
+        '- checkpoint-backed resume exists',
+        '',
+        '## Runtime Ref',
+        'runtime.github_local',
+        '',
+        '## Policy Ref',
+        'policy.operator_gated',
+        '',
+        '## Human Gates',
+        '- operator_resume',
+      ].join('\n'),
+      now: '2026-03-30T10:00:00.000Z',
+    });
+
+    const repository = createStateRepository({
+      repoRoot,
+      projectId: PROJECT_ID,
+    });
+    repository.ensureRuntimePreflights({
+      cwd: repoRoot,
+      now: '2026-03-30T10:01:00.000Z',
+      probes: {
+        commandExists: () => true,
+        pathExists: () => true,
+        capability: () => true,
+      },
+    });
+    const checkpointStore = createCheckpointStore({
+      repository,
+      now: () => '2026-03-30T10:02:00.000Z',
+    });
+    const checkpoint = checkpointStore.captureCheckpoint({
+      taskId: 'issue-110',
+      controllerId: 'default',
+      derivedTrigger: 'manual',
+      observedAt: '2026-03-30T10:02:00.000Z',
+      actionIds: ['proposal-issue-110-continue'],
+    });
+
+    await runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'unmanage',
+      issueNumber: 110,
+      now: '2026-03-30T10:03:00.000Z',
+      reason: 'worker_exited',
+    });
+
+    const result = await runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'resume',
+      issueNumber: 110,
+      ownerSessionName: 'cie-57',
+      ownerSessionId: 'cie-57',
+      now: '2026-03-30T10:04:00.000Z',
+    });
+
+    expect(result.task).toMatchObject({
+      task_id: 'issue-110',
+      status: 'active',
+      branch_name: 'feat/110',
+      worktree_path: '/tmp/cie-57',
+      metadata: expect.objectContaining({
+        resume: expect.objectContaining({
+          last_resume_checkpoint_id: checkpoint.checkpoint_id,
+          resume_kind: 'explicit_checkpoint',
+          resumed_at: '2026-03-30T10:04:00.000Z',
+        }),
+      }),
+    });
+    expect(result.prBinding).toMatchObject({
+      pr_number: 120,
+      status: 'bound',
+    });
+    expect(result.ownershipLease).toMatchObject({
+      owner_session_name: 'cie-57',
+      status: 'active',
+    });
+    expect(result.resume).toMatchObject({
+      checkpoint_id: checkpoint.checkpoint_id,
+      state: 'valid',
+    });
+  });
+
+  it('fails closed when explicit resume sees a stale checkpoint', async () => {
+    const repoRoot = createTempRepo();
+
+    await runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'enroll',
+      issueNumber: 110,
+      title: 'feat(ao): add checkpoint schema and explicit resume',
+      branchName: 'feat/110',
+      worktreePath: '/tmp/cie-57',
+      taskSpecBody: [
+        '## Problem Type',
+        'issue_delivery',
+        '',
+        '## Acceptance Contract',
+        '- checkpoint-backed resume exists',
+        '',
+        '## Runtime Ref',
+        'runtime.github_local',
+        '',
+        '## Policy Ref',
+        'policy.operator_gated',
+        '',
+        '## Human Gates',
+        '- operator_resume',
+      ].join('\n'),
+      now: '2026-03-30T10:00:00.000Z',
+    });
+
+    const repository = createStateRepository({
+      repoRoot,
+      projectId: PROJECT_ID,
+    });
+    repository.ensureRuntimePreflights({
+      cwd: repoRoot,
+      now: '2026-03-30T10:01:00.000Z',
+      probes: {
+        commandExists: () => true,
+        pathExists: () => true,
+        capability: () => true,
+      },
+    });
+    const checkpointStore = createCheckpointStore({
+      repository,
+      now: () => '2026-03-30T10:02:00.000Z',
+    });
+    checkpointStore.captureCheckpoint({
+      taskId: 'issue-110',
+      controllerId: 'default',
+      derivedTrigger: 'manual',
+      observedAt: '2026-03-30T10:02:00.000Z',
+      actionIds: [],
+    });
+
+    await runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'adopt',
+      issueNumber: 110,
+      branchName: 'feat/110b',
+      worktreePath: '/tmp/cie-57b',
+      now: '2026-03-30T10:03:00.000Z',
+    });
+
+    await expect(runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'resume',
+      issueNumber: 110,
+      ownerSessionName: 'cie-57',
+      ownerSessionId: 'cie-57',
+      now: '2026-03-30T10:04:00.000Z',
+    })).rejects.toThrow(/stale checkpoint/i);
   });
 
   it('unmanages and retires a task without deleting its durable bindings', async () => {

--- a/tests/ao/state-contracts.test.js
+++ b/tests/ao/state-contracts.test.js
@@ -45,7 +45,7 @@ describe('ao state contracts', () => {
     expect(CONTROLLER_MODES).toEqual(['off', 'observe', 'shadow', 'assist']);
     expect(POLICY_DECISIONS).toEqual(['allow', 'deny', 'downgrade']);
     expect(CREDENTIAL_PROVENANCE_TRUST_DECISIONS).toEqual(['trusted', 'untrusted']);
-    expect(CONTROL_PLANE_LATEST_VERSION).toBe(5);
+    expect(CONTROL_PLANE_LATEST_VERSION).toBe(6);
   });
 
   it('creates durable managed-task, binding, lease, action, override, and controller-mode records', () => {
@@ -444,6 +444,7 @@ describe('ao state contracts', () => {
       credential_provenances: [],
       task_specs: [],
       runtime_preflights: [],
+      checkpoints: [],
     });
 
     expect(createControlPlaneAuditEntry({

--- a/tests/ao/state-migrations.test.js
+++ b/tests/ao/state-migrations.test.js
@@ -73,8 +73,8 @@ describe('ao state migrations', () => {
 
     expect(readJson(paths.schemaPath)).toMatchObject({
       project_id: PROJECT_ID,
-      current_version: 5,
-      latest_version: 5,
+      current_version: 6,
+      latest_version: 6,
       applied_migrations: [
         {
           version: 1,
@@ -101,6 +101,11 @@ describe('ao state migrations', () => {
           key: '0005_runtime_preflight_v1',
           applied_at: FIXED_NOW,
         },
+        {
+          version: 6,
+          key: '0006_checkpoint_v1',
+          applied_at: FIXED_NOW,
+        },
       ],
     });
     expect(readJson(paths.statePath)).toMatchObject({
@@ -110,6 +115,7 @@ describe('ao state migrations', () => {
       credential_provenances: [],
       task_specs: [],
       runtime_preflights: [],
+      checkpoints: [],
       controller_modes: [
         {
           controller_id: 'default',
@@ -150,6 +156,12 @@ describe('ao state migrations', () => {
         operation: 'migrate',
         summary: 'Applied control-plane runtime-preflight migration.',
       }),
+      expect.objectContaining({
+        entity_kind: 'schema',
+        entity_id: 'v6',
+        operation: 'migrate',
+        summary: 'Applied control-plane checkpoint migration.',
+      }),
     ]);
   });
 
@@ -176,7 +188,7 @@ describe('ao state migrations', () => {
       migrated: false,
     });
     expect(readJson(paths.schemaPath).updated_at).toBe(FIXED_NOW);
-    expect(readAuditEntries(paths.auditPath)).toHaveLength(5);
+    expect(readAuditEntries(paths.auditPath)).toHaveLength(6);
   });
 
   it('upgrades a stale schema version and backfills invalid task specs for enrolled tasks', () => {
@@ -192,7 +204,7 @@ describe('ao state migrations', () => {
       format: 'ao_control_plane_schema',
       project_id: PROJECT_ID,
       current_version: 1,
-      latest_version: 5,
+      latest_version: 6,
       created_at: '2026-03-29T03:00:00.000Z',
       updated_at: '2026-03-29T03:00:00.000Z',
       applied_migrations: [
@@ -252,7 +264,7 @@ describe('ao state migrations', () => {
       migrated: true,
     });
     expect(readJson(paths.schemaPath)).toMatchObject({
-      current_version: 5,
+      current_version: 6,
       applied_migrations: [
         {
           version: 1,
@@ -274,6 +286,10 @@ describe('ao state migrations', () => {
           version: 5,
           key: '0005_runtime_preflight_v1',
         },
+        {
+          version: 6,
+          key: '0006_checkpoint_v1',
+        },
       ],
     });
     expect(readJson(paths.statePath)).toMatchObject({
@@ -281,6 +297,7 @@ describe('ao state migrations', () => {
       policy_decisions: [],
       credential_provenances: [],
       runtime_preflights: [],
+      checkpoints: [],
       task_specs: [
         {
           task_id: 'issue-105',

--- a/tests/ao/state-repository.test.js
+++ b/tests/ao/state-repository.test.js
@@ -263,6 +263,7 @@ describe('ao state repository', () => {
       'schema:migrate:v3',
       'schema:migrate:v4',
       'schema:migrate:v5',
+      'schema:migrate:v6',
       'managed_task:upsert:task-1',
       'pr_binding:upsert:binding-1',
       'ownership_lease:upsert:ownership-1',

--- a/tests/ao/state-runner.test.js
+++ b/tests/ao/state-runner.test.js
@@ -4,10 +4,13 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from '@jest/globals';
 
+import { createCheckpointStore } from '../../scripts/ao/lib/checkpoint-store.js';
 import {
   createControllerModeRecord,
   createManagedTask,
   createOverrideRecord,
+  createPrBinding,
+  createTaskSpecRecord,
 } from '../../scripts/ao/lib/state-contracts.js';
 import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
 import { loadAoStateReport } from '../../scripts/ao/lib/state-runner.js';
@@ -136,7 +139,7 @@ describe('ao state runner', () => {
       active_override_count: 1,
       controller_mode_count: 1,
       controller_modes: ['default=observe'],
-      audit_entry_count: 8,
+      audit_entry_count: 9,
     });
     expect(report.audit.recent_entries).toEqual([
       expect.objectContaining({
@@ -146,6 +149,104 @@ describe('ao state runner', () => {
       expect.objectContaining({
         entity_kind: 'controller_mode',
         entity_id: 'default',
+      }),
+    ]);
+  });
+
+  it('includes checkpoint inspection state in the operator-visible AO state report', async () => {
+    const repoRoot = createTempRepo();
+    const repository = createStateRepository({
+      repoRoot,
+      projectId: PROJECT_ID,
+      clock: createClock(
+        '2026-03-30T10:00:00.000Z',
+        '2026-03-30T10:01:00.000Z',
+        '2026-03-30T10:02:00.000Z',
+        '2026-03-30T10:03:00.000Z',
+      ),
+      auditIdGenerator: createIdGenerator('audit'),
+    });
+
+    repository.upsertManagedTask(createManagedTask({
+      task_id: 'issue-110',
+      issue_number: 110,
+      title: 'feat(ao): add checkpoint schema and explicit resume',
+      branch_name: 'feat/110',
+      worktree_path: '/tmp/cie-57',
+      status: 'active',
+      created_at: '2026-03-30T10:00:00.000Z',
+      updated_at: '2026-03-30T10:00:00.000Z',
+    }));
+    repository.upsertPrBinding(createPrBinding({
+      binding_id: 'binding-issue-110-pr-110',
+      task_id: 'issue-110',
+      pr_number: 110,
+      branch_name: 'feat/110',
+      base_branch: 'main',
+      status: 'bound',
+      created_at: '2026-03-30T10:00:00.000Z',
+      updated_at: '2026-03-30T10:00:00.000Z',
+    }));
+    repository.upsertControllerMode(createControllerModeRecord({
+      controller_id: 'default',
+      mode: 'observe',
+      updated_at: '2026-03-30T10:01:00.000Z',
+      updated_by: 'operator',
+      reason: 'Checkpoint inspection setup',
+    }));
+    repository.upsertTaskSpec(createTaskSpecRecord({
+      task_id: 'issue-110',
+      source_kind: 'github_issue',
+      source_issue_number: 110,
+      created_at: '2026-03-30T10:01:00.000Z',
+      updated_at: '2026-03-30T10:01:00.000Z',
+      snapshot: {
+        schema_version: 'ao.task-spec.v1alpha1',
+        spec: {
+          problem_type: 'issue_delivery',
+          acceptance_contract: ['checkpoint-backed resume exists'],
+          runtime_ref: 'runtime.github_local',
+          policy_ref: 'policy.operator_gated',
+          human_gates: ['operator_resume'],
+        },
+      },
+    }));
+    repository.ensureRuntimePreflights({
+      cwd: repoRoot,
+      now: '2026-03-30T10:02:00.000Z',
+      probes: {
+        commandExists: () => true,
+        pathExists: () => true,
+        capability: () => true,
+      },
+    });
+    createCheckpointStore({
+      repository,
+      now: () => '2026-03-30T10:03:00.000Z',
+    }).captureCheckpoint({
+      taskId: 'issue-110',
+      controllerId: 'default',
+      derivedTrigger: 'manual',
+      observedAt: '2026-03-30T10:03:00.000Z',
+      actionIds: [],
+    });
+
+    const report = await loadAoStateReport({
+      repoRoot,
+      projectId: PROJECT_ID,
+      auditLimit: 2,
+    });
+
+    expect(report.summary).toMatchObject({
+      checkpoint_count: 1,
+      valid_checkpoint_count: 1,
+      stale_checkpoint_count: 0,
+      invalid_checkpoint_count: 0,
+    });
+    expect(report.checkpoints.inspections).toEqual([
+      expect.objectContaining({
+        task_id: 'issue-110',
+        state: 'valid',
       }),
     ]);
   });


### PR DESCRIPTION
Closes #110

## Summary
- add a durable checkpoint artifact schema and control-plane migration (`0006_checkpoint_v1`) with explicit versioning and repository persistence
- add `checkpoint-store` validation/capture so resume only uses resume-safe task, verification, and execution references
- add explicit `resume` handling in AO manage plus controller-loop checkpoint capture and AO state inspection counts

## Acceptance Mapping
- Checkpoint persistence exists with explicit schema version
  - Added `ao.checkpoint.v1alpha1` snapshot/record contracts in `scripts/ao/lib/state-contracts.js`
  - Added repo-local checkpoint persistence in `scripts/ao/lib/state-repository.js` and migration `0006_checkpoint_v1` in `scripts/ao/lib/state-migrations.js`
  - Covered by `tests/ao/checkpoint-store.test.js`
- Invalid or stale checkpoints fail closed
  - `scripts/ao/lib/checkpoint-store.js` rejects mixed-version, invalid-format, stale task/binding, and invalid verification/runtime refs
  - `scripts/ao/lib/manage-runner.js` uses `loadCheckpointForResume()` and aborts explicit resume on invalid/stale checkpoints
  - Covered by `tests/ao/checkpoint-store.test.js` and `tests/ao/manage-runner.test.js`
- Resumed work is recognized as resume rather than new-task creation
  - `scripts/ao-manage.js` now supports explicit `resume`
  - `scripts/ao/lib/manage-runner.js` restores branch/worktree/PR from the checkpoint and stamps durable task metadata under `metadata.resume`
  - Covered by `tests/ao/manage-runner.test.js` and `tests/ao/ao-manage-cli.test.js`
- Operator-visible surfaces can inspect checkpoint state
  - `scripts/ao/lib/state-runner.js` now emits checkpoint inspection counts and details
  - `scripts/ao/lib/state-report.js` includes checkpoint summary in the human-readable AO state output
  - Covered by `tests/ao/state-runner.test.js`
- Mixed-version checkpoint state is detectable
  - `scripts/ao/lib/checkpoint-store.js` surfaces `checkpoint_mixed_version`
  - Covered by `tests/ao/checkpoint-store.test.js`

## Out Of Scope Preserved
- no ownership transfer between workers
- no transcript replay source of truth
- no parallel-writer support
- no successor handoff authority transfer

## Verification
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/checkpoint-store.test.js tests/ao/controller-loop.test.js tests/ao/manage-runner.test.js`
  - PASS
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand tests/ao`
  - PASS (42 suites, 190 tests)
