### PR TITLE
feat(learning): add question import flow and pilot trig scope gating

### DIFF
--- a/api/learning/__tests__/question-import-service.test.js
+++ b/api/learning/__tests__/question-import-service.test.js
@@ -1,5 +1,4 @@
 import { jest } from '@jest/globals';
-import { buildIdempotencyRequestFingerprint } from '../lib/repositories/request-idempotency-repository.js';
 import { createLoopbackHttpTestClient } from './loopback-test-client.js';
 
 process.env.NODE_ENV = 'test';
@@ -10,47 +9,40 @@ process.env.SUPABASE_URL = 'https://example.supabase.co';
 process.env.SUPABASE_ANON_KEY = 'anon-key';
 process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
 
+const LOCAL_TEST_USER_ID = '99ab903e-46aa-4cfb-9317-cf09aae34d79';
+
 const clientState = {
   calls: [],
   idempotencyRows: new Map(),
   nextIdempotencyId: 1,
   nextQuestionId: 1,
   nextSnapshotId: 1,
-  nextSessionId: 1,
+  registryFamilies: new Map(),
   registryTypes: new Map(),
   questions: new Map(),
   snapshots: new Map(),
-  topics: new Map(),
-  sessions: new Map(),
-  lineage: new Map(),
-  workspaceProjections: new Map(),
-  questionInsertGate: null,
 };
-const LOCAL_TEST_USER_ID = '99ab903e-46aa-4cfb-9317-cf09aae34d79';
 
