### PR TITLE
feat(ao): add trace, cost, and failure taxonomy

### DIFF
--- a/scripts/ao-metrics.js
+++ b/scripts/ao-metrics.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_PROJECT_ID,
+  loadAoMetricsReport,
+  renderAoMetricsHumanSummary,
+} from './ao/lib/run-metrics.js';
+
+function createDefaultIo() {
+  return {
+    writeStdout: (text) => process.stdout.write(text),
+    writeStderr: (text) => process.stderr.write(text),
+  };
+}
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1] ?? null;
+  if (value == null || value.startsWith('-')) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+
+  return value;
+}
+
+function parseArgs(argv) {
+  const options = {
+    projectId: DEFAULT_PROJECT_ID,
+    traceLimit: 5,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--project') {
+      try {
+        options.projectId = readOptionValue(argv, index, '--project');
+      } catch (error) {
+        return {
+          ok: false,
+          error: error.message,
+        };
+      }
+      index += 1;
+    } else if (arg === '--limit') {
+      const value = argv[index + 1] ?? null;
+      options.traceLimit = value == null ? null : Number(value);
+      index += 1;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      return {
+        ok: false,
+        error: `Unknown argument: ${arg}`,
+      };
+    }
+  }
+
+  if (options.projectId == null || String(options.projectId).trim() === '') {
+    return {
+      ok: false,
+      error: 'Missing value for --project',
+    };
+  }
+
+  if (!Number.isInteger(options.traceLimit) || options.traceLimit <= 0) {
+    return {
+      ok: false,
+      error: 'Invalid value for --limit',
+    };
+  }
+
+  return {
+    ok: true,
+    options,
+  };
+}
+
+function renderHelp() {
+  return [
+    'Usage: node scripts/ao-metrics.js [options]',
+    '',
+    'Options:',
+    '  --project <project_id>   AO project id. Default: ciecopilot-home',
+    '  --limit <number>         Number of recent traces to include. Default: 5',
+    '  --json                   Print machine-readable JSON output',
+    '  -h, --help               Show help',
+  ].join('\n');
+}
+
+export async function runCli(argv, io = createDefaultIo()) {
+  const parsed = parseArgs(argv);
+  if (!parsed.ok) {
+    io.writeStderr(`${parsed.error}\n`);
+    return {
+      exitCode: 4,
+      report: null,
+    };
+  }
+
+  const { options } = parsed;
+  if (options.help) {
+    io.writeStdout(`${renderHelp()}\n`);
+    return {
+      exitCode: 0,
+      report: null,
+    };
+  }
+
+  try {
+    const report = await loadAoMetricsReport({
+      cwd: process.cwd(),
+      projectId: options.projectId,
+      traceLimit: options.traceLimit,
+    });
+
+    if (options.json) {
+      io.writeStdout(JSON.stringify(report, null, 2));
+    } else {
+      io.writeStdout(`${renderAoMetricsHumanSummary(report)}\n`);
+    }
+
+    return {
+      exitCode: 0,
+      report,
+    };
+  } catch (error) {
+    io.writeStderr(`${error.message}\n`);
+    return {
+      exitCode: 3,
+      report: null,
+    };
+  }
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+const executedFile = process.argv[1] ? path.resolve(process.argv[1]) : null;
+
+if (executedFile && executedFile === currentFile) {
+  const { exitCode } = await runCli(process.argv.slice(2));
+  process.exitCode = exitCode;
+}

--- a/scripts/ao/lib/action-executor.js
+++ b/scripts/ao/lib/action-executor.js
@@ -1,4 +1,5 @@
 import { createActionRecord } from './state-contracts.js';
+import { buildAssistExecutionAttemptMetric } from './run-metrics.js';
 
 export const ASSIST_ACTION_MODEL_SCHEMA_VERSION = 'ao.control-plane.action-model.v1alpha1';
 export const ASSIST_ACTION_MODEL_FORMAT = 'ao_control_plane_action_model';
@@ -370,6 +371,26 @@ function hasDurableAllowPolicy(record) {
   return policyDecisionId !== '' && record?.payload?.policy?.decision === 'allow';
 }
 
+function persistExecutionAttemptMetric(repository, {
+  controllerId,
+  task,
+  record,
+  model,
+  status,
+  reason,
+  timestamp,
+} = {}) {
+  repository.upsertExecutionAttemptMetric(buildAssistExecutionAttemptMetric({
+    task,
+    controllerId,
+    actionRecord: record,
+    model,
+    status,
+    reason,
+    now: timestamp,
+  }));
+}
+
 export async function executeAssistActions({
   repository,
   controllerId,
@@ -413,6 +434,15 @@ export async function executeAssistActions({
         },
         recordedAt: timestamp,
       });
+      persistExecutionAttemptMetric(repository, {
+        controllerId,
+        task,
+        record,
+        model,
+        status: 'blocked',
+        reason: 'policy_allow_required',
+        timestamp,
+      });
       blockedActionIds.push(record.action_id);
       continue;
     }
@@ -446,6 +476,15 @@ export async function executeAssistActions({
         },
         recordedAt: timestamp,
       });
+      persistExecutionAttemptMetric(repository, {
+        controllerId,
+        task,
+        record,
+        model,
+        status: 'blocked',
+        reason: blockingOverrides[0].reason,
+        timestamp,
+      });
       blockedActionIds.push(record.action_id);
       continue;
     }
@@ -472,6 +511,15 @@ export async function executeAssistActions({
         },
         recordedAt: timestamp,
       });
+      persistExecutionAttemptMetric(repository, {
+        controllerId,
+        task,
+        record,
+        model,
+        status: 'blocked',
+        reason: model.phase4_assist?.reason ?? 'phase4_assist_not_executable',
+        timestamp,
+      });
       blockedActionIds.push(record.action_id);
       continue;
     }
@@ -495,6 +543,15 @@ export async function executeAssistActions({
         policy_decision_id: record?.payload?.policy_decision_id ?? null,
       },
       recordedAt: timestamp,
+    });
+    persistExecutionAttemptMetric(repository, {
+      controllerId,
+      task,
+      record,
+      model,
+      status: 'executed',
+      reason: 'class_a_assist_execution',
+      timestamp,
     });
     executedActionIds.push(record.action_id);
   }

--- a/scripts/ao/lib/controller-loop.js
+++ b/scripts/ao/lib/controller-loop.js
@@ -30,6 +30,7 @@ import {
   buildAssistActionModel,
   executeAssistActions,
 } from './action-executor.js';
