### PR TITLE
feat(ao): build issue-to-PR eval harness and scorecard

### DIFF
--- a/scripts/ao-eval.js
+++ b/scripts/ao-eval.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runAoEvalHarness } from './ao/lib/eval-harness.js';
+import { findRepoRoot } from './ao/lib/repo-root.js';
+import {
+  buildAoEvalScorecard,
+  compareAoEvalScorecards,
+  DEFAULT_PROJECT_ID,
+  loadAoEvalBaseline,
+  persistAoEvalScorecard,
+  renderAoEvalHumanSummary,
+} from './ao/lib/scorecard.js';
+
+function createDefaultIo() {
+  return {
+    writeStdout: (text) => process.stdout.write(text),
+    writeStderr: (text) => process.stderr.write(text),
+  };
+}
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1] ?? null;
+  if (value == null || value.startsWith('-')) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+  return value;
+}
+
+function parseArgs(argv) {
+  const options = {
+    projectId: DEFAULT_PROJECT_ID,
+    packNames: [],
+    baselineRef: null,
+    saveBaseline: null,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--project') {
+      try {
+        options.projectId = readOptionValue(argv, index, '--project');
+      } catch (error) {
+        return {
+          ok: false,
+          error: error.message,
+        };
+      }
+      index += 1;
+    } else if (arg === '--pack') {
+      try {
+        options.packNames.push(readOptionValue(argv, index, '--pack'));
+      } catch (error) {
+        return {
+          ok: false,
+          error: error.message,
+        };
+      }
+      index += 1;
+    } else if (arg === '--baseline') {
+      try {
+        options.baselineRef = readOptionValue(argv, index, '--baseline');
+      } catch (error) {
+        return {
+          ok: false,
+          error: error.message,
+        };
+      }
+      index += 1;
+    } else if (arg === '--save-baseline') {
+      try {
+        options.saveBaseline = readOptionValue(argv, index, '--save-baseline');
+      } catch (error) {
+        return {
+          ok: false,
+          error: error.message,
+        };
+      }
+      index += 1;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      return {
+        ok: false,
+        error: `Unknown argument: ${arg}`,
+      };
+    }
+  }
+
+  if (!options.packNames.length) {
+    options.packNames = ['all'];
+  }
+
+  if (options.projectId == null || String(options.projectId).trim() === '') {
+    return {
+      ok: false,
+      error: 'Missing value for --project',
+    };
+  }
+
+  return {
+    ok: true,
+    options,
+  };
+}
+
+function renderHelp() {
+  return [
+    'Usage: node scripts/ao-eval.js [options]',
+    '',
+    'Options:',
+    '  --project <project_id>       AO project id. Default: ciecopilot-home',
+    '  --pack <name>               Eval pack to run. Repeatable. Default: all',
+    '  --baseline <ref>            Compare against a saved baseline alias, scorecard id, or JSON path',
+    '  --save-baseline <name>      Save the current scorecard as a named baseline alias',
+    '  --json                      Print machine-readable JSON output',
+    '  -h, --help                  Show help',
+  ].join('\n');
+}
+
+function exitCodeForResult(scorecard, comparison) {
+  if ((scorecard?.summary?.failed_scenario_count ?? 0) > 0) return 1;
+  if (comparison != null && comparison.status !== 'ok') return 1;
+  return 0;
+}
+
+export async function runCli(argv, io = createDefaultIo()) {
+  const parsed = parseArgs(argv);
+  if (!parsed.ok) {
+    io.writeStderr(`${parsed.error}\n`);
+    return {
+      exitCode: 4,
+      scorecard: null,
+      comparison: null,
+      persisted: null,
+    };
+  }
+
+  const { options } = parsed;
+  if (options.help) {
+    io.writeStdout(`${renderHelp()}\n`);
+    return {
+      exitCode: 0,
+      scorecard: null,
+      comparison: null,
+      persisted: null,
+    };
+  }
+
+  try {
+    const repoRoot = findRepoRoot(process.cwd());
+    if (!repoRoot) {
+      throw new Error(`Could not locate repo root from ${process.cwd()}`);
+    }
+
+    const harnessResult = await runAoEvalHarness({
+      projectId: options.projectId,
+      fixtureRoot: path.join(repoRoot, 'tests', 'ao', 'fixtures', 'eval'),
+      packNames: options.packNames,
+    });
+    const scorecard = buildAoEvalScorecard({
+      projectId: options.projectId,
+      harnessResult,
+    });
+    const comparison = options.baselineRef == null
+      ? null
+      : compareAoEvalScorecards({
+          baselineScorecard: loadAoEvalBaseline({
+            repoRoot,
+            projectId: options.projectId,
+            baselineRef: options.baselineRef,
+            cwd: process.cwd(),
+          }),
+          currentScorecard: scorecard,
+        });
+    const persisted = persistAoEvalScorecard({
+      repoRoot,
+      projectId: options.projectId,
+      scorecard,
+      baselineName: options.saveBaseline,
+    });
+    const payload = {
+      scorecard,
+      comparison,
+      persisted,
+    };
+
+    if (options.json) {
+      io.writeStdout(JSON.stringify(payload, null, 2));
+    } else {
+      io.writeStdout(`${renderAoEvalHumanSummary(payload)}\n`);
+    }
+
+    return {
+      exitCode: exitCodeForResult(scorecard, comparison),
+      scorecard,
+      comparison,
+      persisted,
+    };
+  } catch (error) {
+    io.writeStderr(`${error.message}\n`);
+    return {
+      exitCode: 3,
+      scorecard: null,
+      comparison: null,
+      persisted: null,
+    };
+  }
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+const executedFile = process.argv[1] ? path.resolve(process.argv[1]) : null;
+
+if (executedFile && executedFile === currentFile) {
+  const { exitCode } = await runCli(process.argv.slice(2));
+  process.exitCode = exitCode;
+}

--- a/scripts/ao/lib/eval-harness.js
+++ b/scripts/ao/lib/eval-harness.js
@@ -1,0 +1,967 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { runControllerLoop } from './controller-loop.js';
+import { loadAoProjectObservation } from './ao-observation-source.js';
+import { createCheckpointStore } from './checkpoint-store.js';
+import { createDoctorPrScope } from './doctor-contracts.js';
+import { buildDoctorReport } from './doctor-engine.js';
+import { loadDoctorLocalState } from './doctor-local-state-source.js';
+import { loadGitHubObservationSet } from './github-observation-source.js';
+import { createHandoffProtocol } from './handoff-protocol.js';
+import { createLifecyclePrScope } from './lifecycle-contracts.js';
+import { buildLifecycleReport } from './lifecycle-engine.js';
+import { runManageCommand } from './manage-runner.js';
+import { buildAoMetricsReport } from './run-metrics.js';
+import { createPrScope } from './reconciliation-contracts.js';
+import { reconcileObservations } from './reconciliation-engine.js';
+import {
+  AO_EVAL_HARNESS_RUN_FORMAT,
+  AO_EVAL_HARNESS_RUN_SCHEMA_VERSION,
+  createControllerModeRecord,
+  createCredentialProvenanceRecord,
+  createManagedTask,
+  createPrBinding,
+  createTaskSpecRecord,
+} from './state-contracts.js';
+import { createStateRepository } from './state-repository.js';
+
+export const DEFAULT_PROJECT_ID = 'ciecopilot-home';
+
+function readJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function stableObject(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableObject(item));
+  }
+  if (value != null && typeof value === 'object') {
+    return Object.keys(value)
+      .sort((left, right) => left.localeCompare(right))
+      .reduce((result, key) => {
+        result[key] = stableObject(value[key]);
+        return result;
+      }, {});
+  }
+  return value;
+}
+
+function buildFingerprint(value) {
+  return createHash('sha1')
+    .update(JSON.stringify(stableObject(value)))
+    .digest('hex');
+}
+
+function createTempRepo(prefix, { git = false } = {}) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  if (git) {
+    fs.mkdirSync(path.join(repoRoot, '.git'));
+  }
+  return repoRoot;
+}
+
+function removeTempRepo(repoRoot) {
+  fs.rmSync(repoRoot, { recursive: true, force: true });
+}
+
+function joinTaskSpecBody(lines = []) {
+  return Array.isArray(lines) ? lines.join('\n') : '';
+}
+
+function countInterventions(interventionCounts = {}) {
+  return Object.values(interventionCounts ?? {}).reduce((total, value) => total + Number(value ?? 0), 0);
+}
+
+function summarizeMetrics(snapshot, projectId) {
+  const report = buildAoMetricsReport({
+    projectId,
+    snapshot,
+    traceLimit: 5,
+  });
+  const measurementRecords = [
+    ...(snapshot?.state?.controller_run_metrics ?? []),
+    ...(snapshot?.state?.execution_attempt_metrics ?? []),
+  ];
+
+  return {
+    controller_run_count: report.summary.controller_run_count,
+    execution_attempt_count: report.summary.execution_attempt_count,
+    measurement_count: measurementRecords.length,
+    intervened_measurement_count: measurementRecords.filter(
+      (record) => countInterventions(record?.intervention_counts) > 0,
+    ).length,
+    intervention_counts: report.summary.intervention_counts,
+    failure_class_counts: report.summary.failure_class_counts,
+  };
+}
+
+function buildVerification(findings = []) {
+  return {
+    status: findings.length === 0 ? 'passed' : 'failed',
+    findings,
+  };
+}
+
+function createFinding(code, summary, details = null) {
+  return {
+    code,
+    summary,
+    details,
+  };
+}
+
+function buildHarnessSummary(scenarioResults = []) {
+  const continuityScenarios = scenarioResults.filter((scenario) => scenario.continuity.kind !== 'none');
+  return {
+    scenario_count: scenarioResults.length,
+    passed_scenario_count: scenarioResults.filter((scenario) => scenario.status === 'passed').length,
+    failed_scenario_count: scenarioResults.filter((scenario) => scenario.status === 'failed').length,
+    replay_stable_scenario_count: scenarioResults.filter((scenario) => scenario.replay.stable).length,
+    continuity_scenario_count: continuityScenarios.length,
+    continuity_success_count: continuityScenarios.filter(
+      (scenario) => scenario.continuity.status === 'success',
+    ).length,
+  };
+}
+
+function loadPackRegistry(fixtureRoot) {
+  const registry = readJsonFile(path.join(fixtureRoot, 'packs.json'));
+  const packs = Array.isArray(registry?.packs) ? registry.packs : [];
+  return new Map(packs.map((pack) => [pack.pack_id, pack]));
+}
+
+function resolveRequestedPacks(packRegistry, packNames = ['all']) {
+  const requestedPackIds = Array.isArray(packNames) && packNames.length > 0 ? packNames : ['all'];
+  const normalizedPackIds = [...new Set(requestedPackIds.map((value) => String(value).trim()).filter(Boolean))];
+
+  if (normalizedPackIds.includes('all')) {
+    return [...packRegistry.values()]
+      .map((pack) => pack.pack_id)
+      .filter((packId) => packId !== 'all');
+  }
+
+  for (const packId of normalizedPackIds) {
+    if (!packRegistry.has(packId)) {
+      throw new Error(`Unknown eval pack: ${packId}`);
+    }
+  }
+
+  return normalizedPackIds;
+}
+
+function resolveScenarioIds(packRegistry, resolvedPackIds) {
+  const scenarioIds = [];
+  const seen = new Set();
+  for (const packId of resolvedPackIds) {
+    const pack = packRegistry.get(packId);
+    for (const scenarioId of pack?.scenario_ids ?? []) {
+      if (seen.has(scenarioId)) continue;
+      seen.add(scenarioId);
+      scenarioIds.push(scenarioId);
+    }
+  }
+  return scenarioIds;
+}
+
+function loadScenarioDefinition(fixtureRoot, scenarioId) {
+  return readJsonFile(path.join(fixtureRoot, 'scenarios', `${scenarioId}.json`));
+}
+
+function buildControllerTaskSeed(repository, scenario, now, { withCredentials = false } = {}) {
+  repository.upsertManagedTask(createManagedTask({
+    task_id: scenario.task.task_id,
+    issue_number: scenario.task.issue_number,
+    title: scenario.task.title,
+    branch_name: scenario.task.branch_name,
+    worktree_path: scenario.task.worktree_path,
+    status: 'active',
+    created_at: now,
+    updated_at: now,
+  }));
+  repository.upsertPrBinding(createPrBinding({
+    binding_id: `binding-${scenario.task.task_id}-pr-${scenario.pr_binding.pr_number}`,
+    task_id: scenario.task.task_id,
+    pr_number: scenario.pr_binding.pr_number,
+    branch_name: scenario.task.branch_name,
+    base_branch: scenario.pr_binding.base_branch ?? 'main',
+    status: 'bound',
+    created_at: now,
+    updated_at: now,
+  }));
+  repository.upsertControllerMode(createControllerModeRecord({
+    controller_id: scenario.controller.controller_id,
+    mode: scenario.controller.mode,
+    updated_at: now,
+    updated_by: 'ao_eval',
+    reason: `Eval scenario ${scenario.scenario_id}`,
+  }));
+
+  if (withCredentials) {
+    for (const record of scenario.seed?.credential_provenances ?? []) {
+      repository.upsertCredentialProvenance(createCredentialProvenanceRecord(record));
+    }
+  }
+}
+
+function seedCleanRuntimeContracts(repository, scenario, now) {
+  repository.upsertTaskSpec(createTaskSpecRecord({
+    task_id: scenario.task.task_id,
+    source_kind: 'github_issue',
+    source_issue_number: scenario.task.issue_number,
+    created_at: now,
+    updated_at: now,
+    snapshot: {
+      schema_version: 'ao.task-spec.v1alpha1',
+      spec: {
+        problem_type: 'issue_delivery',
+        acceptance_contract: [`Eval parity fixture for ${scenario.scenario_id}`],
+        runtime_ref: 'runtime.github_local',
+        policy_ref: 'policy.operator_gated',
+        human_gates: ['operator_review'],
+      },
+    },
+  }));
+  repository.ensureRuntimePreflights({
+    cwd: repository.getSnapshot().paths.repoRoot,
+    now,
+    probes: {
+      commandExists: () => true,
+      pathExists: () => true,
+      capability: () => true,
+    },
+  });
+}
+
+async function executeControllerParityScenario({
+  scenario,
+  fixtureRoot,
+  projectId,
+} = {}) {
+  const repoRoot = createTempRepo('ao-eval-parity-');
+  const acceptanceFixtureRoot = path.resolve(fixtureRoot, scenario.acceptance_fixture);
+  const priorFixtureRoot = process.env.AO_FIXTURE_ROOT;
+
+  try {
+    process.env.AO_FIXTURE_ROOT = acceptanceFixtureRoot;
+    const repository = createStateRepository({
+      repoRoot,
+      projectId,
+    });
+    buildControllerTaskSeed(repository, scenario, scenario.timing.created_at);
+    seedCleanRuntimeContracts(repository, scenario, scenario.timing.created_at);
+
+    const controllerResult = await runControllerLoop({
+      repoRoot,
+      cwd: repoRoot,
+      projectId,
+      controllerId: scenario.controller.controller_id,
+      mode: scenario.controller.mode,
+      now: scenario.timing.run_at,
+      deps: {
+        ensureRuntimePreflights: ({ repository, cwd, now }) => repository.ensureRuntimePreflights({
+          cwd,
+          now,
+          probes: {
+            commandExists: () => true,
+            pathExists: () => true,
+            capability: () => true,
+          },
+        }),
+      },
+    });
+
+    const reconciliationScope = createPrScope(scenario.pr_binding.pr_number);
+    const aoObservation = await loadAoProjectObservation({
+      projectId,
+      now: scenario.timing.run_at,
+    });
+    const githubObservation = await loadGitHubObservationSet({
+      scope: reconciliationScope,
+      now: scenario.timing.run_at,
+    });
+    const reconciliationReport = reconcileObservations({
+      scope: reconciliationScope,
+      aoObservation,
+      githubObservation,
+    });
+    const localState = await loadDoctorLocalState({
+      cwd: repoRoot,
+    });
+    const doctorReport = buildDoctorReport({
+      scope: createDoctorPrScope({
+        projectId,
+        prNumber: scenario.pr_binding.pr_number,
+      }),
+      reconciliationReport,
+      localState,
+    });
+    const lifecycleReport = buildLifecycleReport({
+      scope: createLifecyclePrScope({
+        projectId,
+        prNumber: scenario.pr_binding.pr_number,
+        trigger: scenario.expected.derived_trigger,
+      }),
+      reconciliationReport,
+      doctorReport,
+    });
+
+    const snapshot = repository.getSnapshot();
+    const findings = [];
+    if (controllerResult.task_results[0]?.derived_trigger !== scenario.expected.derived_trigger) {
+      findings.push(createFinding(
+        'derived_trigger_mismatch',
+        `Expected derived trigger ${scenario.expected.derived_trigger} but received ${controllerResult.task_results[0]?.derived_trigger}.`,
+      ));
+    }
+
+    const actualActions = snapshot.state.actions
+      .filter((record) => record.task_id === scenario.task.task_id)
+      .map((record) => ({
+        id: record.action_kind,
+        action_class: record.payload.action_class,
+        commands: record.payload.commands,
+      }))
+      .sort((left, right) => left.id.localeCompare(right.id));
+    const expectedActions = lifecycleReport.actions
+      .map((action) => ({
+        id: action.id,
+        action_class: action.action_class,
+        commands: action.commands,
+      }))
+      .sort((left, right) => left.id.localeCompare(right.id));
+
+    if (JSON.stringify(actualActions) !== JSON.stringify(expectedActions)) {
+      findings.push(createFinding(
+        'action_parity_mismatch',
+        'Controller action proposals did not match the lifecycle report actions.',
+      ));
+    }
+
+    const deliveryFamilies = snapshot.state.delivery_events
+      .filter((record) => record.task_id === scenario.task.task_id)
+      .map((record) => record.event_family)
+      .sort((left, right) => left.localeCompare(right));
+    for (const requiredFamily of ['check', 'pr', 'review']) {
+      if (!deliveryFamilies.includes(requiredFamily)) {
+        findings.push(createFinding(
+          'delivery_event_missing',
+          `Expected ${requiredFamily} delivery event for ${scenario.scenario_id}.`,
+          {
+            required_family: requiredFamily,
+          },
+        ));
+      }
+    }
+
+    const controllerMetric = snapshot.state.controller_run_metrics[0] ?? null;
+    return {
+      verification: buildVerification(findings),
+      continuity: {
+        kind: 'none',
+        status: 'not_applicable',
+        outcome: 'none',
+      },
+      metrics: summarizeMetrics(snapshot, projectId),
+      stabilityVector: {
+        derived_trigger: controllerResult.task_results[0]?.derived_trigger ?? null,
+        actual_actions: actualActions,
+        expected_actions: expectedActions,
+        delivery_families: deliveryFamilies,
+        controller_metric: controllerMetric == null
+          ? null
+          : {
+              failure_class: controllerMetric.failure_class,
+              trigger_kind: controllerMetric.trigger_kind,
+              action_class_counts: controllerMetric.action_class_counts,
+              intervention_counts: controllerMetric.intervention_counts,
+            },
+      },
+    };
+  } finally {
+    if (priorFixtureRoot == null) {
+      delete process.env.AO_FIXTURE_ROOT;
+    } else {
+      process.env.AO_FIXTURE_ROOT = priorFixtureRoot;
+    }
+    removeTempRepo(repoRoot);
+  }
+}
+
+async function executeControllerPolicyScenario({
+  scenario,
+  projectId,
+} = {}) {
+  const repoRoot = createTempRepo('ao-eval-policy-');
+
+  try {
+    const repository = createStateRepository({
+      repoRoot,
+      projectId,
+    });
+    buildControllerTaskSeed(repository, scenario, scenario.timing.created_at, {
+      withCredentials: true,
+    });
+
+    const controllerResult = await runControllerLoop({
+      repoRoot,
+      cwd: repoRoot,
+      projectId,
+      controllerId: scenario.controller.controller_id,
+      mode: scenario.controller.mode,
+      now: scenario.timing.run_at,
+      deps: {
+        loadAoProjectObservation: async () => ({
+          observed_at: scenario.timing.run_at,
+          workers: [
+            {
+              session_name: scenario.task.owner_session_name ?? 'cie-54',
+              session_runtime_id: scenario.task.owner_session_id ?? 'cie-54',
+              issue_number: scenario.task.issue_number,
+              branch_name: scenario.task.branch_name,
+              pr_number: scenario.pr_binding.pr_number,
+              lifecycle_state: 'idle',
+              last_seen_at: scenario.timing.run_at,
+              freshness: {
+                status: 'fresh',
+              },
+            },
+          ],
+        }),
+        loadGitHubObservationSet: async () => ({
+          observed_at: scenario.timing.run_at,
+          prs: [
+            {
+              pr_number: scenario.pr_binding.pr_number,
+              state: 'OPEN',
+              head_branch: scenario.task.branch_name,
+              head_sha: 'abc107',
+              review_status: 'pending',
+              ci_status: 'pending',
+              mergeability: 'mergeable',
+              is_draft: false,
+              url: `https://example.test/pr/${scenario.pr_binding.pr_number}`,
+            },
+          ],
+        }),
+        resolveLifecycleReport: async () => scenario.lifecycle_report,
+      },
+    });
+
+    const snapshot = repository.getSnapshot();
+    const taskResult = controllerResult.task_results[0] ?? {};
+    const findings = [];
+    for (const fieldName of [
+      'policy_decision_count',
+      'policy_blocked_action_count',
+      'denied_action_count',
+      'downgraded_action_count',
+    ]) {
+      if (taskResult[fieldName] !== scenario.expected[fieldName]) {
+        findings.push(createFinding(
+          'policy_result_mismatch',
+          `Expected ${fieldName}=${scenario.expected[fieldName]} but received ${taskResult[fieldName]}.`,
+          {
+            field: fieldName,
+          },
+        ));
+      }
+    }
+
+    const decisionsByActionKind = snapshot.state.policy_decisions
+      .map((record) => [record.action_kind, record.decision])
+      .sort((left, right) => left[0].localeCompare(right[0]));
+    const expectedDecisions = [
+      ['continue_worker', 'allow'],
+      ['gh_review', 'allow'],
+      ['unknown_tool', 'deny'],
+      ['workflow_gate', 'downgrade'],
+    ];
+    if (JSON.stringify(decisionsByActionKind) !== JSON.stringify(expectedDecisions)) {
+      findings.push(createFinding(
+        'policy_decision_mismatch',
+        'Policy decisions did not match the expected fail-closed routing.',
+      ));
+    }
+
+    const actionStatuses = snapshot.state.actions
+      .map((record) => [record.action_kind, record.status])
+      .sort((left, right) => left[0].localeCompare(right[0]));
+    const expectedStatuses = [
+      ['continue_worker', 'proposed'],
+      ['gh_review', 'proposed'],
+      ['unknown_tool', 'blocked'],
+      ['workflow_gate', 'blocked'],
+    ];
+    if (JSON.stringify(actionStatuses) !== JSON.stringify(expectedStatuses)) {
+      findings.push(createFinding(
+        'policy_block_status_mismatch',
+        'Action status did not reflect allow versus blocked policy outcomes.',
+      ));
+    }
+
+    const controllerMetric = snapshot.state.controller_run_metrics[0] ?? null;
+    return {
+      verification: buildVerification(findings),
+      continuity: {
+        kind: 'none',
+        status: 'not_applicable',
+        outcome: 'none',
+      },
+      metrics: summarizeMetrics(snapshot, projectId),
+      stabilityVector: {
+        task_result: {
+          policy_decision_count: taskResult.policy_decision_count ?? 0,
+          policy_blocked_action_count: taskResult.policy_blocked_action_count ?? 0,
+          denied_action_count: taskResult.denied_action_count ?? 0,
+          downgraded_action_count: taskResult.downgraded_action_count ?? 0,
+        },
+        policy_decisions: decisionsByActionKind,
+        action_statuses: actionStatuses,
+        controller_metric: controllerMetric == null
+          ? null
+          : {
+              failure_class: controllerMetric.failure_class,
+              intervention_counts: controllerMetric.intervention_counts,
+            },
+      },
+    };
+  } finally {
+    removeTempRepo(repoRoot);
+  }
+}
+
+function sortExecutionAttempts(records = []) {
+  return [...records].sort((left, right) => String(left?.started_at ?? '').localeCompare(String(right?.started_at ?? '')));
+}
+
+async function executeResumeContinuityScenario({
+  scenario,
+  projectId,
+} = {}) {
+  const repoRoot = createTempRepo('ao-eval-resume-', { git: true });
+
+  try {
+    await runManageCommand({
+      repoRoot,
+      projectId,
+      command: 'enroll',
+      issueNumber: scenario.task.issue_number,
+      title: scenario.task.title,
+      branchName: scenario.task.branch_name,
+      worktreePath: scenario.task.worktree_path,
+      prNumber: scenario.task.pr_number,
+      ownerSessionName: scenario.task.owner_session_name,
+      ownerSessionId: scenario.task.owner_session_id,
+      taskSpecBody: joinTaskSpecBody(scenario.task_spec_body),
+      now: scenario.timing.enroll_at,
+    });
+
+    const repository = createStateRepository({
+      repoRoot,
+      projectId,
+    });
+    repository.ensureRuntimePreflights({
+      cwd: repoRoot,
+      now: scenario.timing.preflight_at,
+      probes: {
+        commandExists: () => true,
+        pathExists: () => true,
+        capability: () => true,
+      },
+    });
+    const checkpoint = createCheckpointStore({
+      repository,
+      now: () => scenario.timing.checkpoint_at,
+    }).captureCheckpoint({
+      taskId: `issue-${scenario.task.issue_number}`,
+      controllerId: 'default',
+      derivedTrigger: 'manual',
+      observedAt: scenario.timing.checkpoint_at,
+      actionIds: ['proposal-resume-continuity'],
+    });
+
+    await runManageCommand({
+      repoRoot,
+      projectId,
+      command: 'unmanage',
+      issueNumber: scenario.task.issue_number,
+      now: scenario.timing.pause_at,
+      reason: 'worker_exited',
+    });
+
+    const result = await runManageCommand({
+      repoRoot,
+      projectId,
+      command: 'resume',
+      issueNumber: scenario.task.issue_number,
+      ownerSessionName: scenario.task.owner_session_name,
+      ownerSessionId: scenario.task.owner_session_id,
+      now: scenario.timing.resume_at,
+    });
+
+    const snapshot = repository.getSnapshot();
+    const executionAttempts = sortExecutionAttempts(snapshot.state.execution_attempt_metrics);
+    const findings = [];
+    if (result.resume?.state !== 'valid') {
+      findings.push(createFinding(
+        'resume_checkpoint_invalid',
+        'Explicit resume did not resolve a valid checkpoint.',
+      ));
+    }
+    if (result.task?.metadata?.resume?.last_resume_checkpoint_id !== checkpoint.checkpoint_id) {
+      findings.push(createFinding(
+        'resume_checkpoint_lineage_missing',
+        'Resumed managed task did not retain checkpoint lineage metadata.',
+      ));
+    }
+    if (!executionAttempts.some((record) => (
+      record.command === 'resume'
+        && record.retry_cause === 'explicit_resume'
+        && record.status === 'active'
+    ))) {
+      findings.push(createFinding(
+        'resume_retry_cause_missing',
+        'Resume attempt did not record an explicit_resume retry cause.',
+      ));
+    }
+    if (!executionAttempts.some((record) => (
+      record.command === 'enroll'
+        && record.failure_class === 'worker_exit'
+        && record.status === 'paused'
+    ))) {
+      findings.push(createFinding(
+        'resume_prior_attempt_missing',
+        'Paused enrollment attempt was not retained as worker_exit history.',
+      ));
+    }
+
+    return {
+      verification: buildVerification(findings),
+      continuity: {
+        kind: 'resume',
+        status: findings.length === 0 ? 'success' : 'failed',
+        outcome: findings.length === 0 ? 'explicit_resume' : 'failed',
+      },
+      metrics: summarizeMetrics(snapshot, projectId),
+      stabilityVector: {
+        task: {
+          status: result.task?.status ?? null,
+          branch_name: result.task?.branch_name ?? null,
+          worktree_path: result.task?.worktree_path ?? null,
+        },
+        ownership_lease: {
+          owner_session_name: result.ownershipLease?.owner_session_name ?? null,
+          status: result.ownershipLease?.status ?? null,
+        },
+        resume: {
+          checkpoint_id: result.resume?.checkpoint_id ?? null,
+          state: result.resume?.state ?? null,
+        },
+        execution_attempts: executionAttempts.map((record) => ({
+          command: record.command,
+          status: record.status,
+          retry_cause: record.retry_cause,
+          failure_class: record.failure_class,
+        })),
+      },
+    };
+  } finally {
+    removeTempRepo(repoRoot);
+  }
+}
+
+async function executeSuccessorHandoffScenario({
+  scenario,
+  projectId,
+} = {}) {
+  const repoRoot = createTempRepo('ao-eval-handoff-', { git: true });
+
+  try {
+    await runManageCommand({
+      repoRoot,
+      projectId,
+      command: 'enroll',
+      issueNumber: scenario.task.issue_number,
+      title: scenario.task.title,
+      branchName: scenario.task.branch_name,
+      worktreePath: scenario.task.worktree_path,
+      prNumber: scenario.task.pr_number,
+      ownerSessionName: scenario.task.owner_session_name,
+      ownerSessionId: scenario.task.owner_session_id,
+      taskSpecBody: joinTaskSpecBody(scenario.task_spec_body),
+      now: scenario.timing.enroll_at,
+    });
+
+    const repository = createStateRepository({
+      repoRoot,
+      projectId,
+    });
+    repository.ensureRuntimePreflights({
+      cwd: repoRoot,
+      now: scenario.timing.preflight_at,
+      probes: {
+        commandExists: () => true,
+        pathExists: () => true,
+        capability: () => true,
+      },
+    });
+    createCheckpointStore({
+      repository,
+      now: () => scenario.timing.checkpoint_at,
+    }).captureCheckpoint({
+      taskId: `issue-${scenario.task.issue_number}`,
+      controllerId: 'default',
+      derivedTrigger: 'agent_exited',
+      observedAt: scenario.timing.checkpoint_at,
+      actionIds: ['proposal-handoff-continuity'],
+    });
+
+    await runManageCommand({
+      repoRoot,
+      projectId,
+      command: 'unmanage',
+      issueNumber: scenario.task.issue_number,
+      now: scenario.timing.pause_at,
+      reason: 'worker_stale',
+    });
+
+    const handoffProtocol = createHandoffProtocol({
+      repository,
+      now: () => scenario.timing.handoff_at,
+    });
+    const request = handoffProtocol.requestHandoff({
+      taskId: `issue-${scenario.task.issue_number}`,
+      requestedBySessionName: scenario.task.operator_session_name,
+      requestedBySessionId: scenario.task.operator_session_id,
+      operatorSessionName: scenario.task.operator_session_name,
+      operatorSessionId: scenario.task.operator_session_id,
+      successorSessionName: scenario.task.successor_session_name,
+      successorSessionId: scenario.task.successor_session_id,
+      reason: 'owner_stale',
+    });
+    const claim = handoffProtocol.claimHandoff({
+      requestId: request.request_id,
+      successorSessionName: scenario.task.successor_session_name,
+      successorSessionId: scenario.task.successor_session_id,
+      reason: 'resume_as_successor',
+    });
+    handoffProtocol.acceptHandoff({
+      requestId: request.request_id,
+      claimId: claim.claim_id,
+      operatorSessionName: scenario.task.operator_session_name,
+      operatorSessionId: scenario.task.operator_session_id,
+      reason: 'approved_successor',
+      grantExpiresAt: scenario.timing.grant_expires_at,
+    });
+
+    const result = await runManageCommand({
+      repoRoot,
+      projectId,
+      command: 'resume',
+      issueNumber: scenario.task.issue_number,
+      ownerSessionName: scenario.task.successor_session_name,
+      ownerSessionId: scenario.task.successor_session_id,
+      now: scenario.timing.resume_at,
+    });
+
+    const snapshot = repository.getSnapshot();
+    const executionAttempts = sortExecutionAttempts(snapshot.state.execution_attempt_metrics);
+    const findings = [];
+    if (result.handoffTransfer == null) {
+      findings.push(createFinding(
+        'handoff_transfer_missing',
+        'Resume did not complete the accepted handoff transfer.',
+      ));
+    }
+    if (!snapshot.state.handoff_requests.some((record) => record.status === 'completed')) {
+      findings.push(createFinding(
+        'handoff_request_not_completed',
+        'Accepted handoff request was not marked completed after resume.',
+      ));
+    }
+    if (!executionAttempts.some((record) => (
+      record.command === 'resume'
+        && record.retry_cause === 'successor_handoff'
+        && record.status === 'active'
+    ))) {
+      findings.push(createFinding(
+        'handoff_retry_cause_missing',
+        'Successor resume did not record a successor_handoff retry cause.',
+      ));
+    }
+
+    return {
+      verification: buildVerification(findings),
+      continuity: {
+        kind: 'handoff',
+        status: findings.length === 0 ? 'success' : 'failed',
+        outcome: findings.length === 0 ? 'successor_handoff' : 'failed',
+      },
+      metrics: summarizeMetrics(snapshot, projectId),
+      stabilityVector: {
+        ownership_lease: {
+          owner_session_name: result.ownershipLease?.owner_session_name ?? null,
+          status: result.ownershipLease?.status ?? null,
+        },
+        handoff_transfer: {
+          successor_session_name: result.handoffTransfer?.successor_session_name ?? null,
+          reason: result.handoffTransfer?.reason ?? null,
+        },
+        handoff_request_statuses: snapshot.state.handoff_requests.map((record) => record.status).sort(),
+        execution_attempts: executionAttempts.map((record) => ({
+          command: record.command,
+          status: record.status,
+          retry_cause: record.retry_cause,
+          failure_class: record.failure_class,
+        })),
+      },
+    };
+  } finally {
+    removeTempRepo(repoRoot);
+  }
+}
+
+async function executeScenario({
+  scenario,
+  fixtureRoot,
+  projectId,
+} = {}) {
+  switch (scenario.runner) {
+    case 'controller_shadow_parity':
+      return executeControllerParityScenario({
+        scenario,
+        fixtureRoot,
+        projectId,
+      });
+    case 'controller_policy_fail_closed':
+      return executeControllerPolicyScenario({
+        scenario,
+        projectId,
+      });
+    case 'managed_resume_continuity':
+      return executeResumeContinuityScenario({
+        scenario,
+        projectId,
+      });
+    case 'managed_successor_handoff':
+      return executeSuccessorHandoffScenario({
+        scenario,
+        projectId,
+      });
+    default:
+      throw new Error(`Unsupported eval runner: ${scenario.runner}`);
+  }
+}
+
+export async function runAoEvalHarness({
+  projectId = DEFAULT_PROJECT_ID,
+  fixtureRoot,
+  packNames = ['all'],
+} = {}) {
+  const resolvedFixtureRoot = path.resolve(String(fixtureRoot));
+  const packRegistry = loadPackRegistry(resolvedFixtureRoot);
+  const resolvedPackIds = resolveRequestedPacks(packRegistry, packNames);
+  const scenarioIds = resolveScenarioIds(packRegistry, resolvedPackIds);
+  const scenarioResults = [];
+
+  for (const scenarioId of scenarioIds) {
+    const scenario = loadScenarioDefinition(resolvedFixtureRoot, scenarioId);
+    try {
+      const primaryResult = await executeScenario({
+        scenario,
+        fixtureRoot: resolvedFixtureRoot,
+        projectId,
+      });
+      const replayResult = await executeScenario({
+        scenario,
+        fixtureRoot: resolvedFixtureRoot,
+        projectId,
+      });
+      const fingerprint = buildFingerprint(primaryResult.stabilityVector);
+      const replayFingerprint = buildFingerprint(replayResult.stabilityVector);
+      const replayStable = fingerprint === replayFingerprint;
+
+      scenarioResults.push({
+        scenario_id: scenario.scenario_id,
+        pack_id: scenario.pack_id,
+        runner: scenario.runner,
+        title: scenario.title,
+        status: primaryResult.verification.status === 'passed' ? 'passed' : 'failed',
+        verification: primaryResult.verification,
+        replay: {
+          stable: replayStable,
+          fingerprint,
+          replay_fingerprint: replayFingerprint,
+        },
+        continuity: primaryResult.continuity,
+        metrics: primaryResult.metrics,
+      });
+    } catch (error) {
+      scenarioResults.push({
+        scenario_id: scenario.scenario_id,
+        pack_id: scenario.pack_id,
+        runner: scenario.runner,
+        title: scenario.title,
+        status: 'failed',
+        verification: buildVerification([
+          createFinding(
+            'scenario_runtime_error',
+            error.message,
+          ),
+        ]),
+        replay: {
+          stable: false,
+          fingerprint: null,
+          replay_fingerprint: null,
+        },
+        continuity: {
+          kind: scenario.runner.startsWith('managed_') ? (scenario.runner === 'managed_resume_continuity' ? 'resume' : 'handoff') : 'none',
+          status: 'failed',
+          outcome: 'failed',
+        },
+        metrics: {
+          controller_run_count: 0,
+          execution_attempt_count: 0,
+          measurement_count: 0,
+          intervened_measurement_count: 0,
+          intervention_counts: {
+            human_gate: 0,
+            override: 0,
+            explicit_resume: 0,
+            successor_handoff: 0,
+            policy_block: 0,
+            preflight_block: 0,
+          },
+          failure_class_counts: {
+            none: 0,
+            ci_failure: 0,
+            review_blocked: 0,
+            merge_conflict: 0,
+            source_failure: 0,
+            human_gate: 0,
+            override: 0,
+            policy_block: 0,
+            preflight_block: 0,
+            worker_exit: 0,
+            successor_handoff: 0,
+            unknown: 0,
+          },
+        },
+      });
+    }
+  }
+
+  return {
+    schema_version: AO_EVAL_HARNESS_RUN_SCHEMA_VERSION,
+    format: AO_EVAL_HARNESS_RUN_FORMAT,
+    project_id: projectId,
+    fixture_root: resolvedFixtureRoot,
+    pack_ids: resolvedPackIds,
+    scenario_ids: scenarioIds,
+    scenario_results: scenarioResults,
+    summary: buildHarnessSummary(scenarioResults),
+  };
+}

