### PR TITLE
feat(ao): add successor handoff and authority transfer protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "ao:state:json": "node scripts/ao-state.js --json",
     "ao:manage": "node scripts/ao-manage.js",
     "ao:manage:json": "node scripts/ao-manage.js --json",
+    "ao:handoff": "node scripts/ao-handoff.js",
+    "ao:handoff:json": "node scripts/ao-handoff.js --json",
     "ao:override": "node scripts/ao-override.js",
     "ao:controller": "node scripts/ao-controller.js",
     "ao:controller:json": "node scripts/ao-controller.js --json",

--- a/scripts/ao-handoff.js
+++ b/scripts/ao-handoff.js
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHandoffProtocol } from './ao/lib/handoff-protocol.js';
+import { findRepoRoot } from './ao/lib/repo-root.js';
+import { createStateRepository } from './ao/lib/state-repository.js';
+
+export const DEFAULT_PROJECT_ID = 'ciecopilot-home';
+
+function createDefaultIo() {
+  return {
+    writeStdout: (text) => process.stdout.write(text),
+    writeStderr: (text) => process.stderr.write(text),
+  };
+}
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1] ?? null;
+  if (value == null || value.startsWith('-')) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+  return value;
+}
+
+function parseArgs(argv) {
+  const options = {
+    command: null,
+    projectId: DEFAULT_PROJECT_ID,
+    taskId: null,
+    issueNumber: null,
+    requestId: null,
+    claimId: null,
+    requestedBySessionName: null,
+    requestedBySessionId: null,
+    successorSessionName: null,
+    successorSessionId: null,
+    operatorSessionName: null,
+    operatorSessionId: null,
+    reason: null,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (options.command == null && !arg.startsWith('-')) {
+      options.command = arg;
+      continue;
+    }
+
+    if (arg === '--project') {
+      options.projectId = readOptionValue(argv, index, '--project');
+      index += 1;
+    } else if (arg === '--task') {
+      options.taskId = readOptionValue(argv, index, '--task');
+      index += 1;
+    } else if (arg === '--issue') {
+      options.issueNumber = Number(readOptionValue(argv, index, '--issue'));
+      index += 1;
+    } else if (arg === '--request') {
+      options.requestId = readOptionValue(argv, index, '--request');
+      index += 1;
+    } else if (arg === '--claim') {
+      options.claimId = readOptionValue(argv, index, '--claim');
+      index += 1;
+    } else if (arg === '--successor-session') {
+      options.successorSessionName = readOptionValue(argv, index, '--successor-session');
+      index += 1;
+    } else if (arg === '--successor-session-id') {
+      options.successorSessionId = readOptionValue(argv, index, '--successor-session-id');
+      index += 1;
+    } else if (arg === '--operator-session') {
+      options.operatorSessionName = readOptionValue(argv, index, '--operator-session');
+      index += 1;
+    } else if (arg === '--operator-session-id') {
+      options.operatorSessionId = readOptionValue(argv, index, '--operator-session-id');
+      index += 1;
+    } else if (arg === '--reason') {
+      options.reason = readOptionValue(argv, index, '--reason');
+      index += 1;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      return {
+        ok: false,
+        error: `Unknown argument: ${arg}`,
+      };
+    }
+  }
+
+  if (options.help) {
+    return { ok: true, options };
+  }
+
+  if (!['request', 'claim', 'accept', 'reject', 'expire', 'inspect'].includes(options.command)) {
+    return {
+      ok: false,
+      error: `Unsupported command: ${options.command ?? 'none'}`,
+    };
+  }
+
+  if (options.issueNumber != null && (!Number.isInteger(options.issueNumber) || options.issueNumber <= 0)) {
+    return {
+      ok: false,
+      error: 'Invalid value for --issue',
+    };
+  }
+
+  return {
+    ok: true,
+    options,
+  };
+}
+
+function renderHelp() {
+  return [
+    'Usage: node scripts/ao-handoff.js <command> [options]',
+    '',
+    'Commands:',
+    '  request     Create a durable successor handoff request',
+    '  claim       Record a successor claim',
+    '  accept      Accept one successor claim',
+    '  reject      Reject a handoff request or claim',
+    '  expire      Expire a handoff request',
+    '  inspect     Inspect one handoff request or task handoff state',
+    '',
+    'Options:',
+    '  --project <project_id>           AO project id. Default: ciecopilot-home',
+    '  --task <task_id>                 Managed task id',
+    '  --issue <number>                 Issue number used to derive task id',
+    '  --request <request_id>           Handoff request id',
+    '  --claim <claim_id>               Handoff claim id',
+    '  --successor-session <name>       Successor session name',
+    '  --successor-session-id <id>      Successor session id',
+    '  --operator-session <name>        Operator session name',
+    '  --operator-session-id <id>       Operator session id',
+    '  --reason <text>                  Operation reason',
+    '  --json                           Print machine-readable JSON output',
+    '  -h, --help                       Show help',
+  ].join('\n');
+}
+
+function renderHumanSummary(result) {
+  if (Array.isArray(result)) {
+    return result.map((inspection) => (
+      `${inspection.task_id}: ${inspection.top_status} (${(inspection.reason_codes ?? []).join(', ') || 'none'})`
+    )).join('\n');
+  }
+
+  if (result?.request_id) {
+    return [
+      `request: ${result.request_id}`,
+      `task: ${result.task_id}`,
+      `status: ${result.status ?? result.top_status ?? 'unknown'}`,
+      `successor: ${result.successor_session_name ?? 'none'}`,
+    ].join('\n');
+  }
+
+  return JSON.stringify(result, null, 2);
+}
+
+export async function runCli(argv, io = createDefaultIo()) {
+  const parsed = parseArgs(argv);
+  if (!parsed.ok) {
+    io.writeStderr(`${parsed.error}\n`);
+    return {
+      exitCode: 4,
+      result: null,
+    };
+  }
+
+  const { options } = parsed;
+  if (options.help) {
+    io.writeStdout(`${renderHelp()}\n`);
+    return {
+      exitCode: 0,
+      result: null,
+    };
+  }
+
+  const repoRoot = findRepoRoot(process.cwd());
+  if (!repoRoot) {
+    io.writeStderr(`Could not locate repo root from ${process.cwd()}\n`);
+    return {
+      exitCode: 3,
+      result: null,
+    };
+  }
+
+  try {
+    const repository = createStateRepository({
+      repoRoot,
+      projectId: options.projectId,
+    });
+    const protocol = createHandoffProtocol({
+      repository,
+    });
+    const payload = {
+      taskId: options.taskId,
+      issueNumber: options.issueNumber,
+      requestId: options.requestId,
+      claimId: options.claimId,
+      requestedBySessionName: options.requestedBySessionName,
+      requestedBySessionId: options.requestedBySessionId,
+      operatorSessionName: options.operatorSessionName,
+      operatorSessionId: options.operatorSessionId,
+      successorSessionName: options.successorSessionName,
+      successorSessionId: options.successorSessionId,
+      reason: options.reason,
+    };
+
+    let result;
+    if (options.command === 'request') {
+      result = protocol.requestHandoff(payload);
+    } else if (options.command === 'claim') {
+      result = protocol.claimHandoff(payload);
+    } else if (options.command === 'accept') {
+      result = protocol.acceptHandoff(payload);
+    } else if (options.command === 'reject') {
+      result = protocol.rejectHandoff(payload);
+    } else if (options.command === 'expire') {
+      result = protocol.expireHandoff(payload);
+    } else if (options.requestId || options.taskId || options.issueNumber != null) {
+      result = protocol.inspectTaskHandoff({
+        taskId: options.taskId,
+        issueNumber: options.issueNumber,
+        requestId: options.requestId,
+      });
+    } else {
+      result = protocol.inspectAllHandoffs();
+    }
+
+    if (options.json) {
+      io.writeStdout(JSON.stringify(result, null, 2));
+    } else {
+      io.writeStdout(`${renderHumanSummary(result)}\n`);
+    }
+
+    return {
+      exitCode: 0,
+      result,
+    };
+  } catch (error) {
+    io.writeStderr(`${error.message}\n`);
+    return {
+      exitCode: 3,
+      result: null,
+    };
+  }
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+const executedFile = process.argv[1] ? path.resolve(process.argv[1]) : null;
+
+if (executedFile && executedFile === currentFile) {
+  const { exitCode } = await runCli(process.argv.slice(2));
+  process.exitCode = exitCode;
+}

--- a/scripts/ao-manage.js
+++ b/scripts/ao-manage.js
@@ -172,6 +172,7 @@ function renderHumanSummary(result) {
     `pr_binding: ${result.prBinding ? `${result.prBinding.pr_number}/${result.prBinding.status}` : 'none'}`,
     `ownership_lease: ${result.ownershipLease ? `${result.ownershipLease.owner_session_name}/${result.ownershipLease.status}` : 'none'}`,
     `resume_checkpoint: ${result.resume ? `${result.resume.checkpoint_id}/${result.resume.state}` : 'none'}`,
+    `handoff_transfer: ${result.handoffTransfer ? `${result.handoffTransfer.request_id}/${result.handoffTransfer.transfer_id}` : 'none'}`,
     `released_ownership_leases: ${result.releasedOwnershipLeaseIds.length ? result.releasedOwnershipLeaseIds.join(', ') : 'none'}`,
     `released_pr_bindings: ${result.releasedPrBindingIds.length ? result.releasedPrBindingIds.join(', ') : 'none'}`,
   ].join('\n');

--- a/scripts/ao-reconcile.js
+++ b/scripts/ao-reconcile.js
@@ -123,6 +123,7 @@ export async function runCli(argv, io = createDefaultIo()) {
   const { report } = await runReconciliation({
     projectId: options.projectId,
     prNumber: options.prNumber,
+    cwd: process.cwd(),
   });
 
   if (options.json) {

--- a/scripts/ao/lib/controller-loop.js
+++ b/scripts/ao/lib/controller-loop.js
@@ -393,13 +393,14 @@ async function resolveLifecycleReportForTask({
       : createDoctorProjectScope({ projectId }),
     reconciliationReport,
     localState,
+    controlPlaneSnapshot: deps.controlPlaneSnapshot ?? null,
   });
   const lifecycleReport = deps.buildLifecycleReport({
-    scope: prNumber != null
-      ? createLifecyclePrScope({ projectId, prNumber, trigger: derivedTrigger })
-      : createLifecycleProjectScope({ projectId, trigger: derivedTrigger }),
-    reconciliationReport,
-    doctorReport,
+        scope: prNumber != null
+          ? createLifecyclePrScope({ projectId, prNumber, trigger: derivedTrigger })
+          : createLifecycleProjectScope({ projectId, trigger: derivedTrigger }),
+        reconciliationReport,
+        doctorReport,
   });
 
   return {
@@ -577,7 +578,10 @@ export async function runControllerLoop({
               githubObservation,
               cwd,
               projectId,
-              deps: services,
+              deps: {
+                ...services,
+                controlPlaneSnapshot: repository.getSnapshot(),
+              },
             });
         const lifecycleReport = resolvedLifecycle.lifecycleReport ?? resolvedLifecycle;
         lifecycleTopStatus = lifecycleReport.top_status ?? null;

--- a/scripts/ao/lib/doctor-engine.js
+++ b/scripts/ao/lib/doctor-engine.js
@@ -4,6 +4,7 @@ import {
   createDoctorFinding,
   createDoctorSuggestion,
 } from './doctor-contracts.js';
+import { createHandoffProtocol } from './handoff-protocol.js';
 import { RUNTIME_PREFLIGHT_SCHEMA_VERSION } from './runtime-contracts.js';
 import { CONTROL_PLANE_LATEST_VERSION } from './state-contracts.js';
 import { TASK_SPEC_SCHEMA_VERSION } from './task-spec.js';
@@ -361,6 +362,77 @@ function buildRuntimePreflightFindings({ controlPlaneSnapshot, projectId }) {
   return findings;
 }
 
+function buildHandoffFindings({ controlPlaneSnapshot, projectId }) {
+  if (!controlPlaneSnapshot?.bootstrapped) return [];
+
+  const inspections = createHandoffProtocol({
+    repository: {
+      getSnapshot: () => controlPlaneSnapshot,
+    },
+  }).inspectAllHandoffs();
+
+  const findings = [];
+  for (const inspection of inspections) {
+    if (inspection?.top_status === 'invalid') {
+      findings.push(createDoctorFinding({
+        code: 'handoff_state_invalid',
+        severity: 'blocker',
+        origin: 'doctor',
+        source_area: 'control_plane',
+        subject_type: 'task',
+        subject_id: inspection.task_id ?? projectId,
+        summary: 'Managed task has invalid successor handoff state.',
+        details: inspection.reason_codes ?? [],
+        evidence_refs: [],
+        suggestion_ids: ['human_review'],
+      }));
+    } else if (inspection?.top_status === 'ambiguous') {
+      findings.push(createDoctorFinding({
+        code: 'handoff_successor_ambiguous',
+        severity: 'ambiguous',
+        origin: 'doctor',
+        source_area: 'control_plane',
+        subject_type: 'task',
+        subject_id: inspection.task_id ?? projectId,
+        summary: 'Managed task has ambiguous successor selection.',
+        details: inspection.reason_codes ?? [],
+        evidence_refs: [],
+        suggestion_ids: ['human_review'],
+      }));
+    } else if (inspection?.top_status === 'expired') {
+      findings.push(createDoctorFinding({
+        code: 'handoff_grant_expired',
+        severity: 'blocker',
+        origin: 'doctor',
+        source_area: 'control_plane',
+        subject_type: 'task',
+        subject_id: inspection.task_id ?? projectId,
+        summary: 'Managed task has expired handoff authority.',
+        details: inspection.reason_codes ?? [],
+        evidence_refs: [],
+        suggestion_ids: ['human_review'],
+      }));
+    } else if (inspection?.top_status === 'accepted' || inspection?.top_status === 'pending_decision') {
+      findings.push(createDoctorFinding({
+        code: inspection.top_status === 'accepted' ? 'handoff_transfer_pending' : 'handoff_decision_pending',
+        severity: 'warning',
+        origin: 'doctor',
+        source_area: 'control_plane',
+        subject_type: 'task',
+        subject_id: inspection.task_id ?? projectId,
+        summary: inspection.top_status === 'accepted'
+          ? 'Managed task is waiting for successor transfer completion.'
+          : 'Managed task is waiting for an explicit handoff decision.',
+        details: inspection.reason_codes ?? [],
+        evidence_refs: [],
+        suggestion_ids: ['human_review'],
+      }));
+    }
+  }
+
+  return findings;
+}
+
 function buildDoctorOnlyFindings({
   scope,
   reconciliationReport,
@@ -566,6 +638,10 @@ function buildDoctorOnlyFindings({
       projectId,
     }),
     ...buildRuntimePreflightFindings({
+      controlPlaneSnapshot,
+      projectId,
+    }),
+    ...buildHandoffFindings({
       controlPlaneSnapshot,
       projectId,
     }),

--- a/scripts/ao/lib/handoff-protocol.js
+++ b/scripts/ao/lib/handoff-protocol.js
@@ -1,0 +1,654 @@
+import { createCheckpointStore } from './checkpoint-store.js';
+import {
+  HANDOFF_CLAIM_FORMAT,
+  HANDOFF_CLAIM_SCHEMA_VERSION,
+  HANDOFF_DECISION_FORMAT,
+  HANDOFF_DECISION_SCHEMA_VERSION,
+  HANDOFF_REQUEST_FORMAT,
+  HANDOFF_REQUEST_SCHEMA_VERSION,
+  HANDOFF_TRANSFER_FORMAT,
+  HANDOFF_TRANSFER_SCHEMA_VERSION,
+} from './state-contracts.js';
+import {
+  createHandoffDecisionTransition,
+  createHandoffTransferTransition,
+  transitionHandoffClaim,
+  transitionHandoffRequest,
+} from './transition-engine.js';
+
+function resolveNow(now) {
+  if (typeof now === 'function') return resolveNow(now());
+  if (typeof now === 'string' && now.trim() !== '') return now.trim();
+  return new Date().toISOString();
+}
+
+function sanitizeToken(value) {
+  return String(value ?? '')
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '_');
+}
+
+function compareIsoDescending(left, right) {
+  return String(right ?? '').localeCompare(String(left ?? ''));
+}
+
+function sortByUpdatedAtDescending(items = [], key = 'updated_at') {
+  return [...items].sort((left, right) => {
+    const byTimestamp = compareIsoDescending(left?.[key], right?.[key]);
+    if (byTimestamp !== 0) return byTimestamp;
+    return String(right?.request_id ?? right?.claim_id ?? right?.decision_id ?? right?.transfer_id ?? '')
+      .localeCompare(String(left?.request_id ?? left?.claim_id ?? left?.decision_id ?? left?.transfer_id ?? ''));
+  });
+}
+
+function isExpired(isoTimestamp, now) {
+  if (!isoTimestamp) return false;
+  return new Date(isoTimestamp).getTime() <= new Date(now).getTime();
+}
+
+function latestLeaseForTask(snapshot, taskId) {
+  return sortByUpdatedAtDescending(
+    (snapshot?.state?.ownership_leases ?? []).filter((lease) => lease?.task_id === taskId),
+    'acquired_at',
+  )[0] ?? null;
+}
+
+function activeLeasesForTask(snapshot, taskId) {
+  return (snapshot?.state?.ownership_leases ?? []).filter((lease) => (
+    lease?.task_id === taskId && lease?.status === 'active'
+  ));
+}
+
+function resolveTask(snapshot, {
+  taskId = null,
+  issueNumber = null,
+} = {}) {
+  const normalizedIssueNumber = issueNumber == null ? null : Number(issueNumber);
+  return (snapshot?.state?.managed_tasks ?? []).find((task) => (
+    (taskId && task?.task_id === taskId)
+      || (normalizedIssueNumber != null && task?.issue_number === normalizedIssueNumber)
+  )) ?? null;
+}
+
+function resolveRequest(snapshot, {
+  requestId = null,
+  taskId = null,
+  issueNumber = null,
+} = {}) {
+  if (requestId) {
+    return (snapshot?.state?.handoff_requests ?? []).find((request) => request?.request_id === requestId) ?? null;
+  }
+
+  const task = resolveTask(snapshot, { taskId, issueNumber });
+  if (!task) return null;
+  return sortByUpdatedAtDescending(
+    (snapshot?.state?.handoff_requests ?? []).filter((request) => request?.task_id === task.task_id),
+  )[0] ?? null;
+}
+
+function buildProtocolRequestId(snapshot, taskId, timestamp) {
+  const count = (snapshot?.state?.handoff_requests ?? []).filter((request) => request?.task_id === taskId).length + 1;
+  return `handoff-${sanitizeToken(taskId)}-${sanitizeToken(timestamp)}-${count}`;
+}
+
+function buildProtocolClaimId(snapshot, requestId, successorSessionName, timestamp) {
+  const count = (snapshot?.state?.handoff_claims ?? []).filter((claim) => claim?.request_id === requestId).length + 1;
+  return `claim-${sanitizeToken(requestId)}-${sanitizeToken(successorSessionName)}-${sanitizeToken(timestamp)}-${count}`;
+}
+
+function distinctPendingSuccessors(claims = []) {
+  return [...new Set(
+    claims
+      .filter((claim) => claim?.status === 'pending')
+      .map((claim) => claim?.successor_session_name)
+      .filter(Boolean),
+  )];
+}
+
+function inspectHandoffRequest({
+  snapshot,
+  checkpointStore,
+  request,
+  now,
+} = {}) {
+  if (!request) return null;
+
+  const reasonCodes = [];
+  const claims = (snapshot?.state?.handoff_claims ?? []).filter((claim) => claim?.request_id === request.request_id);
+  const decisions = (snapshot?.state?.handoff_decisions ?? []).filter((decision) => decision?.request_id === request.request_id);
+  const transfers = (snapshot?.state?.handoff_transfers ?? []).filter((transfer) => transfer?.request_id === request.request_id);
+  const task = resolveTask(snapshot, { taskId: request.task_id });
+  const checkpointInspection = checkpointStore.inspectCheckpoint({
+    checkpointId: request?.lineage?.checkpoint_id,
+  });
+  const activeLeases = activeLeasesForTask(snapshot, request.task_id);
+  const selectedClaim = request.selected_claim_id == null
+    ? null
+    : (claims.find((claim) => claim.claim_id === request.selected_claim_id) ?? null);
+  const acceptedDecision = request.accepted_decision_id == null
+    ? null
+    : (decisions.find((decision) => decision.decision_id === request.accepted_decision_id) ?? null);
+  const pendingSuccessors = distinctPendingSuccessors(claims);
+
+  if (request.schema_version !== HANDOFF_REQUEST_SCHEMA_VERSION || request.format !== HANDOFF_REQUEST_FORMAT) {
+    reasonCodes.push('handoff_request_mixed_version');
+  }
+  if (!task) {
+    reasonCodes.push('handoff_task_missing');
+  } else if (task.status === 'retired') {
+    reasonCodes.push('handoff_task_retired');
+  }
+  if (checkpointInspection?.state !== 'valid') {
+    reasonCodes.push(
+      checkpointInspection?.state === 'stale'
+        ? 'handoff_checkpoint_stale'
+        : 'handoff_checkpoint_invalid',
+    );
+  }
+  if (activeLeases.length > 1) {
+    reasonCodes.push('conflicting_active_owner');
+  } else if (
+    activeLeases.length === 1
+      && request.status !== 'completed'
+      && request.lineage?.prior_ownership_lease_id
+      && activeLeases[0].lease_id !== request.lineage.prior_ownership_lease_id
+      && activeLeases[0].owner_session_name !== selectedClaim?.successor_session_name
+  ) {
+    reasonCodes.push('conflicting_active_owner');
+  }
+  if (isExpired(request.expires_at, now) && ['open', 'accepted'].includes(request.status)) {
+    reasonCodes.push('handoff_request_expired');
+  }
+
+  for (const claim of claims) {
+    if (claim.schema_version !== HANDOFF_CLAIM_SCHEMA_VERSION || claim.format !== HANDOFF_CLAIM_FORMAT) {
+      reasonCodes.push('handoff_claim_mixed_version');
+      break;
+    }
+  }
+  for (const decision of decisions) {
+    if (decision.schema_version !== HANDOFF_DECISION_SCHEMA_VERSION || decision.format !== HANDOFF_DECISION_FORMAT) {
+      reasonCodes.push('handoff_decision_mixed_version');
+      break;
+    }
+  }
+  for (const transfer of transfers) {
+    if (transfer.schema_version !== HANDOFF_TRANSFER_SCHEMA_VERSION || transfer.format !== HANDOFF_TRANSFER_FORMAT) {
+      reasonCodes.push('handoff_transfer_mixed_version');
+      break;
+    }
+  }
+
+  if (!acceptedDecision && request.status === 'accepted') {
+    reasonCodes.push('accepted_decision_missing');
+  }
+  if (acceptedDecision && isExpired(acceptedDecision.grant_expires_at, now) && transfers.length === 0) {
+    reasonCodes.push('expired_grant');
+  }
+  if (pendingSuccessors.length > 1 && request.status === 'open' && request.accepted_decision_id == null) {
+    reasonCodes.push('ambiguous_successor_selection');
+  }
+
+  let topStatus = 'open';
+  if (reasonCodes.some((code) => (
+    code.endsWith('_mixed_version')
+      || code === 'handoff_task_missing'
+      || code === 'handoff_task_retired'
+      || code === 'handoff_checkpoint_invalid'
+      || code === 'conflicting_active_owner'
+  ))) {
+    topStatus = 'invalid';
+  } else if (request.status === 'completed' || transfers.length > 0) {
+    topStatus = 'completed';
+  } else if (request.status === 'rejected') {
+    topStatus = 'rejected';
+  } else if (
+    request.status === 'expired'
+      || reasonCodes.includes('handoff_request_expired')
+      || reasonCodes.includes('expired_grant')
+  ) {
+    topStatus = 'expired';
+  } else if (reasonCodes.includes('ambiguous_successor_selection')) {
+    topStatus = 'ambiguous';
+  } else if (request.status === 'accepted' || acceptedDecision) {
+    topStatus = 'accepted';
+  } else if (pendingSuccessors.length === 1) {
+    topStatus = 'pending_decision';
+  }
+
+  return {
+    task_id: request.task_id,
+    request_id: request.request_id,
+    top_status: topStatus,
+    reason_codes: [...new Set([...request.reason_codes, ...reasonCodes])],
+    request,
+    claims: sortByUpdatedAtDescending(claims),
+    decisions: sortByUpdatedAtDescending(decisions, 'decided_at'),
+    transfers: sortByUpdatedAtDescending(transfers, 'transferred_at'),
+    checkpoint: checkpointInspection,
+  };
+}
+
+export function createHandoffProtocol({
+  repository,
+  now = () => new Date().toISOString(),
+} = {}) {
+  const checkpointStore = createCheckpointStore({
+    repository,
+    now,
+  });
+
+  function resolveSnapshot() {
+    return repository.getSnapshot();
+  }
+
+  function resolveTaskOrThrow(identity) {
+    const snapshot = resolveSnapshot();
+    const task = resolveTask(snapshot, identity);
+    if (!task) {
+      throw new Error(`Missing managed task for ${identity.taskId ?? identity.issueNumber}`);
+    }
+    return {
+      snapshot,
+      task,
+    };
+  }
+
+  function assertRequestable(snapshot, task, timestamp, allowDuplicateTaskRequest = false) {
+    const activeRequests = (snapshot?.state?.handoff_requests ?? []).filter((request) => (
+      request?.task_id === task.task_id && ['open', 'accepted'].includes(request?.status)
+    ));
+    if (activeRequests.length > 0 && !allowDuplicateTaskRequest) {
+      throw new Error(`Active handoff request already exists for ${task.task_id}`);
+    }
+
+    const activeLeases = activeLeasesForTask(snapshot, task.task_id);
+    if (activeLeases.length > 1) {
+      throw new Error(`Cannot request handoff for ${task.task_id} with conflicting active owners`);
+    }
+    if (activeLeases.length === 1 && !isExpired(activeLeases[0].expires_at, timestamp)) {
+      throw new Error(`Cannot request handoff for ${task.task_id} while ownership lease remains active`);
+    }
+  }
+
+  return {
+    requestHandoff({
+      taskId = null,
+      issueNumber = null,
+      requestedBySessionName = null,
+      requestedBySessionId = null,
+      operatorSessionName = null,
+      operatorSessionId = null,
+      successorSessionName = null,
+      successorSessionId = null,
+      reason = null,
+      allowDuplicateTaskRequest = false,
+    } = {}) {
+      const timestamp = resolveNow(now);
+      const { snapshot, task } = resolveTaskOrThrow({ taskId, issueNumber });
+      assertRequestable(snapshot, task, timestamp, allowDuplicateTaskRequest);
+
+      const checkpoint = checkpointStore.loadCheckpointForResume({
+        taskId: task.task_id,
+      });
+      const latestLease = latestLeaseForTask(snapshot, task.task_id);
+      const activeBinding = (snapshot.state.pr_bindings ?? []).find((binding) => (
+        binding?.task_id === task.task_id && binding?.status === 'bound'
+      )) ?? null;
+
+      const request = transitionHandoffRequest({
+        intent: 'create',
+        now: timestamp,
+        requestId: buildProtocolRequestId(snapshot, task.task_id, timestamp),
+        taskId: task.task_id,
+        requestedBySessionName,
+        requestedBySessionId,
+        operatorSessionName,
+        operatorSessionId,
+        successorSessionName,
+        successorSessionId,
+        reason,
+        lineage: {
+          checkpoint_id: checkpoint.checkpoint_id,
+          checkpoint_recorded_at: checkpoint.record.recorded_at,
+          checkpoint_state: checkpoint.state,
+          prior_ownership_lease_id: latestLease?.lease_id ?? null,
+          prior_owner_session_name: latestLease?.owner_session_name ?? null,
+          prior_owner_session_id: latestLease?.owner_session_id ?? null,
+          prior_ownership_status: latestLease?.status ?? null,
+          pr_binding_id: activeBinding?.binding_id ?? null,
+          pr_number: activeBinding?.pr_number ?? null,
+        },
+      });
+
+      return repository.upsertHandoffRequest(request);
+    },
+
+    claimHandoff({
+      requestId = null,
+      taskId = null,
+      issueNumber = null,
+      successorSessionName,
+      successorSessionId = null,
+      reason = null,
+    } = {}) {
+      const timestamp = resolveNow(now);
+      const snapshot = resolveSnapshot();
+      const request = resolveRequest(snapshot, {
+        requestId,
+        taskId,
+        issueNumber,
+      });
+
+      if (!request) {
+        throw new Error('Missing handoff request');
+      }
+
+      const existingClaims = (snapshot.state.handoff_claims ?? []).filter((claim) => claim.request_id === request.request_id);
+      if (request.status !== 'open') {
+        return repository.upsertHandoffClaim(transitionHandoffClaim({
+          intent: 'block',
+          claimId: buildProtocolClaimId(snapshot, request.request_id, successorSessionName, timestamp),
+          now: timestamp,
+          requestId: request.request_id,
+          taskId: request.task_id,
+          successorSessionName,
+          successorSessionId,
+          reason,
+          reasonCodes: ['request_not_open'],
+        }));
+      }
+      if (request.successor_session_name && request.successor_session_name !== successorSessionName) {
+        return repository.upsertHandoffClaim(transitionHandoffClaim({
+          intent: 'block',
+          now: timestamp,
+          requestId: request.request_id,
+          taskId: request.task_id,
+          successorSessionName,
+          successorSessionId,
+          reason,
+          reasonCodes: ['successor_not_authorized'],
+        }));
+      }
+
+      const duplicateClaim = existingClaims.find((claim) => (
+        claim.successor_session_name === successorSessionName
+          && ['pending', 'accepted'].includes(claim.status)
+      ));
+      if (duplicateClaim) {
+        return repository.upsertHandoffClaim(transitionHandoffClaim({
+          intent: 'block',
+          claimId: buildProtocolClaimId(snapshot, request.request_id, successorSessionName, timestamp),
+          now: timestamp,
+          requestId: request.request_id,
+          taskId: request.task_id,
+          successorSessionName,
+          successorSessionId,
+          reason,
+          reasonCodes: ['duplicate_successor_claim'],
+        }));
+      }
+
+      return repository.upsertHandoffClaim(transitionHandoffClaim({
+        intent: 'create',
+        claimId: buildProtocolClaimId(snapshot, request.request_id, successorSessionName, timestamp),
+        now: timestamp,
+        requestId: request.request_id,
+        taskId: request.task_id,
+        successorSessionName,
+        successorSessionId,
+        reason,
+      }));
+    },
+
+    acceptHandoff({
+      requestId,
+      claimId = null,
+      operatorSessionName,
+      operatorSessionId = null,
+      reason = null,
+      grantExpiresAt = null,
+    } = {}) {
+      const timestamp = resolveNow(now);
+      const snapshot = resolveSnapshot();
+      const request = resolveRequest(snapshot, { requestId });
+      if (!request) {
+        throw new Error('Missing handoff request');
+      }
+
+      const claims = (snapshot.state.handoff_claims ?? []).filter((claim) => (
+        claim.request_id === request.request_id && claim.status === 'pending'
+      ));
+      const claim = claimId
+        ? claims.find((record) => record.claim_id === claimId) ?? null
+        : (claims.length === 1 ? claims[0] : null);
+      if (!claim) {
+        throw new Error(`Ambiguous successor selection for ${request.request_id}`);
+      }
+
+      const decision = createHandoffDecisionTransition({
+        requestId: request.request_id,
+        claimId: claim.claim_id,
+        taskId: request.task_id,
+        outcome: 'accept',
+        now: timestamp,
+        operatorSessionName,
+        operatorSessionId,
+        successorSessionName: claim.successor_session_name,
+        successorSessionId: claim.successor_session_id,
+        grantExpiresAt,
+        reason,
+      });
+      repository.upsertHandoffDecision(decision);
+      repository.upsertHandoffClaim(transitionHandoffClaim({
+        intent: 'accept',
+        existingClaim: claim,
+        now: timestamp,
+        operatorSessionName,
+        operatorSessionId,
+        decisionId: decision.decision_id,
+      }));
+
+      return repository.upsertHandoffRequest(transitionHandoffRequest({
+        intent: 'accept',
+        existingRequest: request,
+        now: timestamp,
+        selectedClaimId: claim.claim_id,
+        acceptedDecisionId: decision.decision_id,
+      }));
+    },
+
+    rejectHandoff({
+      requestId,
+      claimId = null,
+      operatorSessionName,
+      operatorSessionId = null,
+      reason = null,
+    } = {}) {
+      const timestamp = resolveNow(now);
+      const snapshot = resolveSnapshot();
+      const request = resolveRequest(snapshot, { requestId });
+      if (!request) {
+        throw new Error('Missing handoff request');
+      }
+
+      const decision = createHandoffDecisionTransition({
+        requestId: request.request_id,
+        claimId,
+        taskId: request.task_id,
+        outcome: 'reject',
+        now: timestamp,
+        operatorSessionName,
+        operatorSessionId,
+        reason,
+      });
+      repository.upsertHandoffDecision(decision);
+
+      if (claimId) {
+        const claim = (snapshot.state.handoff_claims ?? []).find((record) => record.claim_id === claimId) ?? null;
+        if (claim) {
+          repository.upsertHandoffClaim(transitionHandoffClaim({
+            intent: 'reject',
+            existingClaim: claim,
+            now: timestamp,
+            operatorSessionName,
+            operatorSessionId,
+            decisionId: decision.decision_id,
+          }));
+        }
+      }
+
+      return repository.upsertHandoffRequest(transitionHandoffRequest({
+        intent: 'reject',
+        existingRequest: request,
+        now: timestamp,
+      }));
+    },
+
+    expireHandoff({
+      requestId,
+      operatorSessionName,
+      operatorSessionId = null,
+      reason = null,
+    } = {}) {
+      const timestamp = resolveNow(now);
+      const snapshot = resolveSnapshot();
+      const request = resolveRequest(snapshot, { requestId });
+      if (!request) {
+        throw new Error('Missing handoff request');
+      }
+
+      const decision = createHandoffDecisionTransition({
+        requestId: request.request_id,
+        taskId: request.task_id,
+        outcome: 'expire',
+        now: timestamp,
+        operatorSessionName,
+        operatorSessionId,
+        reason,
+      });
+      repository.upsertHandoffDecision(decision);
+
+      return repository.upsertHandoffRequest(transitionHandoffRequest({
+        intent: 'expire',
+        existingRequest: request,
+        now: timestamp,
+      }));
+    },
+
+    inspectTaskHandoff({
+      taskId = null,
+      issueNumber = null,
+      requestId = null,
+    } = {}) {
+      const snapshot = resolveSnapshot();
+      return inspectHandoffRequest({
+        snapshot,
+        checkpointStore,
+        request: resolveRequest(snapshot, {
+          taskId,
+          issueNumber,
+          requestId,
+        }),
+        now: resolveNow(now),
+      });
+    },
+
+    inspectAllHandoffs() {
+      const snapshot = resolveSnapshot();
+      return sortByUpdatedAtDescending(snapshot.state.handoff_requests ?? [])
+        .map((request) => inspectHandoffRequest({
+          snapshot,
+          checkpointStore,
+          request,
+          now: resolveNow(now),
+        }))
+        .filter(Boolean);
+    },
+
+    resolveAcceptedHandoff({
+      taskId,
+      successorSessionName,
+      requestId = null,
+    } = {}) {
+      const inspections = this.inspectAllHandoffs()
+        .filter((inspection) => inspection?.task_id === taskId)
+        .filter((inspection) => requestId == null || inspection?.request_id === requestId)
+        .filter((inspection) => inspection?.top_status === 'accepted')
+        .filter((inspection) => (
+          inspection?.request?.selected_claim_id
+            ? inspection.claims.some((claim) => (
+              claim.claim_id === inspection.request.selected_claim_id
+                && claim.successor_session_name === successorSessionName
+            ))
+            : inspection.request?.successor_session_name === successorSessionName
+        ));
+
+      if (inspections.length > 1) {
+        throw new Error(`Ambiguous accepted handoff for ${taskId}`);
+      }
+
+      return inspections[0] ?? null;
+    },
+
+    completeAcceptedHandoff({
+      taskId,
+      successorSessionName,
+      successorSessionId = null,
+      successorOwnershipLeaseId,
+      successorOwnershipLease,
+      transferredBy = null,
+      reason = null,
+      requestId = null,
+    } = {}) {
+      const timestamp = resolveNow(now);
+      const acceptedInspection = this.resolveAcceptedHandoff({
+        taskId,
+        successorSessionName,
+        requestId,
+      });
+      if (!acceptedInspection) {
+        return null;
+      }
+
+      const request = acceptedInspection.request;
+      const claim = acceptedInspection.claims.find((record) => record.claim_id === request.selected_claim_id) ?? null;
+      const decision = acceptedInspection.decisions.find((record) => record.decision_id === request.accepted_decision_id) ?? null;
+      if (!claim || !decision) {
+        throw new Error(`Accepted handoff metadata is incomplete for ${taskId}`);
+      }
+      if (isExpired(decision.grant_expires_at, timestamp)) {
+        throw new Error(`Accepted handoff grant expired for ${taskId}`);
+      }
+
+      const transfer = createHandoffTransferTransition({
+        requestId: request.request_id,
+        claimId: claim.claim_id,
+        decisionId: decision.decision_id,
+        taskId,
+        checkpointId: request.lineage.checkpoint_id,
+        previousOwnershipLeaseId: request.lineage.prior_ownership_lease_id,
+        previousOwnerSessionName: request.lineage.prior_owner_session_name,
+        previousOwnerSessionId: request.lineage.prior_owner_session_id,
+        successorOwnershipLeaseId,
+        successorSessionName,
+        successorSessionId,
+        now: timestamp,
+        transferredBy,
+        reason,
+        metadata: {
+          successor_lease: successorOwnershipLease ?? null,
+        },
+      });
+      repository.upsertHandoffTransfer(transfer);
+      repository.upsertHandoffRequest(transitionHandoffRequest({
+        intent: 'complete',
+        existingRequest: request,
+        now: timestamp,
+        completedTransferId: transfer.transfer_id,
+      }));
+
+      return transfer;
+    },
+  };
+}

--- a/scripts/ao/lib/manage-runner.js
+++ b/scripts/ao/lib/manage-runner.js
@@ -1,4 +1,5 @@
 import { createCheckpointStore } from './checkpoint-store.js';
+import { createHandoffProtocol } from './handoff-protocol.js';
 import { normalizeIssueIntake } from './issue-intake.js';
 import { createStateRepository } from './state-repository.js';
 import { createTaskSpecRecord } from './state-contracts.js';
@@ -49,6 +50,16 @@ function releaseActiveOwnershipLeases(repository, taskId, now, reason) {
 }
 
 function releaseConflictingOwnershipLeases(repository, taskId, ownerSessionName, now) {
+  return releaseConflictingOwnershipLeasesWithReason(
+    repository,
+    taskId,
+    ownerSessionName,
+    now,
+    'ownership_replaced',
+  );
+}
+
+function releaseConflictingOwnershipLeasesWithReason(repository, taskId, ownerSessionName, now, reason) {
   const snapshot = repository.getSnapshot();
   const activeLeases = snapshot.state.ownership_leases.filter(
     (lease) => lease.task_id === taskId && lease.status === 'active' && lease.owner_session_name !== ownerSessionName,
@@ -59,11 +70,17 @@ function releaseConflictingOwnershipLeases(repository, taskId, ownerSessionName,
       intent: 'release',
       existingLease: lease,
       now,
-      reason: 'ownership_replaced',
+      reason,
     }));
   }
 
   return activeLeases.map((lease) => lease.lease_id);
+}
+
+function latestTaskOwnershipLease(snapshot, taskId) {
+  return [...snapshot.state.ownership_leases]
+    .filter((lease) => lease.task_id === taskId)
+    .sort((left, right) => String(right?.acquired_at ?? '').localeCompare(String(left?.acquired_at ?? '')))[0] ?? null;
 }
 
 function releaseBoundPrBindings(repository, taskId, now, reason) {
@@ -127,6 +144,10 @@ export async function runManageCommand({
     projectId,
   });
   const checkpointStore = createCheckpointStore({
+    repository,
+    now: () => timestamp,
+  });
+  const handoffProtocol = createHandoffProtocol({
     repository,
     now: () => timestamp,
   });
@@ -208,11 +229,49 @@ export async function runManageCommand({
 
   let prBinding = null;
   let ownershipLease = null;
+  let handoffTransfer = null;
   let releasedOwnershipLeaseIds = [];
   let releasedPrBindingIds = [];
 
   if (ownerSessionName && ['enroll', 'adopt', 'resume'].includes(command)) {
-    releasedOwnershipLeaseIds = releaseConflictingOwnershipLeases(repository, task.task_id, ownerSessionName, timestamp);
+    if (command === 'resume') {
+      const resumeSnapshot = repository.getSnapshot();
+      const activeOwnershipLeases = resumeSnapshot.state.ownership_leases.filter(
+        (lease) => lease.task_id === task.task_id && lease.status === 'active',
+      );
+      const latestOwnershipLease = latestTaskOwnershipLease(resumeSnapshot, task.task_id);
+      const sameOwnerResume = latestOwnershipLease?.owner_session_name === ownerSessionName
+        || activeOwnershipLeases.some((lease) => lease.owner_session_name === ownerSessionName);
+      const acceptedHandoff = sameOwnerResume
+        ? null
+        : handoffProtocol.resolveAcceptedHandoff({
+            taskId: task.task_id,
+            successorSessionName: ownerSessionName,
+          });
+
+      if (activeOwnershipLeases.length > 1) {
+        throw new Error(`Cannot resume ${task.task_id} with conflicting active owners`);
+      }
+      if (!sameOwnerResume && !acceptedHandoff) {
+        throw new Error(`Cannot resume ${task.task_id} without an accepted handoff`);
+      }
+      if (acceptedHandoff?.reason_codes?.includes('conflicting_active_owner')) {
+        throw new Error(`Cannot resume ${task.task_id} with conflicting active owners`);
+      }
+
+      releasedOwnershipLeaseIds = acceptedHandoff
+        ? releaseConflictingOwnershipLeasesWithReason(
+            repository,
+            task.task_id,
+            ownerSessionName,
+            timestamp,
+            'accepted_handoff_transfer',
+          )
+        : releaseConflictingOwnershipLeases(repository, task.task_id, ownerSessionName, timestamp);
+    } else {
+      releasedOwnershipLeaseIds = releaseConflictingOwnershipLeases(repository, task.task_id, ownerSessionName, timestamp);
+    }
+
     const postReleaseSnapshot = repository.getSnapshot();
     const existingOwnershipLease = postReleaseSnapshot.state.ownership_leases.find(
       (lease) => lease.lease_id === buildOwnershipLeaseId({
@@ -237,6 +296,18 @@ export async function runManageCommand({
         ownerSessionId,
       });
       repository.upsertOwnershipLease(ownershipLease);
+    }
+
+    if (command === 'resume') {
+      handoffTransfer = handoffProtocol.completeAcceptedHandoff({
+        taskId: task.task_id,
+        successorSessionName: ownerSessionName,
+        successorSessionId: ownerSessionId,
+        successorOwnershipLeaseId: ownershipLease.lease_id,
+        successorOwnershipLease: ownershipLease,
+        transferredBy: 'manage_runner',
+        reason: 'accepted_handoff_resume',
+      });
     }
   }
 
@@ -291,6 +362,7 @@ export async function runManageCommand({
     taskSpec,
     prBinding,
     ownershipLease,
+    handoffTransfer,
     resume: resumeCheckpoint == null ? null : {
       checkpoint_id: resumeCheckpoint.checkpoint_id,
       state: resumeCheckpoint.state,

--- a/scripts/ao/lib/reconciliation-report.js
+++ b/scripts/ao/lib/reconciliation-report.js
@@ -76,6 +76,7 @@ export function renderHumanSummary(report) {
     `not_applicable_prs: ${formatList(report.project_summary.not_applicable_pr_numbers)}`,
     `ownership_summary: ${summarizeOwnership(report.pr_assessments)}`,
     `release_readiness_summary: ${summarizeReleaseReadiness(report.pr_assessments)}`,
+    `handoff_summary: inspections=${report.handoff_summary?.inspection_count ?? 0}, active=${report.handoff_summary?.active_count ?? 0}, ambiguous=${report.handoff_summary?.ambiguous_count ?? 0}, accepted=${report.handoff_summary?.accepted_count ?? 0}`,
     `key_findings: ${summarizeFindings(report.findings)}`,
     `recommended_actions: ${summarizeActions(report.recommended_actions)}`,
   ].join('\n');

--- a/scripts/ao/lib/reconciliation-runner.js
+++ b/scripts/ao/lib/reconciliation-runner.js
@@ -4,7 +4,10 @@ import {
 } from './reconciliation-contracts.js';
 import { loadAoProjectObservation } from './ao-observation-source.js';
 import { loadGitHubObservationSet } from './github-observation-source.js';
+import { createHandoffProtocol } from './handoff-protocol.js';
+import { findRepoRoot } from './repo-root.js';
 import { reconcileObservations } from './reconciliation-engine.js';
+import { createStateRepository } from './state-repository.js';
 
 export const DEFAULT_PROJECT_ID = 'ciecopilot-home';
 
@@ -32,6 +35,7 @@ export function buildProjectScopeFromAoObservation(aoObservation) {
 export async function runReconciliation({
   projectId = DEFAULT_PROJECT_ID,
   prNumber = null,
+  cwd = process.cwd(),
 } = {}) {
   const aoObservation = await loadAoProjectObservation({
     projectId,
@@ -45,11 +49,53 @@ export async function runReconciliation({
     aoObservation,
     githubObservation,
   });
+  const repoRoot = findRepoRoot(cwd);
+  let handoffSummary = {
+    inspection_count: 0,
+    active_count: 0,
+    ambiguous_count: 0,
+    accepted_count: 0,
+    tasks: [],
+  };
+
+  if (repoRoot) {
+    const repository = createStateRepository({
+      repoRoot,
+      projectId,
+    });
+    const inspections = createHandoffProtocol({
+      repository,
+    }).inspectAllHandoffs();
+    const prSelections = new Set(scope.selected_pr_numbers ?? []);
+    const taskIds = prSelections.size === 0
+      ? new Set(inspections.map((inspection) => inspection.task_id))
+      : new Set(
+          repository.getSnapshot().state.pr_bindings
+            .filter((binding) => binding.status === 'bound' && prSelections.has(binding.pr_number))
+            .map((binding) => binding.task_id),
+        );
+    const relevantInspections = inspections.filter((inspection) => taskIds.has(inspection.task_id));
+
+    handoffSummary = {
+      inspection_count: relevantInspections.length,
+      active_count: relevantInspections.filter((inspection) => ['open', 'pending_decision', 'accepted'].includes(inspection.top_status)).length,
+      ambiguous_count: relevantInspections.filter((inspection) => inspection.top_status === 'ambiguous').length,
+      accepted_count: relevantInspections.filter((inspection) => inspection.top_status === 'accepted').length,
+      tasks: relevantInspections.map((inspection) => ({
+        task_id: inspection.task_id,
+        request_id: inspection.request_id,
+        top_status: inspection.top_status,
+      })),
+    };
+  }
 
   return {
     scope,
     aoObservation,
     githubObservation,
-    report,
+    report: {
+      ...report,
+      handoff_summary: handoffSummary,
+    },
   };
 }

--- a/scripts/ao/lib/state-contracts.js
+++ b/scripts/ao/lib/state-contracts.js
@@ -7,10 +7,18 @@ export const CONTROL_PLANE_STATE_SCHEMA_VERSION = 'ao.control-plane.state.v1alph
 export const CONTROL_PLANE_STATE_FORMAT = 'ao_control_plane_state';
 export const CONTROL_PLANE_AUDIT_SCHEMA_VERSION = 'ao.control-plane.audit.v1alpha1';
 export const CONTROL_PLANE_AUDIT_FORMAT = 'ao_control_plane_audit_entry';
-export const CONTROL_PLANE_LATEST_VERSION = 6;
+export const CONTROL_PLANE_LATEST_VERSION = 7;
 export const CONTROL_PLANE_DEFAULT_CONTROLLER_ID = 'default';
 export const CHECKPOINT_SCHEMA_VERSION = 'ao.checkpoint.v1alpha1';
 export const CHECKPOINT_FORMAT = 'ao_checkpoint';
+export const HANDOFF_REQUEST_SCHEMA_VERSION = 'ao.handoff-request.v1alpha1';
+export const HANDOFF_REQUEST_FORMAT = 'ao_handoff_request';
+export const HANDOFF_CLAIM_SCHEMA_VERSION = 'ao.handoff-claim.v1alpha1';
+export const HANDOFF_CLAIM_FORMAT = 'ao_handoff_claim';
+export const HANDOFF_DECISION_SCHEMA_VERSION = 'ao.handoff-decision.v1alpha1';
+export const HANDOFF_DECISION_FORMAT = 'ao_handoff_decision';
+export const HANDOFF_TRANSFER_SCHEMA_VERSION = 'ao.handoff-transfer.v1alpha1';
+export const HANDOFF_TRANSFER_FORMAT = 'ao_handoff_transfer';
 
 export const MANAGED_TASK_STATUSES = ['active', 'paused', 'retired'];
 export const PR_BINDING_STATUSES = ['bound', 'released', 'closed'];
@@ -25,6 +33,9 @@ export const TASK_SPEC_RECORD_STATES = ['valid', 'invalid'];
 export const DELIVERY_EVENT_FAMILIES = ['pr', 'check', 'review', 'review_comment'];
 export const POLICY_DECISIONS = ['allow', 'deny', 'downgrade'];
 export const CREDENTIAL_PROVENANCE_TRUST_DECISIONS = ['trusted', 'untrusted'];
+export const HANDOFF_REQUEST_STATUSES = ['open', 'accepted', 'rejected', 'expired', 'completed'];
+export const HANDOFF_CLAIM_STATUSES = ['pending', 'blocked', 'accepted', 'rejected', 'expired'];
+export const HANDOFF_DECISION_OUTCOMES = ['accept', 'reject', 'expire'];
 
 function isPlainObject(value) {
   return value != null && typeof value === 'object' && !Array.isArray(value);
@@ -178,6 +189,10 @@ export function createEmptyControlPlaneState({
     task_specs: [],
     runtime_preflights: [],
     checkpoints: [],
+    handoff_requests: [],
+    handoff_claims: [],
+    handoff_decisions: [],
+    handoff_transfers: [],
   };
 }
 
@@ -703,6 +718,192 @@ export function createCheckpointRecord({
     reason: normalizeOptionalString(reason),
     metadata: normalizeMetadata(metadata),
     snapshot: normalizedSnapshot,
+  };
+}
+
+function normalizeReasonCodes(reasonCodes = []) {
+  return normalizeStringArray(reasonCodes ?? [], 'reason_codes');
+}
+
+function normalizeHandoffLineage(value = {}) {
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid lineage');
+  }
+
+  return {
+    checkpoint_id: normalizeRequiredString(value.checkpoint_id, 'lineage.checkpoint_id'),
+    checkpoint_recorded_at: normalizeIsoTimestamp(
+      value.checkpoint_recorded_at,
+      'lineage.checkpoint_recorded_at',
+    ),
+    checkpoint_state: normalizeRequiredString(value.checkpoint_state, 'lineage.checkpoint_state'),
+    prior_ownership_lease_id: normalizeOptionalString(value.prior_ownership_lease_id),
+    prior_owner_session_name: normalizeOptionalString(value.prior_owner_session_name),
+    prior_owner_session_id: normalizeOptionalString(value.prior_owner_session_id),
+    prior_ownership_status: normalizeOptionalString(value.prior_ownership_status),
+    pr_binding_id: normalizeOptionalString(value.pr_binding_id),
+    pr_number: normalizePositiveInteger(value.pr_number, 'lineage.pr_number', { nullable: true }),
+  };
+}
+
+export function createHandoffRequestRecord({
+  request_id,
+  task_id,
+  status,
+  created_at,
+  updated_at,
+  requested_by_session_name = null,
+  requested_by_session_id = null,
+  operator_session_name = null,
+  operator_session_id = null,
+  successor_session_name = null,
+  successor_session_id = null,
+  reason = null,
+  expires_at = null,
+  selected_claim_id = null,
+  accepted_decision_id = null,
+  completed_transfer_id = null,
+  reason_codes = [],
+  lineage,
+  metadata = {},
+} = {}) {
+  return {
+    schema_version: HANDOFF_REQUEST_SCHEMA_VERSION,
+    format: HANDOFF_REQUEST_FORMAT,
+    request_id: normalizeRequiredString(request_id, 'request_id'),
+    task_id: normalizeRequiredString(task_id, 'task_id'),
+    status: normalizeEnum(status, 'status', HANDOFF_REQUEST_STATUSES),
+    created_at: normalizeIsoTimestamp(created_at, 'created_at'),
+    updated_at: normalizeIsoTimestamp(updated_at, 'updated_at'),
+    requested_by_session_name: normalizeOptionalString(requested_by_session_name),
+    requested_by_session_id: normalizeOptionalString(requested_by_session_id),
+    operator_session_name: normalizeOptionalString(operator_session_name),
+    operator_session_id: normalizeOptionalString(operator_session_id),
+    successor_session_name: normalizeOptionalString(successor_session_name),
+    successor_session_id: normalizeOptionalString(successor_session_id),
+    reason: normalizeOptionalString(reason),
+    expires_at: normalizeIsoTimestamp(expires_at, 'expires_at', { nullable: true }),
+    selected_claim_id: normalizeOptionalString(selected_claim_id),
+    accepted_decision_id: normalizeOptionalString(accepted_decision_id),
+    completed_transfer_id: normalizeOptionalString(completed_transfer_id),
+    reason_codes: normalizeReasonCodes(reason_codes),
+    lineage: normalizeHandoffLineage(lineage),
+    metadata: normalizeMetadata(metadata),
+  };
+}
+
+export function createHandoffClaimRecord({
+  claim_id,
+  request_id,
+  task_id,
+  status,
+  created_at,
+  updated_at,
+  successor_session_name,
+  successor_session_id = null,
+  operator_session_name = null,
+  operator_session_id = null,
+  decision_id = null,
+  reason = null,
+  reason_codes = [],
+  metadata = {},
+} = {}) {
+  return {
+    schema_version: HANDOFF_CLAIM_SCHEMA_VERSION,
+    format: HANDOFF_CLAIM_FORMAT,
+    claim_id: normalizeRequiredString(claim_id, 'claim_id'),
+    request_id: normalizeRequiredString(request_id, 'request_id'),
+    task_id: normalizeRequiredString(task_id, 'task_id'),
+    status: normalizeEnum(status, 'status', HANDOFF_CLAIM_STATUSES),
+    created_at: normalizeIsoTimestamp(created_at, 'created_at'),
+    updated_at: normalizeIsoTimestamp(updated_at, 'updated_at'),
+    successor_session_name: normalizeRequiredString(successor_session_name, 'successor_session_name'),
+    successor_session_id: normalizeOptionalString(successor_session_id),
+    operator_session_name: normalizeOptionalString(operator_session_name),
+    operator_session_id: normalizeOptionalString(operator_session_id),
+    decision_id: normalizeOptionalString(decision_id),
+    reason: normalizeOptionalString(reason),
+    reason_codes: normalizeReasonCodes(reason_codes),
+    metadata: normalizeMetadata(metadata),
+  };
+}
+
+export function createHandoffDecisionRecord({
+  decision_id,
+  request_id,
+  claim_id = null,
+  task_id,
+  outcome,
+  decided_at,
+  operator_session_name,
+  operator_session_id = null,
+  successor_session_name = null,
+  successor_session_id = null,
+  grant_expires_at = null,
+  reason = null,
+  reason_codes = [],
+  metadata = {},
+} = {}) {
+  return {
+    schema_version: HANDOFF_DECISION_SCHEMA_VERSION,
+    format: HANDOFF_DECISION_FORMAT,
+    decision_id: normalizeRequiredString(decision_id, 'decision_id'),
+    request_id: normalizeRequiredString(request_id, 'request_id'),
+    claim_id: normalizeOptionalString(claim_id),
+    task_id: normalizeRequiredString(task_id, 'task_id'),
+    outcome: normalizeEnum(outcome, 'outcome', HANDOFF_DECISION_OUTCOMES),
+    decided_at: normalizeIsoTimestamp(decided_at, 'decided_at'),
+    operator_session_name: normalizeRequiredString(operator_session_name, 'operator_session_name'),
+    operator_session_id: normalizeOptionalString(operator_session_id),
+    successor_session_name: normalizeOptionalString(successor_session_name),
+    successor_session_id: normalizeOptionalString(successor_session_id),
+    grant_expires_at: normalizeIsoTimestamp(grant_expires_at, 'grant_expires_at', { nullable: true }),
+    reason: normalizeOptionalString(reason),
+    reason_codes: normalizeReasonCodes(reason_codes),
+    metadata: normalizeMetadata(metadata),
+  };
+}
+
+export function createHandoffTransferRecord({
+  transfer_id,
+  request_id,
+  claim_id,
+  decision_id,
+  task_id,
+  checkpoint_id,
+  previous_ownership_lease_id = null,
+  previous_owner_session_name = null,
+  previous_owner_session_id = null,
+  successor_ownership_lease_id,
+  successor_session_name,
+  successor_session_id = null,
+  transferred_at,
+  transferred_by = null,
+  reason = null,
+  metadata = {},
+} = {}) {
+  return {
+    schema_version: HANDOFF_TRANSFER_SCHEMA_VERSION,
+    format: HANDOFF_TRANSFER_FORMAT,
+    transfer_id: normalizeRequiredString(transfer_id, 'transfer_id'),
+    request_id: normalizeRequiredString(request_id, 'request_id'),
+    claim_id: normalizeRequiredString(claim_id, 'claim_id'),
+    decision_id: normalizeRequiredString(decision_id, 'decision_id'),
+    task_id: normalizeRequiredString(task_id, 'task_id'),
+    checkpoint_id: normalizeRequiredString(checkpoint_id, 'checkpoint_id'),
+    previous_ownership_lease_id: normalizeOptionalString(previous_ownership_lease_id),
+    previous_owner_session_name: normalizeOptionalString(previous_owner_session_name),
+    previous_owner_session_id: normalizeOptionalString(previous_owner_session_id),
+    successor_ownership_lease_id: normalizeRequiredString(
+      successor_ownership_lease_id,
+      'successor_ownership_lease_id',
+    ),
+    successor_session_name: normalizeRequiredString(successor_session_name, 'successor_session_name'),
+    successor_session_id: normalizeOptionalString(successor_session_id),
+    transferred_at: normalizeIsoTimestamp(transferred_at, 'transferred_at'),
+    transferred_by: normalizeOptionalString(transferred_by),
+    reason: normalizeOptionalString(reason),
+    metadata: normalizeMetadata(metadata),
   };
 }
 

--- a/scripts/ao/lib/state-migrations.js
+++ b/scripts/ao/lib/state-migrations.js
@@ -47,6 +47,11 @@ export const CONTROL_PLANE_CHECKPOINT_MIGRATION = {
   key: '0006_checkpoint_v1',
 };
 
+export const CONTROL_PLANE_HANDOFF_PROTOCOL_MIGRATION = {
+  version: 7,
+  key: '0007_handoff_protocol_v1',
+};
+
 const CONTROL_PLANE_MIGRATIONS = [
   CONTROL_PLANE_BOOTSTRAP_MIGRATION,
   CONTROL_PLANE_TASK_SPEC_MIGRATION,
@@ -54,6 +59,7 @@ const CONTROL_PLANE_MIGRATIONS = [
   CONTROL_PLANE_POLICY_ENGINE_MIGRATION,
   CONTROL_PLANE_RUNTIME_PREFLIGHT_MIGRATION,
   CONTROL_PLANE_CHECKPOINT_MIGRATION,
+  CONTROL_PLANE_HANDOFF_PROTOCOL_MIGRATION,
 ];
 
 function resolveNow(now) {
@@ -117,6 +123,10 @@ function buildBootstrapState({
     'task_specs',
     'runtime_preflights',
     'checkpoints',
+    'handoff_requests',
+    'handoff_claims',
+    'handoff_decisions',
+    'handoff_transfers',
   ]) {
     if (Array.isArray(existingState?.[collectionKey])) {
       state[collectionKey] = cloneJsonValue(existingState[collectionKey]);
@@ -221,6 +231,14 @@ function applyMigration({
     });
   }
 
+  if (migration.version === CONTROL_PLANE_HANDOFF_PROTOCOL_MIGRATION.version) {
+    return buildBootstrapState({
+      projectId,
+      now,
+      existingState: state,
+    });
+  }
+
   throw new Error(`Unsupported migration version ${migration.version}`);
 }
 
@@ -257,6 +275,13 @@ function buildAuditSummary(migration) {
     return {
       operation: 'migrate',
       summary: 'Applied control-plane checkpoint migration.',
+    };
+  }
+
+  if (migration.version === CONTROL_PLANE_HANDOFF_PROTOCOL_MIGRATION.version) {
+    return {
+      operation: 'migrate',
+      summary: 'Applied control-plane handoff-protocol migration.',
     };
   }
 

--- a/scripts/ao/lib/state-report.js
+++ b/scripts/ao/lib/state-report.js
@@ -22,6 +22,7 @@ export function renderAoStateHumanSummary(report) {
     `observations: ${report.summary.observation_count}`,
     `controller_cursors: ${report.summary.controller_cursor_count}`,
     `checkpoints: ${report.summary.checkpoint_count} (valid=${report.summary.valid_checkpoint_count}, stale=${report.summary.stale_checkpoint_count}, invalid=${report.summary.invalid_checkpoint_count})`,
+    `handoffs: requests=${report.summary.handoff_request_count ?? 0}, claims=${report.summary.handoff_claim_count ?? 0}, decisions=${report.summary.handoff_decision_count ?? 0}, transfers=${report.summary.handoff_transfer_count ?? 0}, active=${report.summary.active_handoff_count ?? 0}`,
     `audit_entries: ${report.summary.audit_entry_count}`,
     `recent_audit: ${formatList(recentAudit)}`,
   ].join('\n');

--- a/scripts/ao/lib/state-repository.js
+++ b/scripts/ao/lib/state-repository.js
@@ -12,6 +12,10 @@ import {
   createCredentialProvenanceRecord,
   createDeliveryEventRecord,
   createEmptyControlPlaneState,
+  createHandoffClaimRecord,
+  createHandoffDecisionRecord,
+  createHandoffRequestRecord,
+  createHandoffTransferRecord,
   createManagedTask,
   createObservationRecord,
   createOverrideRecord,
@@ -119,6 +123,10 @@ export function createStateRepository({
     nextState.task_specs = sortCollectionByKey(nextState.task_specs, 'task_id');
     nextState.runtime_preflights = sortCollectionByKey(nextState.runtime_preflights, 'runtime_ref');
     nextState.checkpoints = sortCollectionByKey(nextState.checkpoints, 'checkpoint_id');
+    nextState.handoff_requests = sortCollectionByKey(nextState.handoff_requests, 'request_id');
+    nextState.handoff_claims = sortCollectionByKey(nextState.handoff_claims, 'claim_id');
+    nextState.handoff_decisions = sortCollectionByKey(nextState.handoff_decisions, 'decision_id');
+    nextState.handoff_transfers = sortCollectionByKey(nextState.handoff_transfers, 'transfer_id');
 
     return {
       bootstrapped: true,
@@ -385,6 +393,50 @@ export function createStateRepository({
         record,
         normalize: createRuntimePreflightRecord,
         summary: `Persisted runtime preflight ${record?.runtime_ref ?? record?.snapshot?.runtime_ref}.`,
+      });
+    },
+
+    upsertHandoffRequest(record) {
+      return upsertCollectionRecord({
+        collectionKey: 'handoff_requests',
+        identityKey: 'request_id',
+        entityKind: 'handoff_request',
+        record,
+        normalize: createHandoffRequestRecord,
+        summary: `Persisted handoff request ${record?.request_id}.`,
+      });
+    },
+
+    upsertHandoffClaim(record) {
+      return upsertCollectionRecord({
+        collectionKey: 'handoff_claims',
+        identityKey: 'claim_id',
+        entityKind: 'handoff_claim',
+        record,
+        normalize: createHandoffClaimRecord,
+        summary: `Persisted handoff claim ${record?.claim_id}.`,
+      });
+    },
+
+    upsertHandoffDecision(record) {
+      return upsertCollectionRecord({
+        collectionKey: 'handoff_decisions',
+        identityKey: 'decision_id',
+        entityKind: 'handoff_decision',
+        record,
+        normalize: createHandoffDecisionRecord,
+        summary: `Persisted handoff decision ${record?.decision_id}.`,
+      });
+    },
+
+    upsertHandoffTransfer(record) {
+      return upsertCollectionRecord({
+        collectionKey: 'handoff_transfers',
+        identityKey: 'transfer_id',
+        entityKind: 'handoff_transfer',
+        record,
+        normalize: createHandoffTransferRecord,
+        summary: `Persisted handoff transfer ${record?.transfer_id}.`,
       });
     },
 

--- a/scripts/ao/lib/state-runner.js
+++ b/scripts/ao/lib/state-runner.js
@@ -1,4 +1,5 @@
 import { createCheckpointStore } from './checkpoint-store.js';
+import { createHandoffProtocol } from './handoff-protocol.js';
 import * as fs from 'node:fs';
 import path from 'node:path';
 
@@ -49,9 +50,15 @@ export async function loadAoStateReport({
   const checkpointInspections = createCheckpointStore({
     repository,
   }).inspectAllCheckpoints();
+  const handoffInspections = createHandoffProtocol({
+    repository,
+  }).inspectAllHandoffs();
   const validCheckpointCount = checkpointInspections.filter((inspection) => inspection.state === 'valid').length;
   const staleCheckpointCount = checkpointInspections.filter((inspection) => inspection.state === 'stale').length;
   const invalidCheckpointCount = checkpointInspections.filter((inspection) => inspection.state === 'invalid').length;
+  const activeHandoffCount = handoffInspections.filter((inspection) => (
+    ['open', 'pending_decision', 'accepted'].includes(inspection.top_status)
+  )).length;
 
   return {
     schema_version: AO_STATE_SCHEMA_VERSION,
@@ -77,10 +84,18 @@ export async function loadAoStateReport({
       valid_checkpoint_count: validCheckpointCount,
       stale_checkpoint_count: staleCheckpointCount,
       invalid_checkpoint_count: invalidCheckpointCount,
+      handoff_request_count: snapshot.state.handoff_requests.length,
+      handoff_claim_count: snapshot.state.handoff_claims.length,
+      handoff_decision_count: snapshot.state.handoff_decisions.length,
+      handoff_transfer_count: snapshot.state.handoff_transfers.length,
+      active_handoff_count: activeHandoffCount,
       audit_entry_count: auditEntries.length,
     },
     checkpoints: {
       inspections: checkpointInspections,
+    },
+    handoffs: {
+      inspections: handoffInspections,
     },
     audit: {
       recent_entries: recentEntries,

--- a/scripts/ao/lib/transition-engine.js
+++ b/scripts/ao/lib/transition-engine.js
@@ -1,6 +1,10 @@
 import {
   CONTROL_PLANE_DEFAULT_CONTROLLER_ID,
   createControllerLease,
+  createHandoffClaimRecord,
+  createHandoffDecisionRecord,
+  createHandoffRequestRecord,
+  createHandoffTransferRecord,
   createManagedTask,
   createOwnershipLease,
   createPrBinding,
@@ -8,6 +12,8 @@ import {
 
 export const DEFAULT_OWNERSHIP_LEASE_DURATION_MS = 20 * 60 * 1000;
 export const DEFAULT_CONTROLLER_LEASE_DURATION_MS = 5 * 60 * 1000;
+export const DEFAULT_HANDOFF_REQUEST_DURATION_MS = 24 * 60 * 60 * 1000;
+export const DEFAULT_HANDOFF_GRANT_DURATION_MS = 20 * 60 * 1000;
 
 function resolveNow(now) {
   if (typeof now === 'function') return resolveNow(now());
@@ -60,6 +66,22 @@ export function buildControllerLeaseId({
   holderId,
 } = {}) {
   return `controller-${sanitizeToken(controllerId)}-${sanitizeToken(holderId)}`;
+}
+
+export function buildHandoffRequestId({ taskId, requestedAt } = {}) {
+  return `handoff-${sanitizeToken(taskId)}-${sanitizeToken(requestedAt)}`;
+}
+
+export function buildHandoffClaimId({ requestId, successorSessionName } = {}) {
+  return `claim-${sanitizeToken(requestId)}-${sanitizeToken(successorSessionName)}`;
+}
+
+export function buildHandoffDecisionId({ requestId, outcome, decidedAt } = {}) {
+  return `decision-${sanitizeToken(requestId)}-${sanitizeToken(outcome)}-${sanitizeToken(decidedAt)}`;
+}
+
+export function buildHandoffTransferId({ requestId, transferredAt } = {}) {
+  return `transfer-${sanitizeToken(requestId)}-${sanitizeToken(transferredAt)}`;
 }
 
 export function transitionManagedTask({
@@ -295,6 +317,295 @@ export function transitionControllerLease({
     holder_id: holderId ?? existingLease?.holder_id,
     holder_type: holderType ?? existingLease?.holder_type ?? 'session',
     expiresAt,
+    metadata,
+  });
+}
+
+export function transitionHandoffRequest({
+  intent,
+  existingRequest = null,
+  now = new Date().toISOString(),
+  requestId = null,
+  taskId = null,
+  requestedBySessionName = null,
+  requestedBySessionId = null,
+  operatorSessionName = null,
+  operatorSessionId = null,
+  successorSessionName = null,
+  successorSessionId = null,
+  reason = null,
+  expiresAt = null,
+  selectedClaimId = null,
+  acceptedDecisionId = null,
+  completedTransferId = null,
+  reasonCodes = null,
+  lineage = null,
+  metadata = null,
+} = {}) {
+  const timestamp = resolveNow(now);
+  const currentStatus = existingRequest?.status ?? null;
+
+  switch (intent) {
+    case 'create':
+      if (existingRequest && ['open', 'accepted'].includes(currentStatus)) {
+        illegalTransition('handoff-request', currentStatus, intent);
+      }
+      return createHandoffRequestRecord({
+        request_id: requestId ?? existingRequest?.request_id ?? buildHandoffRequestId({
+          taskId,
+          requestedAt: timestamp,
+        }),
+        task_id: taskId ?? existingRequest?.task_id,
+        status: 'open',
+        created_at: existingRequest?.created_at ?? timestamp,
+        updated_at: timestamp,
+        requested_by_session_name: requestedBySessionName ?? existingRequest?.requested_by_session_name,
+        requested_by_session_id: requestedBySessionId ?? existingRequest?.requested_by_session_id,
+        operator_session_name: operatorSessionName ?? existingRequest?.operator_session_name,
+        operator_session_id: operatorSessionId ?? existingRequest?.operator_session_id,
+        successor_session_name: successorSessionName ?? existingRequest?.successor_session_name,
+        successor_session_id: successorSessionId ?? existingRequest?.successor_session_id,
+        reason: reason ?? existingRequest?.reason ?? null,
+        expires_at: expiresAt ?? existingRequest?.expires_at ?? addMilliseconds(timestamp, DEFAULT_HANDOFF_REQUEST_DURATION_MS),
+        selected_claim_id: null,
+        accepted_decision_id: null,
+        completed_transfer_id: null,
+        reason_codes: reasonCodes ?? existingRequest?.reason_codes ?? [],
+        lineage: lineage ?? existingRequest?.lineage,
+        metadata: metadata ?? existingRequest?.metadata ?? {},
+      });
+    case 'accept':
+      if (!existingRequest || !['open', 'accepted'].includes(currentStatus)) {
+        illegalTransition('handoff-request', currentStatus, intent);
+      }
+      return createHandoffRequestRecord({
+        ...existingRequest,
+        status: 'accepted',
+        updated_at: timestamp,
+        selected_claim_id: selectedClaimId ?? existingRequest.selected_claim_id,
+        accepted_decision_id: acceptedDecisionId ?? existingRequest.accepted_decision_id,
+        reason_codes: reasonCodes ?? existingRequest.reason_codes ?? [],
+      });
+    case 'reject':
+      if (!existingRequest || !['open', 'accepted'].includes(currentStatus)) {
+        illegalTransition('handoff-request', currentStatus, intent);
+      }
+      return createHandoffRequestRecord({
+        ...existingRequest,
+        status: 'rejected',
+        updated_at: timestamp,
+        reason_codes: reasonCodes ?? existingRequest.reason_codes ?? [],
+      });
+    case 'expire':
+      if (!existingRequest || ['completed', 'rejected', 'expired'].includes(currentStatus)) {
+        illegalTransition('handoff-request', currentStatus, intent);
+      }
+      return createHandoffRequestRecord({
+        ...existingRequest,
+        status: 'expired',
+        updated_at: timestamp,
+        reason_codes: reasonCodes ?? existingRequest.reason_codes ?? [],
+      });
+    case 'complete':
+      if (!existingRequest || currentStatus !== 'accepted') {
+        illegalTransition('handoff-request', currentStatus, intent);
+      }
+      return createHandoffRequestRecord({
+        ...existingRequest,
+        status: 'completed',
+        updated_at: timestamp,
+        completed_transfer_id: completedTransferId ?? existingRequest.completed_transfer_id,
+        reason_codes: reasonCodes ?? existingRequest.reason_codes ?? [],
+      });
+    default:
+      throw new Error(`Unsupported handoff-request intent: ${intent}`);
+  }
+}
+
+export function transitionHandoffClaim({
+  intent,
+  existingClaim = null,
+  now = new Date().toISOString(),
+  claimId = null,
+  requestId = null,
+  taskId = null,
+  successorSessionName = null,
+  successorSessionId = null,
+  operatorSessionName = null,
+  operatorSessionId = null,
+  decisionId = null,
+  reason = null,
+  reasonCodes = null,
+  metadata = null,
+} = {}) {
+  const timestamp = resolveNow(now);
+  const currentStatus = existingClaim?.status ?? null;
+
+  switch (intent) {
+    case 'create':
+      if (existingClaim && ['pending', 'accepted'].includes(currentStatus)) {
+        illegalTransition('handoff-claim', currentStatus, intent);
+      }
+      return createHandoffClaimRecord({
+        claim_id: claimId ?? existingClaim?.claim_id ?? buildHandoffClaimId({
+          requestId,
+          successorSessionName,
+        }),
+        request_id: requestId ?? existingClaim?.request_id,
+        task_id: taskId ?? existingClaim?.task_id,
+        status: 'pending',
+        created_at: existingClaim?.created_at ?? timestamp,
+        updated_at: timestamp,
+        successor_session_name: successorSessionName ?? existingClaim?.successor_session_name,
+        successor_session_id: successorSessionId ?? existingClaim?.successor_session_id,
+        operator_session_name: operatorSessionName ?? existingClaim?.operator_session_name,
+        operator_session_id: operatorSessionId ?? existingClaim?.operator_session_id,
+        decision_id: decisionId ?? existingClaim?.decision_id ?? null,
+        reason: reason ?? existingClaim?.reason ?? null,
+        reason_codes: reasonCodes ?? existingClaim?.reason_codes ?? [],
+        metadata: metadata ?? existingClaim?.metadata ?? {},
+      });
+    case 'block':
+      return createHandoffClaimRecord({
+        claim_id: claimId ?? existingClaim?.claim_id ?? buildHandoffClaimId({
+          requestId,
+          successorSessionName,
+        }),
+        request_id: requestId ?? existingClaim?.request_id,
+        task_id: taskId ?? existingClaim?.task_id,
+        status: 'blocked',
+        created_at: existingClaim?.created_at ?? timestamp,
+        updated_at: timestamp,
+        successor_session_name: successorSessionName ?? existingClaim?.successor_session_name,
+        successor_session_id: successorSessionId ?? existingClaim?.successor_session_id,
+        operator_session_name: operatorSessionName ?? existingClaim?.operator_session_name,
+        operator_session_id: operatorSessionId ?? existingClaim?.operator_session_id,
+        decision_id: decisionId ?? existingClaim?.decision_id ?? null,
+        reason: reason ?? existingClaim?.reason ?? null,
+        reason_codes: reasonCodes ?? existingClaim?.reason_codes ?? [],
+        metadata: metadata ?? existingClaim?.metadata ?? {},
+      });
+    case 'accept':
+      if (!existingClaim || !['pending', 'accepted'].includes(currentStatus)) {
+        illegalTransition('handoff-claim', currentStatus, intent);
+      }
+      return createHandoffClaimRecord({
+        ...existingClaim,
+        status: 'accepted',
+        updated_at: timestamp,
+        operator_session_name: operatorSessionName ?? existingClaim.operator_session_name,
+        operator_session_id: operatorSessionId ?? existingClaim.operator_session_id,
+        decision_id: decisionId ?? existingClaim.decision_id,
+        reason_codes: reasonCodes ?? existingClaim.reason_codes ?? [],
+      });
+    case 'reject':
+      if (!existingClaim || !['pending', 'accepted'].includes(currentStatus)) {
+        illegalTransition('handoff-claim', currentStatus, intent);
+      }
+      return createHandoffClaimRecord({
+        ...existingClaim,
+        status: 'rejected',
+        updated_at: timestamp,
+        operator_session_name: operatorSessionName ?? existingClaim.operator_session_name,
+        operator_session_id: operatorSessionId ?? existingClaim.operator_session_id,
+        decision_id: decisionId ?? existingClaim.decision_id,
+        reason_codes: reasonCodes ?? existingClaim.reason_codes ?? [],
+      });
+    case 'expire':
+      if (!existingClaim || ['blocked', 'rejected', 'expired'].includes(currentStatus)) {
+        illegalTransition('handoff-claim', currentStatus, intent);
+      }
+      return createHandoffClaimRecord({
+        ...existingClaim,
+        status: 'expired',
+        updated_at: timestamp,
+        operator_session_name: operatorSessionName ?? existingClaim.operator_session_name,
+        operator_session_id: operatorSessionId ?? existingClaim.operator_session_id,
+        decision_id: decisionId ?? existingClaim.decision_id,
+        reason_codes: reasonCodes ?? existingClaim.reason_codes ?? [],
+      });
+    default:
+      throw new Error(`Unsupported handoff-claim intent: ${intent}`);
+  }
+}
+
+export function createHandoffDecisionTransition({
+  requestId,
+  claimId = null,
+  taskId,
+  outcome,
+  now = new Date().toISOString(),
+  operatorSessionName,
+  operatorSessionId = null,
+  successorSessionName = null,
+  successorSessionId = null,
+  grantExpiresAt = null,
+  reason = null,
+  reasonCodes = [],
+  metadata = {},
+} = {}) {
+  const timestamp = resolveNow(now);
+  return createHandoffDecisionRecord({
+    decision_id: buildHandoffDecisionId({
+      requestId,
+      outcome,
+      decidedAt: timestamp,
+    }),
+    request_id: requestId,
+    claim_id: claimId,
+    task_id: taskId,
+    outcome,
+    decided_at: timestamp,
+    operator_session_name: operatorSessionName,
+    operator_session_id: operatorSessionId,
+    successor_session_name: successorSessionName,
+    successor_session_id: successorSessionId,
+    grant_expires_at: grantExpiresAt ?? (outcome === 'accept'
+      ? addMilliseconds(timestamp, DEFAULT_HANDOFF_GRANT_DURATION_MS)
+      : null),
+    reason,
+    reason_codes: reasonCodes,
+    metadata,
+  });
+}
+
+export function createHandoffTransferTransition({
+  requestId,
+  claimId,
+  decisionId,
+  taskId,
+  checkpointId,
+  previousOwnershipLeaseId = null,
+  previousOwnerSessionName = null,
+  previousOwnerSessionId = null,
+  successorOwnershipLeaseId,
+  successorSessionName,
+  successorSessionId = null,
+  now = new Date().toISOString(),
+  transferredBy = null,
+  reason = null,
+  metadata = {},
+} = {}) {
+  const timestamp = resolveNow(now);
+  return createHandoffTransferRecord({
+    transfer_id: buildHandoffTransferId({
+      requestId,
+      transferredAt: timestamp,
+    }),
+    request_id: requestId,
+    claim_id: claimId,
+    decision_id: decisionId,
+    task_id: taskId,
+    checkpoint_id: checkpointId,
+    previous_ownership_lease_id: previousOwnershipLeaseId,
+    previous_owner_session_name: previousOwnerSessionName,
+    previous_owner_session_id: previousOwnerSessionId,
+    successor_ownership_lease_id: successorOwnershipLeaseId,
+    successor_session_name: successorSessionName,
+    successor_session_id: successorSessionId,
+    transferred_at: timestamp,
+    transferred_by: transferredBy,
+    reason,
     metadata,
   });
 }

--- a/tests/ao/ao-handoff-cli.test.js
+++ b/tests/ao/ao-handoff-cli.test.js
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockFindRepoRoot = jest.fn();
+const mockCreateStateRepository = jest.fn();
+const mockCreateHandoffProtocol = jest.fn();
+
+jest.unstable_mockModule('../../scripts/ao/lib/repo-root.js', () => ({
+  findRepoRoot: mockFindRepoRoot,
+}));
+
+jest.unstable_mockModule('../../scripts/ao/lib/state-repository.js', () => ({
+  createStateRepository: mockCreateStateRepository,
+}));
+
+jest.unstable_mockModule('../../scripts/ao/lib/handoff-protocol.js', () => ({
+  createHandoffProtocol: mockCreateHandoffProtocol,
+}));
+
+const { runCli } = await import('../../scripts/ao-handoff.js');
+
+describe('ao handoff cli', () => {
+  beforeEach(() => {
+    mockFindRepoRoot.mockReset();
+    mockCreateStateRepository.mockReset();
+    mockCreateHandoffProtocol.mockReset();
+
+    mockFindRepoRoot.mockReturnValue('/repo');
+    mockCreateStateRepository.mockReturnValue({ kind: 'repository' });
+    mockCreateHandoffProtocol.mockReturnValue({
+      requestHandoff: jest.fn().mockReturnValue({
+        request_id: 'handoff-issue-117',
+        task_id: 'issue-117',
+        status: 'open',
+        successor_session_name: 'cie-59',
+      }),
+      claimHandoff: jest.fn(),
+      acceptHandoff: jest.fn(),
+      rejectHandoff: jest.fn(),
+      expireHandoff: jest.fn(),
+      inspectTaskHandoff: jest.fn().mockReturnValue({
+        task_id: 'issue-117',
+        top_status: 'accepted',
+        reason_codes: [],
+      }),
+      inspectAllHandoffs: jest.fn().mockReturnValue([]),
+    });
+  });
+
+  it('dispatches request in JSON mode with explicit successor and operator surfaces', async () => {
+    const stdout = [];
+
+    const result = await runCli([
+      'request',
+      '--issue', '117',
+      '--successor-session', 'cie-59',
+      '--successor-session-id', 'cie-59',
+      '--operator-session', 'operator-1',
+      '--operator-session-id', 'operator-1',
+      '--reason', 'owner_stale',
+      '--json',
+    ], {
+      writeStdout: (text) => stdout.push(text),
+      writeStderr: () => {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockCreateStateRepository).toHaveBeenCalledWith({
+      repoRoot: '/repo',
+      projectId: 'ciecopilot-home',
+    });
+    expect(mockCreateHandoffProtocol().requestHandoff).toHaveBeenCalledWith({
+      taskId: null,
+      issueNumber: 117,
+      requestedBySessionName: null,
+      requestedBySessionId: null,
+      operatorSessionName: 'operator-1',
+      operatorSessionId: 'operator-1',
+      successorSessionName: 'cie-59',
+      successorSessionId: 'cie-59',
+      reason: 'owner_stale',
+      requestId: null,
+      claimId: null,
+    });
+    expect(JSON.parse(stdout.join(''))).toMatchObject({
+      request_id: 'handoff-issue-117',
+      status: 'open',
+    });
+  });
+
+  it('dispatches inspect against a task scope', async () => {
+    const stdout = [];
+
+    const result = await runCli(['inspect', '--issue', '117', '--json'], {
+      writeStdout: (text) => stdout.push(text),
+      writeStderr: () => {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockCreateHandoffProtocol().inspectTaskHandoff).toHaveBeenCalledWith({
+      taskId: null,
+      issueNumber: 117,
+      requestId: null,
+    });
+    expect(JSON.parse(stdout.join(''))).toMatchObject({
+      task_id: 'issue-117',
+      top_status: 'accepted',
+    });
+  });
+
+  it('rejects unsupported commands before touching the repo', async () => {
+    const stderr = [];
+
+    const result = await runCli(['bogus'], {
+      writeStdout: () => {},
+      writeStderr: (text) => stderr.push(text),
+    });
+
+    expect(result.exitCode).toBe(4);
+    expect(mockFindRepoRoot).not.toHaveBeenCalled();
+    expect(stderr.join('')).toContain('Unsupported command');
+  });
+});

--- a/tests/ao/controller-loop.test.js
+++ b/tests/ao/controller-loop.test.js
@@ -343,6 +343,120 @@ describe('ao controller loop', () => {
     );
   });
 
+  it('passes the control-plane snapshot into doctor resolution for lifecycle handoff analysis', async () => {
+    const repository = createStateRepository({
+      repoRoot: createTempRepo(),
+      projectId: PROJECT_ID,
+    });
+    seedActiveTask(repository, 'shadow');
+    seedCleanRuntimePreflight(repository);
+    const buildDoctorReport = jest.fn(() => ({
+      top_status: 'healthy',
+      source_health: {
+        reconciliation: 'ok',
+        ao: 'ok',
+        github: 'ok',
+        git: 'ok',
+        worktree: 'ok',
+      },
+      reconciliation_summary: {
+        top_status: 'healthy',
+        selected_pr_numbers: [92],
+      },
+      local_state: {
+        current_branch: 'feat/issue-92',
+        upstream_branch: 'origin/feat/issue-92',
+        worktree_dirty: false,
+        ao_artifact_paths: [],
+      },
+      findings: [],
+      suggestions: [],
+    }));
+    const buildLifecycleReport = jest.fn(() => ({
+      top_status: 'continue',
+      routing_decision: {
+        action: 'continue_current_worker',
+      },
+      release_decision: {
+        disposition: 'continue_current_worker',
+      },
+      actions: [],
+    }));
+
+    await runControllerLoop({
+      repoRoot: repository.getSnapshot().paths.repoRoot,
+      cwd: repository.getSnapshot().paths.repoRoot,
+      projectId: PROJECT_ID,
+      controllerId: 'default',
+      now: '2026-03-29T06:41:00.000Z',
+      deps: {
+        loadAoProjectObservation: async () => ({
+          observed_at: '2026-03-29T06:41:00.000Z',
+          workers: [
+            {
+              session_name: 'cie-92',
+              session_runtime_id: 'cie-92',
+              issue_number: 92,
+              branch_name: 'feat/issue-92',
+              pr_number: 92,
+              lifecycle_state: 'idle',
+              last_seen_at: '2026-03-29T06:40:45.000Z',
+              freshness: { status: 'fresh' },
+            },
+          ],
+        }),
+        loadGitHubObservationSet: async () => ({
+          observed_at: '2026-03-29T06:41:00.000Z',
+          prs: [
+            {
+              pr_number: 92,
+              state: 'OPEN',
+              head_branch: 'feat/issue-92',
+              head_sha: 'abc123',
+              review_status: 'pending',
+              ci_status: 'pending',
+              mergeability: 'mergeable',
+              is_draft: false,
+              url: 'https://example.test/pr/92',
+            },
+          ],
+        }),
+        reconcileObservations: () => ({
+          top_status: 'healthy',
+          source_health: { ao: 'ok', github: 'ok' },
+          scope: { selected_pr_numbers: [92] },
+          pr_assessments: [],
+          findings: [],
+        }),
+        loadDoctorLocalState: async () => ({
+          git_observable: true,
+          repo_root: repository.getSnapshot().paths.repoRoot,
+          head_sha: 'abc123',
+          current_branch: 'feat/issue-92',
+          upstream_branch: 'origin/feat/issue-92',
+          upstream_tracking: 'present',
+          worktree_dirty: false,
+          staged_changes: false,
+          unstaged_changes: false,
+          untracked_file_count: 0,
+          untracked_file_samples: [],
+          ao_artifact_paths: [],
+        }),
+        buildDoctorReport,
+        buildLifecycleReport,
+      },
+    });
+
+    expect(buildDoctorReport).toHaveBeenCalledWith(expect.objectContaining({
+      controlPlaneSnapshot: expect.objectContaining({
+        bootstrapped: true,
+        state: expect.objectContaining({
+          handoff_requests: expect.any(Array),
+        }),
+      }),
+    }));
+  });
+
   it('derives bugbot comment follow-up from protocolized review-comment delivery events', async () => {
     const repository = createStateRepository({
       repoRoot: createTempRepo(),

--- a/tests/ao/handoff-protocol.test.js
+++ b/tests/ao/handoff-protocol.test.js
@@ -1,0 +1,242 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+import { createCheckpointStore } from '../../scripts/ao/lib/checkpoint-store.js';
+import { createHandoffProtocol } from '../../scripts/ao/lib/handoff-protocol.js';
+import {
+  createManagedTask,
+  createOwnershipLease,
+  createPrBinding,
+  createTaskSpecRecord,
+} from '../../scripts/ao/lib/state-contracts.js';
+import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
+
+const PROJECT_ID = 'ciecopilot-home';
+const tempDirs = [];
+
+function createTempRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-handoff-protocol-'));
+  tempDirs.push(repoRoot);
+  return repoRoot;
+}
+
+function seedHandoffTask(repository, {
+  taskId = 'issue-117',
+  issueNumber = 117,
+  title = 'feat(ao): add successor handoff and authority transfer protocol',
+  ownerSessionName = 'cie-58',
+  ownerSessionId = 'cie-58',
+} = {}) {
+  repository.upsertManagedTask(createManagedTask({
+    task_id: taskId,
+    issue_number: issueNumber,
+    title,
+    branch_name: 'feat/117',
+    worktree_path: '/tmp/cie-58',
+    status: 'active',
+    created_at: '2026-03-31T10:00:00.000Z',
+    updated_at: '2026-03-31T10:00:00.000Z',
+  }));
+  repository.upsertPrBinding(createPrBinding({
+    binding_id: `binding-${taskId}-pr-${issueNumber}`,
+    task_id: taskId,
+    pr_number: issueNumber,
+    branch_name: 'feat/117',
+    base_branch: 'main',
+    status: 'bound',
+    created_at: '2026-03-31T10:00:00.000Z',
+    updated_at: '2026-03-31T10:00:00.000Z',
+  }));
+  repository.upsertOwnershipLease(createOwnershipLease({
+    lease_id: `ownership-${taskId}-${ownerSessionName}`,
+    task_id: taskId,
+    owner_session_name: ownerSessionName,
+    owner_session_id: ownerSessionId,
+    status: 'active',
+    acquired_at: '2026-03-31T10:00:00.000Z',
+    expires_at: '2026-03-31T10:20:00.000Z',
+  }));
+  repository.upsertTaskSpec(createTaskSpecRecord({
+    task_id: taskId,
+    source_kind: 'github_issue',
+    source_issue_number: issueNumber,
+    created_at: '2026-03-31T10:00:00.000Z',
+    updated_at: '2026-03-31T10:00:00.000Z',
+    snapshot: {
+      schema_version: 'ao.task-spec.v1alpha1',
+      spec: {
+        problem_type: 'issue_delivery',
+        acceptance_contract: ['successor handoff protocol exists'],
+        runtime_ref: 'runtime.github_local',
+        policy_ref: 'policy.operator_gated',
+        human_gates: ['operator_handoff'],
+      },
+    },
+  }));
+  repository.ensureRuntimePreflights({
+    cwd: repository.getSnapshot().paths.repoRoot,
+    now: '2026-03-31T10:01:00.000Z',
+    probes: {
+      commandExists: () => true,
+      pathExists: () => true,
+      capability: () => true,
+    },
+  });
+
+  const checkpoint = createCheckpointStore({
+    repository,
+    now: () => '2026-03-31T10:15:00.000Z',
+  }).captureCheckpoint({
+    taskId,
+    controllerId: 'default',
+    derivedTrigger: 'agent_exited',
+    observedAt: '2026-03-31T10:15:00.000Z',
+    actionIds: ['proposal-handoff'],
+  });
+
+  return {
+    checkpoint,
+  };
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('ao handoff protocol', () => {
+  it('creates a durable handoff request with checkpoint and lease lineage', () => {
+    const repository = createStateRepository({
+      repoRoot: createTempRepo(),
+      projectId: PROJECT_ID,
+    });
+    const { checkpoint } = seedHandoffTask(repository);
+
+    const protocol = createHandoffProtocol({
+      repository,
+      now: () => '2026-03-31T10:30:00.000Z',
+    });
+    const request = protocol.requestHandoff({
+      taskId: 'issue-117',
+      requestedBySessionName: 'operator-1',
+      requestedBySessionId: 'operator-1',
+      operatorSessionName: 'operator-1',
+      operatorSessionId: 'operator-1',
+      successorSessionName: 'cie-59',
+      successorSessionId: 'cie-59',
+      reason: 'owner_stale',
+    });
+
+    expect(request).toMatchObject({
+      task_id: 'issue-117',
+      status: 'open',
+      operator_session_name: 'operator-1',
+      successor_session_name: 'cie-59',
+      lineage: expect.objectContaining({
+        checkpoint_id: checkpoint.checkpoint_id,
+        checkpoint_state: 'valid',
+        prior_ownership_lease_id: 'ownership-issue-117-cie-58',
+        prior_owner_session_name: 'cie-58',
+      }),
+    });
+    expect(repository.getSnapshot().state.handoff_requests).toEqual([
+      expect.objectContaining({
+        request_id: request.request_id,
+        status: 'open',
+      }),
+    ]);
+  });
+
+  it('blocks unauthorized and duplicate claims and human-gates competing successors', () => {
+    const repository = createStateRepository({
+      repoRoot: createTempRepo(),
+      projectId: PROJECT_ID,
+    });
+    seedHandoffTask(repository);
+
+    const protocol = createHandoffProtocol({
+      repository,
+      now: () => '2026-03-31T10:30:00.000Z',
+    });
+    const explicitRequest = protocol.requestHandoff({
+      taskId: 'issue-117',
+      requestedBySessionName: 'operator-1',
+      requestedBySessionId: 'operator-1',
+      operatorSessionName: 'operator-1',
+      operatorSessionId: 'operator-1',
+      successorSessionName: 'cie-59',
+      successorSessionId: 'cie-59',
+      reason: 'owner_stale',
+    });
+    const unauthorizedClaim = protocol.claimHandoff({
+      requestId: explicitRequest.request_id,
+      successorSessionName: 'cie-60',
+      successorSessionId: 'cie-60',
+      reason: 'takeover_attempt',
+    });
+
+    expect(unauthorizedClaim).toMatchObject({
+      request_id: explicitRequest.request_id,
+      status: 'blocked',
+      successor_session_name: 'cie-60',
+      reason_codes: expect.arrayContaining(['successor_not_authorized']),
+    });
+
+    const openRequest = protocol.requestHandoff({
+      taskId: 'issue-117',
+      requestedBySessionName: 'operator-2',
+      requestedBySessionId: 'operator-2',
+      operatorSessionName: 'operator-2',
+      operatorSessionId: 'operator-2',
+      successorSessionName: null,
+      successorSessionId: null,
+      reason: 'open_successor_selection',
+      allowDuplicateTaskRequest: true,
+    });
+    const firstClaim = protocol.claimHandoff({
+      requestId: openRequest.request_id,
+      successorSessionName: 'cie-59',
+      successorSessionId: 'cie-59',
+      reason: 'ready_to_continue',
+    });
+    const duplicateClaim = protocol.claimHandoff({
+      requestId: openRequest.request_id,
+      successorSessionName: 'cie-59',
+      successorSessionId: 'cie-59',
+      reason: 'duplicate_submission',
+    });
+    const competingClaim = protocol.claimHandoff({
+      requestId: openRequest.request_id,
+      successorSessionName: 'cie-60',
+      successorSessionId: 'cie-60',
+      reason: 'alternate_successor',
+    });
+    const inspection = protocol.inspectTaskHandoff({
+      taskId: 'issue-117',
+      requestId: openRequest.request_id,
+    });
+
+    expect(firstClaim).toMatchObject({
+      status: 'pending',
+      successor_session_name: 'cie-59',
+    });
+    expect(duplicateClaim).toMatchObject({
+      status: 'blocked',
+      reason_codes: expect.arrayContaining(['duplicate_successor_claim']),
+    });
+    expect(competingClaim).toMatchObject({
+      status: 'pending',
+      successor_session_name: 'cie-60',
+    });
+    expect(inspection).toMatchObject({
+      task_id: 'issue-117',
+      request_id: openRequest.request_id,
+      top_status: 'ambiguous',
+      reason_codes: expect.arrayContaining(['ambiguous_successor_selection']),
+    });
+  });
+});

--- a/tests/ao/manage-runner.test.js
+++ b/tests/ao/manage-runner.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from '@jest/globals';
 
 import { createCheckpointStore } from '../../scripts/ao/lib/checkpoint-store.js';
+import { createHandoffProtocol } from '../../scripts/ao/lib/handoff-protocol.js';
 import { resolveControlPlanePaths } from '../../scripts/ao/lib/state-migrations.js';
 import { runManageCommand } from '../../scripts/ao/lib/manage-runner.js';
 import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
@@ -353,6 +354,215 @@ describe('ao manage runner', () => {
       ownerSessionId: 'cie-57',
       now: '2026-03-30T10:04:00.000Z',
     })).rejects.toThrow(/stale checkpoint/i);
+  });
+
+  it('blocks successor resume until an accepted handoff grant exists', async () => {
+    const repoRoot = createTempRepo();
+
+    await runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'enroll',
+      issueNumber: 117,
+      title: 'feat(ao): add successor handoff and authority transfer protocol',
+      branchName: 'feat/117',
+      worktreePath: '/tmp/cie-58',
+      prNumber: 127,
+      ownerSessionName: 'cie-58',
+      ownerSessionId: 'cie-58',
+      taskSpecBody: [
+        '## Problem Type',
+        'issue_delivery',
+        '',
+        '## Acceptance Contract',
+        '- successor handoff protocol exists',
+        '',
+        '## Runtime Ref',
+        'runtime.github_local',
+        '',
+        '## Policy Ref',
+        'policy.operator_gated',
+        '',
+        '## Human Gates',
+        '- operator_handoff',
+      ].join('\n'),
+      now: '2026-03-31T10:00:00.000Z',
+    });
+
+    const repository = createStateRepository({
+      repoRoot,
+      projectId: PROJECT_ID,
+    });
+    repository.ensureRuntimePreflights({
+      cwd: repoRoot,
+      now: '2026-03-31T10:01:00.000Z',
+      probes: {
+        commandExists: () => true,
+        pathExists: () => true,
+        capability: () => true,
+      },
+    });
+    createCheckpointStore({
+      repository,
+      now: () => '2026-03-31T10:02:00.000Z',
+    }).captureCheckpoint({
+      taskId: 'issue-117',
+      controllerId: 'default',
+      derivedTrigger: 'agent_exited',
+      observedAt: '2026-03-31T10:02:00.000Z',
+      actionIds: ['proposal-issue-117-handoff'],
+    });
+
+    await runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'unmanage',
+      issueNumber: 117,
+      now: '2026-03-31T10:03:00.000Z',
+      reason: 'worker_stale',
+    });
+
+    await expect(runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'resume',
+      issueNumber: 117,
+      ownerSessionName: 'cie-59',
+      ownerSessionId: 'cie-59',
+      now: '2026-03-31T10:04:00.000Z',
+    })).rejects.toThrow(/accepted handoff/i);
+  });
+
+  it('transfers ownership to the accepted successor during resume', async () => {
+    const repoRoot = createTempRepo();
+
+    await runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'enroll',
+      issueNumber: 117,
+      title: 'feat(ao): add successor handoff and authority transfer protocol',
+      branchName: 'feat/117',
+      worktreePath: '/tmp/cie-58',
+      prNumber: 127,
+      ownerSessionName: 'cie-58',
+      ownerSessionId: 'cie-58',
+      taskSpecBody: [
+        '## Problem Type',
+        'issue_delivery',
+        '',
+        '## Acceptance Contract',
+        '- successor handoff protocol exists',
+        '',
+        '## Runtime Ref',
+        'runtime.github_local',
+        '',
+        '## Policy Ref',
+        'policy.operator_gated',
+        '',
+        '## Human Gates',
+        '- operator_handoff',
+      ].join('\n'),
+      now: '2026-03-31T10:00:00.000Z',
+    });
+
+    const repository = createStateRepository({
+      repoRoot,
+      projectId: PROJECT_ID,
+    });
+    repository.ensureRuntimePreflights({
+      cwd: repoRoot,
+      now: '2026-03-31T10:01:00.000Z',
+      probes: {
+        commandExists: () => true,
+        pathExists: () => true,
+        capability: () => true,
+      },
+    });
+    createCheckpointStore({
+      repository,
+      now: () => '2026-03-31T10:02:00.000Z',
+    }).captureCheckpoint({
+      taskId: 'issue-117',
+      controllerId: 'default',
+      derivedTrigger: 'agent_exited',
+      observedAt: '2026-03-31T10:02:00.000Z',
+      actionIds: ['proposal-issue-117-handoff'],
+    });
+
+    await runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'unmanage',
+      issueNumber: 117,
+      now: '2026-03-31T10:03:00.000Z',
+      reason: 'worker_stale',
+    });
+
+    const handoffProtocol = createHandoffProtocol({
+      repository,
+      now: () => '2026-03-31T10:04:00.000Z',
+    });
+    const request = handoffProtocol.requestHandoff({
+      taskId: 'issue-117',
+      requestedBySessionName: 'operator-1',
+      requestedBySessionId: 'operator-1',
+      operatorSessionName: 'operator-1',
+      operatorSessionId: 'operator-1',
+      successorSessionName: 'cie-59',
+      successorSessionId: 'cie-59',
+      reason: 'owner_stale',
+    });
+    const claim = handoffProtocol.claimHandoff({
+      requestId: request.request_id,
+      successorSessionName: 'cie-59',
+      successorSessionId: 'cie-59',
+      reason: 'resume_as_successor',
+    });
+    handoffProtocol.acceptHandoff({
+      requestId: request.request_id,
+      claimId: claim.claim_id,
+      operatorSessionName: 'operator-1',
+      operatorSessionId: 'operator-1',
+      reason: 'approved_successor',
+      grantExpiresAt: '2026-03-31T10:20:00.000Z',
+    });
+
+    const result = await runManageCommand({
+      repoRoot,
+      projectId: PROJECT_ID,
+      command: 'resume',
+      issueNumber: 117,
+      ownerSessionName: 'cie-59',
+      ownerSessionId: 'cie-59',
+      now: '2026-03-31T10:05:00.000Z',
+    });
+
+    expect(result.ownershipLease).toMatchObject({
+      task_id: 'issue-117',
+      owner_session_name: 'cie-59',
+      status: 'active',
+    });
+    expect(result.handoffTransfer).toMatchObject({
+      request_id: request.request_id,
+      claim_id: claim.claim_id,
+      successor_session_name: 'cie-59',
+      checkpoint_id: expect.stringMatching(/^checkpoint-issue-117-/),
+    });
+
+    const state = readState(repoRoot);
+    expect(state.handoff_requests).toEqual([
+      expect.objectContaining({
+        request_id: request.request_id,
+        status: 'completed',
+      }),
+    ]);
+    expect(state.handoff_transfers).toEqual([
+      expect.objectContaining({
+        request_id: request.request_id,
+        successor_session_name: 'cie-59',
+      }),
+    ]);
   });
 
   it('unmanages and retires a task without deleting its durable bindings', async () => {

--- a/tests/ao/state-contracts.test.js
+++ b/tests/ao/state-contracts.test.js
@@ -21,6 +21,10 @@ import {
   createCredentialProvenanceRecord,
   createDeliveryEventRecord,
   createEmptyControlPlaneState,
+  createHandoffClaimRecord,
+  createHandoffDecisionRecord,
+  createHandoffRequestRecord,
+  createHandoffTransferRecord,
   createManagedTask,
   createOverrideRecord,
   createOwnershipLease,
@@ -45,7 +49,7 @@ describe('ao state contracts', () => {
     expect(CONTROLLER_MODES).toEqual(['off', 'observe', 'shadow', 'assist']);
     expect(POLICY_DECISIONS).toEqual(['allow', 'deny', 'downgrade']);
     expect(CREDENTIAL_PROVENANCE_TRUST_DECISIONS).toEqual(['trusted', 'untrusted']);
-    expect(CONTROL_PLANE_LATEST_VERSION).toBe(6);
+    expect(CONTROL_PLANE_LATEST_VERSION).toBe(7);
   });
 
   it('creates durable managed-task, binding, lease, action, override, and controller-mode records', () => {
@@ -387,6 +391,112 @@ describe('ao state contracts', () => {
         author_login: 'chatgpt-codex-connector',
       },
     });
+
+    expect(createHandoffRequestRecord({
+      request_id: 'handoff-task-1-1',
+      task_id: 'task-1',
+      status: 'open',
+      created_at: NOW,
+      updated_at: NOW,
+      requested_by_session_name: 'operator-1',
+      requested_by_session_id: 'operator-1',
+      operator_session_name: 'operator-1',
+      operator_session_id: 'operator-1',
+      successor_session_name: 'cie-59',
+      successor_session_id: 'cie-59',
+      reason: 'owner_stale',
+      expires_at: '2026-03-29T05:10:00.000Z',
+      selected_claim_id: null,
+      accepted_decision_id: null,
+      completed_transfer_id: null,
+      reason_codes: [],
+      lineage: {
+        checkpoint_id: 'checkpoint-task-1',
+        checkpoint_recorded_at: NOW,
+        checkpoint_state: 'valid',
+        prior_ownership_lease_id: 'lease-1',
+        prior_owner_session_name: 'cie-48',
+        prior_owner_session_id: 'session-48',
+        prior_ownership_status: 'expired',
+        pr_binding_id: 'binding-1',
+        pr_number: 101,
+      },
+    })).toMatchObject({
+      schema_version: 'ao.handoff-request.v1alpha1',
+      format: 'ao_handoff_request',
+      request_id: 'handoff-task-1-1',
+      task_id: 'task-1',
+      status: 'open',
+      successor_session_name: 'cie-59',
+      lineage: {
+        checkpoint_id: 'checkpoint-task-1',
+        prior_ownership_lease_id: 'lease-1',
+      },
+    });
+
+    expect(createHandoffClaimRecord({
+      claim_id: 'claim-handoff-task-1-1',
+      request_id: 'handoff-task-1-1',
+      task_id: 'task-1',
+      status: 'pending',
+      created_at: NOW,
+      updated_at: NOW,
+      successor_session_name: 'cie-59',
+      successor_session_id: 'cie-59',
+    })).toMatchObject({
+      schema_version: 'ao.handoff-claim.v1alpha1',
+      format: 'ao_handoff_claim',
+      claim_id: 'claim-handoff-task-1-1',
+      status: 'pending',
+      successor_session_name: 'cie-59',
+    });
+
+    expect(createHandoffDecisionRecord({
+      decision_id: 'decision-handoff-task-1-1',
+      request_id: 'handoff-task-1-1',
+      claim_id: 'claim-handoff-task-1-1',
+      task_id: 'task-1',
+      outcome: 'accept',
+      decided_at: NOW,
+      operator_session_name: 'operator-1',
+      operator_session_id: 'operator-1',
+      successor_session_name: 'cie-59',
+      successor_session_id: 'cie-59',
+      grant_expires_at: '2026-03-29T05:00:00.000Z',
+      reason: 'approved_successor',
+    })).toMatchObject({
+      schema_version: 'ao.handoff-decision.v1alpha1',
+      format: 'ao_handoff_decision',
+      decision_id: 'decision-handoff-task-1-1',
+      outcome: 'accept',
+      operator_session_name: 'operator-1',
+      successor_session_name: 'cie-59',
+    });
+
+    expect(createHandoffTransferRecord({
+      transfer_id: 'transfer-handoff-task-1-1',
+      request_id: 'handoff-task-1-1',
+      claim_id: 'claim-handoff-task-1-1',
+      decision_id: 'decision-handoff-task-1-1',
+      task_id: 'task-1',
+      checkpoint_id: 'checkpoint-task-1',
+      previous_ownership_lease_id: 'lease-1',
+      previous_owner_session_name: 'cie-48',
+      previous_owner_session_id: 'session-48',
+      successor_ownership_lease_id: 'lease-2',
+      successor_session_name: 'cie-59',
+      successor_session_id: 'cie-59',
+      transferred_at: NOW,
+      transferred_by: 'manage_runner',
+      reason: 'accepted_handoff_resume',
+    })).toMatchObject({
+      schema_version: 'ao.handoff-transfer.v1alpha1',
+      format: 'ao_handoff_transfer',
+      transfer_id: 'transfer-handoff-task-1-1',
+      request_id: 'handoff-task-1-1',
+      successor_session_name: 'cie-59',
+      successor_ownership_lease_id: 'lease-2',
+    });
   });
 
   it('creates empty schema, state, and audit envelopes for repo-local bootstrap', () => {
@@ -445,6 +555,10 @@ describe('ao state contracts', () => {
       task_specs: [],
       runtime_preflights: [],
       checkpoints: [],
+      handoff_requests: [],
+      handoff_claims: [],
+      handoff_decisions: [],
+      handoff_transfers: [],
     });
 
     expect(createControlPlaneAuditEntry({

--- a/tests/ao/state-migrations.test.js
+++ b/tests/ao/state-migrations.test.js
@@ -73,8 +73,8 @@ describe('ao state migrations', () => {
 
     expect(readJson(paths.schemaPath)).toMatchObject({
       project_id: PROJECT_ID,
-      current_version: 6,
-      latest_version: 6,
+      current_version: 7,
+      latest_version: 7,
       applied_migrations: [
         {
           version: 1,
@@ -106,6 +106,11 @@ describe('ao state migrations', () => {
           key: '0006_checkpoint_v1',
           applied_at: FIXED_NOW,
         },
+        {
+          version: 7,
+          key: '0007_handoff_protocol_v1',
+          applied_at: FIXED_NOW,
+        },
       ],
     });
     expect(readJson(paths.statePath)).toMatchObject({
@@ -116,6 +121,10 @@ describe('ao state migrations', () => {
       task_specs: [],
       runtime_preflights: [],
       checkpoints: [],
+      handoff_requests: [],
+      handoff_claims: [],
+      handoff_decisions: [],
+      handoff_transfers: [],
       controller_modes: [
         {
           controller_id: 'default',
@@ -162,6 +171,12 @@ describe('ao state migrations', () => {
         operation: 'migrate',
         summary: 'Applied control-plane checkpoint migration.',
       }),
+      expect.objectContaining({
+        entity_kind: 'schema',
+        entity_id: 'v7',
+        operation: 'migrate',
+        summary: 'Applied control-plane handoff-protocol migration.',
+      }),
     ]);
   });
 
@@ -188,7 +203,7 @@ describe('ao state migrations', () => {
       migrated: false,
     });
     expect(readJson(paths.schemaPath).updated_at).toBe(FIXED_NOW);
-    expect(readAuditEntries(paths.auditPath)).toHaveLength(6);
+    expect(readAuditEntries(paths.auditPath)).toHaveLength(7);
   });
 
   it('upgrades a stale schema version and backfills invalid task specs for enrolled tasks', () => {
@@ -204,7 +219,7 @@ describe('ao state migrations', () => {
       format: 'ao_control_plane_schema',
       project_id: PROJECT_ID,
       current_version: 1,
-      latest_version: 6,
+      latest_version: 7,
       created_at: '2026-03-29T03:00:00.000Z',
       updated_at: '2026-03-29T03:00:00.000Z',
       applied_migrations: [
@@ -264,7 +279,7 @@ describe('ao state migrations', () => {
       migrated: true,
     });
     expect(readJson(paths.schemaPath)).toMatchObject({
-      current_version: 6,
+      current_version: 7,
       applied_migrations: [
         {
           version: 1,
@@ -290,6 +305,10 @@ describe('ao state migrations', () => {
           version: 6,
           key: '0006_checkpoint_v1',
         },
+        {
+          version: 7,
+          key: '0007_handoff_protocol_v1',
+        },
       ],
     });
     expect(readJson(paths.statePath)).toMatchObject({
@@ -298,6 +317,10 @@ describe('ao state migrations', () => {
       credential_provenances: [],
       runtime_preflights: [],
       checkpoints: [],
+      handoff_requests: [],
+      handoff_claims: [],
+      handoff_decisions: [],
+      handoff_transfers: [],
       task_specs: [
         {
           task_id: 'issue-105',

--- a/tests/ao/state-repository.test.js
+++ b/tests/ao/state-repository.test.js
@@ -264,6 +264,7 @@ describe('ao state repository', () => {
       'schema:migrate:v4',
       'schema:migrate:v5',
       'schema:migrate:v6',
+      'schema:migrate:v7',
       'managed_task:upsert:task-1',
       'pr_binding:upsert:binding-1',
       'ownership_lease:upsert:ownership-1',

--- a/tests/ao/state-runner.test.js
+++ b/tests/ao/state-runner.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from '@jest/globals';
 
 import { createCheckpointStore } from '../../scripts/ao/lib/checkpoint-store.js';
+import { createHandoffProtocol } from '../../scripts/ao/lib/handoff-protocol.js';
 import {
   createControllerModeRecord,
   createManagedTask,
@@ -139,7 +140,7 @@ describe('ao state runner', () => {
       active_override_count: 1,
       controller_mode_count: 1,
       controller_modes: ['default=observe'],
-      audit_entry_count: 9,
+      audit_entry_count: 10,
     });
     expect(report.audit.recent_entries).toEqual([
       expect.objectContaining({
@@ -247,6 +248,128 @@ describe('ao state runner', () => {
       expect.objectContaining({
         task_id: 'issue-110',
         state: 'valid',
+      }),
+    ]);
+  });
+
+  it('includes successor handoff inspection state in the operator-visible AO state report', async () => {
+    const repoRoot = createTempRepo();
+    const repository = createStateRepository({
+      repoRoot,
+      projectId: PROJECT_ID,
+      clock: createClock(
+        '2026-03-31T10:00:00.000Z',
+        '2026-03-31T10:01:00.000Z',
+        '2026-03-31T10:02:00.000Z',
+        '2026-03-31T10:03:00.000Z',
+      ),
+      auditIdGenerator: createIdGenerator('audit'),
+    });
+
+    repository.upsertManagedTask(createManagedTask({
+      task_id: 'issue-117',
+      issue_number: 117,
+      title: 'feat(ao): add successor handoff and authority transfer protocol',
+      branch_name: 'feat/117',
+      worktree_path: '/tmp/cie-58',
+      status: 'active',
+      created_at: '2026-03-31T10:00:00.000Z',
+      updated_at: '2026-03-31T10:00:00.000Z',
+    }));
+    repository.upsertPrBinding(createPrBinding({
+      binding_id: 'binding-issue-117-pr-117',
+      task_id: 'issue-117',
+      pr_number: 117,
+      branch_name: 'feat/117',
+      base_branch: 'main',
+      status: 'bound',
+      created_at: '2026-03-31T10:00:00.000Z',
+      updated_at: '2026-03-31T10:00:00.000Z',
+    }));
+    repository.upsertTaskSpec(createTaskSpecRecord({
+      task_id: 'issue-117',
+      source_kind: 'github_issue',
+      source_issue_number: 117,
+      created_at: '2026-03-31T10:00:00.000Z',
+      updated_at: '2026-03-31T10:00:00.000Z',
+      snapshot: {
+        schema_version: 'ao.task-spec.v1alpha1',
+        spec: {
+          problem_type: 'issue_delivery',
+          acceptance_contract: ['successor handoff protocol exists'],
+          runtime_ref: 'runtime.github_local',
+          policy_ref: 'policy.operator_gated',
+          human_gates: ['operator_handoff'],
+        },
+      },
+    }));
+    repository.ensureRuntimePreflights({
+      cwd: repoRoot,
+      now: '2026-03-31T10:01:00.000Z',
+      probes: {
+        commandExists: () => true,
+        pathExists: () => true,
+        capability: () => true,
+      },
+    });
+    createCheckpointStore({
+      repository,
+      now: () => '2026-03-31T10:02:00.000Z',
+    }).captureCheckpoint({
+      taskId: 'issue-117',
+      controllerId: 'default',
+      derivedTrigger: 'agent_exited',
+      observedAt: '2026-03-31T10:02:00.000Z',
+      actionIds: [],
+    });
+
+    const handoffProtocol = createHandoffProtocol({
+      repository,
+      now: () => '2026-03-31T10:03:00.000Z',
+    });
+    const request = handoffProtocol.requestHandoff({
+      taskId: 'issue-117',
+      requestedBySessionName: 'operator-1',
+      requestedBySessionId: 'operator-1',
+      operatorSessionName: 'operator-1',
+      operatorSessionId: 'operator-1',
+      successorSessionName: 'cie-59',
+      successorSessionId: 'cie-59',
+      reason: 'owner_stale',
+    });
+    const claim = handoffProtocol.claimHandoff({
+      requestId: request.request_id,
+      successorSessionName: 'cie-59',
+      successorSessionId: 'cie-59',
+      reason: 'continue_issue_117',
+    });
+    handoffProtocol.acceptHandoff({
+      requestId: request.request_id,
+      claimId: claim.claim_id,
+      operatorSessionName: 'operator-1',
+      operatorSessionId: 'operator-1',
+      reason: 'approved_successor',
+      grantExpiresAt: '2026-03-31T10:20:00.000Z',
+    });
+
+    const report = await loadAoStateReport({
+      repoRoot,
+      projectId: PROJECT_ID,
+      auditLimit: 2,
+    });
+
+    expect(report.summary).toMatchObject({
+      handoff_request_count: 1,
+      handoff_claim_count: 1,
+      handoff_decision_count: 1,
+      handoff_transfer_count: 0,
+      active_handoff_count: 1,
+    });
+    expect(report.handoffs.inspections).toEqual([
+      expect.objectContaining({
+        task_id: 'issue-117',
+        request_id: request.request_id,
+        top_status: 'accepted',
       }),
     ]);
   });


### PR DESCRIPTION
## Summary
- add durable handoff request, claim, decision, and transfer records plus protocol inspection logic
- require accepted successor handoffs for non-owner resume authority transfer and surface state through AO state/doctor/reconcile tooling
- add the ao-handoff CLI and focused test coverage for protocol, manage, controller, and state flows

## Verification
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/handoff-protocol.test.js tests/ao/manage-runner.test.js tests/ao/controller-loop.test.js tests/ao/state-runner.test.js tests/ao/ao-handoff-cli.test.js
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/state-contracts.test.js tests/ao/state-migrations.test.js tests/ao/state-repository.test.js tests/ao/transition-engine.test.js tests/ao/ao-reconcile-cli.test.js tests/ao/ao-state-cli.test.js tests/ao/ao-doctor-cli.test.js
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/doctor-engine.test.js tests/ao/doctor-runner.test.js tests/ao/reconciliation-runner.test.js tests/ao/ao-manage-cli.test.js

Closes #117