-function createDeferred() {
-  let resolve;
-  let reject;
-  const promise = new Promise((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
+function seedCanonicalRegistry() {
+  clientState.registryFamilies = new Map([
+    [
+      '9709.trigonometry_manipulation_equations',
+      {
+        family_id: '9709.trigonometry_manipulation_equations',
+        subject_code: '9709',
+        release_state: 'released',
+      },
+    ],
+    [
+      '9709.integration_techniques',
+      {
+        family_id: '9709.integration_techniques',
+        subject_code: '9709',
+        release_state: 'released',
+      },
+    ],
+  ]);
 
-async function waitForCondition(predicate, { attempts = 50, delayMs = 0 } = {}) {
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    if (predicate()) {
-      return;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
-  }
-
-  throw new Error('Condition not reached in time.');
-}
-
-function seedRegistryTypes() {
   clientState.registryTypes = new Map([
     [
       '9709.trigonometry.identities',
@@ -79,65 +71,6 @@ function seedRegistryTypes() {
         release_state: 'released',
       },
     ],
-    [
-      '9709.differential_equations.separable',
-      {
-        question_type_id: '9709.differential_equations.separable',
-        family_id: '9709.differential_equations',
-        subject_code: '9709',
-        release_state: 'released',
-      },
-    ],
-  ]);
-}
-
-function seedTopics() {
-  clientState.topics = new Map([
-    [
-      'topic-integration-1',
-      {
-        node_id: 'topic-integration-1',
-        topic_path: '9709.integration.application',
-      },
-    ],
-  ]);
-}
-
-function seedWorkspaceProjections() {
-  clientState.workspaceProjections = new Map([
-    [
-      `${LOCAL_TEST_USER_ID}:topic-integration-1`,
-      {
-        workspace_id: 'workspace-integration-1',
-        user_id: LOCAL_TEST_USER_ID,
-        topic_id: 'topic-integration-1',
-        topic_path: '9709.integration.application',
-        slot_state: {
-          common_traps: 'active',
-          review_queue: 'active',
-        },
-        linked_reference_summary: {
-          total_linked_references: 0,
-        },
-        updated_at: '2026-03-22T09:00:00.000Z',
-        slots: [
-          {
-            workspace_slot_id: 'slot-common-traps-integration',
-            slot_key: 'common_traps',
-            primary_artifact_ref: null,
-            linked_reference_refs: [],
-            updated_at: '2026-03-22T09:00:00.000Z',
-          },
-          {
-            workspace_slot_id: 'slot-review-queue-integration',
-            slot_key: 'review_queue',
-            primary_artifact_ref: null,
-            linked_reference_refs: [],
-            updated_at: '2026-03-22T09:00:00.000Z',
-          },
-        ],
-      },
-    ],
   ]);
 }
 
@@ -147,15 +80,9 @@ function resetClientState() {
   clientState.nextIdempotencyId = 1;
   clientState.nextQuestionId = 1;
   clientState.nextSnapshotId = 1;
-  clientState.nextSessionId = 1;
   clientState.questions = new Map();
   clientState.snapshots = new Map();
-  clientState.sessions = new Map();
-  clientState.lineage = new Map();
-  clientState.questionInsertGate = null;
-  seedRegistryTypes();
-  seedTopics();
-  seedWorkspaceProjections();
+  seedCanonicalRegistry();
 }
 
 function findFilter(query, field) {
@@ -170,54 +97,52 @@ function createNowTimestamp() {
   return new Date().toISOString();
 }
 
-function createSessionRow(payload) {
-  const sessionId = `session-${clientState.nextSessionId++}`;
-  const now = '2026-03-22T09:00:00.000Z';
+function resolveRegistryRow(map, {
+  idField,
+  idValue,
+  subjectCode,
+  releaseState,
+}) {
+  const row = map.get(idValue) || null;
 
-  return {
-    session_id: sessionId,
-    created_at: now,
-    updated_at: now,
-    ...payload,
-  };
-}
-
-function buildResumeProjection(sessionId) {
-  const session = clientState.sessions.get(sessionId);
-  if (!session) {
-    return null;
+  if (!row) {
+    return { data: null, error: null };
   }
 
-  const lineage = clientState.lineage.get(sessionId) || {
-    parent_session_id: null,
-    handoff_kind: null,
-    summary_snapshot: session.summary_state || {},
-  };
+  if (subjectCode && row.subject_code !== subjectCode) {
+    return { data: null, error: null };
+  }
+
+  if (releaseState && row.release_state !== releaseState) {
+    return { data: null, error: null };
+  }
 
   return {
-    ...session,
-    parent_session_id: lineage.parent_session_id,
-    handoff_kind: lineage.handoff_kind,
-    summary_snapshot: lineage.summary_snapshot,
+    data: {
+      [idField]: idValue,
+      ...row,
+    },
+    error: null,
   };
 }
 
 function resolveQuery(query) {
+  if (query.table === 'learning_question_families' && query.operation === 'select') {
+    return resolveRegistryRow(clientState.registryFamilies, {
+      idField: 'family_id',
+      idValue: findFilter(query, 'family_id'),
+      subjectCode: findFilter(query, 'subject_code'),
+      releaseState: findFilter(query, 'release_state'),
+    });
+  }
+
   if (query.table === 'learning_question_types' && query.operation === 'select') {
-    const questionTypeId = findFilter(query, 'question_type_id');
-    const subjectCode = findFilter(query, 'subject_code');
-    const releaseState = findFilter(query, 'release_state');
-    const row = clientState.registryTypes.get(questionTypeId) || null;
-
-    if (!row || (subjectCode && row.subject_code !== subjectCode)) {
-      return { data: null, error: null };
-    }
-
-    if (releaseState && row.release_state !== releaseState) {
-      return { data: null, error: null };
-    }
-
-    return { data: row, error: null };
+    return resolveRegistryRow(clientState.registryTypes, {
+      idField: 'question_type_id',
+      idValue: findFilter(query, 'question_type_id'),
+      subjectCode: findFilter(query, 'subject_code'),
+      releaseState: findFilter(query, 'release_state'),
+    });
   }
 
   if (query.table === 'learning_request_idempotency') {
@@ -251,10 +176,7 @@ function resolveQuery(query) {
         completed_at: null,
         ...query.payload,
       };
-      clientState.idempotencyRows.set(
-        buildIdempotencyKey(row.user_id, row.request_path, row.idempotency_key),
-        row,
-      );
+      clientState.idempotencyRows.set(rowKey, row);
       return { data: row, error: null };
     }
 
@@ -267,15 +189,16 @@ function resolveQuery(query) {
 
     if (query.operation === 'update') {
       const current = clientState.idempotencyRows.get(rowKey) || null;
-      const now = createNowTimestamp();
-      const next = current ? {
+      if (!current) {
+        return { data: null, error: null };
+      }
+
+      const next = {
         ...current,
         ...query.payload,
-        updated_at: now,
-      } : null;
-      if (next) {
-        clientState.idempotencyRows.set(rowKey, next);
-      }
+        updated_at: createNowTimestamp(),
+      };
+      clientState.idempotencyRows.set(rowKey, next);
       return { data: next, error: null };
     }
 
@@ -286,13 +209,7 @@ function resolveQuery(query) {
   }
 
   if (query.table === 'question_bank' && query.operation === 'insert') {
-    if (clientState.questionInsertGate) {
-      const gate = clientState.questionInsertGate;
-      clientState.questionInsertGate = null;
-      return gate.promise.then(() => resolveQuery(query));
-    }
-
-    const questionId = `question-${clientState.nextQuestionId++}`;
+    const questionId = query.payload?.question_id || `question-${clientState.nextQuestionId++}`;
     const row = {
       question_id: questionId,
       ...query.payload,
@@ -306,6 +223,22 @@ function resolveQuery(query) {
     return { data: clientState.questions.get(questionId) || null, error: null };
   }
 
+  if (query.table === 'question_bank' && query.operation === 'update') {
+    const questionId = findFilter(query, 'question_id');
+    const current = clientState.questions.get(questionId) || null;
+
+    if (!current) {
+      return { data: null, error: null };
+    }
+
+    const next = {
+      ...current,
+      ...query.payload,
+    };
+    clientState.questions.set(questionId, next);
+    return { data: next, error: null };
+  }
+
   if (query.table === 'learning_question_analysis_snapshots' && query.operation === 'insert') {
     const snapshotId = `snapshot-${clientState.nextSnapshotId++}`;
     const row = {
@@ -314,62 +247,6 @@ function resolveQuery(query) {
     };
     clientState.snapshots.set(snapshotId, row);
     return { data: row, error: null };
-  }
-
-  if (query.table === 'question_bank' && query.operation === 'update') {
-    const questionId = findFilter(query, 'question_id');
-    const current = clientState.questions.get(questionId);
-    const next = current ? { ...current, ...query.payload } : null;
-
-    if (next) {
-      clientState.questions.set(questionId, next);
-    }
-
-    return { data: next, error: null };
-  }
-
-  if (query.table === 'curriculum_nodes' && query.operation === 'select') {
-    const nodeId = findFilter(query, 'node_id');
-    return { data: clientState.topics.get(nodeId) || null, error: null };
-  }
-
-  if (query.table === 'learning_sessions' && query.operation === 'insert') {
-    const row = createSessionRow(query.payload);
-    clientState.sessions.set(row.session_id, row);
-    return { data: row, error: null };
-  }
-
-  if (query.table === 'learning_session_lineage' && query.operation === 'insert') {
-    const row = {
-      lineage_id: `lineage-${query.payload.child_session_id}`,
-      created_at: '2026-03-22T09:00:00.000Z',
-      ...query.payload,
-    };
-    clientState.lineage.set(query.payload.child_session_id, row);
-    return { data: row, error: null };
-  }
-
-  if (query.table === 'learning_session_resume_projection' && query.operation === 'select') {
-    const sessionId = findFilter(query, 'session_id');
-    const userId = findFilter(query, 'user_id');
-    const row = buildResumeProjection(sessionId);
-
-    if (!row || (userId && row.user_id !== userId)) {
-      return { data: null, error: null };
-    }
-
-    return { data: row, error: null };
-  }
-
-  if (query.table === 'learning_workspace_projection' && query.operation === 'select') {
-    const topicId = findFilter(query, 'topic_id');
-    const userId = findFilter(query, 'user_id');
-    const row = clientState.workspaceProjections.get(`${userId}:${topicId}`) || null;
-    return { data: row, error: null };
-  }
-
-  if (query.table === 'learning_review_queue_projection' && query.operation === 'select') {
-    return { data: [], error: null };
   }
 
   throw new Error(`Unhandled learning query: ${query.table}:${query.operation}`);
@@ -381,11 +258,9 @@ class QueryBuilder {
     this.operation = 'select';
     this.payload = null;
     this.filters = [];
-    this.options = {};
   }
 
-  select(columns) {
-    this.options.columns = columns;
+  select() {
     return this;
   }
 
@@ -412,27 +287,23 @@ class QueryBuilder {
   }
 
   single() {
-    return this.#resolve({ single: true });
+    return this.#resolve();
   }
 
   maybeSingle() {
-    return this.#resolve({ maybeSingle: true });
+    return this.#resolve();
   }
 
   then(resolve, reject) {
-    return this.#resolve({}).then(resolve, reject);
+    return this.#resolve().then(resolve, reject);
   }
 
-  #resolve(extra = {}) {
+  #resolve() {
     const query = {
       table: this.table,
       operation: this.operation,
       payload: this.payload,
       filters: [...this.filters],
-      options: {
-        ...this.options,
-        ...extra,
-      },
     };
     clientState.calls.push(query);
     return Promise.resolve(resolveQuery(query));
@@ -440,35 +311,29 @@ class QueryBuilder {
 }
 
 function createClient() {
-  const listUsers = jest.fn(async ({ page }) => ({
+  const listUsers = jest.fn(async () => ({
     data: {
-      users: page === 1
-        ? [
-          {
-            id: LOCAL_TEST_USER_ID,
-            email: 'student-1@example.test',
-            user_metadata: {
-              name: 'student-1',
-              role: 'student',
-              auth_source: 'local_test',
-            },
-            app_metadata: {
-              role: 'student',
-              auth_source: 'local_test',
-            },
+      users: [
+        {
+          id: LOCAL_TEST_USER_ID,
+          email: 'student-1@example.test',
+          user_metadata: {
+            name: 'student-1',
+            role: 'student',
+            auth_source: 'local_test',
           },
-        ]
-        : [],
+          app_metadata: {
+            role: 'student',
+            auth_source: 'local_test',
+          },
+        },
+      ],
       nextPage: 0,
     },
     error: null,
   }));
 
-  const createUser = jest.fn(async ({
-    email,
-    user_metadata = {},
-    app_metadata = {},
-  }) => ({
+  const createUser = jest.fn(async ({ email, user_metadata = {}, app_metadata = {} }) => ({
     data: {
       user: {
         id: LOCAL_TEST_USER_ID,
@@ -494,27 +359,19 @@ function createClient() {
 }
 
 const mockGetServiceClient = jest.fn(() => createClient());
-const mockAskWithinLearningSession = jest.fn();
 
 jest.unstable_mockModule('../../lib/supabase/client.js', () => ({
   getServiceClient: mockGetServiceClient,
 }));
 
-jest.unstable_mockModule('../../rag/lib/ask-service.js', () => ({
-  askWithinLearningSession: mockAskWithinLearningSession,
-}));
-
-const {
-  __resetQuestionImportIdempotencyCache,
-  importQuestion,
-} = await import('../lib/import/question-import-service.js');
+const { importQuestion } = await import('../lib/import/question-import-service.js');
 const { default: apiHandler } = await import('../../index.js');
 
 function buildReleasedRubricRef(overrides = {}) {
   return {
     kind: 'rubric_release',
     rubric_set_id: '9709.trigonometry.identities',
-    rubric_version_id: 'v1',
+    rubric_version_id: 'trig-identities-v1',
     scope_level: 'question_type',
     release_state: 'released',
     ...overrides,
@@ -528,7 +385,7 @@ function buildTrigIdentityInput(overrides = {}) {
     subject_code: '9709',
     prompt_representation: {
       type: 'text',
-      value: 'Prove that 1 - tan^2(x) = (cos(2x)) / (cos^2(x)).',
+      value: 'Prove that 1 - tan^2(x) = cos(2x) / cos^2(x).',
     },
     provenance_summary: {
       import_source: 'manual_paste',
@@ -538,6 +395,9 @@ function buildTrigIdentityInput(overrides = {}) {
       classification_confidence: 0.93,
       candidate_rubric_refs: [buildReleasedRubricRef()],
       uncertainty_validated: true,
+      uncertainty_posture: {
+        status: 'validated',
+      },
       variant_tags: ['paper:p1', 'structure:identity_rewrite'],
       ...classification,
     },
@@ -547,76 +407,11 @@ function buildTrigIdentityInput(overrides = {}) {
       classification_confidence: 0.93,
       candidate_rubric_refs: [buildReleasedRubricRef()],
       uncertainty_validated: true,
+      uncertainty_posture: {
+        status: 'validated',
+      },
       variant_tags: ['paper:p1', 'structure:identity_rewrite'],
       ...classification,
-    },
-  };
-}
-
-function buildTrigEquationInput(overrides = {}) {
-  const classification = overrides.classification || {};
-
-  return {
-    subject_code: '9709',
-    prompt_representation: {
-      type: 'text',
-      value: 'Solve 2cos(2x)-3sin x=0 for 0<=x<=180 degrees.',
-    },
-    provenance_summary: {
-      import_source: 'manual_paste',
-    },
-    classification: {
-      primary_question_type_id: '9709.trigonometry.equations',
-      classification_confidence: 0.91,
-      candidate_rubric_refs: [
-        buildReleasedRubricRef({
-          rubric_set_id: '9709.trigonometry.equations',
-        }),
-      ],
-      uncertainty_validated: true,
-      variant_tags: ['paper:p1', 'structure:solve_in_domain'],
-      ...classification,
-    },
-    ...overrides,
-    classification: {
-      primary_question_type_id: '9709.trigonometry.equations',
-      classification_confidence: 0.91,
-      candidate_rubric_refs: [
-        buildReleasedRubricRef({
-          rubric_set_id: '9709.trigonometry.equations',
-        }),
-      ],
-      uncertainty_validated: true,
-      variant_tags: ['paper:p1', 'structure:solve_in_domain'],
-      ...classification,
-    },
-  };
-}
-
-function buildNormalizedQuestionImportPayload(overrides = {}) {
-  const input = buildTrigIdentityInput(overrides);
-  const classification = input.classification || {};
-
-  return {
-    source_kind: 'imported_question',
-    subject_code: input.subject_code,
-    prompt_representation: input.prompt_representation,
-    paper_scope: input.paper_scope ?? null,
-    provenance_summary: input.provenance_summary ?? {},
-    classification: {
-      primary_topic_id: classification.primary_topic_id ?? input.primary_topic_id ?? null,
-      secondary_topic_ids: classification.secondary_topic_ids ?? input.secondary_topic_ids ?? [],
-      family_id: classification.family_id ?? input.family_id ?? null,
-      primary_question_type_id:
-        classification.primary_question_type_id ?? input.primary_question_type_id ?? null,
-      secondary_question_type_ids:
-        classification.secondary_question_type_ids ?? input.secondary_question_type_ids ?? [],
-      variant_tags: classification.variant_tags ?? input.variant_tags ?? [],
-      classification_source: classification.classification_source ?? 'imported_question',
-      classification_confidence: classification.classification_confidence ?? null,
-      candidate_rubric_refs: classification.candidate_rubric_refs ?? [],
-      uncertainty_validated: classification.uncertainty_validated ?? false,
-      uncertainty_posture: classification.uncertainty_posture ?? null,
     },
   };
 }
@@ -635,7 +430,7 @@ function buildTrigWithoutReleasedRubricInput() {
   });
 }
 
-function buildPromotedIntegrationInput(overrides = {}) {
+function buildIntegrationInput(overrides = {}) {
   const classification = overrides.classification || {};
 
   return {
@@ -648,247 +443,62 @@ function buildPromotedIntegrationInput(overrides = {}) {
       import_source: 'manual_paste',
     },
     classification: {
-      family_id: '9709.integration_techniques',
       primary_question_type_id: '9709.integration.application',
-      primary_topic_id: 'topic-integration-1',
       classification_confidence: 0.77,
       candidate_rubric_refs: [
         buildReleasedRubricRef({
           rubric_set_id: '9709.integration.application',
+          rubric_version_id: 'integration-application-v1',
           release_state: 'released',
         }),
       ],
       uncertainty_validated: true,
+      uncertainty_posture: {
+        status: 'validated',
+      },
       variant_tags: ['paper:p3'],
       ...classification,
     },
     ...overrides,
     classification: {
-      family_id: '9709.integration_techniques',
       primary_question_type_id: '9709.integration.application',
-      primary_topic_id: 'topic-integration-1',
       classification_confidence: 0.77,
       candidate_rubric_refs: [
         buildReleasedRubricRef({
           rubric_set_id: '9709.integration.application',
+          rubric_version_id: 'integration-application-v1',
           release_state: 'released',
         }),
       ],
       uncertainty_validated: true,
+      uncertainty_posture: {
+        status: 'validated',
+      },
       variant_tags: ['paper:p3'],
-      ...classification,
-    },
-  };
-}
-
-function buildPromotedIntegrationWithoutUncertaintyInput() {
-  return buildPromotedIntegrationInput({
-    classification: {
-      uncertainty_validated: false,
-    },
-  });
-}
-
-function buildUnpromotedIntegrationInput(overrides = {}) {
-  const classification = overrides.classification || {};
-
-  return {
-    subject_code: '9709',
-    prompt_representation: {
-      type: 'text',
-      value: 'Find the volume generated when the region is rotated about the x-axis.',
-    },
-    provenance_summary: {
-      import_source: 'manual_paste',
-    },
-    classification: {
-      family_id: '9709.integration_techniques',
-      primary_question_type_id: '9709.integration.volume_of_revolution',
-      primary_topic_id: 'topic-integration-1',
-      classification_confidence: 0.77,
-      candidate_rubric_refs: [
-        buildReleasedRubricRef({
-          rubric_set_id: '9709.integration.volume_of_revolution',
-          release_state: 'released',
-        }),
-      ],
-      uncertainty_validated: true,
-      variant_tags: ['paper:p1'],
-      ...classification,
-    },
-    ...overrides,
-    classification: {
-      family_id: '9709.integration_techniques',
-      primary_question_type_id: '9709.integration.volume_of_revolution',
-      primary_topic_id: 'topic-integration-1',
-      classification_confidence: 0.77,
-      candidate_rubric_refs: [
-        buildReleasedRubricRef({
-          rubric_set_id: '9709.integration.volume_of_revolution',
-          release_state: 'released',
-        }),
-      ],
-      uncertainty_validated: true,
-      variant_tags: ['paper:p1'],
-      ...classification,
-    },
-  };
-}
-
-function buildPromotedDifferentialEquationsInput(overrides = {}) {
-  const classification = overrides.classification || {};
-
-  return {
-    subject_code: '9709',
-    prompt_representation: {
-      type: 'text',
-      value: 'Solve the differential equation dy/dx = 2xy.',
-    },
-    provenance_summary: {
-      import_source: 'manual_paste',
-    },
-    classification: {
-      family_id: '9709.differential_equations',
-      primary_question_type_id: '9709.differential_equations.separable',
-      classification_confidence: 0.91,
-      candidate_rubric_refs: [
-        buildReleasedRubricRef({
-          rubric_set_id: '9709.differential_equations.separable',
-          rubric_version_id: 'diff-eq-v1',
-          release_state: 'released',
-        }),
-      ],
-      uncertainty_validated: true,
-      variant_tags: ['paper:p3'],
-      ...classification,
-    },
-    ...overrides,
-    classification: {
-      family_id: '9709.differential_equations',
-      primary_question_type_id: '9709.differential_equations.separable',
-      classification_confidence: 0.91,
-      candidate_rubric_refs: [
-        buildReleasedRubricRef({
-          rubric_set_id: '9709.differential_equations.separable',
-          rubric_version_id: 'diff-eq-v1',
-          release_state: 'released',
-        }),
-      ],
-      uncertainty_validated: true,
-      variant_tags: ['paper:p3'],
-      ...classification,
-    },
-  };
-}
-
-function buildPromotedDifferentialEquationsWithoutUncertaintyInput() {
-  return buildPromotedDifferentialEquationsInput({
-    classification: {
-      uncertainty_validated: false,
-    },
-  });
-}
-
-function buildUnpromotedDifferentialEquationsInput(overrides = {}) {
-  const classification = overrides.classification || {};
-
-  return {
-    subject_code: '9709',
-    prompt_representation: {
-      type: 'text',
-      value: 'A population changes at a rate proportional to the remaining capacity.',
-    },
-    provenance_summary: {
-      import_source: 'manual_paste',
-    },
-    classification: {
-      family_id: '9709.differential_equations',
-      primary_question_type_id: '9709.differential_equations.modelling',
-      classification_confidence: 0.78,
-      candidate_rubric_refs: [
-        buildReleasedRubricRef({
-          rubric_set_id: '9709.differential_equations.modelling',
-          rubric_version_id: 'diff-eq-modelling-v1',
-          release_state: 'released',
-        }),
-      ],
-      uncertainty_validated: true,
-      variant_tags: ['paper:p3'],
-      ...classification,
-    },
-    ...overrides,
-    classification: {
-      family_id: '9709.differential_equations',
-      primary_question_type_id: '9709.differential_equations.modelling',
-      classification_confidence: 0.78,
-      candidate_rubric_refs: [
-        buildReleasedRubricRef({
-          rubric_set_id: '9709.differential_equations.modelling',
-          rubric_version_id: 'diff-eq-modelling-v1',
-          release_state: 'released',
-        }),
-      ],
-      uncertainty_validated: true,
-      variant_tags: ['paper:p3'],
-      ...classification,
-    },
-  };
-}
-
-function buildPhysicsFallbackOnlyInput(overrides = {}) {
-  const classification = overrides.classification || {};
-
-  return {
-    subject_code: '9702',
-    prompt_representation: {
-      type: 'text',
-      value: 'A car accelerates uniformly from rest along a straight road.',
-    },
-    provenance_summary: {
-      import_source: 'manual_paste',
-    },
-    classification: {
-      family_id: '9702.mechanics_dynamics',
-      primary_question_type_id: '9702.mechanics.force_balance',
-      classification_confidence: 0.61,
-      candidate_rubric_refs: [
-        buildReleasedRubricRef({
-          rubric_set_id: '9702.mechanics.force_balance',
-          rubric_version_id: '9702.mechanics.force_balance.v1',
-          release_state: 'released',
-        }),
-      ],
-      uncertainty_validated: true,
-      variant_tags: ['paper:p1'],
-      ...classification,
-    },
-    ...overrides,
-    classification: {
-      family_id: '9702.mechanics_dynamics',
-      primary_question_type_id: '9702.mechanics.force_balance',
-      classification_confidence: 0.61,
-      candidate_rubric_refs: [
-        buildReleasedRubricRef({
-          rubric_set_id: '9702.mechanics.force_balance',
-          rubric_version_id: '9702.mechanics.force_balance.v1',
-          release_state: 'released',
-        }),
-      ],
-      uncertainty_validated: true,
-      variant_tags: ['paper:p1'],
       ...classification,
     },
   };
 }
 
 describe('question import service', () => {
+  let harness;
+
+  beforeAll(async () => {
+    harness = await createLoopbackHttpTestClient(apiHandler);
+  });
+
+  afterAll(async () => {
+    if (harness) {
+      await harness.close();
+    }
+  });
+
   beforeEach(() => {
     resetClientState();
-    __resetQuestionImportIdempotencyCache();
     jest.clearAllMocks();
   });
 
-  test('imported trigonometry identity question gets pilot released scope posture', async () => {
+  test('imported trigonometry identity question gets authoritative scoring only when the pilot released gate is satisfied', async () => {
     const result = await importQuestion(createClient(), {
       userId: 'student-1',
       body: buildTrigIdentityInput(),
@@ -905,7 +515,6 @@ describe('question import service', () => {
       release_scope_status: 'released_scoring',
       fallback_mode: null,
     });
-
     expect(
       clientState.calls.some(
         (call) =>
@@ -913,9 +522,16 @@ describe('question import service', () => {
           && findFilter(call, 'question_type_id') === '9709.trigonometry.identities',
       ),
     ).toBe(true);
+    expect(
+      clientState.calls.some(
+        (call) =>
+          call.table === 'learning_question_families'
+          && findFilter(call, 'family_id') === '9709.trigonometry_manipulation_equations',
+      ),
+    ).toBe(true);
   });
 
-  test('trigonometry type without a released rubric ref still falls back', async () => {
+  test('trigonometry type without a released rubric ref falls back to non_released_fallback', async () => {
     const result = await importQuestion(createClient(), {
       userId: 'student-1',
       body: buildTrigWithoutReleasedRubricInput(),
@@ -930,312 +546,39 @@ describe('question import service', () => {
     expect(result.question.release_scope_status).toBe('non_released_fallback');
   });
 
-  test('imported promoted integration question gets released scope posture when all gates pass', async () => {
+  test('imported integration question remains fallback-only even with released rubric metadata', async () => {
     const result = await importQuestion(createClient(), {
       userId: 'student-1',
-      body: buildPromotedIntegrationInput(),
+      body: buildIntegrationInput(),
     });
 
     expect(result.scoring_scope_posture).toMatchObject({
-      authoritative_scoring_allowed: true,
-      release_scope_status: 'released_scoring',
-      fallback_mode: null,
+      fallback_mode: 'non_released_fallback',
+      authoritative_scoring_allowed: false,
+      fallback_reason_code: expect.any(String),
+      classification_confidence: expect.any(Number),
+      learning_signal_posture: expect.any(String),
     });
     expect(result.question).toMatchObject({
       family_id: '9709.integration_techniques',
       primary_question_type_id: '9709.integration.application',
-      release_scope_status: 'released_scoring',
-    });
-  });
-
-  test('promoted integration question still falls back when uncertainty is not validated', async () => {
-    const result = await importQuestion(createClient(), {
-      userId: 'student-1',
-      body: buildPromotedIntegrationWithoutUncertaintyInput(),
-    });
-
-    expect(result.scoring_scope_posture).toMatchObject({
-      fallback_mode: 'non_released_fallback',
-      authoritative_scoring_allowed: false,
-      fallback_reason_code: 'unvalidated_uncertainty_posture',
-      classification_confidence: 0.77,
-      learning_signal_posture: 'conservative_fallback',
-    });
-    expect(result.question.release_scope_status).toBe('non_released_fallback');
-  });
-
-  test('imported non-promoted integration question remains fallback-only', async () => {
-    const result = await importQuestion(createClient(), {
-      userId: 'student-1',
-      body: buildUnpromotedIntegrationInput(),
-    });
-
-    expect(result.scoring_scope_posture).toMatchObject({
-      fallback_mode: 'non_released_fallback',
-      authoritative_scoring_allowed: false,
-      fallback_reason_code: 'non_pilot_question_type',
-      classification_confidence: 0.77,
-      learning_signal_posture: 'conservative_fallback',
-    });
-    expect(result.question).toMatchObject({
-      family_id: '9709.integration_techniques',
-      primary_question_type_id: '9709.integration.volume_of_revolution',
       release_scope_status: 'non_released_fallback',
     });
   });
 
-  test('imported promoted differential equations question gets released scope posture when all gates pass', async () => {
-    const result = await importQuestion(createClient(), {
-      userId: 'student-1',
-      body: buildPromotedDifferentialEquationsInput(),
-    });
-
-    expect(result.scoring_scope_posture).toMatchObject({
-      authoritative_scoring_allowed: true,
-      release_scope_status: 'released_scoring',
-      fallback_mode: null,
-    });
-    expect(result.question).toMatchObject({
-      family_id: '9709.differential_equations',
-      primary_question_type_id: '9709.differential_equations.separable',
-      release_scope_status: 'released_scoring',
-    });
-  });
-
-  test('promoted differential equations question still falls back when uncertainty is not validated', async () => {
-    const result = await importQuestion(createClient(), {
-      userId: 'student-1',
-      body: buildPromotedDifferentialEquationsWithoutUncertaintyInput(),
-    });
-
-    expect(result.scoring_scope_posture).toMatchObject({
-      fallback_mode: 'non_released_fallback',
-      authoritative_scoring_allowed: false,
-      fallback_reason_code: 'unvalidated_uncertainty_posture',
-      classification_confidence: 0.91,
-      learning_signal_posture: 'conservative_fallback',
-    });
-    expect(result.question.release_scope_status).toBe('non_released_fallback');
-  });
-
-  test('imported non-promoted differential equations question remains fallback-only', async () => {
-    const result = await importQuestion(createClient(), {
-      userId: 'student-1',
-      body: buildUnpromotedDifferentialEquationsInput(),
-    });
-
-    expect(result.scoring_scope_posture).toMatchObject({
-      fallback_mode: 'non_released_fallback',
-      authoritative_scoring_allowed: false,
-      fallback_reason_code: 'non_pilot_question_type',
-      classification_confidence: 0.78,
-      learning_signal_posture: 'conservative_fallback',
-    });
-    expect(result.question).toMatchObject({
-      family_id: '9709.differential_equations',
-      primary_question_type_id: '9709.differential_equations.modelling',
-      release_scope_status: 'non_released_fallback',
-    });
-  });
-
-  test('imported physics question gets an explicit fallback-only posture instead of math scoring defaults', async () => {
-    const result = await importQuestion(createClient(), {
-      userId: 'student-1',
-      body: buildPhysicsFallbackOnlyInput(),
-    });
-
-    expect(result.scoring_scope_posture).toMatchObject({
-      fallback_mode: 'non_released_fallback',
-      authoritative_scoring_allowed: false,
-      fallback_reason_code: 'subject_adapter_capability_not_enabled',
-      classification_confidence: 0.61,
-      learning_signal_posture: 'conservative_fallback',
-    });
-    expect(result.question).toMatchObject({
-      subject_code: '9702',
-      family_id: '9702.mechanics_dynamics',
-      primary_question_type_id: '9702.mechanics.force_balance',
-      release_scope_status: 'non_released_fallback',
-    });
-    expect(
-      clientState.calls.some(
-        (call) =>
-          call.table === 'learning_question_types'
-          && findFilter(call, 'subject_code') === '9702'
-          && findFilter(call, 'question_type_id') === '9702.mechanics.force_balance',
-      ),
-    ).toBe(true);
-  });
-
-  test('same idempotency key allows only one writer under concurrent durable replay', async () => {
-    const gate = createDeferred();
-    clientState.questionInsertGate = gate;
-
-    const firstImport = importQuestion(createClient(), {
-      userId: 'student-1',
-      body: buildTrigIdentityInput(),
-      idempotencyKey: 'import-race-1',
-    });
-    const secondImport = importQuestion(createClient(), {
-      userId: 'student-1',
-      body: buildTrigIdentityInput(),
-      idempotencyKey: 'import-race-1',
-    });
-
-    await waitForCondition(
-      () =>
-        clientState.calls.filter(
-          (call) => call.table === 'question_bank' && call.operation === 'insert',
-        ).length >= 1,
-    );
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    const questionInsertCallsBeforeRelease = clientState.calls.filter(
-      (call) => call.table === 'question_bank' && call.operation === 'insert',
-    );
-    expect(questionInsertCallsBeforeRelease).toHaveLength(1);
-    expect(clientState.idempotencyRows.size).toBe(1);
-
-    gate.resolve();
-    const [first, second] = await Promise.all([firstImport, secondImport]);
-
-    expect(first.question.question_id).toBe(second.question.question_id);
-    expect(
-      clientState.calls.filter(
-        (call) => call.table === 'question_bank' && call.operation === 'insert',
-      ),
-    ).toHaveLength(1);
-    expect(
-      clientState.calls.filter(
-        (call) =>
-          call.table === 'learning_question_analysis_snapshots' && call.operation === 'insert',
-      ),
-    ).toHaveLength(1);
-    expect(
-      clientState.calls.some(
-        (call) => call.table === 'learning_request_idempotency' && call.operation === 'update',
-      ),
-    ).toBe(true);
-  });
-
-  test('question import recovers a pending durable reservation when the reserved question already exists', async () => {
-    clientState.questions.set('question-recovered-1', {
-      question_id: 'question-recovered-1',
-      source_kind: 'imported_question',
-      subject_code: '9709',
-      paper_scope: null,
-      primary_topic_id: null,
-      secondary_topic_ids: [],
-      family_id: '9709.trigonometry_manipulation_equations',
-      primary_question_type_id: '9709.trigonometry.identities',
-      secondary_question_type_ids: [],
-      variant_tags: ['paper:p1', 'structure:identity_rewrite'],
-      release_scope_status: 'released_scoring',
-      prompt_representation: {
-        type: 'text',
-        value: 'Recovered question',
-      },
-      provenance_summary: {
-        import_source: 'manual_paste',
-      },
-      classification_snapshot_ref: {
-        kind: 'classification_snapshot',
-        classification_snapshot_id: 'snapshot-recovered-1',
-      },
-    });
-    clientState.idempotencyRows.set(
-      buildIdempotencyKey('student-1', '/api/learning/questions/import', 'import-recover-1'),
-      {
-        request_idempotency_id: 'idem-import-recover-1',
-        user_id: 'student-1',
-        request_path: '/api/learning/questions/import',
-        idempotency_key: 'import-recover-1',
-        request_kind: 'import_learning_question',
-        request_fingerprint: buildIdempotencyRequestFingerprint(
-          buildNormalizedQuestionImportPayload(),
-        ),
-        request_payload: buildNormalizedQuestionImportPayload(),
-        status: 'pending',
-        resource_ref: {
-          kind: 'question',
-          question_id: 'question-recovered-1',
-        },
-        response_payload: null,
-        created_at: '2026-03-22T08:50:00.000Z',
-        updated_at: '2026-03-22T08:50:00.000Z',
-        completed_at: null,
-      },
-    );
-
-    const result = await importQuestion(createClient(), {
-      userId: 'student-1',
-      body: buildTrigIdentityInput(),
-      idempotencyKey: 'import-recover-1',
-    });
-
-    expect(result.question.question_id).toBe('question-recovered-1');
-    expect(
-      clientState.calls.filter(
-        (call) => call.table === 'question_bank' && call.operation === 'insert',
-      ),
-    ).toHaveLength(0);
-  });
-
-  test('question import normalizes runtime topic aliases before durable writes', async () => {
-    const result = await importQuestion(createClient(), {
-      userId: 'student-1',
-      body: buildTrigEquationInput({
-        classification: {
-          primary_topic_id: 'topic-trig-equations',
-        },
-      }),
-      idempotencyKey: 'import-topic-alias-1',
-    });
-
-    expect(result.question).toMatchObject({
-      primary_topic_id: null,
-      primary_question_type_id: '9709.trigonometry.equations',
-    });
-    const [storedQuestion] = clientState.questions.values();
-    expect(storedQuestion).toMatchObject({
-      primary_topic_id: null,
-      primary_question_type_id: '9709.trigonometry.equations',
-    });
-  });
-});
-
-describe('learning question import api', () => {
-  let harness;
-
-  beforeAll(async () => {
-    harness = await createLoopbackHttpTestClient(apiHandler);
-  });
-
-  afterAll(async () => {
-    await harness?.close();
-  });
-
-  beforeEach(() => {
-    resetClientState();
-    __resetQuestionImportIdempotencyCache();
-    jest.clearAllMocks();
-  });
-
-  test('POST /api/learning/questions/import returns a durable question and scoring posture metadata', async () => {
-    const res = await harness.request
+  test('POST /api/learning/questions/import returns 200 with question id and scoring posture', async () => {
+    const response = await harness.request
       .post('/api/learning/questions/import')
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
       .send(buildTrigIdentityInput());
 
-    expect(res.status).toBe(200);
-    expect(res.body.question.question_id).toBeDefined();
-    expect(res.body.question.classification_snapshot_ref).toEqual({
-      kind: 'classification_snapshot',
-      classification_snapshot_id: 'snapshot-1',
+    expect(response.status).toBe(200);
+    expect(response.body.question.question_id).toEqual(expect.any(String));
+    expect(response.body.scoring_scope_posture).toMatchObject({
+      authoritative_scoring_allowed: true,
+      release_scope_status: 'released_scoring',
     });
-    expect(res.body.scoring_scope_posture.authoritative_scoring_allowed).toBe(true);
-    expect(res.body.request_id).toEqual(expect.any(String));
   });
 
   test('POST /api/learning/questions/import returns 409 idempotency_conflict on conflicting replay', async () => {
@@ -1251,280 +594,10 @@ describe('learning question import api', () => {
       .set('Origin', 'http://localhost:3000')
       .set('Authorization', 'Bearer test-user:student-1:student')
       .set('Idempotency-Key', 'import-1')
-      .send(buildPromotedIntegrationInput());
+      .send(buildIntegrationInput());
 
     expect(first.status).toBe(200);
     expect(second.status).toBe(409);
     expect(second.body.error.code).toBe('idempotency_conflict');
-  });
-
-  test('POST /api/learning/questions/import returns explicit fallback posture for the selected next subject', async () => {
-    const res = await harness.request
-      .post('/api/learning/questions/import')
-      .set('Origin', 'http://localhost:3000')
-      .set('Authorization', 'Bearer test-user:student-1:student')
-      .send(buildPhysicsFallbackOnlyInput());
-
-    expect(res.status).toBe(200);
-    expect(res.body.question).toMatchObject({
-      subject_code: '9702',
-      primary_question_type_id: '9702.mechanics.force_balance',
-      release_scope_status: 'non_released_fallback',
-    });
-    expect(res.body.scoring_scope_posture).toMatchObject({
-      authoritative_scoring_allowed: false,
-      fallback_mode: 'non_released_fallback',
-      fallback_reason_code: 'subject_adapter_capability_not_enabled',
-      learning_signal_posture: 'conservative_fallback',
-    });
-  });
-
-  test('imported question sessions keep a canonical topic path even when the stored topic id is absent', async () => {
-    const importRes = await harness.request
-      .post('/api/learning/questions/import')
-      .set('Origin', 'http://localhost:3000')
-      .set('Authorization', 'Bearer test-user:student-1:student')
-      .send(buildTrigIdentityInput());
-
-    expect(importRes.status).toBe(200);
-    expect(importRes.body.question).toMatchObject({
-      primary_topic_id: null,
-      primary_question_type_id: '9709.trigonometry.identities',
-    });
-
-    const questionId = importRes.body.question.question_id;
-    const createSessionRes = await harness.request
-      .post('/api/learning/sessions')
-      .set('Origin', 'http://localhost:3000')
-      .set('Authorization', 'Bearer test-user:student-1:student')
-      .send({
-        subject_code: '9709',
-        mode: 'guided_solve',
-        session_goal: 'Work through imported identity question',
-        anchor_kind: 'question',
-        anchor_ref: {
-          kind: 'question',
-          question_id: questionId,
-        },
-        current_question_id: questionId,
-        current_question_type_id: null,
-      });
-
-    expect(createSessionRes.status).toBe(200);
-    expect(createSessionRes.body.session.active_scope_bundle).toMatchObject({
-      primary_topic_id: null,
-      primary_topic_path: '9709.trigonometry.identities',
-      current_question_ref: {
-        kind: 'question',
-        question_id: questionId,
-      },
-      current_question_type_ref: {
-        kind: 'question_type',
-        question_type_id: '9709.trigonometry.identities',
-      },
-    });
-  });
-
-  test('POST /api/learning/questions/import replays the canonical durable response on same-payload retry after completion', async () => {
-    const first = await harness.request
-      .post('/api/learning/questions/import')
-      .set('Origin', 'http://localhost:3000')
-      .set('Authorization', 'Bearer test-user:student-1:student')
-      .set('Idempotency-Key', 'import-replay-1')
-      .send(buildTrigIdentityInput());
-
-    expect(first.status).toBe(200);
-
-    const questionId = first.body.question.question_id;
-    const storedQuestion = clientState.questions.get(questionId);
-    clientState.questions.set(questionId, {
-      ...storedQuestion,
-      family_id: '9709.integration_techniques',
-      primary_question_type_id: '9709.integration.application',
-      release_scope_status: 'non_released_fallback',
-      classification_snapshot_ref: {
-        kind: 'classification_snapshot',
-        classification_snapshot_id: 'snapshot-mutated',
-      },
-    });
-
-    const second = await harness.request
-      .post('/api/learning/questions/import')
-      .set('Origin', 'http://localhost:3000')
-      .set('Authorization', 'Bearer test-user:student-1:student')
-      .set('Idempotency-Key', 'import-replay-1')
-      .send(buildTrigIdentityInput());
-
-    expect(second.status).toBe(200);
-    expect(second.body.request_id).toEqual(expect.any(String));
-
-    const { request_id: firstRequestId, ...firstBody } = first.body;
-    const { request_id: secondRequestId, ...secondBody } = second.body;
-    expect(firstRequestId).toEqual(expect.any(String));
-    expect(secondRequestId).toEqual(expect.any(String));
-    expect(secondBody).toEqual(firstBody);
-    expect(second.body.question.question_id).toBe(questionId);
-    expect(
-      clientState.calls.filter(
-        (call) => call.table === 'question_bank' && call.operation === 'insert',
-      ),
-    ).toHaveLength(1);
-    expect(
-      clientState.calls.filter(
-        (call) => call.table === 'question_bank' && call.operation === 'select',
-      ),
-    ).toHaveLength(0);
-  });
-
-  test('import -> create session -> ask -> workspace read keeps fallback posture and canonical-home consistency', async () => {
-    const importRes = await harness.request
-      .post('/api/learning/questions/import')
-      .set('Origin', 'http://localhost:3000')
-      .set('Authorization', 'Bearer test-user:student-1:student')
-      .send(buildPromotedIntegrationWithoutUncertaintyInput());
-
-    expect(importRes.status).toBe(200);
-    expect(importRes.body.question).toMatchObject({
-      release_scope_status: 'non_released_fallback',
-      primary_question_type_id: '9709.integration.application',
-      primary_topic_id: 'topic-integration-1',
-    });
-
-    const questionId = importRes.body.question.question_id;
-    const createSessionRes = await harness.request
-      .post('/api/learning/sessions')
-      .set('Origin', 'http://localhost:3000')
-      .set('Authorization', 'Bearer test-user:student-1:student')
-      .send({
-        subject_code: '9709',
-        mode: 'guided_solve',
-        session_goal: 'Repair integration setup',
-        anchor_kind: 'question',
-        anchor_ref: {
-          kind: 'question',
-          question_id: questionId,
-        },
-        current_question_id: questionId,
-        current_question_type_id: null,
-      });
-
-    expect(createSessionRes.status).toBe(200);
-    expect(createSessionRes.body.session.active_scope_bundle).toMatchObject({
-      primary_topic_id: 'topic-integration-1',
-      primary_topic_path: '9709.integration.application',
-      current_question_ref: {
-        kind: 'question',
-        question_id: questionId,
-      },
-      current_question_type_ref: {
-        kind: 'question_type',
-        question_type_id: '9709.integration.application',
-      },
-    });
-
-    const sessionId = createSessionRes.body.session.session_id;
-    mockAskWithinLearningSession.mockResolvedValueOnce({
-      assistant_message: 'Choose u = x^2 + x and du = (2x + 1)dx.',
-      evidence_summary: {
-        source_topic_path: '9709.integration.application',
-        retrieved_evidence_count: 0,
-      },
-      fallback_posture: {
-        fallback_mode: 'non_released_fallback',
-        authoritative_scoring_allowed: false,
-        fallback_reason_code: 'unvalidated_uncertainty_posture',
-        classification_confidence: 0.77,
-        learning_signal_posture: 'conservative_fallback',
-      },
-      session_delta: {
-        client_turn_id: 'turn-1',
-        current_question_ref: {
-          kind: 'question',
-          question_id: questionId,
-        },
-        current_question_type_ref: {
-          kind: 'question_type',
-          question_type_id: '9709.integration.application',
-        },
-      },
-      suggested_actions: [
-        {
-          kind: 'review_workspace',
-          workspace_id: 'workspace-integration-1',
-        },
-      ],
-    });
-
-    const askRes = await harness.request
-      .post(`/api/learning/sessions/${sessionId}/ask`)
-      .set('Origin', 'http://localhost:3000')
-      .set('Authorization', 'Bearer test-user:student-1:student')
-      .send({
-        message: 'Give me the next substitution hint only.',
-        client_turn_id: 'turn-1',
-      });
-
-    expect(askRes.status).toBe(200);
-    expect(mockAskWithinLearningSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        supabase: expect.any(Object),
-        req: expect.any(Object),
-      }),
-      expect.objectContaining({
-        clientTurnId: 'turn-1',
-        message: 'Give me the next substitution hint only.',
-        session: expect.objectContaining({
-          session_id: sessionId,
-          active_scope_bundle: expect.objectContaining({
-            primary_topic_id: 'topic-integration-1',
-            current_question_type_ref: {
-              kind: 'question_type',
-              question_type_id: '9709.integration.application',
-            },
-          }),
-        }),
-      }),
-    );
-    expect(askRes.body.fallback_posture).toMatchObject({
-      fallback_mode: 'non_released_fallback',
-      authoritative_scoring_allowed: false,
-      fallback_reason_code: 'unvalidated_uncertainty_posture',
-    });
-
-    const workspaceRes = await harness.request
-      .get('/api/learning/workspaces/topic-integration-1')
-      .set('Origin', 'http://localhost:3000')
-      .set('Authorization', 'Bearer test-user:student-1:student');
-
-    expect(workspaceRes.status).toBe(200);
-    expect(workspaceRes.body.workspace).toMatchObject({
-      workspace_id: 'workspace-integration-1',
-      topic_id: 'topic-integration-1',
-      topic_path: '9709.integration.application',
-    });
-    expect(workspaceRes.body.workspace.topic_id)
-      .toBe(createSessionRes.body.session.active_scope_bundle.primary_topic_id);
-    expect(workspaceRes.body.workspace.slots.common_traps).toEqual({
-      workspace_slot_id: 'slot-common-traps-integration',
-      primary_artifact_ref: null,
-      linked_references: [],
-      updated_at: '2026-03-22T09:00:00.000Z',
-    });
-    expect(workspaceRes.body.review_queue).toMatchObject({
-      scope: 'global_queue_projection',
-      topic_id: 'topic-integration-1',
-      status: null,
-      due_before: null,
-      items: [],
-      policy: {
-        daily_recommendation_cap: 3,
-        max_high_priority_open_per_type: 1,
-        immediate_repair_max_deferral_hours: 12,
-      },
-      summary: {
-        total: 0,
-        open: 0,
-      },
-    });
   });
 });

--- a/api/learning/lib/import/question-import-service.js
+++ b/api/learning/lib/import/question-import-service.js
@@ -1,8 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { LEARNING_ERROR_CODES } from '../contracts/error-contract.js';
+import { resolveInlineReleasedScoringPosture } from '../contracts/released-scope-core.js';
 import { LearningHttpError } from '../http/learning-http.js';
 import {
-  getCanonicalQuestionType,
+  getCanonicalReleasedScopeContext,
   getQuestionById,
   insertImportedQuestion,
 } from '../repositories/question-registry-repository.js';
@@ -21,6 +22,8 @@ import { validateQuestionImportInput } from '../validators/question-import-valid
 const IDEMPOTENCY_POLL_ATTEMPTS = 10;
 const IDEMPOTENCY_POLL_INTERVAL_MS = 250;
 const IDEMPOTENCY_ABANDONED_AGE_MS = 5 * 60 * 1000;
+const FROZEN_PILOT_FAMILY_ID = '9709.trigonometry_manipulation_equations';
+const RELEASED_STATE = 'released';
 const COMPAT_RUNTIME_TOPIC_ALIAS_BY_QUESTION_TYPE = Object.freeze({
   '9709.trigonometry.equations': new Set(['topic-trig-equations']),
   '9709.trigonometry.identities': new Set(['topic-trig-identities']),
@@ -176,6 +179,89 @@ function isPendingReservationAbandoned(row) {
   return (Date.now() - createdAt) >= IDEMPOTENCY_ABANDONED_AGE_MS;
 }
 
+function isReleasedPilotRegistryContext({
+  canonicalQuestionType,
+  canonicalQuestionFamily,
+} = {}) {
+  const familyId = normalizeNullableString(canonicalQuestionFamily?.family_id);
+  const questionTypeFamilyId = normalizeNullableString(canonicalQuestionType?.family_id);
+  const familySubjectCode = normalizeNullableString(canonicalQuestionFamily?.subject_code);
+  const questionTypeSubjectCode = normalizeNullableString(canonicalQuestionType?.subject_code);
+  const familyReleaseState = normalizeString(canonicalQuestionFamily?.release_state).toLowerCase();
+  const questionTypeReleaseState = normalizeString(canonicalQuestionType?.release_state).toLowerCase();
+
+  return Boolean(
+    familyId
+    && familyId === FROZEN_PILOT_FAMILY_ID
+    && questionTypeFamilyId === FROZEN_PILOT_FAMILY_ID
+    && familySubjectCode
+    && familySubjectCode === questionTypeSubjectCode
+    && familyReleaseState === RELEASED_STATE
+    && questionTypeReleaseState === RELEASED_STATE
+  );
+}
+
+function mergeCanonicalClassification({
+  subjectCode,
+  classification,
+  canonicalQuestionType,
+  canonicalQuestionFamily,
+} = {}) {
+  const adapter = getSubjectAdapter(subjectCode);
+  const mergedClassification = adapter.classification.mergeCanonicalClassification({
+    classification,
+    canonicalQuestionType,
+  });
+
+  return {
+    ...mergedClassification,
+    family_id:
+      canonicalQuestionFamily?.family_id
+      ?? canonicalQuestionType?.family_id
+      ?? mergedClassification.family_id
+      ?? null,
+  };
+}
+
+export async function resolveReleasedScoringPosture(client, {
+  subjectCode,
+  classification,
+} = {}) {
+  const normalizedSubjectCode = normalizeNullableString(subjectCode);
+  const normalizedClassification = isPlainObject(classification) ? cloneJson(classification) : {};
+  const canonicalContext = await getCanonicalReleasedScopeContext(client, {
+    subjectCode: normalizedSubjectCode,
+    questionTypeId: normalizedClassification.primary_question_type_id ?? null,
+  });
+  const canonicalQuestionType = canonicalContext?.questionType ?? null;
+  const canonicalQuestionFamily = canonicalContext?.family ?? null;
+  const mergedClassification = mergeCanonicalClassification({
+    subjectCode: normalizedSubjectCode,
+    classification: normalizedClassification,
+    canonicalQuestionType,
+    canonicalQuestionFamily,
+  });
+  const scoringScopePosture = resolveInlineReleasedScoringPosture({
+    questionTypeId: mergedClassification.primary_question_type_id,
+    questionTypeReleaseState: canonicalQuestionType?.release_state ?? null,
+    candidateRubricRefs: mergedClassification.candidate_rubric_refs,
+    uncertaintyValidated: mergedClassification.uncertainty_validated,
+    uncertaintyPosture: mergedClassification.uncertainty_posture,
+    classificationConfidence: mergedClassification.classification_confidence,
+    isPilotQuestionType: isReleasedPilotRegistryContext({
+      canonicalQuestionType,
+      canonicalQuestionFamily,
+    }),
+  });
+
+  return {
+    classification: mergedClassification,
+    canonicalQuestionType,
+    canonicalQuestionFamily,
+    scoringScopePosture,
+  };
+}
+
 async function buildQuestionImportResponse(client, {
   question,
   requestPayload,
@@ -183,26 +269,16 @@ async function buildQuestionImportResponse(client, {
   const requestClassification = isPlainObject(requestPayload?.classification)
     ? requestPayload.classification
     : {};
-  const adapter = getSubjectAdapter(
-    question?.subject_code ?? requestPayload?.subject_code ?? null,
-  );
-  const canonicalQuestionType = await getCanonicalQuestionType(client, {
+  const { scoringScopePosture } = await resolveReleasedScoringPosture(client, {
     subjectCode: question?.subject_code ?? requestPayload?.subject_code ?? null,
-    questionTypeId:
-      question?.primary_question_type_id ?? requestClassification.primary_question_type_id ?? null,
-  });
-  const classification = adapter.classification.mergeCanonicalClassification({
-    classification: requestClassification,
-    canonicalQuestionType,
-  });
-  const scoringScopePosture = adapter.marking.resolveReleasedScoringPosture({
-    questionTypeId:
-      question?.primary_question_type_id ?? classification.primary_question_type_id ?? null,
-    questionTypeReleaseState: canonicalQuestionType?.release_state ?? null,
-    candidateRubricRefs: classification.candidate_rubric_refs,
-    uncertaintyValidated: classification.uncertainty_validated,
-    uncertaintyPosture: classification.uncertainty_posture,
-    classificationConfidence: classification.classification_confidence,
+    classification: {
+      ...requestClassification,
+      family_id: question?.family_id ?? requestClassification.family_id ?? null,
+      primary_question_type_id:
+        question?.primary_question_type_id
+        ?? requestClassification.primary_question_type_id
+        ?? null,
+    },
   });
 
   return {
@@ -302,27 +378,17 @@ async function performQuestionImport(client, {
   normalizedInput,
   questionId = null,
 } = {}) {
-  const adapter = getSubjectAdapter(normalizedInput.subject_code);
-  const canonicalQuestionType = await getCanonicalQuestionType(client, {
+  const {
+    classification,
+    scoringScopePosture,
+  } = await resolveReleasedScoringPosture(client, {
     subjectCode: normalizedInput.subject_code,
-    questionTypeId: normalizedInput.classification.primary_question_type_id,
-  });
-  const classification = adapter.classification.mergeCanonicalClassification({
     classification: normalizedInput.classification,
-    canonicalQuestionType,
   });
   classification.primary_topic_id = normalizeCompatibleRuntimeTopicId(
     classification.primary_topic_id,
     classification.primary_question_type_id,
   );
-  const scoringScopePosture = adapter.marking.resolveReleasedScoringPosture({
-    questionTypeId: classification.primary_question_type_id,
-    questionTypeReleaseState: canonicalQuestionType?.release_state ?? null,
-    candidateRubricRefs: classification.candidate_rubric_refs,
-    uncertaintyValidated: classification.uncertainty_validated,
-    uncertaintyPosture: classification.uncertainty_posture,
-    classificationConfidence: classification.classification_confidence,
-  });
 
   const question = await insertImportedQuestion(client, {
     question_id: questionId,

--- a/api/learning/lib/repositories/question-registry-repository.js
+++ b/api/learning/lib/repositories/question-registry-repository.js
@@ -77,6 +77,83 @@ export async function getCanonicalQuestionType(client, {
   return data || null;
 }
 
+export async function getCanonicalQuestionTypeTruth(client, {
+  subjectCode,
+  questionTypeId,
+} = {}) {
+  const normalizedSubjectCode = typeof subjectCode === 'string' ? subjectCode.trim() : '';
+  const normalizedQuestionTypeId = typeof questionTypeId === 'string' ? questionTypeId.trim() : '';
+
+  if (!normalizedSubjectCode || !normalizedQuestionTypeId) {
+    return null;
+  }
+
+  const { data, error } = await client
+    .from('learning_question_types')
+    .select('question_type_id, family_id, subject_code, release_state')
+    .eq('question_type_id', normalizedQuestionTypeId)
+    .eq('subject_code', normalizedSubjectCode)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load canonical question type truth: ${error.message}`);
+  }
+
+  return data || null;
+}
+
+export async function getCanonicalQuestionFamilyTruth(client, {
+  subjectCode,
+  familyId,
+} = {}) {
+  const normalizedSubjectCode = typeof subjectCode === 'string' ? subjectCode.trim() : '';
+  const normalizedFamilyId = typeof familyId === 'string' ? familyId.trim() : '';
+
+  if (!normalizedSubjectCode || !normalizedFamilyId) {
+    return null;
+  }
+
+  const { data, error } = await client
+    .from('learning_question_families')
+    .select('family_id, subject_code, release_state')
+    .eq('family_id', normalizedFamilyId)
+    .eq('subject_code', normalizedSubjectCode)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load canonical question family truth: ${error.message}`);
+  }
+
+  return data || null;
+}
+
+export async function getCanonicalReleasedScopeContext(client, {
+  subjectCode,
+  questionTypeId,
+} = {}) {
+  const questionType = await getCanonicalQuestionTypeTruth(client, {
+    subjectCode,
+    questionTypeId,
+  });
+
+  if (!questionType?.family_id) {
+    return {
+      questionType,
+      family: null,
+    };
+  }
+
+  const family = await getCanonicalQuestionFamilyTruth(client, {
+    subjectCode,
+    familyId: questionType.family_id,
+  });
+
+  return {
+    questionType,
+    family,
+  };
+}
+
 export async function findQuestionById(client, { questionId } = {}) {
   const normalizedQuestionId = typeof questionId === 'string' ? questionId.trim() : '';
 


### PR DESCRIPTION
Closes #151

## Summary
This PR implements Task 6 for the learning runtime import flow. Imported questions now resolve released-scope posture against canonical registry truth from `learning_question_types` and `learning_question_families`, and authoritative scoring stays restricted to the frozen pilot trigonometry slice.

The import service no longer treats a released question type as sufficient by itself. It now requires the full Task 6 gate: canonical pilot type membership under the released trigonometry family, a released rubric ref, and validated uncertainty posture. Questions outside that scope, including integration imports, return explicit `non_released_fallback` posture instead of widening released scoring.

## What Changed
- Added focused Task 6 tests for import service and `POST /api/learning/questions/import`.
- Added registry-backed released-scope resolution in `question-import-service` and exported a service-level `resolveReleasedScoringPosture` helper.
- Extended `question-registry-repository` with canonical family/type truth lookups used by the import flow.

## Verification
- `npm test -- --runInBand api/learning/__tests__/question-import-service.test.js --verbose`
- `npm test -- --runInBand api/learning/__tests__/question-registry-repository.test.js --verbose`