--- a/scripts/ao/lib/scorecard.js
+++ b/scripts/ao/lib/scorecard.js
@@ -1,0 +1,385 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+
+import {
+  AO_EVAL_SCORECARD_FORMAT,
+  AO_EVAL_SCORECARD_SCHEMA_VERSION,
+} from './state-contracts.js';
+import { resolveControlPlanePaths } from './state-migrations.js';
+import { createStateRepository } from './state-repository.js';
+
+export const DEFAULT_PROJECT_ID = 'ciecopilot-home';
+
+function ratio(numerator, denominator) {
+  if (!Number.isFinite(denominator) || denominator <= 0) return 0;
+  return numerator / denominator;
+}
+
+function buildScorecardId({ projectId, generatedAt, scenarioIds, packIds }) {
+  const digest = createHash('sha1')
+    .update(JSON.stringify({
+      project_id: projectId,
+      generated_at: generatedAt,
+      scenario_ids: scenarioIds,
+      pack_ids: packIds,
+    }))
+    .digest('hex')
+    .slice(0, 12);
+  return `scorecard-${digest}`;
+}
+
+function sumCountMaps(countMaps = []) {
+  const result = {};
+  for (const countMap of countMaps) {
+    for (const [key, value] of Object.entries(countMap ?? {})) {
+      result[key] = (result[key] ?? 0) + Number(value ?? 0);
+    }
+  }
+  return result;
+}
+
+function buildFailureRates(counts, totalMeasurementCount) {
+  const rates = {};
+  for (const [key, value] of Object.entries(counts)) {
+    rates[key] = ratio(value, totalMeasurementCount);
+  }
+  return rates;
+}
+
+function buildDefaultGuardrails() {
+  return {
+    verification_success: 'non_decreasing',
+    replay_stability: 'non_decreasing',
+    continuity_success: 'non_decreasing',
+    intervention_rate: 'non_increasing',
+    failure_class_distribution: 'non_increasing_non_none',
+  };
+}
+
+export function buildAoEvalScorecard({
+  projectId = DEFAULT_PROJECT_ID,
+  harnessResult,
+  generatedAt = new Date().toISOString(),
+} = {}) {
+  const scenarioResults = Array.isArray(harnessResult?.scenario_results)
+    ? harnessResult.scenario_results
+    : [];
+  const packIds = Array.isArray(harnessResult?.pack_ids) ? harnessResult.pack_ids : [];
+  const scenarioIds = Array.isArray(harnessResult?.scenario_ids)
+    ? harnessResult.scenario_ids
+    : scenarioResults.map((scenario) => scenario.scenario_id);
+  const totalMeasurementCount = scenarioResults.reduce(
+    (total, scenario) => total + Number(scenario?.metrics?.measurement_count ?? 0),
+    0,
+  );
+  const verificationPassedCount = scenarioResults.filter(
+    (scenario) => scenario?.verification?.status === 'passed',
+  ).length;
+  const replayStableCount = scenarioResults.filter(
+    (scenario) => scenario?.replay?.stable === true,
+  ).length;
+  const continuityResults = scenarioResults.filter((scenario) => scenario?.continuity?.kind !== 'none');
+  const continuitySuccessCount = continuityResults.filter(
+    (scenario) => scenario?.continuity?.status === 'success',
+  ).length;
+  const interventionCount = scenarioResults.reduce(
+    (total, scenario) => total + Number(scenario?.metrics?.intervened_measurement_count ?? 0),
+    0,
+  );
+  const failureCounts = sumCountMaps(
+    scenarioResults.map((scenario) => scenario?.metrics?.failure_class_counts ?? {}),
+  );
+  const interventionCounts = sumCountMaps(
+    scenarioResults.map((scenario) => scenario?.metrics?.intervention_counts ?? {}),
+  );
+  const continuityOutcomeCounts = {
+    explicit_resume_success: 0,
+    successor_handoff_success: 0,
+    failed: 0,
+    not_applicable: 0,
+  };
+  for (const scenario of scenarioResults) {
+    if (scenario?.continuity?.kind === 'none') {
+      continuityOutcomeCounts.not_applicable += 1;
+      continue;
+    }
+    if (scenario?.continuity?.outcome === 'explicit_resume' && scenario?.continuity?.status === 'success') {
+      continuityOutcomeCounts.explicit_resume_success += 1;
+      continue;
+    }
+    if (scenario?.continuity?.outcome === 'successor_handoff' && scenario?.continuity?.status === 'success') {
+      continuityOutcomeCounts.successor_handoff_success += 1;
+      continue;
+    }
+    continuityOutcomeCounts.failed += 1;
+  }
+
+  const findings = [];
+  for (const scenario of scenarioResults) {
+    if (scenario?.verification?.status === 'failed') {
+      findings.push({
+        code: 'scenario_verification_failed',
+        scenario_id: scenario.scenario_id,
+        summary: `Scenario ${scenario.scenario_id} failed verification.`,
+      });
+    }
+    if (scenario?.replay?.stable === false) {
+      findings.push({
+        code: 'scenario_replay_unstable',
+        scenario_id: scenario.scenario_id,
+        summary: `Scenario ${scenario.scenario_id} was not stable under replay.`,
+      });
+    }
+    if (scenario?.continuity?.kind !== 'none' && scenario?.continuity?.status === 'failed') {
+      findings.push({
+        code: 'scenario_continuity_failed',
+        scenario_id: scenario.scenario_id,
+        summary: `Scenario ${scenario.scenario_id} failed its continuity contract.`,
+      });
+    }
+  }
+
+  return {
+    schema_version: AO_EVAL_SCORECARD_SCHEMA_VERSION,
+    format: AO_EVAL_SCORECARD_FORMAT,
+    scorecard_id: buildScorecardId({
+      projectId,
+      generatedAt,
+      scenarioIds,
+      packIds,
+    }),
+    project_id: projectId,
+    generated_at: generatedAt,
+    pack_ids: packIds,
+    scenario_ids: scenarioIds,
+    guardrails: buildDefaultGuardrails(),
+    summary: {
+      scenario_count: scenarioResults.length,
+      passed_scenario_count: scenarioResults.filter((scenario) => scenario?.status === 'passed').length,
+      failed_scenario_count: scenarioResults.filter((scenario) => scenario?.status === 'failed').length,
+      verification_success: {
+        passed: verificationPassedCount,
+        total: scenarioResults.length,
+        rate: ratio(verificationPassedCount, scenarioResults.length),
+      },
+      replay_stability: {
+        stable: replayStableCount,
+        total: scenarioResults.length,
+        rate: ratio(replayStableCount, scenarioResults.length),
+      },
+      continuity: {
+        successful: continuitySuccessCount,
+        total: continuityResults.length,
+        rate: ratio(continuitySuccessCount, continuityResults.length),
+        outcome_counts: continuityOutcomeCounts,
+      },
+      intervention_rate: {
+        intervened_measurement_count: interventionCount,
+        total_measurement_count: totalMeasurementCount,
+        rate: ratio(interventionCount, totalMeasurementCount),
+      },
+      intervention_counts: interventionCounts,
+      failure_class_distribution: {
+        counts: failureCounts,
+        rates: buildFailureRates(failureCounts, totalMeasurementCount),
+      },
+    },
+    scenarios: scenarioResults,
+    findings,
+  };
+}
+
+function createRegressionFinding(code, metric, baselineValue, currentValue) {
+  return {
+    code,
+    metric,
+    baseline_value: baselineValue,
+    current_value: currentValue,
+  };
+}
+
+export function compareAoEvalScorecards({
+  baselineScorecard,
+  currentScorecard,
+  comparedAt = new Date().toISOString(),
+} = {}) {
+  const findings = [];
+
+  const baselineScenarioIds = JSON.stringify(baselineScorecard?.scenario_ids ?? []);
+  const currentScenarioIds = JSON.stringify(currentScorecard?.scenario_ids ?? []);
+  if (baselineScenarioIds !== currentScenarioIds) {
+    return {
+      status: 'invalid',
+      compared_at: comparedAt,
+      baseline_scorecard_id: baselineScorecard?.scorecard_id ?? null,
+      current_scorecard_id: currentScorecard?.scorecard_id ?? null,
+      findings: [
+        createRegressionFinding(
+          'scorecard_scope_mismatch',
+          'scenario_ids',
+          baselineScorecard?.scenario_ids ?? [],
+          currentScorecard?.scenario_ids ?? [],
+        ),
+      ],
+    };
+  }
+
+  const baselineVerificationRate = baselineScorecard?.summary?.verification_success?.rate ?? 0;
+  const currentVerificationRate = currentScorecard?.summary?.verification_success?.rate ?? 0;
+  if (currentVerificationRate < baselineVerificationRate) {
+    findings.push(createRegressionFinding(
+      'verification_success_regressed',
+      'verification_success.rate',
+      baselineVerificationRate,
+      currentVerificationRate,
+    ));
+  }
+
+  const baselineReplayRate = baselineScorecard?.summary?.replay_stability?.rate ?? 0;
+  const currentReplayRate = currentScorecard?.summary?.replay_stability?.rate ?? 0;
+  if (currentReplayRate < baselineReplayRate) {
+    findings.push(createRegressionFinding(
+      'replay_stability_regressed',
+      'replay_stability.rate',
+      baselineReplayRate,
+      currentReplayRate,
+    ));
+  }
+
+  const baselineContinuityRate = baselineScorecard?.summary?.continuity?.rate ?? 0;
+  const currentContinuityRate = currentScorecard?.summary?.continuity?.rate ?? 0;
+  if (currentContinuityRate < baselineContinuityRate) {
+    findings.push(createRegressionFinding(
+      'continuity_success_regressed',
+      'continuity.rate',
+      baselineContinuityRate,
+      currentContinuityRate,
+    ));
+  }
+
+  const baselineInterventionRate = baselineScorecard?.summary?.intervention_rate?.rate ?? 0;
+  const currentInterventionRate = currentScorecard?.summary?.intervention_rate?.rate ?? 0;
+  if (currentInterventionRate > baselineInterventionRate) {
+    findings.push(createRegressionFinding(
+      'intervention_rate_regressed',
+      'intervention_rate.rate',
+      baselineInterventionRate,
+      currentInterventionRate,
+    ));
+  }
+
+  const baselineFailureCounts = baselineScorecard?.summary?.failure_class_distribution?.counts ?? {};
+  const currentFailureCounts = currentScorecard?.summary?.failure_class_distribution?.counts ?? {};
+  const failureMetrics = new Set([
+    ...Object.keys(baselineFailureCounts),
+    ...Object.keys(currentFailureCounts),
+  ]);
+  for (const metric of failureMetrics) {
+    if (metric === 'none') continue;
+    const baselineValue = Number(baselineFailureCounts[metric] ?? 0);
+    const currentValue = Number(currentFailureCounts[metric] ?? 0);
+    if (currentValue > baselineValue) {
+      findings.push(createRegressionFinding(
+        'failure_class_distribution_regressed',
+        metric,
+        baselineValue,
+        currentValue,
+      ));
+    }
+  }
+
+  return {
+    status: findings.length === 0 ? 'ok' : 'regressed',
+    compared_at: comparedAt,
+    baseline_scorecard_id: baselineScorecard?.scorecard_id ?? null,
+    current_scorecard_id: currentScorecard?.scorecard_id ?? null,
+    findings,
+  };
+}
+
+export function persistAoEvalScorecard({
+  repoRoot,
+  projectId = DEFAULT_PROJECT_ID,
+  scorecard,
+  baselineName = null,
+} = {}) {
+  const repository = createStateRepository({
+    repoRoot,
+    projectId,
+  });
+  return repository.persistEvalScorecardArtifact({
+    scorecard,
+    baselineName,
+  });
+}
+
+export function loadAoEvalBaseline({
+  repoRoot,
+  projectId = DEFAULT_PROJECT_ID,
+  baselineRef,
+  cwd = repoRoot ?? process.cwd(),
+} = {}) {
+  if (typeof baselineRef !== 'string' || baselineRef.trim() === '') {
+    throw new Error('Missing baselineRef');
+  }
+
+  const normalizedBaselineRef = baselineRef.trim();
+  const candidatePath = path.isAbsolute(normalizedBaselineRef)
+    ? normalizedBaselineRef
+    : path.resolve(cwd, normalizedBaselineRef);
+  if (fs.existsSync(candidatePath)) {
+    return JSON.parse(fs.readFileSync(candidatePath, 'utf8'));
+  }
+
+  const repository = createStateRepository({
+    repoRoot,
+    projectId,
+  });
+  const baseline = repository.readEvalBaselineArtifact({
+    baselineName: normalizedBaselineRef,
+  });
+  if (baseline != null) return baseline;
+
+  const controlPlanePaths = resolveControlPlanePaths({
+    repoRoot,
+    projectId,
+  });
+  if (normalizedBaselineRef === 'latest' && fs.existsSync(controlPlanePaths.latestEvalScorecardPath)) {
+    return JSON.parse(fs.readFileSync(controlPlanePaths.latestEvalScorecardPath, 'utf8'));
+  }
+
+  const scorecard = repository.readEvalScorecardArtifact({
+    scorecardId: normalizedBaselineRef,
+  });
+  if (scorecard != null) return scorecard;
+
+  throw new Error(`Unknown eval baseline: ${normalizedBaselineRef}`);
+}
+
+function formatFailureCounts(counts = {}) {
+  return Object.entries(counts)
+    .filter(([, value]) => Number(value) > 0)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(', ') || 'none';
+}
+
+export function renderAoEvalHumanSummary({
+  scorecard,
+  comparison = null,
+  persisted = null,
+} = {}) {
+  return [
+    `scorecard_id: ${scorecard?.scorecard_id ?? 'unknown'}`,
+    `packs: ${(scorecard?.pack_ids ?? []).join(', ') || 'none'}`,
+    `scenarios: ${scorecard?.summary?.scenario_count ?? 0}`,
+    `verification_success: ${scorecard?.summary?.verification_success?.passed ?? 0}/${scorecard?.summary?.verification_success?.total ?? 0}`,
+    `replay_stability: ${scorecard?.summary?.replay_stability?.stable ?? 0}/${scorecard?.summary?.replay_stability?.total ?? 0}`,
+    `continuity_success: ${scorecard?.summary?.continuity?.successful ?? 0}/${scorecard?.summary?.continuity?.total ?? 0}`,
+    `intervention_rate: ${scorecard?.summary?.intervention_rate?.intervened_measurement_count ?? 0}/${scorecard?.summary?.intervention_rate?.total_measurement_count ?? 0}`,
+    `failure_classes: ${formatFailureCounts(scorecard?.summary?.failure_class_distribution?.counts ?? {})}`,
+    `comparison: ${comparison?.status ?? 'not_requested'}`,
+    `scorecard_path: ${persisted?.scorecard_path ?? 'not_persisted'}`,
+    `baseline_path: ${persisted?.baseline_path ?? 'none'}`,
+  ].join('\n');
+}