+import { buildControllerRunMetric } from './run-metrics.js';
 import {
   buildPolicyInputForAction,
   evaluatePolicyDecision,
@@ -548,6 +549,7 @@ export async function runControllerLoop({
         matchedPrs: ingestResult.matchedPrs,
         deliveryEvents: ingestResult.deliveryEvents,
       });
+      const prNumber = resolveLifecyclePrNumber(prBindings, ingestResult.matchedPrs);
 
       let lifecycleTopStatus = null;
       let proposedActionIds = [];
@@ -559,7 +561,6 @@ export async function runControllerLoop({
       let downgradedActionIds = [];
 
       if (resolvedMode === 'shadow' || resolvedMode === 'assist') {
-        const prNumber = resolveLifecyclePrNumber(prBindings, ingestResult.matchedPrs);
         const resolvedLifecycle = services.resolveLifecycleReport
           ? await services.resolveLifecycleReport({
               task,
@@ -645,6 +646,31 @@ export async function runControllerLoop({
           recordedAt: timestamp,
         });
       }
+
+      const completedAt = resolveNow(now);
+      const actionRecords = [...new Set(proposedActionIds)]
+        .map((actionId) => repository.getSnapshot().state.actions.find((record) => record.action_id === actionId) ?? null)
+        .filter(Boolean);
+      repository.upsertControllerRunMetric(buildControllerRunMetric({
+        task,
+        controllerId,
+        controllerMode: resolvedMode,
+        triggerKind: derivedTrigger,
+        lifecycleTopStatus,
+        startedAt: timestamp,
+        completedAt,
+        observationCount: ingestResult.ingested_count,
+        deliveryEventCount: ingestResult.delivery_event_count ?? 0,
+        proposedActionCount: proposedActionIds.length,
+        executedActionCount: executedActionIds.length,
+        blockedActionCount: blockedActionIds.length,
+        policyDecisionCount: policyDecisionIds.length,
+        policyBlockedActionCount: policyBlockedActionIds.length,
+        deniedActionCount: deniedActionIds.length,
+        downgradedActionCount: downgradedActionIds.length,
+        actionRecords,
+        prNumber,
+      }));
 
       taskResults.push({
         task_id: task.task_id,

--- a/scripts/ao/lib/manage-runner.js
+++ b/scripts/ao/lib/manage-runner.js
@@ -1,6 +1,10 @@
 import { createCheckpointStore } from './checkpoint-store.js';
 import { createHandoffProtocol } from './handoff-protocol.js';
 import { normalizeIssueIntake } from './issue-intake.js';
+import {
+  buildManagedTaskExecutionAttemptMetric,
+  completeManagedTaskExecutionAttemptMetric,
+} from './run-metrics.js';
 import { createStateRepository } from './state-repository.js';
 import { createTaskSpecRecord } from './state-contracts.js';
 import {
@@ -29,6 +33,16 @@ function matchesTaskIdentity(task, { taskId = null, issueNumber = null } = {}) {
   if (taskId && task.task_id === taskId) return true;
   if (issueNumber != null && task.issue_number === Number(issueNumber)) return true;
   return false;
+}
+
+function latestActiveManagedExecutionAttempt(snapshot, taskId) {
+  return [...(snapshot?.state?.execution_attempt_metrics ?? [])]
+    .filter((record) => (
+      record?.attempt_kind === 'managed_task'
+        && record?.task_id === taskId
+        && record?.status === 'active'
+    ))
+    .sort((left, right) => String(right?.started_at ?? '').localeCompare(String(left?.started_at ?? '')))[0] ?? null;
 }
 
 function releaseActiveOwnershipLeases(repository, taskId, now, reason) {
@@ -232,6 +246,7 @@ export async function runManageCommand({
   let handoffTransfer = null;
   let releasedOwnershipLeaseIds = [];
   let releasedPrBindingIds = [];
+  let acceptedHandoff = null;
 
   if (ownerSessionName && ['enroll', 'adopt', 'resume'].includes(command)) {
     if (command === 'resume') {
@@ -242,7 +257,7 @@ export async function runManageCommand({
       const latestOwnershipLease = latestTaskOwnershipLease(resumeSnapshot, task.task_id);
       const sameOwnerResume = latestOwnershipLease?.owner_session_name === ownerSessionName
         || activeOwnershipLeases.some((lease) => lease.owner_session_name === ownerSessionName);
-      const acceptedHandoff = sameOwnerResume
+      acceptedHandoff = sameOwnerResume
         ? null
         : handoffProtocol.resolveAcceptedHandoff({
             taskId: task.task_id,
@@ -337,6 +352,18 @@ export async function runManageCommand({
     repository.upsertPrBinding(prBinding);
   }
 
+  if (ownerSessionName && ['enroll', 'adopt', 'resume'].includes(command)) {
+    repository.upsertExecutionAttemptMetric(buildManagedTaskExecutionAttemptMetric({
+      task,
+      ownerSessionName,
+      ownerSessionId,
+      prNumber: resolvedPrNumber,
+      command,
+      acceptedHandoff: acceptedHandoff != null,
+      now: timestamp,
+    }));
+  }
+
   if (command === 'unmanage' || command === 'retire') {
     releasedOwnershipLeaseIds = releaseActiveOwnershipLeases(
       repository,
@@ -351,6 +378,19 @@ export async function runManageCommand({
         timestamp,
         reason ?? 'task_retired',
       );
+    }
+
+    const activeExecutionAttempt = latestActiveManagedExecutionAttempt(
+      repository.getSnapshot(),
+      task.task_id,
+    );
+    if (activeExecutionAttempt) {
+      repository.upsertExecutionAttemptMetric(completeManagedTaskExecutionAttemptMetric({
+        attemptRecord: activeExecutionAttempt,
+        status: command === 'retire' ? 'retired' : 'paused',
+        reason,
+        now: timestamp,
+      }));
     }
   }
 

--- a/scripts/ao/lib/measurement-taxonomy.js
+++ b/scripts/ao/lib/measurement-taxonomy.js
@@ -1,0 +1,202 @@
+import { LIFECYCLE_TRIGGERS, normalizeLifecycleTrigger } from './lifecycle-contracts.js';
+
+export const CONTROLLER_RUN_MEASUREMENT_SCHEMA_VERSION = 'ao.controller-run-measurement.v1alpha1';
+export const CONTROLLER_RUN_MEASUREMENT_FORMAT = 'ao_controller_run_measurement';
+export const EXECUTION_ATTEMPT_MEASUREMENT_SCHEMA_VERSION = 'ao.execution-attempt-measurement.v1alpha1';
+export const EXECUTION_ATTEMPT_MEASUREMENT_FORMAT = 'ao_execution_attempt_measurement';
+
+export const MEASUREMENT_TRIGGER_KINDS = [...LIFECYCLE_TRIGGERS];
+
+export const MEASUREMENT_ACTION_CLASSES = [
+  'continue_worker',
+  'notify_human',
+  'hold',
+  'human_gate',
+  'restore_worker',
+  'handoff_worker',
+  'unknown',
+];
+
+export const MEASUREMENT_INTERVENTION_KINDS = [
+  'human_gate',
+  'override',
+  'explicit_resume',
+  'successor_handoff',
+  'policy_block',
+  'preflight_block',
+];
+
+export const MEASUREMENT_RETRY_CAUSES = [
+  'none',
+  'explicit_resume',
+  'successor_handoff',
+  'policy_retry',
+  'preflight_retry',
+  'unknown',
+];
+
+export const MEASUREMENT_FAILURE_CLASSES = [
+  'none',
+  'ci_failure',
+  'review_blocked',
+  'merge_conflict',
+  'source_failure',
+  'human_gate',
+  'override',
+  'policy_block',
+  'preflight_block',
+  'worker_exit',
+  'successor_handoff',
+  'unknown',
+];
+
+function normalizeEnum(value, allowedValues, fallback = null) {
+  if (value == null && fallback != null) return fallback;
+  const normalized = String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/-/g, '_');
+  if (!allowedValues.includes(normalized)) {
+    throw new Error(`Unsupported measurement value: ${value}`);
+  }
+  return normalized;
+}
+
+function toPositiveCount(value) {
+  const normalized = Number(value);
+  if (!Number.isInteger(normalized) || normalized < 0) {
+    throw new Error(`Invalid measurement count: ${value}`);
+  }
+  return normalized;
+}
+
+export function normalizeMeasurementTrigger(trigger = 'manual') {
+  return normalizeLifecycleTrigger(trigger);
+}
+
+export function normalizeMeasurementActionClass(actionClass = 'unknown') {
+  return normalizeEnum(actionClass, MEASUREMENT_ACTION_CLASSES, 'unknown');
+}
+
+export function normalizeMeasurementInterventionKind(kind) {
+  return normalizeEnum(kind, MEASUREMENT_INTERVENTION_KINDS);
+}
+
+export function normalizeMeasurementRetryCause(cause = 'none') {
+  return normalizeEnum(cause, MEASUREMENT_RETRY_CAUSES, 'none');
+}
+
+export function normalizeMeasurementFailureClass(failureClass = 'none') {
+  return normalizeEnum(failureClass, MEASUREMENT_FAILURE_CLASSES, 'none');
+}
+
+export function createMeasurementCountMap(keys, values = {}) {
+  const counts = {};
+
+  for (const key of keys) {
+    counts[key] = 0;
+  }
+
+  for (const [key, value] of Object.entries(values ?? {})) {
+    if (!keys.includes(key)) {
+      throw new Error(`Unsupported measurement count key: ${key}`);
+    }
+    counts[key] = toPositiveCount(value);
+  }
+
+  return counts;
+}
+
+export function resolveMeasurementActionClass({
+  actionKind = null,
+  actionClass = null,
+} = {}) {
+  const normalizedActionKind = actionKind == null ? '' : String(actionKind).trim().toLowerCase();
+  const normalizedActionClass = actionClass == null ? '' : String(actionClass).trim().toLowerCase();
+
+  if (normalizedActionKind === 'continue_worker' || normalizedActionClass === 'continue_worker') {
+    return 'continue_worker';
+  }
+  if (normalizedActionKind === 'notify_human_ready' || normalizedActionClass === 'notify_human') {
+    return 'notify_human';
+  }
+  if (
+    ['hold_ci', 'hold_review', 'hold_mergeability', 'hold_local_control'].includes(normalizedActionKind)
+    || normalizedActionClass === 'hold'
+  ) {
+    return 'hold';
+  }
+  if (normalizedActionKind === 'human_gate' || normalizedActionClass === 'human_gate') {
+    return 'human_gate';
+  }
+  if (normalizedActionKind === 'restore_worker' || normalizedActionClass === 'restore_worker') {
+    return 'restore_worker';
+  }
+  if (normalizedActionKind === 'handoff_worker' || normalizedActionClass === 'handoff_worker') {
+    return 'handoff_worker';
+  }
+  return 'unknown';
+}
+
+export function resolveExecutionAttemptRetryCause({
+  command = null,
+  acceptedHandoff = false,
+} = {}) {
+  const normalizedCommand = command == null ? '' : String(command).trim().toLowerCase();
+
+  if (acceptedHandoff) return 'successor_handoff';
+  if (normalizedCommand === 'resume') return 'explicit_resume';
+  return 'none';
+}
+
+export function resolveExecutionAttemptFailureClass({
+  reason = null,
+  triggerKind = null,
+  lifecycleTopStatus = null,
+} = {}) {
+  const normalizedReason = reason == null ? '' : String(reason).trim().toLowerCase();
+  const normalizedTriggerKind = triggerKind == null ? null : normalizeMeasurementTrigger(triggerKind);
+  const normalizedLifecycleTopStatus = lifecycleTopStatus == null
+    ? null
+    : String(lifecycleTopStatus).trim().toLowerCase().replace(/-/g, '_');
+
+  if (normalizedReason.startsWith('override_')) return 'override';
+  if (normalizedReason === 'policy_allow_required') return 'policy_block';
+  if (normalizedReason.startsWith('runtime_preflight_') || normalizedReason === 'runtime_preflight_clean') {
+    return 'preflight_block';
+  }
+  if (normalizedReason === 'explicit_human_gate_required') return 'human_gate';
+  if (normalizedReason === 'worker_exited' || normalizedReason === 'worker_stale') return 'worker_exit';
+  if (normalizedReason.includes('handoff')) return 'successor_handoff';
+  if (normalizedLifecycleTopStatus === 'source_failure') return 'source_failure';
+  if (normalizedTriggerKind === 'ci_failed') return 'ci_failure';
+  if (['changes_requested', 'bugbot_comments'].includes(normalizedTriggerKind)) return 'review_blocked';
+  if (normalizedTriggerKind === 'merge_conflicts') return 'merge_conflict';
+  if (normalizedTriggerKind === 'agent_exited') return 'worker_exit';
+  return 'none';
+}
+
+export function resolveControllerRunFailureClass({
+  triggerKind = 'manual',
+  interventionCounts = createMeasurementCountMap(MEASUREMENT_INTERVENTION_KINDS),
+  lifecycleTopStatus = null,
+} = {}) {
+  const normalizedTriggerKind = normalizeMeasurementTrigger(triggerKind);
+  const normalizedLifecycleTopStatus = lifecycleTopStatus == null
+    ? null
+    : String(lifecycleTopStatus).trim().toLowerCase().replace(/-/g, '_');
+
+  if ((interventionCounts?.preflight_block ?? 0) > 0) return 'preflight_block';
+  if ((interventionCounts?.policy_block ?? 0) > 0) return 'policy_block';
+  if ((interventionCounts?.override ?? 0) > 0) return 'override';
+  if ((interventionCounts?.human_gate ?? 0) > 0 || normalizedLifecycleTopStatus === 'human_gate') {
+    return 'human_gate';
+  }
+  if ((interventionCounts?.successor_handoff ?? 0) > 0) return 'successor_handoff';
+  if (normalizedLifecycleTopStatus === 'source_failure') return 'source_failure';
+  if (normalizedTriggerKind === 'ci_failed') return 'ci_failure';
+  if (['changes_requested', 'bugbot_comments'].includes(normalizedTriggerKind)) return 'review_blocked';
+  if (normalizedTriggerKind === 'merge_conflicts') return 'merge_conflict';
+  if (normalizedTriggerKind === 'agent_exited') return 'worker_exit';
+  return 'none';
+}

--- a/scripts/ao/lib/run-metrics.js
+++ b/scripts/ao/lib/run-metrics.js
@@ -1,0 +1,506 @@
+import { createHash } from 'node:crypto';
+
+import { findRepoRoot } from './repo-root.js';
+import { createStateRepository } from './state-repository.js';
+import {
+  createControllerRunMetricRecord,
+  createExecutionAttemptMetricRecord,
+} from './state-contracts.js';
+import {
+  MEASUREMENT_ACTION_CLASSES,
+  MEASUREMENT_FAILURE_CLASSES,
+  MEASUREMENT_INTERVENTION_KINDS,
+  MEASUREMENT_RETRY_CAUSES,
+  MEASUREMENT_TRIGGER_KINDS,
+  createMeasurementCountMap,
+  normalizeMeasurementTrigger,
+  resolveControllerRunFailureClass,
+  resolveExecutionAttemptFailureClass,
+  resolveExecutionAttemptRetryCause,
+  resolveMeasurementActionClass,
+} from './measurement-taxonomy.js';
+
+export const DEFAULT_PROJECT_ID = 'ciecopilot-home';
+export const AO_METRICS_REPORT_SCHEMA_VERSION = 'ao.metrics-report.v1alpha1';
+export const AO_METRICS_REPORT_FORMAT = 'ao_metrics_report';
+
+function resolveNow(now) {
+  if (typeof now === 'function') return resolveNow(now());
+  if (typeof now === 'string' && now.trim() !== '') return now.trim();
+  return new Date().toISOString();
+}
+
+function sanitizeToken(value) {
+  return String(value ?? '')
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '_');
+}
+
+function buildDeterministicId(prefix, payload) {
+  const fingerprint = createHash('sha1')
+    .update(JSON.stringify(payload))
+    .digest('hex')
+    .slice(0, 12);
+  return `${prefix}-${fingerprint}`;
+}
+
+function parseTimestamp(value) {
+  if (value == null) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.getTime();
+}
+
+function calculateDurationMs(startedAt, completedAt) {
+  const startedAtMs = parseTimestamp(startedAt);
+  const completedAtMs = parseTimestamp(completedAt);
+  if (startedAtMs == null || completedAtMs == null) return null;
+  return Math.max(0, completedAtMs - startedAtMs);
+}
+
+function zeroTokenUsage() {
+  return {
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+  };
+}
+
+function zeroCost() {
+  return {
+    usd: null,
+  };
+}
+
+function sumCountMaps(keys, records = []) {
+  const total = createMeasurementCountMap(keys);
+
+  for (const record of records) {
+    for (const key of keys) {
+      total[key] += Number(record?.[key] ?? 0);
+    }
+  }
+
+  return total;
+}
+
+function countValues(keys, values = []) {
+  const counts = createMeasurementCountMap(keys);
+
+  for (const value of values) {
+    if (value == null || !keys.includes(value)) continue;
+    counts[value] += 1;
+  }
+
+  return counts;
+}
+
+function compareMetricRecords(left, right) {
+  const leftTimestamp = String(
+    left?.completed_at ?? left?.started_at ?? left?.recorded_at ?? '',
+  );
+  const rightTimestamp = String(
+    right?.completed_at ?? right?.started_at ?? right?.recorded_at ?? '',
+  );
+  if (leftTimestamp !== rightTimestamp) {
+    return rightTimestamp.localeCompare(leftTimestamp);
+  }
+  return String(
+    right?.controller_run_metric_id
+      ?? right?.execution_attempt_metric_id
+      ?? '',
+  ).localeCompare(String(
+    left?.controller_run_metric_id
+      ?? left?.execution_attempt_metric_id
+      ?? '',
+  ));
+}
+
+function buildInterventionCountsFromReason(reason, {
+  actionKind = null,
+  retryCause = 'none',
+} = {}) {
+  const counts = createMeasurementCountMap(MEASUREMENT_INTERVENTION_KINDS);
+  const normalizedReason = reason == null ? '' : String(reason).trim().toLowerCase();
+
+  if (normalizedReason.startsWith('override_')) counts.override += 1;
+  if (normalizedReason === 'policy_allow_required') counts.policy_block += 1;
+  if (normalizedReason.startsWith('runtime_preflight_') || normalizedReason === 'runtime_preflight_clean') {
+    counts.preflight_block += 1;
+  }
+  if (normalizedReason === 'explicit_human_gate_required') counts.human_gate += 1;
+  if (normalizedReason.includes('handoff') || actionKind === 'handoff_worker') counts.successor_handoff += 1;
+  if (retryCause === 'explicit_resume') counts.explicit_resume += 1;
+  if (retryCause === 'successor_handoff') counts.successor_handoff += 1;
+
+  return counts;
+}
+
+function buildActionClassCounts(actionRecords = []) {
+  const counts = createMeasurementCountMap(MEASUREMENT_ACTION_CLASSES);
+
+  for (const record of actionRecords) {
+    const actionClass = resolveMeasurementActionClass({
+      actionKind: record?.action_kind ?? null,
+      actionClass: record?.payload?.action_class ?? record?.payload?.action_model?.action_class ?? null,
+    });
+    counts[actionClass] += 1;
+  }
+
+  return counts;
+}
+
+function buildControllerInterventionCounts(actionRecords = []) {
+  const counts = createMeasurementCountMap(MEASUREMENT_INTERVENTION_KINDS);
+
+  for (const record of actionRecords) {
+    const policyDecision = record?.payload?.policy?.decision ?? null;
+    if (policyDecision === 'deny' || policyDecision === 'downgrade') {
+      counts.policy_block += 1;
+    }
+
+    const actionKind = record?.action_kind ?? null;
+    const actionClass = resolveMeasurementActionClass({
+      actionKind,
+      actionClass: record?.payload?.action_class ?? record?.payload?.action_model?.action_class ?? null,
+    });
+    if (actionClass === 'human_gate') counts.human_gate += 1;
+    if (actionClass === 'handoff_worker') counts.successor_handoff += 1;
+
+    const attemptCounts = buildInterventionCountsFromReason(
+      record?.payload?.execution?.reason ?? null,
+      { actionKind },
+    );
+    for (const key of MEASUREMENT_INTERVENTION_KINDS) {
+      counts[key] += attemptCounts[key];
+    }
+  }
+
+  return counts;
+}
+
+export function buildControllerRunMetricId({
+  taskId,
+  controllerId,
+  startedAt,
+} = {}) {
+  return buildDeterministicId('controller-run', {
+    task_id: taskId,
+    controller_id: controllerId,
+    started_at: startedAt,
+  });
+}
+
+export function buildExecutionAttemptMetricId({
+  attemptKind,
+  taskId,
+  startedAt,
+  ownerSessionName = null,
+  actionId = null,
+  command = null,
+} = {}) {
+  return buildDeterministicId('execution-attempt', {
+    attempt_kind: attemptKind,
+    task_id: taskId,
+    started_at: startedAt,
+    owner_session_name: ownerSessionName,
+    action_id: actionId,
+    command,
+  });
+}
+
+export function buildAssistExecutionAttemptMetric({
+  task,
+  controllerId,
+  actionRecord,
+  model,
+  status,
+  reason = null,
+  now = new Date().toISOString(),
+} = {}) {
+  const timestamp = resolveNow(now);
+  const retryCause = 'none';
+  const actionKind = actionRecord?.action_kind ?? null;
+  const actionClass = resolveMeasurementActionClass({
+    actionKind,
+    actionClass: model?.action_class ?? actionRecord?.payload?.action_class ?? null,
+  });
+  const interventionCounts = buildInterventionCountsFromReason(reason, {
+    actionKind,
+    retryCause,
+  });
+
+  return createExecutionAttemptMetricRecord({
+    execution_attempt_metric_id: buildExecutionAttemptMetricId({
+      attemptKind: 'assist_action',
+      taskId: task?.task_id ?? 'unknown-task',
+      startedAt: timestamp,
+      actionId: actionRecord?.action_id ?? null,
+    }),
+    attempt_kind: 'assist_action',
+    task_id: task?.task_id ?? null,
+    issue_number: task?.issue_number ?? null,
+    pr_number: model?.pr_number ?? actionRecord?.payload?.pr_number ?? null,
+    controller_id: controllerId,
+    owner_session_name: null,
+    owner_session_id: null,
+    action_id: actionRecord?.action_id ?? null,
+    action_kind: actionKind,
+    action_class: actionClass,
+    command: null,
+    status,
+    retry_cause: retryCause,
+    failure_class: resolveExecutionAttemptFailureClass({
+      reason,
+      triggerKind: model?.derived_trigger ?? null,
+      lifecycleTopStatus: model?.lifecycle_top_status ?? null,
+    }),
+    reason,
+    started_at: timestamp,
+    completed_at: timestamp,
+    duration_ms: 0,
+    intervention_counts: interventionCounts,
+    token_usage: zeroTokenUsage(),
+    cost: zeroCost(),
+  });
+}
+
+export function buildManagedTaskExecutionAttemptMetric({
+  task,
+  ownerSessionName = null,
+  ownerSessionId = null,
+  prNumber = null,
+  command,
+  acceptedHandoff = false,
+  now = new Date().toISOString(),
+} = {}) {
+  const timestamp = resolveNow(now);
+  const retryCause = resolveExecutionAttemptRetryCause({
+    command,
+    acceptedHandoff,
+  });
+
+  return createExecutionAttemptMetricRecord({
+    execution_attempt_metric_id: buildExecutionAttemptMetricId({
+      attemptKind: 'managed_task',
+      taskId: task?.task_id ?? 'unknown-task',
+      startedAt: timestamp,
+      ownerSessionName,
+      command,
+    }),
+    attempt_kind: 'managed_task',
+    task_id: task?.task_id ?? null,
+    issue_number: task?.issue_number ?? null,
+    pr_number: prNumber ?? null,
+    controller_id: null,
+    owner_session_name: ownerSessionName,
+    owner_session_id: ownerSessionId,
+    action_id: null,
+    action_kind: null,
+    action_class: null,
+    command,
+    status: 'active',
+    retry_cause: retryCause,
+    failure_class: 'none',
+    reason: null,
+    started_at: timestamp,
+    completed_at: null,
+    duration_ms: null,
+    intervention_counts: buildInterventionCountsFromReason(null, {
+      retryCause,
+    }),
+    token_usage: zeroTokenUsage(),
+    cost: zeroCost(),
+  });
+}
+
+export function completeManagedTaskExecutionAttemptMetric({
+  attemptRecord,
+  status,
+  reason = null,
+  now = new Date().toISOString(),
+} = {}) {
+  const timestamp = resolveNow(now);
+
+  return createExecutionAttemptMetricRecord({
+    ...attemptRecord,
+    status,
+    reason,
+    completed_at: timestamp,
+    duration_ms: calculateDurationMs(attemptRecord?.started_at, timestamp),
+    failure_class: resolveExecutionAttemptFailureClass({ reason }),
+  });
+}
+
+export function buildControllerRunMetric({
+  task,
+  controllerId,
+  controllerMode,
+  triggerKind,
+  lifecycleTopStatus = null,
+  startedAt,
+  completedAt = startedAt,
+  observationCount = 0,
+  deliveryEventCount = 0,
+  proposedActionCount = 0,
+  executedActionCount = 0,
+  blockedActionCount = 0,
+  policyDecisionCount = 0,
+  policyBlockedActionCount = 0,
+  deniedActionCount = 0,
+  downgradedActionCount = 0,
+  actionRecords = [],
+  prNumber = null,
+} = {}) {
+  const actionClassCounts = buildActionClassCounts(actionRecords);
+  const interventionCounts = buildControllerInterventionCounts(actionRecords);
+
+  return createControllerRunMetricRecord({
+    controller_run_metric_id: buildControllerRunMetricId({
+      taskId: task?.task_id ?? 'unknown-task',
+      controllerId,
+      startedAt,
+    }),
+    task_id: task?.task_id ?? null,
+    issue_number: task?.issue_number ?? null,
+    pr_number: prNumber,
+    controller_id: controllerId,
+    controller_mode: controllerMode,
+    trigger_kind: normalizeMeasurementTrigger(triggerKind),
+    lifecycle_top_status: lifecycleTopStatus,
+    failure_class: resolveControllerRunFailureClass({
+      triggerKind,
+      interventionCounts,
+      lifecycleTopStatus,
+    }),
+    started_at: startedAt,
+    completed_at: completedAt,
+    duration_ms: calculateDurationMs(startedAt, completedAt),
+    observation_count: observationCount,
+    delivery_event_count: deliveryEventCount,
+    proposed_action_count: proposedActionCount,
+    executed_action_count: executedActionCount,
+    blocked_action_count: blockedActionCount,
+    policy_decision_count: policyDecisionCount,
+    policy_blocked_action_count: policyBlockedActionCount,
+    denied_action_count: deniedActionCount,
+    downgraded_action_count: downgradedActionCount,
+    action_class_counts: actionClassCounts,
+    intervention_counts: interventionCounts,
+    token_usage: zeroTokenUsage(),
+    cost: zeroCost(),
+  });
+}
+
+function buildZeroMetricsSummary() {
+  return {
+    controller_run_count: 0,
+    execution_attempt_count: 0,
+    trigger_counts: createMeasurementCountMap(MEASUREMENT_TRIGGER_KINDS),
+    action_class_counts: createMeasurementCountMap(MEASUREMENT_ACTION_CLASSES),
+    intervention_counts: createMeasurementCountMap(MEASUREMENT_INTERVENTION_KINDS),
+    failure_class_counts: createMeasurementCountMap(MEASUREMENT_FAILURE_CLASSES),
+    retry_cause_counts: createMeasurementCountMap(MEASUREMENT_RETRY_CAUSES),
+  };
+}
+
+export function buildAoMetricsReport({
+  projectId = DEFAULT_PROJECT_ID,
+  repoRoot = null,
+  snapshot = null,
+  traceLimit = 5,
+} = {}) {
+  const controllerRuns = [...(snapshot?.state?.controller_run_metrics ?? [])].sort(compareMetricRecords);
+  const executionAttempts = [...(snapshot?.state?.execution_attempt_metrics ?? [])].sort(compareMetricRecords);
+
+  const summary = buildZeroMetricsSummary();
+  summary.controller_run_count = controllerRuns.length;
+  summary.execution_attempt_count = executionAttempts.length;
+  summary.trigger_counts = countValues(
+    MEASUREMENT_TRIGGER_KINDS,
+    controllerRuns.map((record) => record.trigger_kind),
+  );
+  summary.action_class_counts = sumCountMaps(
+    MEASUREMENT_ACTION_CLASSES,
+    controllerRuns.map((record) => record.action_class_counts),
+  );
+  summary.intervention_counts = sumCountMaps(
+    MEASUREMENT_INTERVENTION_KINDS,
+    [
+      ...controllerRuns.map((record) => record.intervention_counts),
+      ...executionAttempts.map((record) => record.intervention_counts),
+    ],
+  );
+  summary.failure_class_counts = countValues(
+    MEASUREMENT_FAILURE_CLASSES,
+    [
+      ...controllerRuns.map((record) => record.failure_class),
+      ...executionAttempts.map((record) => record.failure_class),
+    ],
+  );
+  summary.retry_cause_counts = countValues(
+    MEASUREMENT_RETRY_CAUSES,
+    executionAttempts.map((record) => record.retry_cause),
+  );
+
+  return {
+    schema_version: AO_METRICS_REPORT_SCHEMA_VERSION,
+    report_format: AO_METRICS_REPORT_FORMAT,
+    project_id: projectId,
+    repo_root: repoRoot,
+    summary,
+    recent_traces: {
+      controller_runs: controllerRuns.slice(0, traceLimit),
+      execution_attempts: executionAttempts.slice(0, traceLimit),
+    },
+  };
+}
+
+export async function loadAoMetricsReport({
+  cwd = process.cwd(),
+  repoRoot = null,
+  projectId = DEFAULT_PROJECT_ID,
+  traceLimit = 5,
+} = {}) {
+  const resolvedRepoRoot = repoRoot ?? findRepoRoot(cwd);
+  if (!resolvedRepoRoot) {
+    throw new Error(`Could not locate repo root from ${cwd}`);
+  }
+
+  const repository = createStateRepository({
+    repoRoot: resolvedRepoRoot,
+    projectId,
+  });
+
+  return buildAoMetricsReport({
+    projectId,
+    repoRoot: resolvedRepoRoot,
+    snapshot: repository.getSnapshot(),
+    traceLimit,
+  });
+}
+
+function formatCountMap(counts) {
+  return Object.entries(counts)
+    .filter(([, value]) => value > 0)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(', ') || 'none';
+}
+
+export function renderAoMetricsHumanSummary(report) {
+  const controllerTrace = (report.recent_traces?.controller_runs ?? [])
+    .map((record) => `${record.task_id}:${record.trigger_kind}:${record.failure_class}`);
+  const executionTrace = (report.recent_traces?.execution_attempts ?? [])
+    .map((record) => `${record.task_id}:${record.command ?? record.action_kind ?? record.status}:${record.retry_cause}`);
+
+  return [
+    `project_id: ${report.project_id}`,
+    `controller_runs: ${report.summary.controller_run_count}`,
+    `execution_attempts: ${report.summary.execution_attempt_count}`,
+    `interventions: ${formatCountMap(report.summary.intervention_counts)}`,
+    `failures: ${formatCountMap(report.summary.failure_class_counts)}`,
+    `retries: ${formatCountMap(report.summary.retry_cause_counts)}`,
+    `recent_controller_runs: ${controllerTrace.join(', ') || 'none'}`,
+    `recent_execution_attempts: ${executionTrace.join(', ') || 'none'}`,
+  ].join('\n');
+}

--- a/scripts/ao/lib/state-contracts.js
+++ b/scripts/ao/lib/state-contracts.js
@@ -1,5 +1,20 @@
 import { createRuntimePreflightSnapshot } from './runtime-contracts.js';
 import { createTaskSpecSnapshot } from './task-spec.js';
+import {
+  CONTROLLER_RUN_MEASUREMENT_FORMAT,
+  CONTROLLER_RUN_MEASUREMENT_SCHEMA_VERSION,
+  EXECUTION_ATTEMPT_MEASUREMENT_FORMAT,
+  EXECUTION_ATTEMPT_MEASUREMENT_SCHEMA_VERSION,
+  MEASUREMENT_ACTION_CLASSES,
+  MEASUREMENT_FAILURE_CLASSES,
+  MEASUREMENT_INTERVENTION_KINDS,
+  MEASUREMENT_RETRY_CAUSES,
+  createMeasurementCountMap,
+  normalizeMeasurementActionClass,
+  normalizeMeasurementFailureClass,
+  normalizeMeasurementRetryCause,
+  normalizeMeasurementTrigger,
+} from './measurement-taxonomy.js';
 
 export const CONTROL_PLANE_SCHEMA_VERSION = 'ao.control-plane.schema.v1alpha1';
 export const CONTROL_PLANE_SCHEMA_FORMAT = 'ao_control_plane_schema';
@@ -7,7 +22,7 @@ export const CONTROL_PLANE_STATE_SCHEMA_VERSION = 'ao.control-plane.state.v1alph
 export const CONTROL_PLANE_STATE_FORMAT = 'ao_control_plane_state';
 export const CONTROL_PLANE_AUDIT_SCHEMA_VERSION = 'ao.control-plane.audit.v1alpha1';
 export const CONTROL_PLANE_AUDIT_FORMAT = 'ao_control_plane_audit_entry';
-export const CONTROL_PLANE_LATEST_VERSION = 7;
+export const CONTROL_PLANE_LATEST_VERSION = 8;
 export const CONTROL_PLANE_DEFAULT_CONTROLLER_ID = 'default';
 export const CHECKPOINT_SCHEMA_VERSION = 'ao.checkpoint.v1alpha1';
 export const CHECKPOINT_FORMAT = 'ao_checkpoint';
@@ -36,6 +51,8 @@ export const CREDENTIAL_PROVENANCE_TRUST_DECISIONS = ['trusted', 'untrusted'];
 export const HANDOFF_REQUEST_STATUSES = ['open', 'accepted', 'rejected', 'expired', 'completed'];
 export const HANDOFF_CLAIM_STATUSES = ['pending', 'blocked', 'accepted', 'rejected', 'expired'];
 export const HANDOFF_DECISION_OUTCOMES = ['accept', 'reject', 'expire'];
+export const EXECUTION_ATTEMPT_KINDS = ['assist_action', 'managed_task'];
+export const EXECUTION_ATTEMPT_STATUSES = ['active', 'executed', 'blocked', 'paused', 'retired', 'completed'];
 
 function isPlainObject(value) {
   return value != null && typeof value === 'object' && !Array.isArray(value);
@@ -122,6 +139,96 @@ function normalizeMetadata(value = {}) {
   return cloneJsonValue(value);
 }
 
+function normalizeNullableNumber(value, fieldName) {
+  if (value == null) return null;
+  const normalized = Number(value);
+  if (!Number.isFinite(normalized) || normalized < 0) {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+  return normalized;
+}
+
+function normalizeCountMap(values, fieldName, keys) {
+  if (values == null) return createMeasurementCountMap(keys);
+  if (!isPlainObject(values)) {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+
+  const nextValues = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (!keys.includes(key)) {
+      throw new Error(`Invalid ${fieldName}.${key}`);
+    }
+    nextValues[key] = normalizePositiveInteger(value, `${fieldName}.${key}`, {
+      allowZero: true,
+    });
+  }
+
+  return createMeasurementCountMap(keys, nextValues);
+}
+
+function normalizeActionClassCounts(values) {
+  if (values == null) return createMeasurementCountMap(MEASUREMENT_ACTION_CLASSES);
+  if (!isPlainObject(values)) {
+    throw new Error('Invalid action_class_counts');
+  }
+
+  const nextValues = {};
+  for (const [key, value] of Object.entries(values)) {
+    const normalizedKey = normalizeMeasurementActionClass(key);
+    nextValues[normalizedKey] = (nextValues[normalizedKey] ?? 0) + normalizePositiveInteger(
+      value,
+      `action_class_counts.${key}`,
+      { allowZero: true },
+    );
+  }
+
+  return createMeasurementCountMap(MEASUREMENT_ACTION_CLASSES, nextValues);
+}
+
+function normalizeTokenUsage(value) {
+  if (value == null) {
+    return {
+      input_tokens: null,
+      output_tokens: null,
+      total_tokens: null,
+    };
+  }
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid token_usage');
+  }
+
+  return {
+    input_tokens: normalizePositiveInteger(value.input_tokens, 'token_usage.input_tokens', {
+      nullable: true,
+      allowZero: true,
+    }),
+    output_tokens: normalizePositiveInteger(value.output_tokens, 'token_usage.output_tokens', {
+      nullable: true,
+      allowZero: true,
+    }),
+    total_tokens: normalizePositiveInteger(value.total_tokens, 'token_usage.total_tokens', {
+      nullable: true,
+      allowZero: true,
+    }),
+  };
+}
+
+function normalizeCost(value) {
+  if (value == null) {
+    return {
+      usd: null,
+    };
+  }
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid cost');
+  }
+
+  return {
+    usd: normalizeNullableNumber(value.usd, 'cost.usd'),
+  };
+}
+
 function normalizeLineage(value = {}) {
   if (!isPlainObject(value)) {
     throw new Error('Invalid lineage');
@@ -193,6 +300,8 @@ export function createEmptyControlPlaneState({
     handoff_claims: [],
     handoff_decisions: [],
     handoff_transfers: [],
+    controller_run_metrics: [],
+    execution_attempt_metrics: [],
   };
 }
 
@@ -903,6 +1012,162 @@ export function createHandoffTransferRecord({
     transferred_at: normalizeIsoTimestamp(transferred_at, 'transferred_at'),
     transferred_by: normalizeOptionalString(transferred_by),
     reason: normalizeOptionalString(reason),
+    metadata: normalizeMetadata(metadata),
+  };
+}
+
+export function createControllerRunMetricRecord({
+  controller_run_metric_id,
+  task_id,
+  issue_number = null,
+  pr_number = null,
+  controller_id,
+  controller_mode,
+  trigger_kind = 'manual',
+  lifecycle_top_status = null,
+  failure_class = 'none',
+  started_at,
+  completed_at,
+  duration_ms = null,
+  observation_count = 0,
+  delivery_event_count = 0,
+  proposed_action_count = 0,
+  executed_action_count = 0,
+  blocked_action_count = 0,
+  policy_decision_count = 0,
+  policy_blocked_action_count = 0,
+  denied_action_count = 0,
+  downgraded_action_count = 0,
+  action_class_counts = null,
+  intervention_counts = null,
+  token_usage = null,
+  cost = null,
+  metadata = {},
+} = {}) {
+  return {
+    schema_version: CONTROLLER_RUN_MEASUREMENT_SCHEMA_VERSION,
+    format: CONTROLLER_RUN_MEASUREMENT_FORMAT,
+    controller_run_metric_id: normalizeRequiredString(
+      controller_run_metric_id,
+      'controller_run_metric_id',
+    ),
+    task_id: normalizeRequiredString(task_id, 'task_id'),
+    issue_number: normalizePositiveInteger(issue_number, 'issue_number', { nullable: true }),
+    pr_number: normalizePositiveInteger(pr_number, 'pr_number', { nullable: true }),
+    controller_id: normalizeRequiredString(controller_id, 'controller_id'),
+    controller_mode: normalizeEnum(controller_mode, 'controller_mode', CONTROLLER_MODES),
+    trigger_kind: normalizeMeasurementTrigger(trigger_kind),
+    lifecycle_top_status: normalizeOptionalString(lifecycle_top_status),
+    failure_class: normalizeMeasurementFailureClass(failure_class),
+    started_at: normalizeIsoTimestamp(started_at, 'started_at'),
+    completed_at: normalizeIsoTimestamp(completed_at, 'completed_at'),
+    duration_ms: normalizePositiveInteger(duration_ms, 'duration_ms', {
+      nullable: true,
+      allowZero: true,
+    }),
+    observation_count: normalizePositiveInteger(observation_count, 'observation_count', {
+      allowZero: true,
+    }),
+    delivery_event_count: normalizePositiveInteger(delivery_event_count, 'delivery_event_count', {
+      allowZero: true,
+    }),
+    proposed_action_count: normalizePositiveInteger(proposed_action_count, 'proposed_action_count', {
+      allowZero: true,
+    }),
+    executed_action_count: normalizePositiveInteger(executed_action_count, 'executed_action_count', {
+      allowZero: true,
+    }),
+    blocked_action_count: normalizePositiveInteger(blocked_action_count, 'blocked_action_count', {
+      allowZero: true,
+    }),
+    policy_decision_count: normalizePositiveInteger(policy_decision_count, 'policy_decision_count', {
+      allowZero: true,
+    }),
+    policy_blocked_action_count: normalizePositiveInteger(
+      policy_blocked_action_count,
+      'policy_blocked_action_count',
+      { allowZero: true },
+    ),
+    denied_action_count: normalizePositiveInteger(denied_action_count, 'denied_action_count', {
+      allowZero: true,
+    }),
+    downgraded_action_count: normalizePositiveInteger(
+      downgraded_action_count,
+      'downgraded_action_count',
+      { allowZero: true },
+    ),
+    action_class_counts: normalizeActionClassCounts(action_class_counts),
+    intervention_counts: normalizeCountMap(
+      intervention_counts,
+      'intervention_counts',
+      MEASUREMENT_INTERVENTION_KINDS,
+    ),
+    token_usage: normalizeTokenUsage(token_usage),
+    cost: normalizeCost(cost),
+    metadata: normalizeMetadata(metadata),
+  };
+}
+
+export function createExecutionAttemptMetricRecord({
+  execution_attempt_metric_id,
+  attempt_kind,
+  task_id,
+  issue_number = null,
+  pr_number = null,
+  controller_id = null,
+  owner_session_name = null,
+  owner_session_id = null,
+  action_id = null,
+  action_kind = null,
+  action_class = null,
+  command = null,
+  status,
+  retry_cause = 'none',
+  failure_class = 'none',
+  reason = null,
+  started_at,
+  completed_at = null,
+  duration_ms = null,
+  intervention_counts = null,
+  token_usage = null,
+  cost = null,
+  metadata = {},
+} = {}) {
+  return {
+    schema_version: EXECUTION_ATTEMPT_MEASUREMENT_SCHEMA_VERSION,
+    format: EXECUTION_ATTEMPT_MEASUREMENT_FORMAT,
+    execution_attempt_metric_id: normalizeRequiredString(
+      execution_attempt_metric_id,
+      'execution_attempt_metric_id',
+    ),
+    attempt_kind: normalizeEnum(attempt_kind, 'attempt_kind', EXECUTION_ATTEMPT_KINDS),
+    task_id: normalizeRequiredString(task_id, 'task_id'),
+    issue_number: normalizePositiveInteger(issue_number, 'issue_number', { nullable: true }),
+    pr_number: normalizePositiveInteger(pr_number, 'pr_number', { nullable: true }),
+    controller_id: normalizeOptionalString(controller_id),
+    owner_session_name: normalizeOptionalString(owner_session_name),
+    owner_session_id: normalizeOptionalString(owner_session_id),
+    action_id: normalizeOptionalString(action_id),
+    action_kind: normalizeOptionalString(action_kind),
+    action_class: action_class == null ? null : normalizeMeasurementActionClass(action_class),
+    command: normalizeOptionalString(command),
+    status: normalizeEnum(status, 'status', EXECUTION_ATTEMPT_STATUSES),
+    retry_cause: normalizeMeasurementRetryCause(retry_cause),
+    failure_class: normalizeMeasurementFailureClass(failure_class),
+    reason: normalizeOptionalString(reason),
+    started_at: normalizeIsoTimestamp(started_at, 'started_at'),
+    completed_at: normalizeIsoTimestamp(completed_at, 'completed_at', { nullable: true }),
+    duration_ms: normalizePositiveInteger(duration_ms, 'duration_ms', {
+      nullable: true,
+      allowZero: true,
+    }),
+    intervention_counts: normalizeCountMap(
+      intervention_counts,
+      'intervention_counts',
+      MEASUREMENT_INTERVENTION_KINDS,
+    ),
+    token_usage: normalizeTokenUsage(token_usage),
+    cost: normalizeCost(cost),
     metadata: normalizeMetadata(metadata),
   };
 }

--- a/scripts/ao/lib/state-migrations.js
+++ b/scripts/ao/lib/state-migrations.js
@@ -52,6 +52,11 @@ export const CONTROL_PLANE_HANDOFF_PROTOCOL_MIGRATION = {
   key: '0007_handoff_protocol_v1',
 };
 
+export const CONTROL_PLANE_MEASUREMENT_METRICS_MIGRATION = {
+  version: 8,
+  key: '0008_measurement_metrics_v1',
+};
+
 const CONTROL_PLANE_MIGRATIONS = [
   CONTROL_PLANE_BOOTSTRAP_MIGRATION,
   CONTROL_PLANE_TASK_SPEC_MIGRATION,
@@ -60,6 +65,7 @@ const CONTROL_PLANE_MIGRATIONS = [
   CONTROL_PLANE_RUNTIME_PREFLIGHT_MIGRATION,
   CONTROL_PLANE_CHECKPOINT_MIGRATION,
   CONTROL_PLANE_HANDOFF_PROTOCOL_MIGRATION,
+  CONTROL_PLANE_MEASUREMENT_METRICS_MIGRATION,
 ];
 
 function resolveNow(now) {
@@ -127,6 +133,8 @@ function buildBootstrapState({
     'handoff_claims',
     'handoff_decisions',
     'handoff_transfers',
+    'controller_run_metrics',
+    'execution_attempt_metrics',
   ]) {
     if (Array.isArray(existingState?.[collectionKey])) {
       state[collectionKey] = cloneJsonValue(existingState[collectionKey]);
@@ -239,6 +247,14 @@ function applyMigration({
     });
   }
 
+  if (migration.version === CONTROL_PLANE_MEASUREMENT_METRICS_MIGRATION.version) {
+    return buildBootstrapState({
+      projectId,
+      now,
+      existingState: state,
+    });
+  }
+
   throw new Error(`Unsupported migration version ${migration.version}`);
 }
 
@@ -282,6 +298,13 @@ function buildAuditSummary(migration) {
     return {
       operation: 'migrate',
       summary: 'Applied control-plane handoff-protocol migration.',
+    };
+  }
+
+  if (migration.version === CONTROL_PLANE_MEASUREMENT_METRICS_MIGRATION.version) {
+    return {
+      operation: 'migrate',
+      summary: 'Applied control-plane measurement-metrics migration.',
     };
   }
 

--- a/scripts/ao/lib/state-repository.js
+++ b/scripts/ao/lib/state-repository.js
@@ -8,10 +8,12 @@ import {
   createControlPlaneSchema,
   createControllerLease,
   createControllerModeRecord,
+  createControllerRunMetricRecord,
   createControllerCursorRecord,
   createCredentialProvenanceRecord,
   createDeliveryEventRecord,
   createEmptyControlPlaneState,
+  createExecutionAttemptMetricRecord,
   createHandoffClaimRecord,
   createHandoffDecisionRecord,
   createHandoffRequestRecord,
@@ -127,6 +129,14 @@ export function createStateRepository({
     nextState.handoff_claims = sortCollectionByKey(nextState.handoff_claims, 'claim_id');
     nextState.handoff_decisions = sortCollectionByKey(nextState.handoff_decisions, 'decision_id');
     nextState.handoff_transfers = sortCollectionByKey(nextState.handoff_transfers, 'transfer_id');
+    nextState.controller_run_metrics = sortCollectionByKey(
+      nextState.controller_run_metrics,
+      'controller_run_metric_id',
+    );
+    nextState.execution_attempt_metrics = sortCollectionByKey(
+      nextState.execution_attempt_metrics,
+      'execution_attempt_metric_id',
+    );
 
     return {
       bootstrapped: true,
@@ -437,6 +447,28 @@ export function createStateRepository({
         record,
         normalize: createHandoffTransferRecord,
         summary: `Persisted handoff transfer ${record?.transfer_id}.`,
+      });
+    },
+
+    upsertControllerRunMetric(record) {
+      return upsertCollectionRecord({
+        collectionKey: 'controller_run_metrics',
+        identityKey: 'controller_run_metric_id',
+        entityKind: 'controller_run_metric',
+        record,
+        normalize: createControllerRunMetricRecord,
+        summary: `Persisted controller run metric ${record?.controller_run_metric_id}.`,
+      });
+    },
+
+    upsertExecutionAttemptMetric(record) {
+      return upsertCollectionRecord({
+        collectionKey: 'execution_attempt_metrics',
+        identityKey: 'execution_attempt_metric_id',
+        entityKind: 'execution_attempt_metric',
+        record,
+        normalize: createExecutionAttemptMetricRecord,
+        summary: `Persisted execution attempt metric ${record?.execution_attempt_metric_id}.`,
       });
     },
 

--- a/scripts/ao/lib/state-runner.js
+++ b/scripts/ao/lib/state-runner.js
@@ -1,5 +1,6 @@
 import { createCheckpointStore } from './checkpoint-store.js';
 import { createHandoffProtocol } from './handoff-protocol.js';
+import { buildAoMetricsReport } from './run-metrics.js';
 import * as fs from 'node:fs';
 import path from 'node:path';
 
@@ -59,6 +60,12 @@ export async function loadAoStateReport({
   const activeHandoffCount = handoffInspections.filter((inspection) => (
     ['open', 'pending_decision', 'accepted'].includes(inspection.top_status)
   )).length;
+  const metricsReport = buildAoMetricsReport({
+    projectId,
+    repoRoot: resolvedRepoRoot,
+    snapshot,
+    traceLimit: auditLimit,
+  });
 
   return {
     schema_version: AO_STATE_SCHEMA_VERSION,
@@ -89,6 +96,8 @@ export async function loadAoStateReport({
       handoff_decision_count: snapshot.state.handoff_decisions.length,
       handoff_transfer_count: snapshot.state.handoff_transfers.length,
       active_handoff_count: activeHandoffCount,
+      controller_run_metric_count: snapshot.state.controller_run_metrics.length,
+      execution_attempt_metric_count: snapshot.state.execution_attempt_metrics.length,
       audit_entry_count: auditEntries.length,
     },
     checkpoints: {
@@ -96,6 +105,10 @@ export async function loadAoStateReport({
     },
     handoffs: {
       inspections: handoffInspections,
+    },
+    metrics: {
+      summary: metricsReport.summary,
+      recent_traces: metricsReport.recent_traces,
     },
     audit: {
       recent_entries: recentEntries,

--- a/tests/ao/action-executor.test.js
+++ b/tests/ao/action-executor.test.js
@@ -244,6 +244,34 @@ describe('ao action executor', () => {
         }),
       }),
     ]);
+    expect(repository.getSnapshot().state.execution_attempt_metrics).toEqual([
+      expect.objectContaining({
+        attempt_kind: 'assist_action',
+        task_id: 'issue-90',
+        action_id: 'action-1',
+        action_kind: 'continue_worker',
+        action_class: 'continue_worker',
+        status: 'executed',
+        failure_class: 'none',
+        retry_cause: 'none',
+        intervention_counts: expect.objectContaining({
+          human_gate: 0,
+          override: 0,
+          explicit_resume: 0,
+          successor_handoff: 0,
+          policy_block: 0,
+          preflight_block: 0,
+        }),
+        token_usage: {
+          input_tokens: null,
+          output_tokens: null,
+          total_tokens: null,
+        },
+        cost: {
+          usd: null,
+        },
+      }),
+    ]);
 
     expect(repository.listAuditEntries().filter((entry) => (
       entry.entity_kind === 'action' && entry.entity_id === 'action-1'
@@ -320,6 +348,17 @@ describe('ao action executor', () => {
             outcome: 'blocked',
             reason: 'policy_allow_required',
           }),
+        }),
+      }),
+    ]);
+    expect(repository.getSnapshot().state.execution_attempt_metrics).toEqual([
+      expect.objectContaining({
+        attempt_kind: 'assist_action',
+        action_id: 'action-1',
+        status: 'blocked',
+        failure_class: 'policy_block',
+        intervention_counts: expect.objectContaining({
+          policy_block: 1,
         }),
       }),
     ]);
@@ -409,6 +448,17 @@ describe('ao action executor', () => {
             outcome: 'blocked',
             reason: 'override_hold_autonomy',
           }),
+        }),
+      }),
+    ]);
+    expect(repository.getSnapshot().state.execution_attempt_metrics).toEqual([
+      expect.objectContaining({
+        attempt_kind: 'assist_action',
+        action_id: 'action-1',
+        status: 'blocked',
+        failure_class: 'override',
+        intervention_counts: expect.objectContaining({
+          override: 1,
         }),
       }),
     ]);

--- a/tests/ao/ao-metrics-cli.test.js
+++ b/tests/ao/ao-metrics-cli.test.js
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockLoadAoMetricsReport = jest.fn();
+const mockRenderAoMetricsHumanSummary = jest.fn();
+
+jest.unstable_mockModule('../../scripts/ao/lib/run-metrics.js', () => ({
+  DEFAULT_PROJECT_ID: 'ciecopilot-home',
+  loadAoMetricsReport: mockLoadAoMetricsReport,
+  renderAoMetricsHumanSummary: mockRenderAoMetricsHumanSummary,
+}));
+
+const { runCli } = await import('../../scripts/ao-metrics.js');
+
+function buildReport(overrides = {}) {
+  return {
+    schema_version: 'ao.metrics-report.v1alpha1',
+    report_format: 'ao_metrics_report',
+    project_id: 'ciecopilot-home',
+    repo_root: '/home/samsen/code/ciecopilot-home',
+    summary: {
+      controller_run_count: 2,
+      execution_attempt_count: 3,
+      intervention_counts: {
+        human_gate: 0,
+        override: 1,
+        explicit_resume: 1,
+        successor_handoff: 0,
+        policy_block: 1,
+        preflight_block: 0,
+      },
+      failure_class_counts: {
+        none: 1,
+        policy_block: 1,
+        worker_exit: 1,
+      },
+      retry_cause_counts: {
+        none: 2,
+        explicit_resume: 1,
+        successor_handoff: 0,
+        policy_retry: 0,
+        preflight_retry: 0,
+        unknown: 0,
+      },
+    },
+    recent_traces: {
+      controller_runs: [],
+      execution_attempts: [],
+    },
+    ...overrides,
+  };
+}
+
+describe('ao metrics cli', () => {
+  beforeEach(() => {
+    mockLoadAoMetricsReport.mockReset();
+    mockRenderAoMetricsHumanSummary.mockReset();
+
+    mockLoadAoMetricsReport.mockResolvedValue(buildReport());
+    mockRenderAoMetricsHumanSummary.mockReturnValue('controller_runs: 2');
+  });
+
+  it('renders project-mode human summary output', async () => {
+    const stdout = [];
+
+    const result = await runCli([], {
+      writeStdout: (text) => stdout.push(text),
+      writeStderr: () => {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockLoadAoMetricsReport).toHaveBeenCalledWith({
+      cwd: process.cwd(),
+      projectId: 'ciecopilot-home',
+      traceLimit: 5,
+    });
+    expect(stdout.join('')).toContain('controller_runs: 2');
+  });
+
+  it('renders JSON output with an explicit trace limit', async () => {
+    const stdout = [];
+
+    const result = await runCli(['--json', '--limit', '2'], {
+      writeStdout: (text) => stdout.push(text),
+      writeStderr: () => {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockLoadAoMetricsReport).toHaveBeenCalledWith({
+      cwd: process.cwd(),
+      projectId: 'ciecopilot-home',
+      traceLimit: 2,
+    });
+    expect(JSON.parse(stdout.join(''))).toMatchObject({
+      schema_version: 'ao.metrics-report.v1alpha1',
+      summary: {
+        controller_run_count: 2,
+        execution_attempt_count: 3,
+      },
+    });
+  });
+
+  it('rejects invalid limit values and unknown flags before loading metrics', async () => {
+    const stderr = [];
+
+    const invalidLimit = await runCli(['--limit', '0'], {
+      writeStdout: () => {},
+      writeStderr: (text) => stderr.push(text),
+    });
+    const unknownArg = await runCli(['--bogus'], {
+      writeStdout: () => {},
+      writeStderr: (text) => stderr.push(text),
+    });
+
+    expect(invalidLimit.exitCode).toBe(4);
+    expect(unknownArg.exitCode).toBe(4);
+    expect(mockLoadAoMetricsReport).not.toHaveBeenCalled();
+    expect(stderr.join('')).toContain('Invalid value for --limit');
+    expect(stderr.join('')).toContain('Unknown argument: --bogus');
+  });
+
+  it('rejects --project when the next token is another flag', async () => {
+    const stderr = [];
+
+    const result = await runCli(['--project', '--json'], {
+      writeStdout: () => {},
+      writeStderr: (text) => stderr.push(text),
+    });
+
+    expect(result.exitCode).toBe(4);
+    expect(mockLoadAoMetricsReport).not.toHaveBeenCalled();
+    expect(stderr.join('')).toContain('Missing value for --project');
+  });
+});

--- a/tests/ao/controller-loop.test.js
+++ b/tests/ao/controller-loop.test.js
@@ -179,6 +179,37 @@ describe('ao controller loop', () => {
     const snapshot = repository.getSnapshot().state;
     expect(snapshot.observations).toHaveLength(2);
     expect(snapshot.actions).toEqual([]);
+    expect(snapshot.controller_run_metrics).toEqual([
+      expect.objectContaining({
+        task_id: 'issue-92',
+        controller_id: 'default',
+        controller_mode: 'observe',
+        trigger_kind: 'manual',
+        failure_class: 'none',
+        lifecycle_top_status: null,
+        observation_count: 2,
+        delivery_event_count: 3,
+        proposed_action_count: 0,
+        executed_action_count: 0,
+        blocked_action_count: 0,
+        intervention_counts: expect.objectContaining({
+          human_gate: 0,
+          override: 0,
+          explicit_resume: 0,
+          successor_handoff: 0,
+          policy_block: 0,
+          preflight_block: 0,
+        }),
+        token_usage: {
+          input_tokens: null,
+          output_tokens: null,
+          total_tokens: null,
+        },
+        cost: {
+          usd: null,
+        },
+      }),
+    ]);
     expect(snapshot.checkpoints).toEqual([
       expect.objectContaining({
         task_id: 'issue-92',
@@ -311,6 +342,17 @@ describe('ao controller loop', () => {
       'pr',
       'review',
     ]));
+    expect(snapshot.controller_run_metrics).toEqual([
+      expect.objectContaining({
+        task_id: 'issue-92',
+        trigger_kind: 'ci_failed',
+        failure_class: 'ci_failure',
+        action_class_counts: expect.objectContaining({
+          continue_worker: 1,
+          hold: 1,
+        }),
+      }),
+    ]);
     expect(snapshot.actions).toEqual(expect.arrayContaining([
       expect.objectContaining({
         task_id: 'issue-92',
@@ -888,6 +930,22 @@ describe('ao controller loop', () => {
         }),
       }),
     ]));
+    expect(repository.getSnapshot().state.controller_run_metrics).toEqual([
+      expect.objectContaining({
+        task_id: 'issue-92',
+        controller_mode: 'assist',
+        trigger_kind: 'approved_and_green',
+        failure_class: 'policy_block',
+        intervention_counts: expect.objectContaining({
+          human_gate: 0,
+          override: 0,
+          explicit_resume: 0,
+          successor_handoff: 0,
+          policy_block: 1,
+          preflight_block: 0,
+        }),
+      }),
+    ]);
   });
 
   it('assist mode blocks class A actions until runtime preflight has passed', async () => {
@@ -985,6 +1043,16 @@ describe('ao controller loop', () => {
             outcome: 'blocked',
             reason: 'runtime_preflight_clean',
           }),
+        }),
+      }),
+    ]);
+    expect(repository.getSnapshot().state.controller_run_metrics).toEqual([
+      expect.objectContaining({
+        task_id: 'issue-92',
+        trigger_kind: 'approved_and_green',
+        failure_class: 'preflight_block',
+        intervention_counts: expect.objectContaining({
+          preflight_block: 1,
         }),
       }),
     ]);

--- a/tests/ao/manage-runner.test.js
+++ b/tests/ao/manage-runner.test.js
@@ -278,6 +278,32 @@ describe('ao manage runner', () => {
       checkpoint_id: checkpoint.checkpoint_id,
       state: 'valid',
     });
+
+    const state = readState(repoRoot);
+    expect(state.execution_attempt_metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        attempt_kind: 'managed_task',
+        task_id: 'issue-110',
+        owner_session_name: 'cie-57',
+        command: 'enroll',
+        status: 'paused',
+        failure_class: 'worker_exit',
+        retry_cause: 'none',
+      }),
+      expect.objectContaining({
+        attempt_kind: 'managed_task',
+        task_id: 'issue-110',
+        owner_session_name: 'cie-57',
+        command: 'resume',
+        status: 'active',
+        failure_class: 'none',
+        retry_cause: 'explicit_resume',
+        intervention_counts: expect.objectContaining({
+          explicit_resume: 1,
+          successor_handoff: 0,
+        }),
+      }),
+    ]));
   });
 
   it('fails closed when explicit resume sees a stale checkpoint', async () => {
@@ -563,6 +589,28 @@ describe('ao manage runner', () => {
         successor_session_name: 'cie-59',
       }),
     ]);
+    expect(state.execution_attempt_metrics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        attempt_kind: 'managed_task',
+        task_id: 'issue-117',
+        owner_session_name: 'cie-58',
+        command: 'enroll',
+        status: 'paused',
+        failure_class: 'worker_exit',
+      }),
+      expect.objectContaining({
+        attempt_kind: 'managed_task',
+        task_id: 'issue-117',
+        owner_session_name: 'cie-59',
+        command: 'resume',
+        status: 'active',
+        retry_cause: 'successor_handoff',
+        intervention_counts: expect.objectContaining({
+          explicit_resume: 0,
+          successor_handoff: 1,
+        }),
+      }),
+    ]));
   });
 
   it('unmanages and retires a task without deleting its durable bindings', async () => {

--- a/tests/ao/measurement-taxonomy.test.js
+++ b/tests/ao/measurement-taxonomy.test.js
@@ -1,0 +1,160 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  CONTROLLER_RUN_MEASUREMENT_FORMAT,
+  CONTROLLER_RUN_MEASUREMENT_SCHEMA_VERSION,
+  EXECUTION_ATTEMPT_MEASUREMENT_FORMAT,
+  EXECUTION_ATTEMPT_MEASUREMENT_SCHEMA_VERSION,
+  MEASUREMENT_ACTION_CLASSES,
+  MEASUREMENT_FAILURE_CLASSES,
+  MEASUREMENT_INTERVENTION_KINDS,
+  MEASUREMENT_RETRY_CAUSES,
+  MEASUREMENT_TRIGGER_KINDS,
+  createMeasurementCountMap,
+  normalizeMeasurementTrigger,
+  resolveControllerRunFailureClass,
+  resolveExecutionAttemptFailureClass,
+  resolveExecutionAttemptRetryCause,
+  resolveMeasurementActionClass,
+} from '../../scripts/ao/lib/measurement-taxonomy.js';
+
+describe('measurement taxonomy', () => {
+  it('freezes the durable schema identities and stable vocabularies', () => {
+    expect(CONTROLLER_RUN_MEASUREMENT_SCHEMA_VERSION).toBe('ao.controller-run-measurement.v1alpha1');
+    expect(CONTROLLER_RUN_MEASUREMENT_FORMAT).toBe('ao_controller_run_measurement');
+    expect(EXECUTION_ATTEMPT_MEASUREMENT_SCHEMA_VERSION).toBe('ao.execution-attempt-measurement.v1alpha1');
+    expect(EXECUTION_ATTEMPT_MEASUREMENT_FORMAT).toBe('ao_execution_attempt_measurement');
+    expect(MEASUREMENT_TRIGGER_KINDS).toEqual([
+      'manual',
+      'ci_failed',
+      'changes_requested',
+      'bugbot_comments',
+      'merge_conflicts',
+      'approved_and_green',
+      'agent_stuck',
+      'agent_needs_input',
+      'agent_exited',
+    ]);
+    expect(MEASUREMENT_ACTION_CLASSES).toEqual([
+      'continue_worker',
+      'notify_human',
+      'hold',
+      'human_gate',
+      'restore_worker',
+      'handoff_worker',
+      'unknown',
+    ]);
+    expect(MEASUREMENT_INTERVENTION_KINDS).toEqual([
+      'human_gate',
+      'override',
+      'explicit_resume',
+      'successor_handoff',
+      'policy_block',
+      'preflight_block',
+    ]);
+    expect(MEASUREMENT_RETRY_CAUSES).toEqual([
+      'none',
+      'explicit_resume',
+      'successor_handoff',
+      'policy_retry',
+      'preflight_retry',
+      'unknown',
+    ]);
+    expect(MEASUREMENT_FAILURE_CLASSES).toEqual([
+      'none',
+      'ci_failure',
+      'review_blocked',
+      'merge_conflict',
+      'source_failure',
+      'human_gate',
+      'override',
+      'policy_block',
+      'preflight_block',
+      'worker_exit',
+      'successor_handoff',
+      'unknown',
+    ]);
+  });
+
+  it('normalizes trigger and action taxonomies into stable measurement classes', () => {
+    expect(normalizeMeasurementTrigger()).toBe('manual');
+    expect(normalizeMeasurementTrigger('approved-and-green')).toBe('approved_and_green');
+    expect(normalizeMeasurementTrigger('agent-needs-input')).toBe('agent_needs_input');
+
+    expect(resolveMeasurementActionClass({
+      actionKind: 'continue_worker',
+    })).toBe('continue_worker');
+    expect(resolveMeasurementActionClass({
+      actionKind: 'notify_human_ready',
+      actionClass: 'notify_human',
+    })).toBe('notify_human');
+    expect(resolveMeasurementActionClass({
+      actionKind: 'hold_ci',
+      actionClass: 'hold',
+    })).toBe('hold');
+    expect(resolveMeasurementActionClass({
+      actionKind: 'mystery_action',
+      actionClass: 'not_real',
+    })).toBe('unknown');
+  });
+
+  it('classifies retry causes, intervention counts, and stable failure classes', () => {
+    expect(resolveExecutionAttemptRetryCause({
+      command: 'enroll',
+      acceptedHandoff: false,
+    })).toBe('none');
+    expect(resolveExecutionAttemptRetryCause({
+      command: 'resume',
+      acceptedHandoff: false,
+    })).toBe('explicit_resume');
+    expect(resolveExecutionAttemptRetryCause({
+      command: 'resume',
+      acceptedHandoff: true,
+    })).toBe('successor_handoff');
+
+    expect(createMeasurementCountMap(MEASUREMENT_INTERVENTION_KINDS, {
+      policy_block: 2,
+      explicit_resume: 1,
+    })).toEqual({
+      human_gate: 0,
+      override: 0,
+      explicit_resume: 1,
+      successor_handoff: 0,
+      policy_block: 2,
+      preflight_block: 0,
+    });
+
+    expect(resolveExecutionAttemptFailureClass({
+      reason: 'override_hold_autonomy',
+    })).toBe('override');
+    expect(resolveExecutionAttemptFailureClass({
+      reason: 'runtime_preflight_clean',
+    })).toBe('preflight_block');
+    expect(resolveExecutionAttemptFailureClass({
+      reason: 'policy_allow_required',
+    })).toBe('policy_block');
+    expect(resolveExecutionAttemptFailureClass({
+      reason: 'worker_exited',
+    })).toBe('worker_exit');
+
+    expect(resolveControllerRunFailureClass({
+      triggerKind: 'ci_failed',
+      interventionCounts: createMeasurementCountMap(MEASUREMENT_INTERVENTION_KINDS),
+      lifecycleTopStatus: 'hold',
+    })).toBe('ci_failure');
+    expect(resolveControllerRunFailureClass({
+      triggerKind: 'approved_and_green',
+      interventionCounts: createMeasurementCountMap(MEASUREMENT_INTERVENTION_KINDS, {
+        human_gate: 1,
+      }),
+      lifecycleTopStatus: 'human_gate',
+    })).toBe('human_gate');
+    expect(resolveControllerRunFailureClass({
+      triggerKind: 'manual',
+      interventionCounts: createMeasurementCountMap(MEASUREMENT_INTERVENTION_KINDS, {
+        policy_block: 1,
+      }),
+      lifecycleTopStatus: 'continue',
+    })).toBe('policy_block');
+  });
+});

--- a/tests/ao/state-contracts.test.js
+++ b/tests/ao/state-contracts.test.js
@@ -49,7 +49,7 @@ describe('ao state contracts', () => {
     expect(CONTROLLER_MODES).toEqual(['off', 'observe', 'shadow', 'assist']);
     expect(POLICY_DECISIONS).toEqual(['allow', 'deny', 'downgrade']);
     expect(CREDENTIAL_PROVENANCE_TRUST_DECISIONS).toEqual(['trusted', 'untrusted']);
-    expect(CONTROL_PLANE_LATEST_VERSION).toBe(7);
+    expect(CONTROL_PLANE_LATEST_VERSION).toBe(8);
   });
 
   it('creates durable managed-task, binding, lease, action, override, and controller-mode records', () => {
@@ -559,6 +559,8 @@ describe('ao state contracts', () => {
       handoff_claims: [],
       handoff_decisions: [],
       handoff_transfers: [],
+      controller_run_metrics: [],
+      execution_attempt_metrics: [],
     });
 
     expect(createControlPlaneAuditEntry({

--- a/tests/ao/state-migrations.test.js
+++ b/tests/ao/state-migrations.test.js
@@ -73,8 +73,8 @@ describe('ao state migrations', () => {
 
     expect(readJson(paths.schemaPath)).toMatchObject({
       project_id: PROJECT_ID,
-      current_version: 7,
-      latest_version: 7,
+      current_version: 8,
+      latest_version: 8,
       applied_migrations: [
         {
           version: 1,
@@ -111,6 +111,11 @@ describe('ao state migrations', () => {
           key: '0007_handoff_protocol_v1',
           applied_at: FIXED_NOW,
         },
+        {
+          version: 8,
+          key: '0008_measurement_metrics_v1',
+          applied_at: FIXED_NOW,
+        },
       ],
     });
     expect(readJson(paths.statePath)).toMatchObject({
@@ -125,6 +130,8 @@ describe('ao state migrations', () => {
       handoff_claims: [],
       handoff_decisions: [],
       handoff_transfers: [],
+      controller_run_metrics: [],
+      execution_attempt_metrics: [],
       controller_modes: [
         {
           controller_id: 'default',
@@ -177,6 +184,12 @@ describe('ao state migrations', () => {
         operation: 'migrate',
         summary: 'Applied control-plane handoff-protocol migration.',
       }),
+      expect.objectContaining({
+        entity_kind: 'schema',
+        entity_id: 'v8',
+        operation: 'migrate',
+        summary: 'Applied control-plane measurement-metrics migration.',
+      }),
     ]);
   });
 
@@ -203,7 +216,7 @@ describe('ao state migrations', () => {
       migrated: false,
     });
     expect(readJson(paths.schemaPath).updated_at).toBe(FIXED_NOW);
-    expect(readAuditEntries(paths.auditPath)).toHaveLength(7);
+    expect(readAuditEntries(paths.auditPath)).toHaveLength(8);
   });
 
   it('upgrades a stale schema version and backfills invalid task specs for enrolled tasks', () => {
@@ -279,7 +292,7 @@ describe('ao state migrations', () => {
       migrated: true,
     });
     expect(readJson(paths.schemaPath)).toMatchObject({
-      current_version: 7,
+      current_version: 8,
       applied_migrations: [
         {
           version: 1,
@@ -308,6 +321,10 @@ describe('ao state migrations', () => {
         {
           version: 7,
           key: '0007_handoff_protocol_v1',
+        },
+        {
+          version: 8,
+          key: '0008_measurement_metrics_v1',
         },
       ],
     });

--- a/tests/ao/state-repository.test.js
+++ b/tests/ao/state-repository.test.js
@@ -265,6 +265,7 @@ describe('ao state repository', () => {
       'schema:migrate:v5',
       'schema:migrate:v6',
       'schema:migrate:v7',
+      'schema:migrate:v8',
       'managed_task:upsert:task-1',
       'pr_binding:upsert:binding-1',
       'ownership_lease:upsert:ownership-1',

--- a/tests/ao/state-runner.test.js
+++ b/tests/ao/state-runner.test.js
@@ -8,6 +8,8 @@ import { createCheckpointStore } from '../../scripts/ao/lib/checkpoint-store.js'
 import { createHandoffProtocol } from '../../scripts/ao/lib/handoff-protocol.js';
 import {
   createControllerModeRecord,
+  createControllerRunMetricRecord,
+  createExecutionAttemptMetricRecord,
   createManagedTask,
   createOverrideRecord,
   createPrBinding,
@@ -73,6 +75,8 @@ describe('ao state runner', () => {
         active_override_count: 0,
         controller_mode_count: 0,
         controller_modes: [],
+        controller_run_metric_count: 0,
+        execution_attempt_metric_count: 0,
         audit_entry_count: 0,
       },
     });
@@ -140,7 +144,7 @@ describe('ao state runner', () => {
       active_override_count: 1,
       controller_mode_count: 1,
       controller_modes: ['default=observe'],
-      audit_entry_count: 10,
+      audit_entry_count: 11,
     });
     expect(report.audit.recent_entries).toEqual([
       expect.objectContaining({
@@ -372,5 +376,147 @@ describe('ao state runner', () => {
         top_status: 'accepted',
       }),
     ]);
+  });
+
+  it('includes measurement summaries and recent traces in the operator-visible AO state report', async () => {
+    const repoRoot = createTempRepo();
+    const repository = createStateRepository({
+      repoRoot,
+      projectId: PROJECT_ID,
+      clock: createClock(
+        '2026-03-31T12:00:00.000Z',
+        '2026-03-31T12:01:00.000Z',
+        '2026-03-31T12:02:00.000Z',
+      ),
+      auditIdGenerator: createIdGenerator('audit'),
+    });
+
+    repository.upsertManagedTask(createManagedTask({
+      task_id: 'issue-118',
+      issue_number: 118,
+      title: 'feat(ao): add trace, cost, and failure taxonomy',
+      branch_name: 'feat/118',
+      worktree_path: '/tmp/cie-59',
+      status: 'active',
+      created_at: '2026-03-31T12:00:00.000Z',
+      updated_at: '2026-03-31T12:00:00.000Z',
+    }));
+    repository.upsertControllerRunMetric(createControllerRunMetricRecord({
+      controller_run_metric_id: 'controller-run-1',
+      task_id: 'issue-118',
+      issue_number: 118,
+      pr_number: 128,
+      controller_id: 'default',
+      controller_mode: 'assist',
+      trigger_kind: 'approved_and_green',
+      lifecycle_top_status: 'continue',
+      failure_class: 'policy_block',
+      started_at: '2026-03-31T12:00:00.000Z',
+      completed_at: '2026-03-31T12:00:03.000Z',
+      duration_ms: 3000,
+      observation_count: 2,
+      delivery_event_count: 3,
+      proposed_action_count: 2,
+      executed_action_count: 1,
+      blocked_action_count: 1,
+      policy_decision_count: 2,
+      policy_blocked_action_count: 1,
+      denied_action_count: 1,
+      downgraded_action_count: 0,
+      action_class_counts: {
+        continue_worker: 1,
+        notify_human: 1,
+      },
+      intervention_counts: {
+        human_gate: 0,
+        override: 0,
+        explicit_resume: 0,
+        successor_handoff: 0,
+        policy_block: 1,
+        preflight_block: 0,
+      },
+      token_usage: {
+        input_tokens: null,
+        output_tokens: null,
+        total_tokens: null,
+      },
+      cost: {
+        usd: null,
+      },
+    }));
+    repository.upsertExecutionAttemptMetric(createExecutionAttemptMetricRecord({
+      execution_attempt_metric_id: 'execution-attempt-1',
+      attempt_kind: 'managed_task',
+      task_id: 'issue-118',
+      issue_number: 118,
+      pr_number: 128,
+      controller_id: null,
+      owner_session_name: 'cie-59',
+      owner_session_id: 'cie-59',
+      action_id: null,
+      action_kind: null,
+      action_class: null,
+      command: 'resume',
+      status: 'active',
+      retry_cause: 'explicit_resume',
+      failure_class: 'none',
+      reason: null,
+      started_at: '2026-03-31T12:01:00.000Z',
+      completed_at: null,
+      duration_ms: null,
+      intervention_counts: {
+        human_gate: 0,
+        override: 0,
+        explicit_resume: 1,
+        successor_handoff: 0,
+        policy_block: 0,
+        preflight_block: 0,
+      },
+      token_usage: {
+        input_tokens: null,
+        output_tokens: null,
+        total_tokens: null,
+      },
+      cost: {
+        usd: null,
+      },
+    }));
+
+    const report = await loadAoStateReport({
+      repoRoot,
+      projectId: PROJECT_ID,
+      auditLimit: 2,
+    });
+
+    expect(report.summary).toMatchObject({
+      controller_run_metric_count: 1,
+      execution_attempt_metric_count: 1,
+    });
+    expect(report.metrics.summary).toMatchObject({
+      controller_run_count: 1,
+      execution_attempt_count: 1,
+      intervention_counts: expect.objectContaining({
+        explicit_resume: 1,
+        policy_block: 1,
+      }),
+      failure_class_counts: expect.objectContaining({
+        none: 1,
+        policy_block: 1,
+      }),
+    });
+    expect(report.metrics.recent_traces).toMatchObject({
+      controller_runs: [
+        expect.objectContaining({
+          controller_run_metric_id: 'controller-run-1',
+          failure_class: 'policy_block',
+        }),
+      ],
+      execution_attempts: [
+        expect.objectContaining({
+          execution_attempt_metric_id: 'execution-attempt-1',
+          retry_cause: 'explicit_resume',
+        }),
+      ],
+    });
   });
 });


### PR DESCRIPTION
Closes #118

## Summary
- add durable measurement taxonomy and versioned controller-run / execution-attempt records
- persist controller, assist-execution, and manage/resume metrics into AO control-plane state and expose them through a new ao-metrics report/CLI
- extend AO state/reporting tests and schema migration coverage for the new measurement layer

## Testing
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/measurement-taxonomy.test.js tests/ao/controller-loop.test.js tests/ao/action-executor.test.js tests/ao/manage-runner.test.js tests/ao/state-runner.test.js tests/ao/ao-metrics-cli.test.js
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/state-contracts.test.js tests/ao/state-migrations.test.js tests/ao/state-repository.test.js tests/ao/ao-state-cli.test.js