--- a/scripts/ao/lib/state-contracts.js
+++ b/scripts/ao/lib/state-contracts.js
@@ -35,6 +35,10 @@ export const HANDOFF_DECISION_SCHEMA_VERSION = 'ao.handoff-decision.v1alpha1';
 export const HANDOFF_DECISION_FORMAT = 'ao_handoff_decision';
 export const HANDOFF_TRANSFER_SCHEMA_VERSION = 'ao.handoff-transfer.v1alpha1';
 export const HANDOFF_TRANSFER_FORMAT = 'ao_handoff_transfer';
+export const AO_EVAL_HARNESS_RUN_SCHEMA_VERSION = 'ao.eval-harness-run.v1alpha1';
+export const AO_EVAL_HARNESS_RUN_FORMAT = 'ao_eval_harness_run';
+export const AO_EVAL_SCORECARD_SCHEMA_VERSION = 'ao.eval-scorecard.v1alpha1';
+export const AO_EVAL_SCORECARD_FORMAT = 'ao_eval_scorecard';
 
 export const MANAGED_TASK_STATUSES = ['active', 'paused', 'retired'];
 export const PR_BINDING_STATUSES = ['bound', 'released', 'closed'];

--- a/scripts/ao/lib/state-migrations.js
+++ b/scripts/ao/lib/state-migrations.js
@@ -350,6 +350,14 @@ export function resolveControlPlanePaths({
     schemaPath: path.join(stateRoot, 'schema.json'),
     statePath: path.join(stateRoot, 'state.json'),
     auditPath: path.join(stateRoot, 'audit-log.jsonl'),
+    evalRoot: path.join(stateRoot, 'eval'),
+    evalScorecardRoot: path.join(stateRoot, 'eval', 'scorecards'),
+    evalBaselineRoot: path.join(stateRoot, 'eval', 'baselines'),
+    latestEvalScorecardPath: path.join(stateRoot, 'eval', 'latest.json'),
+    operatorEvalRoot: path.join(normalizedRepoRoot, 'ao-artifacts', 'ao-eval'),
+    operatorEvalScorecardRoot: path.join(normalizedRepoRoot, 'ao-artifacts', 'ao-eval', 'scorecards'),
+    operatorEvalBaselineRoot: path.join(normalizedRepoRoot, 'ao-artifacts', 'ao-eval', 'baselines'),
+    operatorLatestEvalScorecardPath: path.join(normalizedRepoRoot, 'ao-artifacts', 'ao-eval', 'latest.json'),
   };
 }
 

--- a/scripts/ao/lib/state-repository.js
+++ b/scripts/ao/lib/state-repository.js
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import path from 'node:path';
 
 import {
   CONTROL_PLANE_LATEST_VERSION,
@@ -37,7 +38,10 @@ import {
   readControlPlaneState,
   resolveControlPlanePaths,
 } from './state-migrations.js';
-import { writeJsonFileAtomic } from './state-storage.js';
+import {
+  readJsonFile,
+  writeJsonFileAtomic,
+} from './state-storage.js';
 
 function resolveNow(clock) {
   if (typeof clock === 'function') return resolveNow(clock());
@@ -85,6 +89,19 @@ function extractRuntimeRefsFromState(state) {
   return normalizeRuntimeRefs(
     (state?.task_specs ?? []).map((record) => record?.snapshot?.spec?.runtime_ref ?? null),
   );
+}
+
+function sanitizeArtifactToken(value, fieldName) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+
+  const normalized = value.trim();
+  if (!/^[A-Za-z0-9._-]+$/.test(normalized)) {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+
+  return normalized;
 }
 
 export function createStateRepository({
@@ -600,6 +617,90 @@ export function createStateRepository({
         normalize: createCheckpointRecord,
         summary: `Persisted checkpoint ${record?.checkpoint_id}.`,
       });
+    },
+
+    persistEvalScorecardArtifact({
+      scorecard,
+      baselineName = null,
+      recordedAt = clock,
+    } = {}) {
+      ensureBootstrapped();
+      const timestamp = resolveNow(recordedAt);
+      const scorecardId = sanitizeArtifactToken(scorecard?.scorecard_id, 'scorecard_id');
+      const scorecardPath = path.join(paths.evalScorecardRoot, `${scorecardId}.json`);
+      const operatorScorecardPath = path.join(paths.operatorEvalScorecardRoot, `${scorecardId}.json`);
+
+      writeJsonFileAtomic(scorecardPath, scorecard);
+      writeJsonFileAtomic(paths.latestEvalScorecardPath, scorecard);
+      writeJsonFileAtomic(operatorScorecardPath, scorecard);
+      writeJsonFileAtomic(paths.operatorLatestEvalScorecardPath, scorecard);
+
+      appendControlPlaneAuditEntry({
+        auditPath: paths.auditPath,
+        entry: createControlPlaneAuditEntry({
+          audit_id: auditIdGenerator(),
+          project_id: projectId,
+          recorded_at: timestamp,
+          entity_kind: 'eval_scorecard',
+          entity_id: scorecardId,
+          operation: 'write',
+          actor: 'state_repository',
+          summary: `Persisted eval scorecard ${scorecardId}.`,
+          details: {
+            scorecard_path: scorecardPath,
+            operator_scorecard_path: operatorScorecardPath,
+          },
+        }),
+      });
+
+      let baselinePath = null;
+      let operatorBaselinePath = null;
+      if (baselineName != null) {
+        const normalizedBaselineName = sanitizeArtifactToken(baselineName, 'baselineName');
+        baselinePath = path.join(paths.evalBaselineRoot, `${normalizedBaselineName}.json`);
+        operatorBaselinePath = path.join(paths.operatorEvalBaselineRoot, `${normalizedBaselineName}.json`);
+        writeJsonFileAtomic(baselinePath, scorecard);
+        writeJsonFileAtomic(operatorBaselinePath, scorecard);
+        appendControlPlaneAuditEntry({
+          auditPath: paths.auditPath,
+          entry: createControlPlaneAuditEntry({
+            audit_id: auditIdGenerator(),
+            project_id: projectId,
+            recorded_at: timestamp,
+            entity_kind: 'eval_baseline',
+            entity_id: normalizedBaselineName,
+            operation: 'write',
+            actor: 'state_repository',
+            summary: `Persisted eval baseline ${normalizedBaselineName}.`,
+            details: {
+              baseline_path: baselinePath,
+              operator_baseline_path: operatorBaselinePath,
+              scorecard_id: scorecardId,
+            },
+          }),
+        });
+      }
+
+      return {
+        scorecard_path: scorecardPath,
+        operator_scorecard_path: operatorScorecardPath,
+        baseline_path: baselinePath,
+        operator_baseline_path: operatorBaselinePath,
+      };
+    },
+
+    readEvalScorecardArtifact({
+      scorecardId,
+    } = {}) {
+      const normalizedScorecardId = sanitizeArtifactToken(scorecardId, 'scorecardId');
+      return readJsonFile(path.join(paths.evalScorecardRoot, `${normalizedScorecardId}.json`));
+    },
+
+    readEvalBaselineArtifact({
+      baselineName,
+    } = {}) {
+      const normalizedBaselineName = sanitizeArtifactToken(baselineName, 'baselineName');
+      return readJsonFile(path.join(paths.evalBaselineRoot, `${normalizedBaselineName}.json`));
     },
   };
 }

--- a/tests/ao/ao-eval-cli.test.js
+++ b/tests/ao/ao-eval-cli.test.js
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockRunAoEvalHarness = jest.fn();
+const mockBuildAoEvalScorecard = jest.fn();
+const mockCompareAoEvalScorecards = jest.fn();
+const mockLoadAoEvalBaseline = jest.fn();
+const mockPersistAoEvalScorecard = jest.fn();
+const mockRenderAoEvalHumanSummary = jest.fn();
+
+jest.unstable_mockModule('../../scripts/ao/lib/eval-harness.js', () => ({
+  runAoEvalHarness: mockRunAoEvalHarness,
+}));
+
+jest.unstable_mockModule('../../scripts/ao/lib/scorecard.js', () => ({
+  DEFAULT_PROJECT_ID: 'ciecopilot-home',
+  buildAoEvalScorecard: mockBuildAoEvalScorecard,
+  compareAoEvalScorecards: mockCompareAoEvalScorecards,
+  loadAoEvalBaseline: mockLoadAoEvalBaseline,
+  persistAoEvalScorecard: mockPersistAoEvalScorecard,
+  renderAoEvalHumanSummary: mockRenderAoEvalHumanSummary,
+}));
+
+const { runCli } = await import('../../scripts/ao-eval.js');
+
+function buildHarnessResult(overrides = {}) {
+  return {
+    schema_version: 'ao.eval-harness-run.v1alpha1',
+    format: 'ao_eval_harness_run',
+    project_id: 'ciecopilot-home',
+    pack_ids: ['all'],
+    scenario_ids: ['parity-ci-failed-pr'],
+    scenario_results: [],
+    summary: {
+      scenario_count: 1,
+      passed_scenario_count: 1,
+      failed_scenario_count: 0,
+      replay_stable_scenario_count: 1,
+      continuity_scenario_count: 0,
+      continuity_success_count: 0,
+    },
+    ...overrides,
+  };
+}
+
+function buildScorecard(overrides = {}) {
+  return {
+    schema_version: 'ao.eval-scorecard.v1alpha1',
+    format: 'ao_eval_scorecard',
+    scorecard_id: 'scorecard-1',
+    project_id: 'ciecopilot-home',
+    summary: {
+      scenario_count: 1,
+      passed_scenario_count: 1,
+      failed_scenario_count: 0,
+    },
+    findings: [],
+    ...overrides,
+  };
+}
+
+describe('ao eval cli', () => {
+  beforeEach(() => {
+    mockRunAoEvalHarness.mockReset();
+    mockBuildAoEvalScorecard.mockReset();
+    mockCompareAoEvalScorecards.mockReset();
+    mockLoadAoEvalBaseline.mockReset();
+    mockPersistAoEvalScorecard.mockReset();
+    mockRenderAoEvalHumanSummary.mockReset();
+
+    mockRunAoEvalHarness.mockResolvedValue(buildHarnessResult());
+    mockBuildAoEvalScorecard.mockReturnValue(buildScorecard());
+    mockCompareAoEvalScorecards.mockReturnValue({
+      status: 'ok',
+      findings: [],
+    });
+    mockPersistAoEvalScorecard.mockReturnValue({
+      scorecard_path: '/tmp/.ao-control-plane/ciecopilot-home/eval/scorecards/scorecard-1.json',
+      operator_scorecard_path: '/tmp/ao-artifacts/ao-eval/scorecards/scorecard-1.json',
+      baseline_path: null,
+      operator_baseline_path: null,
+    });
+    mockRenderAoEvalHumanSummary.mockReturnValue('scorecard_id: scorecard-1');
+  });
+
+  it('runs the full suite by default and renders human summary output', async () => {
+    const stdout = [];
+
+    const result = await runCli([], {
+      writeStdout: (text) => stdout.push(text),
+      writeStderr: () => {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockRunAoEvalHarness).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: 'ciecopilot-home',
+      packNames: ['all'],
+    }));
+    expect(mockPersistAoEvalScorecard).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: 'ciecopilot-home',
+      scorecard: expect.objectContaining({
+        scorecard_id: 'scorecard-1',
+      }),
+      baselineName: null,
+    }));
+    expect(stdout.join('')).toContain('scorecard_id: scorecard-1');
+  });
+
+  it('supports named pack subsets, baseline comparison, baseline saving, and JSON output', async () => {
+    const stdout = [];
+    const baseline = buildScorecard({
+      scorecard_id: 'baseline-1',
+    });
+
+    mockLoadAoEvalBaseline.mockReturnValue(baseline);
+    mockCompareAoEvalScorecards.mockReturnValue({
+      status: 'ok',
+      findings: [],
+      baseline_scorecard_id: 'baseline-1',
+      current_scorecard_id: 'scorecard-1',
+    });
+    mockPersistAoEvalScorecard.mockReturnValue({
+      scorecard_path: '/tmp/.ao-control-plane/ciecopilot-home/eval/scorecards/scorecard-1.json',
+      operator_scorecard_path: '/tmp/ao-artifacts/ao-eval/scorecards/scorecard-1.json',
+      baseline_path: '/tmp/.ao-control-plane/ciecopilot-home/eval/baselines/wave-2.json',
+      operator_baseline_path: '/tmp/ao-artifacts/ao-eval/baselines/wave-2.json',
+    });
+
+    const result = await runCli([
+      '--pack', 'parity',
+      '--pack', 'successor-handoff',
+      '--baseline', 'wave-1',
+      '--save-baseline', 'wave-2',
+      '--json',
+    ], {
+      writeStdout: (text) => stdout.push(text),
+      writeStderr: () => {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockRunAoEvalHarness).toHaveBeenCalledWith(expect.objectContaining({
+      packNames: ['parity', 'successor-handoff'],
+    }));
+    expect(mockLoadAoEvalBaseline).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: 'ciecopilot-home',
+      baselineRef: 'wave-1',
+    }));
+    expect(mockCompareAoEvalScorecards).toHaveBeenCalledWith({
+      baselineScorecard: baseline,
+      currentScorecard: expect.objectContaining({
+        scorecard_id: 'scorecard-1',
+      }),
+    });
+    expect(mockPersistAoEvalScorecard).toHaveBeenCalledWith(expect.objectContaining({
+      baselineName: 'wave-2',
+    }));
+    expect(JSON.parse(stdout.join(''))).toMatchObject({
+      scorecard: {
+        scorecard_id: 'scorecard-1',
+      },
+      comparison: {
+        status: 'ok',
+      },
+      persisted: {
+        baseline_path: '/tmp/.ao-control-plane/ciecopilot-home/eval/baselines/wave-2.json',
+      },
+    });
+  });
+
+  it('fails closed when the scorecard contains failed scenarios or baseline regressions', async () => {
+    mockBuildAoEvalScorecard
+      .mockReturnValueOnce(buildScorecard({
+        summary: {
+          scenario_count: 1,
+          passed_scenario_count: 0,
+          failed_scenario_count: 1,
+        },
+        findings: [
+          {
+            code: 'scenario_verification_failed',
+          },
+        ],
+      }))
+      .mockReturnValueOnce(buildScorecard());
+    mockLoadAoEvalBaseline.mockReturnValue(buildScorecard({
+      scorecard_id: 'baseline-1',
+    }));
+    mockCompareAoEvalScorecards.mockReturnValue({
+      status: 'regressed',
+      findings: [
+        {
+          code: 'verification_success_regressed',
+        },
+      ],
+    });
+
+    const failedScenarioResult = await runCli([], {
+      writeStdout: () => {},
+      writeStderr: () => {},
+    });
+    const regressedResult = await runCli(['--baseline', 'wave-1'], {
+      writeStdout: () => {},
+      writeStderr: () => {},
+    });
+
+    expect(failedScenarioResult.exitCode).toBe(1);
+    expect(regressedResult.exitCode).toBe(1);
+  });
+
+  it('rejects invalid flags and missing option values before running the harness', async () => {
+    const stderr = [];
+
+    const missingPackValue = await runCli(['--pack'], {
+      writeStdout: () => {},
+      writeStderr: (text) => stderr.push(text),
+    });
+    const missingBaselineValue = await runCli(['--baseline'], {
+      writeStdout: () => {},
+      writeStderr: (text) => stderr.push(text),
+    });
+    const unknownFlag = await runCli(['--bogus'], {
+      writeStdout: () => {},
+      writeStderr: (text) => stderr.push(text),
+    });
+
+    expect(missingPackValue.exitCode).toBe(4);
+    expect(missingBaselineValue.exitCode).toBe(4);
+    expect(unknownFlag.exitCode).toBe(4);
+    expect(mockRunAoEvalHarness).not.toHaveBeenCalled();
+    expect(stderr.join('')).toContain('Missing value for --pack');
+    expect(stderr.join('')).toContain('Missing value for --baseline');
+    expect(stderr.join('')).toContain('Unknown argument: --bogus');
+  });
+});

--- a/tests/ao/controller-shadow-parity.test.js
+++ b/tests/ao/controller-shadow-parity.test.js
@@ -19,6 +19,7 @@ import {
   createControllerModeRecord,
   createManagedTask,
   createPrBinding,
+  createTaskSpecRecord,
 } from '../../scripts/ao/lib/state-contracts.js';
 import { createStateRepository } from '../../scripts/ao/lib/state-repository.js';
 
@@ -32,6 +33,39 @@ function createTempRepo() {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-controller-parity-'));
   tempDirs.push(repoRoot);
   return repoRoot;
+}
+
+function seedCleanRuntimePreflight(repository, {
+  taskId,
+  issueNumber,
+  now = '2026-03-29T06:50:00.000Z',
+} = {}) {
+  repository.upsertTaskSpec(createTaskSpecRecord({
+    task_id: taskId,
+    source_kind: 'github_issue',
+    source_issue_number: issueNumber,
+    created_at: now,
+    updated_at: now,
+    snapshot: {
+      schema_version: 'ao.task-spec.v1alpha1',
+      spec: {
+        problem_type: 'issue_delivery',
+        acceptance_contract: ['Fixture parity scenario uses stable runtime contracts.'],
+        runtime_ref: 'runtime.github_local',
+        policy_ref: 'policy.operator_gated',
+        human_gates: ['operator_review'],
+      },
+    },
+  }));
+  repository.ensureRuntimePreflights({
+    cwd: repository.getSnapshot().paths.repoRoot,
+    now,
+    probes: {
+      commandExists: () => true,
+      pathExists: () => true,
+      capability: () => true,
+    },
+  });
 }
 
 afterEach(() => {
@@ -105,6 +139,10 @@ describe('ao controller shadow parity', () => {
       updated_by: 'operator',
       reason: 'Parity test setup',
     }));
+    seedCleanRuntimePreflight(repository, {
+      taskId: `issue-${issueNumber}`,
+      issueNumber,
+    });
 
     const controllerResult = await runControllerLoop({
       repoRoot,
@@ -113,6 +151,17 @@ describe('ao controller shadow parity', () => {
       controllerId: 'default',
       mode: 'shadow',
       now: '2026-03-29T06:51:00.000Z',
+      deps: {
+        ensureRuntimePreflights: ({ repository: activeRepository, cwd, now }) => activeRepository.ensureRuntimePreflights({
+          cwd,
+          now,
+          probes: {
+            commandExists: () => true,
+            pathExists: () => true,
+            capability: () => true,
+          },
+        }),
+      },
     });
 
     expect(controllerResult.task_results[0].derived_trigger).toBe(expectedTrigger);

--- a/tests/ao/eval-harness.test.js
+++ b/tests/ao/eval-harness.test.js
@@ -1,0 +1,159 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from '@jest/globals';
+
+import { runAoEvalHarness } from '../../scripts/ao/lib/eval-harness.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = path.join(__dirname, 'fixtures', 'eval');
+
+describe('ao eval harness', () => {
+  it('runs the full fixture-backed suite reproducibly across named packs', async () => {
+    const result = await runAoEvalHarness({
+      projectId: 'ciecopilot-home',
+      fixtureRoot: FIXTURE_ROOT,
+      packNames: ['all'],
+    });
+
+    expect(result).toMatchObject({
+      schema_version: 'ao.eval-harness-run.v1alpha1',
+      format: 'ao_eval_harness_run',
+      project_id: 'ciecopilot-home',
+      pack_ids: [
+        'parity',
+        'policy-fail-closed',
+        'resume-continuity',
+        'successor-handoff',
+      ],
+      scenario_ids: [
+        'parity-ci-failed-pr',
+        'parity-approved-and-green-pr',
+        'parity-orphaned-ownership',
+        'policy-unknown-tool-fail-closed',
+        'resume-explicit-checkpoint',
+        'handoff-successor-transfer',
+      ],
+      summary: {
+        scenario_count: 6,
+        passed_scenario_count: 6,
+        failed_scenario_count: 0,
+        replay_stable_scenario_count: 6,
+        continuity_scenario_count: 2,
+        continuity_success_count: 2,
+      },
+    });
+
+    expect(result.scenario_results).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        scenario_id: 'parity-ci-failed-pr',
+        pack_id: 'parity',
+        status: 'passed',
+        verification: {
+          status: 'passed',
+          findings: [],
+        },
+        replay: expect.objectContaining({
+          stable: true,
+          fingerprint: expect.any(String),
+        }),
+        continuity: {
+          kind: 'none',
+          status: 'not_applicable',
+          outcome: 'none',
+        },
+        metrics: expect.objectContaining({
+          controller_run_count: 1,
+          execution_attempt_count: 0,
+          failure_class_counts: expect.objectContaining({
+            ci_failure: 1,
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        scenario_id: 'policy-unknown-tool-fail-closed',
+        pack_id: 'policy-fail-closed',
+        status: 'passed',
+        metrics: expect.objectContaining({
+          controller_run_count: 1,
+          measurement_count: 1,
+          intervened_measurement_count: 1,
+          intervention_counts: expect.objectContaining({
+            policy_block: 2,
+          }),
+          failure_class_counts: expect.objectContaining({
+            policy_block: 1,
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        scenario_id: 'resume-explicit-checkpoint',
+        pack_id: 'resume-continuity',
+        status: 'passed',
+        continuity: {
+          kind: 'resume',
+          status: 'success',
+          outcome: 'explicit_resume',
+        },
+        metrics: expect.objectContaining({
+          controller_run_count: 0,
+          execution_attempt_count: 2,
+          intervention_counts: expect.objectContaining({
+            explicit_resume: 1,
+          }),
+          failure_class_counts: expect.objectContaining({
+            worker_exit: 1,
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        scenario_id: 'handoff-successor-transfer',
+        pack_id: 'successor-handoff',
+        status: 'passed',
+        continuity: {
+          kind: 'handoff',
+          status: 'success',
+          outcome: 'successor_handoff',
+        },
+        metrics: expect.objectContaining({
+          controller_run_count: 0,
+          execution_attempt_count: 2,
+          intervention_counts: expect.objectContaining({
+            successor_handoff: 1,
+          }),
+          failure_class_counts: expect.objectContaining({
+            worker_exit: 1,
+          }),
+        }),
+      }),
+    ]));
+  });
+
+  it('supports named pack subsets and rejects unknown pack names fail closed', async () => {
+    const subset = await runAoEvalHarness({
+      projectId: 'ciecopilot-home',
+      fixtureRoot: FIXTURE_ROOT,
+      packNames: ['resume-continuity', 'successor-handoff'],
+    });
+
+    expect(subset.pack_ids).toEqual([
+      'resume-continuity',
+      'successor-handoff',
+    ]);
+    expect(subset.scenario_ids).toEqual([
+      'resume-explicit-checkpoint',
+      'handoff-successor-transfer',
+    ]);
+    expect(subset.summary).toMatchObject({
+      scenario_count: 2,
+      continuity_scenario_count: 2,
+      continuity_success_count: 2,
+    });
+
+    await expect(runAoEvalHarness({
+      projectId: 'ciecopilot-home',
+      fixtureRoot: FIXTURE_ROOT,
+      packNames: ['does-not-exist'],
+    })).rejects.toThrow(/unknown eval pack/i);
+  });
+});

--- a/tests/ao/fixtures/eval/packs.json
+++ b/tests/ao/fixtures/eval/packs.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "ao.eval-pack-registry.v1alpha1",
+  "format": "ao_eval_pack_registry",
+  "packs": [
+    {
+      "pack_id": "all",
+      "title": "Full AO eval suite",
+      "scenario_ids": [
+        "parity-ci-failed-pr",
+        "parity-approved-and-green-pr",
+        "parity-orphaned-ownership",
+        "policy-unknown-tool-fail-closed",
+        "resume-explicit-checkpoint",
+        "handoff-successor-transfer"
+      ]
+    },
+    {
+      "pack_id": "parity",
+      "title": "Controller shadow parity pack",
+      "scenario_ids": [
+        "parity-ci-failed-pr",
+        "parity-approved-and-green-pr",
+        "parity-orphaned-ownership"
+      ]
+    },
+    {
+      "pack_id": "policy-fail-closed",
+      "title": "Policy fail-closed pack",
+      "scenario_ids": [
+        "policy-unknown-tool-fail-closed"
+      ]
+    },
+    {
+      "pack_id": "resume-continuity",
+      "title": "Explicit resume continuity pack",
+      "scenario_ids": [
+        "resume-explicit-checkpoint"
+      ]
+    },
+    {
+      "pack_id": "successor-handoff",
+      "title": "Successor handoff continuity pack",
+      "scenario_ids": [
+        "handoff-successor-transfer"
+      ]
+    }
+  ]
+}

--- a/tests/ao/fixtures/eval/scenarios/handoff-successor-transfer.json
+++ b/tests/ao/fixtures/eval/scenarios/handoff-successor-transfer.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "ao.eval-scenario.v1alpha1",
+  "format": "ao_eval_scenario",
+  "scenario_id": "handoff-successor-transfer",
+  "pack_id": "successor-handoff",
+  "runner": "managed_successor_handoff",
+  "title": "Accepted successor handoff transfers ownership on resume",
+  "task": {
+    "issue_number": 117,
+    "title": "feat(ao): add successor handoff and authority transfer protocol",
+    "branch_name": "feat/117",
+    "worktree_path": "/tmp/cie-58",
+    "pr_number": 127,
+    "owner_session_name": "cie-58",
+    "owner_session_id": "cie-58",
+    "successor_session_name": "cie-59",
+    "successor_session_id": "cie-59",
+    "operator_session_name": "operator-1",
+    "operator_session_id": "operator-1"
+  },
+  "task_spec_body": [
+    "## Problem Type",
+    "issue_delivery",
+    "",
+    "## Acceptance Contract",
+    "- successor handoff protocol exists",
+    "",
+    "## Runtime Ref",
+    "runtime.github_local",
+    "",
+    "## Policy Ref",
+    "policy.operator_gated",
+    "",
+    "## Human Gates",
+    "- operator_handoff"
+  ],
+  "timing": {
+    "enroll_at": "2026-03-31T10:00:00.000Z",
+    "preflight_at": "2026-03-31T10:01:00.000Z",
+    "checkpoint_at": "2026-03-31T10:02:00.000Z",
+    "pause_at": "2026-03-31T10:03:00.000Z",
+    "handoff_at": "2026-03-31T10:04:00.000Z",
+    "resume_at": "2026-03-31T10:05:00.000Z",
+    "grant_expires_at": "2026-03-31T10:20:00.000Z"
+  }
+}

--- a/tests/ao/fixtures/eval/scenarios/parity-approved-and-green-pr.json
+++ b/tests/ao/fixtures/eval/scenarios/parity-approved-and-green-pr.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "ao.eval-scenario.v1alpha1",
+  "format": "ao_eval_scenario",
+  "scenario_id": "parity-approved-and-green-pr",
+  "pack_id": "parity",
+  "runner": "controller_shadow_parity",
+  "title": "Controller shadow parity notifies on approved and green PR",
+  "acceptance_fixture": "../acceptance/approved-and-green-pr",
+  "task": {
+    "task_id": "issue-93",
+    "issue_number": 93,
+    "title": "Fixture parity approved-and-green-pr",
+    "branch_name": "feat/issue-93",
+    "worktree_path": "/tmp/feat-issue-93"
+  },
+  "pr_binding": {
+    "pr_number": 93,
+    "base_branch": "main"
+  },
+  "controller": {
+    "controller_id": "default",
+    "mode": "shadow"
+  },
+  "timing": {
+    "created_at": "2026-03-29T06:50:00.000Z",
+    "run_at": "2026-03-29T06:51:00.000Z"
+  },
+  "expected": {
+    "derived_trigger": "approved_and_green"
+  }
+}

--- a/tests/ao/fixtures/eval/scenarios/parity-ci-failed-pr.json
+++ b/tests/ao/fixtures/eval/scenarios/parity-ci-failed-pr.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "ao.eval-scenario.v1alpha1",
+  "format": "ao_eval_scenario",
+  "scenario_id": "parity-ci-failed-pr",
+  "pack_id": "parity",
+  "runner": "controller_shadow_parity",
+  "title": "Controller shadow parity holds on CI failure",
+  "acceptance_fixture": "../acceptance/ci-failed-pr",
+  "task": {
+    "task_id": "issue-92",
+    "issue_number": 92,
+    "title": "Fixture parity ci-failed-pr",
+    "branch_name": "feat/issue-92",
+    "worktree_path": "/tmp/feat-issue-92"
+  },
+  "pr_binding": {
+    "pr_number": 92,
+    "base_branch": "main"
+  },
+  "controller": {
+    "controller_id": "default",
+    "mode": "shadow"
+  },
+  "timing": {
+    "created_at": "2026-03-29T06:50:00.000Z",
+    "run_at": "2026-03-29T06:51:00.000Z"
+  },
+  "expected": {
+    "derived_trigger": "ci_failed"
+  }
+}

--- a/tests/ao/fixtures/eval/scenarios/parity-orphaned-ownership.json
+++ b/tests/ao/fixtures/eval/scenarios/parity-orphaned-ownership.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "ao.eval-scenario.v1alpha1",
+  "format": "ao_eval_scenario",
+  "scenario_id": "parity-orphaned-ownership",
+  "pack_id": "parity",
+  "runner": "controller_shadow_parity",
+  "title": "Controller shadow parity recommends successor handoff for orphaned ownership",
+  "acceptance_fixture": "../acceptance/orphaned-ownership",
+  "task": {
+    "task_id": "issue-94",
+    "issue_number": 94,
+    "title": "Fixture parity orphaned-ownership",
+    "branch_name": "feat/issue-94",
+    "worktree_path": "/tmp/feat-issue-94"
+  },
+  "pr_binding": {
+    "pr_number": 94,
+    "base_branch": "main"
+  },
+  "controller": {
+    "controller_id": "default",
+    "mode": "shadow"
+  },
+  "timing": {
+    "created_at": "2026-03-29T06:50:00.000Z",
+    "run_at": "2026-03-29T06:51:00.000Z"
+  },
+  "expected": {
+    "derived_trigger": "agent_exited"
+  }
+}

--- a/tests/ao/fixtures/eval/scenarios/policy-unknown-tool-fail-closed.json
+++ b/tests/ao/fixtures/eval/scenarios/policy-unknown-tool-fail-closed.json
@@ -1,0 +1,111 @@
+{
+  "schema_version": "ao.eval-scenario.v1alpha1",
+  "format": "ao_eval_scenario",
+  "scenario_id": "policy-unknown-tool-fail-closed",
+  "pack_id": "policy-fail-closed",
+  "runner": "controller_policy_fail_closed",
+  "title": "Shadow controller policy blocks unknown tools and risky workflow mutations",
+  "task": {
+    "task_id": "issue-107",
+    "issue_number": 107,
+    "title": "Policy engine v1",
+    "branch_name": "feat/107",
+    "worktree_path": "/tmp/cie-54"
+  },
+  "pr_binding": {
+    "pr_number": 107,
+    "base_branch": "main"
+  },
+  "controller": {
+    "controller_id": "default",
+    "mode": "shadow"
+  },
+  "timing": {
+    "created_at": "2026-03-30T10:10:00.000Z",
+    "run_at": "2026-03-30T10:11:00.000Z"
+  },
+  "seed": {
+    "credential_provenances": [
+      {
+        "provenance_id": "cred-gh-cli",
+        "credential_kind": "github_token",
+        "source_kind": "gh_cli_auth",
+        "scope": "github.com",
+        "created_at": "2026-03-30T10:10:00.000Z",
+        "updated_at": "2026-03-30T10:10:00.000Z"
+      }
+    ]
+  },
+  "lifecycle_report": {
+    "top_status": "hold",
+    "routing_decision": {
+      "action": "continue_current_worker"
+    },
+    "release_decision": {
+      "disposition": "await_review"
+    },
+    "actions": [
+      {
+        "id": "continue_worker",
+        "action_class": "continue_worker",
+        "summary": "Continue the current worker owner.",
+        "commands": [
+          "ao status -p ciecopilot-home --json"
+        ],
+        "rationale": "Ownership continuity is clear enough to continue the current worker."
+      },
+      {
+        "id": "workflow_gate",
+        "action_class": "hold",
+        "summary": "Hold workflow mutation for review.",
+        "commands": [
+          "git status --short"
+        ],
+        "rationale": "Workflow mutations require a policy downgrade.",
+        "policy_inputs": {
+          "file_paths": [
+            ".github/workflows/release.yml"
+          ]
+        }
+      },
+      {
+        "id": "unknown_tool",
+        "action_class": "hold",
+        "summary": "Unknown tool should fail closed.",
+        "commands": [
+          "terraform plan"
+        ],
+        "rationale": "Unknown tools must be denied."
+      },
+      {
+        "id": "gh_review",
+        "action_class": "notify_human",
+        "summary": "Review the current PR state.",
+        "commands": [
+          "gh pr view 107 --json reviewDecision,url"
+        ],
+        "rationale": "Known GH credential provenance should pass.",
+        "policy_inputs": {
+          "tools": [
+            "gh"
+          ],
+          "network_targets": [
+            "api.github.com"
+          ],
+          "secret_needs": [
+            {
+              "credential_kind": "github_token",
+              "provenance_id": "cred-gh-cli"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "expected": {
+    "policy_decision_count": 4,
+    "policy_blocked_action_count": 2,
+    "denied_action_count": 1,
+    "downgraded_action_count": 1
+  }
+}

--- a/tests/ao/fixtures/eval/scenarios/resume-explicit-checkpoint.json
+++ b/tests/ao/fixtures/eval/scenarios/resume-explicit-checkpoint.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "ao.eval-scenario.v1alpha1",
+  "format": "ao_eval_scenario",
+  "scenario_id": "resume-explicit-checkpoint",
+  "pack_id": "resume-continuity",
+  "runner": "managed_resume_continuity",
+  "title": "Explicit checkpoint resume preserves continuity",
+  "task": {
+    "issue_number": 110,
+    "title": "feat(ao): add checkpoint schema and explicit resume",
+    "branch_name": "feat/110",
+    "worktree_path": "/tmp/cie-57",
+    "pr_number": 120,
+    "owner_session_name": "cie-57",
+    "owner_session_id": "cie-57"
+  },
+  "task_spec_body": [
+    "## Problem Type",
+    "issue_delivery",
+    "",
+    "## Acceptance Contract",
+    "- checkpoint-backed resume exists",
+    "",
+    "## Runtime Ref",
+    "runtime.github_local",
+    "",
+    "## Policy Ref",
+    "policy.operator_gated",
+    "",
+    "## Human Gates",
+    "- operator_resume"
+  ],
+  "timing": {
+    "enroll_at": "2026-03-30T10:00:00.000Z",
+    "preflight_at": "2026-03-30T10:01:00.000Z",
+    "checkpoint_at": "2026-03-30T10:02:00.000Z",
+    "pause_at": "2026-03-30T10:03:00.000Z",
+    "resume_at": "2026-03-30T10:04:00.000Z"
+  }
+}

--- a/tests/ao/scorecard.test.js
+++ b/tests/ao/scorecard.test.js
@@ -1,0 +1,381 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+import {
+  buildAoEvalScorecard,
+  compareAoEvalScorecards,
+  loadAoEvalBaseline,
+  persistAoEvalScorecard,
+} from '../../scripts/ao/lib/scorecard.js';
+
+const PROJECT_ID = 'ciecopilot-home';
+const tempDirs = [];
+
+function createTempRepo() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-scorecard-'));
+  tempDirs.push(repoRoot);
+  return repoRoot;
+}
+
+function createHarnessResult(overrides = {}) {
+  return {
+    schema_version: 'ao.eval-harness-run.v1alpha1',
+    format: 'ao_eval_harness_run',
+    project_id: PROJECT_ID,
+    fixture_root: '/tmp/fixtures/eval',
+    pack_ids: ['parity', 'resume-continuity', 'successor-handoff'],
+    scenario_ids: [
+      'parity-ci-failed-pr',
+      'resume-explicit-checkpoint',
+      'handoff-successor-transfer',
+    ],
+    scenario_results: [
+      {
+        scenario_id: 'parity-ci-failed-pr',
+        pack_id: 'parity',
+        runner: 'controller_shadow_parity',
+        title: 'Parity scenario',
+        status: 'passed',
+        verification: {
+          status: 'passed',
+          findings: [],
+        },
+        replay: {
+          stable: true,
+          fingerprint: 'scenario:parity',
+        },
+        continuity: {
+          kind: 'none',
+          status: 'not_applicable',
+          outcome: 'none',
+        },
+        metrics: {
+          controller_run_count: 1,
+          execution_attempt_count: 0,
+          measurement_count: 1,
+          intervened_measurement_count: 0,
+          intervention_counts: {
+            human_gate: 0,
+            override: 0,
+            explicit_resume: 0,
+            successor_handoff: 0,
+            policy_block: 0,
+            preflight_block: 0,
+          },
+          failure_class_counts: {
+            none: 1,
+            ci_failure: 0,
+            review_blocked: 0,
+            merge_conflict: 0,
+            source_failure: 0,
+            human_gate: 0,
+            override: 0,
+            policy_block: 0,
+            preflight_block: 0,
+            worker_exit: 0,
+            successor_handoff: 0,
+            unknown: 0,
+          },
+        },
+      },
+      {
+        scenario_id: 'resume-explicit-checkpoint',
+        pack_id: 'resume-continuity',
+        runner: 'managed_resume_continuity',
+        title: 'Resume continuity scenario',
+        status: 'passed',
+        verification: {
+          status: 'passed',
+          findings: [],
+        },
+        replay: {
+          stable: true,
+          fingerprint: 'scenario:resume',
+        },
+        continuity: {
+          kind: 'resume',
+          status: 'success',
+          outcome: 'explicit_resume',
+        },
+        metrics: {
+          controller_run_count: 0,
+          execution_attempt_count: 2,
+          measurement_count: 2,
+          intervened_measurement_count: 1,
+          intervention_counts: {
+            human_gate: 0,
+            override: 0,
+            explicit_resume: 1,
+            successor_handoff: 0,
+            policy_block: 0,
+            preflight_block: 0,
+          },
+          failure_class_counts: {
+            none: 1,
+            ci_failure: 0,
+            review_blocked: 0,
+            merge_conflict: 0,
+            source_failure: 0,
+            human_gate: 0,
+            override: 0,
+            policy_block: 0,
+            preflight_block: 0,
+            worker_exit: 1,
+            successor_handoff: 0,
+            unknown: 0,
+          },
+        },
+      },
+      {
+        scenario_id: 'handoff-successor-transfer',
+        pack_id: 'successor-handoff',
+        runner: 'managed_successor_handoff',
+        title: 'Successor handoff scenario',
+        status: 'failed',
+        verification: {
+          status: 'failed',
+          findings: [
+            {
+              code: 'handoff_resume_failed',
+              summary: 'Accepted handoff transfer did not complete.',
+            },
+          ],
+        },
+        replay: {
+          stable: false,
+          fingerprint: 'scenario:handoff',
+        },
+        continuity: {
+          kind: 'handoff',
+          status: 'failed',
+          outcome: 'failed',
+        },
+        metrics: {
+          controller_run_count: 0,
+          execution_attempt_count: 1,
+          measurement_count: 1,
+          intervened_measurement_count: 1,
+          intervention_counts: {
+            human_gate: 0,
+            override: 0,
+            explicit_resume: 0,
+            successor_handoff: 0,
+            policy_block: 1,
+            preflight_block: 0,
+          },
+          failure_class_counts: {
+            none: 0,
+            ci_failure: 0,
+            review_blocked: 0,
+            merge_conflict: 0,
+            source_failure: 0,
+            human_gate: 0,
+            override: 0,
+            policy_block: 1,
+            preflight_block: 0,
+            worker_exit: 0,
+            successor_handoff: 0,
+            unknown: 0,
+          },
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('ao eval scorecard', () => {
+  it('builds scorecard metrics for verification success, replay stability, continuity, interventions, and failure classes', () => {
+    const scorecard = buildAoEvalScorecard({
+      projectId: PROJECT_ID,
+      harnessResult: createHarnessResult(),
+      generatedAt: '2026-03-31T12:30:00.000Z',
+    });
+
+    expect(scorecard).toMatchObject({
+      schema_version: 'ao.eval-scorecard.v1alpha1',
+      format: 'ao_eval_scorecard',
+      project_id: PROJECT_ID,
+      pack_ids: ['parity', 'resume-continuity', 'successor-handoff'],
+      scenario_ids: [
+        'parity-ci-failed-pr',
+        'resume-explicit-checkpoint',
+        'handoff-successor-transfer',
+      ],
+      summary: {
+        scenario_count: 3,
+        passed_scenario_count: 2,
+        failed_scenario_count: 1,
+        verification_success: {
+          passed: 2,
+          total: 3,
+          rate: 2 / 3,
+        },
+        replay_stability: {
+          stable: 2,
+          total: 3,
+          rate: 2 / 3,
+        },
+        continuity: {
+          successful: 1,
+          total: 2,
+          rate: 0.5,
+          outcome_counts: {
+            explicit_resume_success: 1,
+            successor_handoff_success: 0,
+            failed: 1,
+            not_applicable: 1,
+          },
+        },
+        intervention_rate: {
+          intervened_measurement_count: 2,
+          total_measurement_count: 4,
+          rate: 0.5,
+        },
+        failure_class_distribution: {
+          counts: expect.objectContaining({
+            none: 2,
+            worker_exit: 1,
+            policy_block: 1,
+          }),
+          rates: expect.objectContaining({
+            none: 0.5,
+            worker_exit: 0.25,
+            policy_block: 0.25,
+          }),
+        },
+      },
+    });
+    expect(scorecard.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'scenario_verification_failed',
+        scenario_id: 'handoff-successor-transfer',
+      }),
+      expect.objectContaining({
+        code: 'scenario_replay_unstable',
+        scenario_id: 'handoff-successor-transfer',
+      }),
+    ]));
+  });
+
+  it('compares scorecards against a saved baseline and flags regressions explicitly', () => {
+    const baseline = buildAoEvalScorecard({
+      projectId: PROJECT_ID,
+      generatedAt: '2026-03-31T12:00:00.000Z',
+      harnessResult: createHarnessResult({
+        scenario_results: createHarnessResult().scenario_results.map((scenario) => ({
+          ...scenario,
+          status: 'passed',
+          verification: {
+            status: 'passed',
+            findings: [],
+          },
+          replay: {
+            stable: true,
+            fingerprint: scenario.replay.fingerprint,
+          },
+          continuity: scenario.continuity.kind === 'handoff'
+            ? {
+                kind: 'handoff',
+                status: 'success',
+                outcome: 'successor_handoff',
+              }
+            : scenario.continuity,
+          metrics: {
+            ...scenario.metrics,
+            intervened_measurement_count: scenario.scenario_id === 'handoff-successor-transfer' ? 0 : scenario.metrics.intervened_measurement_count,
+            intervention_counts: scenario.scenario_id === 'handoff-successor-transfer'
+              ? {
+                  ...scenario.metrics.intervention_counts,
+                  policy_block: 0,
+                }
+              : scenario.metrics.intervention_counts,
+            failure_class_counts: scenario.scenario_id === 'handoff-successor-transfer'
+              ? {
+                  ...scenario.metrics.failure_class_counts,
+                  none: 1,
+                  policy_block: 0,
+                }
+              : scenario.metrics.failure_class_counts,
+          },
+        })),
+      }),
+    });
+    const current = buildAoEvalScorecard({
+      projectId: PROJECT_ID,
+      generatedAt: '2026-03-31T12:30:00.000Z',
+      harnessResult: createHarnessResult(),
+    });
+
+    const comparison = compareAoEvalScorecards({
+      baselineScorecard: baseline,
+      currentScorecard: current,
+      comparedAt: '2026-03-31T12:31:00.000Z',
+    });
+
+    expect(comparison).toMatchObject({
+      status: 'regressed',
+      baseline_scorecard_id: baseline.scorecard_id,
+      current_scorecard_id: current.scorecard_id,
+    });
+    expect(comparison.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'verification_success_regressed',
+      }),
+      expect.objectContaining({
+        code: 'replay_stability_regressed',
+      }),
+      expect.objectContaining({
+        code: 'continuity_success_regressed',
+      }),
+      expect.objectContaining({
+        code: 'intervention_rate_regressed',
+      }),
+      expect.objectContaining({
+        code: 'failure_class_distribution_regressed',
+        metric: 'policy_block',
+      }),
+    ]));
+  });
+
+  it('persists versioned scorecards and baseline aliases under AO artifact roots', () => {
+    const repoRoot = createTempRepo();
+    const scorecard = buildAoEvalScorecard({
+      projectId: PROJECT_ID,
+      generatedAt: '2026-03-31T12:40:00.000Z',
+      harnessResult: createHarnessResult(),
+    });
+
+    const persisted = persistAoEvalScorecard({
+      repoRoot,
+      projectId: PROJECT_ID,
+      scorecard,
+      baselineName: 'wave-2-mainline',
+    });
+
+    expect(fs.existsSync(persisted.scorecard_path)).toBe(true);
+    expect(fs.existsSync(persisted.operator_scorecard_path)).toBe(true);
+    expect(fs.existsSync(persisted.baseline_path)).toBe(true);
+    expect(fs.existsSync(persisted.operator_baseline_path)).toBe(true);
+
+    const loadedBaseline = loadAoEvalBaseline({
+      repoRoot,
+      projectId: PROJECT_ID,
+      baselineRef: 'wave-2-mainline',
+    });
+
+    expect(loadedBaseline).toMatchObject({
+      scorecard_id: scorecard.scorecard_id,
+      generated_at: '2026-03-31T12:40:00.000Z',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a fixture-backed AO eval harness with named parity, policy fail-closed, resume continuity, and successor handoff packs
- add scorecard generation, baseline comparison, and versioned artifact persistence under the AO control-plane and operator artifact roots
- add the ao-eval CLI plus focused regression coverage for the new harness and the existing controller parity path

## Verification
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/eval-harness.test.js tests/ao/scorecard.test.js tests/ao/controller-shadow-parity.test.js tests/ao/checkpoint-store.test.js tests/ao/handoff-protocol.test.js tests/ao/ao-eval-cli.test.js
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/ao/state-repository.test.js tests/ao/state-migrations.test.js

Closes #120