### PR TITLE
fix: align released-scope contract with promoted released families

### DIFF
--- a/api/learning/__tests__/question-import-service.test.js
+++ b/api/learning/__tests__/question-import-service.test.js
@@ -41,6 +41,14 @@ function seedCanonicalRegistry() {
         release_state: 'released',
       },
     ],
+    [
+      '9709.differential_equations',
+      {
+        family_id: '9709.differential_equations',
+        subject_code: '9709',
+        release_state: 'released',
+      },
+    ],
   ]);
 
   clientState.registryTypes = new Map([
@@ -67,6 +75,15 @@ function seedCanonicalRegistry() {
       {
         question_type_id: '9709.integration.application',
         family_id: '9709.integration_techniques',
+        subject_code: '9709',
+        release_state: 'released',
+      },
+    ],
+    [
+      '9709.differential_equations.separable',
+      {
+        question_type_id: '9709.differential_equations.separable',
+        family_id: '9709.differential_equations',
         subject_code: '9709',
         release_state: 'released',
       },
@@ -480,6 +497,56 @@ function buildIntegrationInput(overrides = {}) {
   };
 }
 
+function buildDifferentialInput(overrides = {}) {
+  const classification = overrides.classification || {};
+
+  return {
+    subject_code: '9709',
+    prompt_representation: {
+      type: 'text',
+      value: 'Solve the differential equation dy/dx = 2xy given that y = 1 when x = 0.',
+    },
+    provenance_summary: {
+      import_source: 'manual_paste',
+    },
+    classification: {
+      primary_question_type_id: '9709.differential_equations.separable',
+      classification_confidence: 0.82,
+      candidate_rubric_refs: [
+        buildReleasedRubricRef({
+          rubric_set_id: '9709.differential_equations.separable',
+          rubric_version_id: 'differential-separable-v1',
+          release_state: 'released',
+        }),
+      ],
+      uncertainty_validated: true,
+      uncertainty_posture: {
+        status: 'validated',
+      },
+      variant_tags: ['paper:p3'],
+      ...classification,
+    },
+    ...overrides,
+    classification: {
+      primary_question_type_id: '9709.differential_equations.separable',
+      classification_confidence: 0.82,
+      candidate_rubric_refs: [
+        buildReleasedRubricRef({
+          rubric_set_id: '9709.differential_equations.separable',
+          rubric_version_id: 'differential-separable-v1',
+          release_state: 'released',
+        }),
+      ],
+      uncertainty_validated: true,
+      uncertainty_posture: {
+        status: 'validated',
+      },
+      variant_tags: ['paper:p3'],
+      ...classification,
+    },
+  };
+}
+
 describe('question import service', () => {
   let harness;
 
@@ -546,23 +613,39 @@ describe('question import service', () => {
     expect(result.question.release_scope_status).toBe('non_released_fallback');
   });
 
-  test('imported integration question remains fallback-only even with released rubric metadata', async () => {
+  test('imported integration application question gets authoritative scoring when released gates are satisfied', async () => {
     const result = await importQuestion(createClient(), {
       userId: 'student-1',
       body: buildIntegrationInput(),
     });
 
     expect(result.scoring_scope_posture).toMatchObject({
-      fallback_mode: 'non_released_fallback',
-      authoritative_scoring_allowed: false,
-      fallback_reason_code: expect.any(String),
-      classification_confidence: expect.any(Number),
-      learning_signal_posture: expect.any(String),
+      authoritative_scoring_allowed: true,
+      release_scope_status: 'released_scoring',
+      fallback_mode: null,
     });
     expect(result.question).toMatchObject({
       family_id: '9709.integration_techniques',
       primary_question_type_id: '9709.integration.application',
-      release_scope_status: 'non_released_fallback',
+      release_scope_status: 'released_scoring',
+    });
+  });
+
+  test('imported differential equations separable question gets authoritative scoring when released gates are satisfied', async () => {
+    const result = await importQuestion(createClient(), {
+      userId: 'student-1',
+      body: buildDifferentialInput(),
+    });
+
+    expect(result.scoring_scope_posture).toMatchObject({
+      authoritative_scoring_allowed: true,
+      release_scope_status: 'released_scoring',
+      fallback_mode: null,
+    });
+    expect(result.question).toMatchObject({
+      family_id: '9709.differential_equations',
+      primary_question_type_id: '9709.differential_equations.separable',
+      release_scope_status: 'released_scoring',
     });
   });
 

--- a/api/learning/__tests__/released-scope.test.js
+++ b/api/learning/__tests__/released-scope.test.js
@@ -3,15 +3,22 @@ import {
   LEARNING_FALLBACK_MODES,
   LEARNING_SIGNAL_POSTURES,
   RELEASE_SCOPE_STATUSES,
+  isReleasedScoringQuestionType,
   isSeededPilotQuestionType,
   resolveReleasedScoringPosture,
 } from '../lib/contracts/released-scope.js';
 
-test('seeded pilot question-type membership is registry-backed and frozen to trigonometry', () => {
+test('released authoritative question-type membership is registry-backed across promoted 9709 families', () => {
+  expect(isReleasedScoringQuestionType('9709.trigonometry.identities')).toBe(true);
+  expect(isReleasedScoringQuestionType('9709.trigonometry.equations')).toBe(true);
+  expect(isReleasedScoringQuestionType('9709.integration.application')).toBe(true);
+  expect(isReleasedScoringQuestionType('9709.differential_equations.separable')).toBe(true);
+  expect(isReleasedScoringQuestionType('9709.integration.substitution')).toBe(false);
+
   expect(isSeededPilotQuestionType('9709.trigonometry.identities')).toBe(true);
   expect(isSeededPilotQuestionType('9709.trigonometry.equations')).toBe(true);
-  expect(isSeededPilotQuestionType('9709.integration.application')).toBe(false);
-  expect(isSeededPilotQuestionType('9709.differential_equations.separable')).toBe(false);
+  expect(isSeededPilotQuestionType('9709.integration.application')).toBe(true);
+  expect(isSeededPilotQuestionType('9709.differential_equations.separable')).toBe(true);
 });
 
 test('pilot type membership alone does not unlock authoritative scoring', () => {
@@ -33,43 +40,62 @@ test('pilot type membership alone does not unlock authoritative scoring', () => 
   });
 });
 
-test('released trigonometry types can unlock authoritative scoring once all gates pass', () => {
-  expect(
-    resolveReleasedScoringPosture({
-      questionTypeId: '9709.trigonometry.identities',
-      questionTypeReleaseState: 'released',
-      candidateRubricRefs: [
-        {
-          kind: 'rubric_release',
-          rubric_set_id: '9709.trigonometry.identities',
-          rubric_version_id: 'trig-identities-v1',
-          scope_level: 'question_type',
-          release_state: 'released',
-        },
-      ],
-      uncertaintyValidated: true,
-      classificationConfidence: 0.94,
-    }),
-  ).toMatchObject({
-    release_scope_status: RELEASE_SCOPE_STATUSES.RELEASED_SCORING,
-    authoritative_scoring_allowed: true,
-    fallback_mode: null,
-    fallback_reason_code: null,
-    classification_confidence: 0.94,
-    learning_signal_posture: LEARNING_SIGNAL_POSTURES.AUTHORITATIVE_SCORING,
-  });
-});
+test.each([
+  [
+    '9709.trigonometry.identities',
+    'trig-identities-v1',
+    0.94,
+  ],
+  [
+    '9709.integration.application',
+    'integration-application-v1',
+    0.89,
+  ],
+  [
+    '9709.differential_equations.separable',
+    'differential-separable-v1',
+    0.91,
+  ],
+])(
+  'released question type %s can unlock authoritative scoring once all gates pass',
+  (questionTypeId, rubricVersionId, classificationConfidence) => {
+    expect(
+      resolveReleasedScoringPosture({
+        questionTypeId,
+        questionTypeReleaseState: 'released',
+        candidateRubricRefs: [
+          {
+            kind: 'rubric_release',
+            rubric_set_id: questionTypeId,
+            rubric_version_id: rubricVersionId,
+            scope_level: 'question_type',
+            release_state: 'released',
+          },
+        ],
+        uncertaintyValidated: true,
+        classificationConfidence,
+      }),
+    ).toMatchObject({
+      release_scope_status: RELEASE_SCOPE_STATUSES.RELEASED_SCORING,
+      authoritative_scoring_allowed: true,
+      fallback_mode: null,
+      fallback_reason_code: null,
+      classification_confidence: classificationConfidence,
+      learning_signal_posture: LEARNING_SIGNAL_POSTURES.AUTHORITATIVE_SCORING,
+    });
+  },
+);
 
-test('non-pilot released families remain explicit fallback even when other gates pass', () => {
+test('non-promoted released families remain explicit fallback even when other gates pass', () => {
   expect(
     resolveReleasedScoringPosture({
-      questionTypeId: '9709.integration.application',
+      questionTypeId: '9709.integration.substitution',
       questionTypeReleaseState: 'released',
       candidateRubricRefs: [
         {
           kind: 'rubric_release',
-          rubric_set_id: '9709.integration.application',
-          rubric_version_id: 'integration-application-v1',
+          rubric_set_id: '9709.integration.substitution',
+          rubric_version_id: 'integration-substitution-v1',
           scope_level: 'question_type',
           release_state: 'released',
         },

--- a/api/learning/__tests__/review-task-service.test.js
+++ b/api/learning/__tests__/review-task-service.test.js
@@ -246,6 +246,65 @@ describe('learning orchestration', () => {
     expect(reconciliationService.calls).toHaveLength(1);
   });
 
+  test('promoted differential-equations scoring run can create a type-level positive update', async () => {
+    const reviewTaskService = createSpyService('generateTasksFromOutcome', async () => []);
+    const artifactService = createSpyService('buildArtifactCandidates', async () => []);
+    const reconciliationService = createSpyService('reconcileDerivedState', async ({ derivedState }) => ({
+      reconciliation_run_id: 'recon-1c',
+      status: 'completed',
+      derived_state: derivedState,
+    }));
+
+    const result = await applyLearningEffects(
+      {
+        user_id: 'student-1',
+        question_id: 'question-1c',
+        question_context: {
+          family_id: '9709.differential_equations',
+          question_type_id: '9709.differential_equations.separable',
+          question_type_release_state: 'released',
+          primary_topic_id: 'topic-differential-1',
+          primary_topic_path: '9709/differential_equations/separable',
+          classification_confidence: 0.91,
+          candidate_rubric_refs: [
+            {
+              kind: 'rubric_release',
+              rubric_version_id: 'differential-separable-v1',
+              release_state: 'released',
+            },
+          ],
+        },
+        source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1c' },
+        source_mark_run_ref: { kind: 'mark_run', mark_run_id: 'mark-run-1c' },
+        decisions: [
+          {
+            awarded: true,
+            awarded_marks: 4,
+            alignment_confidence: 0.93,
+          },
+        ],
+        uncertainty_validated: true,
+      },
+      {
+        reviewTaskService,
+        artifactService,
+        reconciliationService,
+      },
+    );
+
+    expect(result.release_scope_status).toBe('released_scoring');
+    expect(result.mastery_updates[0]).toMatchObject({
+      level: 'question_type',
+      topic_id: 'topic-differential-1',
+      family_id: '9709.differential_equations',
+      question_type_id: '9709.differential_equations.separable',
+      signal_direction: 'positive',
+    });
+    expect(reviewTaskService.calls).toHaveLength(0);
+    expect(artifactService.calls).toHaveLength(1);
+    expect(reconciliationService.calls).toHaveLength(1);
+  });
+
   test('learning effects fail closed for 9702 without reusing math mastery defaults', async () => {
     const artifactService = createSpyService('buildArtifactCandidates', async () => []);
     const reconciliationService = createSpyService('reconcileDerivedState', async ({ derivedState }) => ({

--- a/api/learning/lib/contracts/released-scope.js
+++ b/api/learning/lib/contracts/released-scope.js
@@ -14,8 +14,6 @@ import {
   withReleasedScopeExplanation,
 } from './released-scope-core.js';
 
-const FROZEN_PILOT_FAMILY_ID = '9709.trigonometry_manipulation_equations';
-
 function normalizeSeedMembershipInput(questionTypeId) {
   return normalizeQuestionTypeId(
     typeof questionTypeId === 'object' && questionTypeId !== null
@@ -24,7 +22,11 @@ function normalizeSeedMembershipInput(questionTypeId) {
   );
 }
 
-function loadSeededPilotQuestionTypeIds() {
+function normalizeReleaseState(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function loadReleasedScoringQuestionTypeIds() {
   let receipt;
 
   try {
@@ -33,24 +35,31 @@ function loadSeededPilotQuestionTypeIds() {
     return Object.freeze([]);
   }
 
-  const frozenPilotFamily = Array.isArray(receipt?.family_results)
-    ? receipt.family_results.find((family) => family?.family_id === FROZEN_PILOT_FAMILY_ID)
-    : null;
-
-  const questionTypeIds = Array.isArray(frozenPilotFamily?.released_question_type_ids)
-    ? [...new Set(frozenPilotFamily.released_question_type_ids
-      .map((questionTypeId) => normalizeQuestionTypeId(questionTypeId))
+  const questionTypeIds = Array.isArray(receipt?.question_type_results)
+    ? [...new Set(receipt.question_type_results
+      .filter((entry) => entry?.status === 'pass')
+      .map((entry) => normalizeQuestionTypeId(entry?.question_type_id))
       .filter(Boolean))]
     : [];
 
   return Object.freeze(questionTypeIds);
 }
 
-const SEEDED_PILOT_QUESTION_TYPE_IDS = loadSeededPilotQuestionTypeIds();
+const RELEASED_SCORING_QUESTION_TYPE_IDS = loadReleasedScoringQuestionTypeIds();
 
-function resolvePilotQuestionTypeMatch(questionTypeId, isPilotQuestionType = null) {
-  const registryMatch = isSeededPilotQuestionType(questionTypeId);
-  return registryMatch && (typeof isPilotQuestionType === 'boolean' ? isPilotQuestionType : true);
+function resolveReleasedQuestionTypeMatch(
+  questionTypeId,
+  questionTypeReleaseState = null,
+  isPilotQuestionType = null,
+) {
+  const releasedScopeMatch = isReleasedScoringQuestionType(questionTypeId);
+  const releasedStateMatch = normalizeReleaseState(questionTypeReleaseState) === 'released';
+
+  return (
+    releasedScopeMatch
+    && releasedStateMatch
+    && (typeof isPilotQuestionType === 'boolean' ? isPilotQuestionType : true)
+  );
 }
 
 export {
@@ -60,19 +69,29 @@ export {
   RELEASE_SCOPE_STATUSES,
 };
 
+export function isReleasedScoringQuestionType(questionTypeId) {
+  return RELEASED_SCORING_QUESTION_TYPE_IDS.includes(normalizeSeedMembershipInput(questionTypeId));
+}
+
 export function isSeededPilotQuestionType(questionTypeId) {
-  return SEEDED_PILOT_QUESTION_TYPE_IDS.includes(normalizeSeedMembershipInput(questionTypeId));
+  return isReleasedScoringQuestionType(questionTypeId);
 }
 
 export function resolveInlineReleasedScoringPosture({
   questionTypeId,
+  questionTypeReleaseState = null,
   isPilotQuestionType = null,
   ...rest
 } = {}) {
   return resolveCoreInlineReleasedScoringPosture({
     questionTypeId,
+    questionTypeReleaseState,
     ...rest,
-    isPilotQuestionType: resolvePilotQuestionTypeMatch(questionTypeId, isPilotQuestionType),
+    isPilotQuestionType: resolveReleasedQuestionTypeMatch(
+      questionTypeId,
+      questionTypeReleaseState,
+      isPilotQuestionType,
+    ),
   });
 }
 
@@ -88,8 +107,9 @@ export function resolveReleasedScoringPosture({
 } = {}) {
   const normalizedQuestionTypeId = normalizeQuestionTypeId(questionTypeId);
   const normalizedClassificationConfidence = normalizeClassificationConfidence(classificationConfidence);
-  const pilotQuestionTypeMatch = resolvePilotQuestionTypeMatch(
+  const releasedQuestionTypeMatch = resolveReleasedQuestionTypeMatch(
     normalizedQuestionTypeId,
+    questionTypeReleaseState,
     isPilotQuestionType,
   );
 
@@ -110,7 +130,7 @@ export function resolveReleasedScoringPosture({
     );
   }
 
-  if (!pilotQuestionTypeMatch) {
+  if (!releasedQuestionTypeMatch) {
     return withReleasedScopeExplanation(
       buildFallbackPosture(
         FALLBACK_REASON_CODES.NON_PILOT_QUESTION_TYPE,
@@ -156,7 +176,7 @@ export function resolveReleasedScoringPosture({
     uncertaintyValidated,
     uncertaintyPosture,
     classificationConfidence: normalizedClassificationConfidence,
-    isPilotQuestionType: pilotQuestionTypeMatch,
+    isPilotQuestionType: releasedQuestionTypeMatch,
   }), {
     questionTypeId: normalizedQuestionTypeId,
     questionTypeReleaseState,

--- a/api/learning/lib/import/question-import-service.js
+++ b/api/learning/lib/import/question-import-service.js
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { LEARNING_ERROR_CODES } from '../contracts/error-contract.js';
-import { resolveInlineReleasedScoringPosture } from '../contracts/released-scope-core.js';
+import { resolveReleasedScoringPosture as resolveContractReleasedScoringPosture } from '../contracts/released-scope.js';
 import { LearningHttpError } from '../http/learning-http.js';
 import {
   getCanonicalReleasedScopeContext,
@@ -22,7 +22,6 @@ import { validateQuestionImportInput } from '../validators/question-import-valid
 const IDEMPOTENCY_POLL_ATTEMPTS = 10;
 const IDEMPOTENCY_POLL_INTERVAL_MS = 250;
 const IDEMPOTENCY_ABANDONED_AGE_MS = 5 * 60 * 1000;
-const FROZEN_PILOT_FAMILY_ID = '9709.trigonometry_manipulation_equations';
 const RELEASED_STATE = 'released';
 const COMPAT_RUNTIME_TOPIC_ALIAS_BY_QUESTION_TYPE = Object.freeze({
   '9709.trigonometry.equations': new Set(['topic-trig-equations']),
@@ -179,7 +178,7 @@ function isPendingReservationAbandoned(row) {
   return (Date.now() - createdAt) >= IDEMPOTENCY_ABANDONED_AGE_MS;
 }
 
-function isReleasedPilotRegistryContext({
+function isReleasedRegistryContext({
   canonicalQuestionType,
   canonicalQuestionFamily,
 } = {}) {
@@ -192,8 +191,7 @@ function isReleasedPilotRegistryContext({
 
   return Boolean(
     familyId
-    && familyId === FROZEN_PILOT_FAMILY_ID
-    && questionTypeFamilyId === FROZEN_PILOT_FAMILY_ID
+    && familyId === questionTypeFamilyId
     && familySubjectCode
     && familySubjectCode === questionTypeSubjectCode
     && familyReleaseState === RELEASED_STATE
@@ -241,14 +239,14 @@ export async function resolveReleasedScoringPosture(client, {
     canonicalQuestionType,
     canonicalQuestionFamily,
   });
-  const scoringScopePosture = resolveInlineReleasedScoringPosture({
+  const scoringScopePosture = resolveContractReleasedScoringPosture({
     questionTypeId: mergedClassification.primary_question_type_id,
     questionTypeReleaseState: canonicalQuestionType?.release_state ?? null,
     candidateRubricRefs: mergedClassification.candidate_rubric_refs,
     uncertaintyValidated: mergedClassification.uncertainty_validated,
     uncertaintyPosture: mergedClassification.uncertainty_posture,
     classificationConfidence: mergedClassification.classification_confidence,
-    isPilotQuestionType: isReleasedPilotRegistryContext({
+    isPilotQuestionType: isReleasedRegistryContext({
       canonicalQuestionType,
       canonicalQuestionFamily,
     }),

--- a/api/learning/lib/mastery/mastery-orchestrator.js
+++ b/api/learning/lib/mastery/mastery-orchestrator.js
@@ -1,6 +1,4 @@
 import { buildAttemptRef, buildMarkRunRef } from '../contracts/runtime-contract.js';
-import { evaluateReleasedFamilyEvidenceGate } from '../contracts/released-family-gate.js';
-import { resolveInlineReleasedScoringPosture } from '../contracts/released-scope-core.js';
 import { createReviewTaskService } from '../review/review-task-service.js';
 import { createDefaultReviewTaskService } from '../review/review-task-service.js';
 import { createArtifactService } from '../artifacts/artifact-service.js';
@@ -76,7 +74,7 @@ function resolveLearningEffectsPosture({
   questionContext,
   adapter,
 } = {}) {
-  const basePosture = input.release_scope_posture || adapter.marking.resolveReleasedScoringPosture({
+  return input.release_scope_posture || adapter.marking.resolveReleasedScoringPosture({
     questionTypeId: questionContext.question_type_id,
     questionTypeReleaseState:
       questionContext.question_type_release_state
@@ -86,31 +84,6 @@ function resolveLearningEffectsPosture({
     classificationConfidence: questionContext.classification_confidence,
     uncertaintyValidated: input.uncertainty_validated ?? false,
   });
-
-  if (basePosture?.fallback_reason_code !== 'non_pilot_question_type') {
-    return basePosture;
-  }
-
-  const releaseEvidence = evaluateReleasedFamilyEvidenceGate(questionContext.question_type_id);
-  const releaseEvidencePosture = releaseEvidence.ok
-    ? resolveInlineReleasedScoringPosture({
-      questionTypeId: questionContext.question_type_id,
-      questionTypeReleaseState:
-        questionContext.question_type_release_state
-        ?? questionContext.primary_question_type_release_state
-        ?? null,
-      candidateRubricRefs: questionContext.candidate_rubric_refs,
-      classificationConfidence: questionContext.classification_confidence,
-      uncertaintyValidated: input.uncertainty_validated ?? false,
-      isPilotQuestionType: true,
-    })
-    : null;
-
-  if (!releaseEvidencePosture?.authoritative_scoring_allowed) {
-    return basePosture;
-  }
-
-  return releaseEvidencePosture;
 }
 
 export function createMasteryOrchestrator({

--- a/api/rag/__tests__/ask-service.test.js
+++ b/api/rag/__tests__/ask-service.test.js
@@ -2135,7 +2135,7 @@ describe('askWithinLearningSession', () => {
     });
   });
 
-  test('non-pilot family ask returns successful fallback posture, not an API error', async () => {
+  test('question-type-only ask without released question metadata returns successful fallback posture, not an API error', async () => {
     const supabase = createLearningSessionSupabaseStub({
       workspaceRow: null,
       evidenceContext: null,

--- a/data/learning_runtime/release_evidence/released-family-gate-receipt.v1.json
+++ b/data/learning_runtime/release_evidence/released-family-gate-receipt.v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "learning_runtime_released_family_gate_receipt_v1",
-  "generated_at": "2026-03-25T03:27:49.198Z",
+  "generated_at": "2026-04-06T09:39:16.262Z",
   "contract_path": "data/learning_runtime/release_evidence/released-family-gate-contract.v1.json",
   "status": "pass",
   "release_ready": true,

--- a/docs/reports/0405task1.md
+++ b/docs/reports/0405task1.md
@@ -1,5 +1,7 @@
 # 0405task1
 
+> Historical note (2026-04-06): this report records the earlier trig-only released-scope freeze from `task/20260405-learning-runtime-contracts`. The current frozen contract is now defined by issue `#160` plus the released-family promotions in [learning_runtime_released_family_gate_2026-03-25.md](/home/samsen/code/ciecopilot-home/docs/reports/learning_runtime_released_family_gate_2026-03-25.md), so `9709.integration.application` and `9709.differential_equations.separable` are no longer fallback-only when all released-scoring gates pass.
+
 ## 一、任务目标
 
 本次任务是收敛 Learning Runtime 的 serial trunk 第一个交付物，聚焦 4 个冻结合约面：
@@ -127,10 +129,10 @@
 验证：
 - `isSeededPilotQuestionType('9709.trigonometry.identities') === true`
 - `isSeededPilotQuestionType('9709.trigonometry.equations') === true`
-- `isSeededPilotQuestionType('9709.integration.application') === false`
-- `isSeededPilotQuestionType('9709.differential_equations.separable') === false`
+- `isSeededPilotQuestionType('9709.integration.application') === false` (historical at the time)
+- `isSeededPilotQuestionType('9709.differential_equations.separable') === false` (historical at the time)
 - pilot membership alone 不能解锁 authoritative scoring
-- 非 pilot released family 即使其他 gate 满足也必须 fallback
+- 当时的非 pilot released family 即使其他 gate 满足也必须 fallback
 
 ---
 

--- a/docs/reports/learning_runtime_released_family_gate_2026-03-25.md
+++ b/docs/reports/learning_runtime_released_family_gate_2026-03-25.md
@@ -2,7 +2,7 @@
 
 - status: `pass`
 - release_ready: `true`
-- generated_at: `2026-03-25T03:27:49.198Z`
+- generated_at: `2026-04-06T09:39:16.262Z`
 - contract_path: `data/learning_runtime/release_evidence/released-family-gate-contract.v1.json`
 
 ## 9709.trigonometry_manipulation_equations

--- a/docs/superpowers/plans/2026-03-20-prd-learning-runtime-pilot-slice-execution.md
+++ b/docs/superpowers/plans/2026-03-20-prd-learning-runtime-pilot-slice-execution.md
@@ -1,8 +1,10 @@
 # PRD Learning Runtime Pilot Slice Implementation Plan
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Historical note (2026-04-06):** This execution plan was written before the later released-family promotions for `9709.integration.application` and `9709.differential_equations.separable`. When older examples below mention trig-only pilot released scope, the current frozen contract should instead follow the promoted released-family gate set recorded in [2026-03-20-prd-learning-runtime-contract-design.md](/home/samsen/code/ciecopilot-home/docs/superpowers/specs/2026-03-20-prd-learning-runtime-contract-design.md) and [learning_runtime_released_family_gate_2026-03-25.md](/home/samsen/code/ciecopilot-home/docs/reports/learning_runtime_released_family_gate_2026-03-25.md).
 
-**Goal:** Implement the first `9709` learning-runtime slice defined by the frozen contract: session-centric AskAI, typed anchors, persistent `active_scope_bundle`, pilot trigonometry scoring scope, conservative fallback/orchestration, topic workspace, artifact lifecycle, and review queue projection without building on legacy Study Hub tables or pages.
+**Goal:** Implement the first `9709` learning-runtime slice defined by the frozen contract: session-centric AskAI, typed anchors, persistent `active_scope_bundle`, released-scope scoring, conservative fallback/orchestration, topic workspace, artifact lifecycle, and review queue projection without building on legacy Study Hub tables or pages.
 
 **Architecture:** Add a new `api/learning/**` and `src/pages/learning-runtime/**` domain layer that wraps the existing ledger, evidence, and RAG primitives rather than rewriting them. Freeze the serial trunk first: runtime contract enums, canonical repositories/migrations, typed refs, session/anchor legality, and registry-backed released-scope posture helpers. Only after that split into safe backend and frontend parallel blocks, with all workers consuming the same contract from [2026-03-20-prd-learning-runtime-contract-design.md](/home/samsen/code/ciecopilot-home/docs/superpowers/specs/2026-03-20-prd-learning-runtime-contract-design.md).
 
@@ -16,7 +18,7 @@
 
 - `api/learning/lib/contracts/runtime-contract.js`: runtime enums, typed ref builders/guards, and slot compatibility map only.
 - `api/learning/lib/contracts/error-contract.js`: machine-readable error codes and envelope helpers for `/api/learning/**`.
-- `api/learning/lib/contracts/released-scope.js`: seeded pilot type membership helpers plus registry-backed released-scope posture helpers.
+- `api/learning/lib/contracts/released-scope.js`: released-scope membership helpers plus registry-backed released-scope posture helpers.
 - `api/learning/lib/validators/session-validator.js`: create/read/ask payload validation, anchor legality matrix.
 - `api/learning/lib/validators/question-import-validator.js`: import payload normalization and validation.
 - `api/learning/lib/http/learning-http.js`: JSON success/error helpers reused by every learning handler.
@@ -157,9 +159,10 @@ test('learning error registry exposes the frozen stage codes', () => {
   });
 });
 
-test('seeded pilot question-type membership is trigonometry only', () => {
+test('released authoritative question-type membership follows the promoted released-family gate', () => {
   expect(isSeededPilotQuestionType('9709.trigonometry.identities')).toBe(true);
-  expect(isSeededPilotQuestionType('9709.integration.application')).toBe(false);
+  expect(isSeededPilotQuestionType('9709.integration.application')).toBe(true);
+  expect(isSeededPilotQuestionType('9709.differential_equations.separable')).toBe(true);
 });
 ```
 
@@ -172,8 +175,8 @@ Expected: FAIL because the contract modules do not exist yet.
 
 ```js
 // runtime-contract.js owns refs, enums, slot compatibility, and typed builders only.
-// released-scope.js owns seeded pilot membership helpers and released-scope posture helpers only.
-// seeded pilot membership alone must not unlock authoritative scoring.
+// released-scope.js owns promoted released question-type membership helpers and released-scope posture helpers only.
+// released-scope membership alone must not unlock authoritative scoring.
 // error-contract.js owns stable stage error codes and envelope builders only.
 ```
 
@@ -819,7 +822,7 @@ git commit -m "feat(learning): add dynamic session routes and skeleton handlers"
 - [ ] **Step 1: Extend the failing import tests to cover pilot trigonometry typing and fallback posture**
 
 ```js
-test('imported trigonometry identity question gets pilot released scope posture', async () => {
+test('imported trigonometry identity question gets released scoring posture', async () => {
   const result = await importQuestion(fakeDb, importedTrigIdentityInput);
   expect(result.scoring_scope_posture.authoritative_scoring_allowed).toBe(true);
 });
@@ -830,14 +833,12 @@ test('trigonometry type without a released rubric ref still falls back', async (
   expect(result.scoring_scope_posture.fallback_mode).toBe('non_released_fallback');
 });
 
-test('imported integration question remains fallback-only', async () => {
+test('imported integration application question gets released scoring posture', async () => {
   const result = await importQuestion(fakeDb, importedIntegrationInput);
   expect(result.scoring_scope_posture).toMatchObject({
-    fallback_mode: 'non_released_fallback',
-    authoritative_scoring_allowed: false,
-    fallback_reason_code: expect.any(String),
-    classification_confidence: expect.any(Number),
-    learning_signal_posture: expect.any(String),
+    authoritative_scoring_allowed: true,
+    release_scope_status: 'released_scoring',
+    fallback_mode: null,
   });
 });
 
@@ -860,7 +861,7 @@ test('POST /api/learning/questions/import returns 409 idempotency_conflict on co
 - [ ] **Step 2: Run the import suite and verify it fails**
 
 Run: `npm test -- --runInBand api/learning/__tests__/question-import-service.test.js --verbose`
-Expected: FAIL until pilot family classification and posture logic exist.
+Expected: FAIL until released-scope classification and posture logic exist.
 
 - [ ] **Step 3: Implement import service and consume the canonical pilot registry**
 
@@ -904,7 +905,7 @@ test('session ask consumes persisted active_scope_bundle instead of route-only s
   expect(res.session_delta).toBeDefined();
 });
 
-test('non-pilot family ask returns successful fallback posture, not an API error', async () => {
+test('question-type-only ask without released question metadata returns successful fallback posture, not an API error', async () => {
   const res = await askWithinSession(fakeDeps, integrationSession, 'mark this');
   expect(res.fallback_posture).toMatchObject({
     fallback_mode: 'non_released_fallback',

--- a/docs/superpowers/specs/2026-03-20-prd-learning-runtime-contract-design.md
+++ b/docs/superpowers/specs/2026-03-20-prd-learning-runtime-contract-design.md
@@ -95,26 +95,23 @@ If a proposed change needs one of those behaviors, it belongs in the new learnin
 
 The pilot subject is fixed to `9709`.
 
-### Runtime pilot family
+### Released authoritative question types
 
-The first scoring-enabled runtime pilot family is fixed to:
-
-- `Trigonometric manipulation / equations`
-
-This choice is based on current repo truth, not taste:
-
-- it is already inside the PRD's released family envelope
-- it has the strongest blind marking-eval presence among the released families
-- it spans both identity manipulation and interval-bounded equation solving, which is enough to exercise canonical-home, post-mark review, artifact promotion, and review-task generation without jumping to whole-paper complexity
-
-### Frozen pilot type seed
-
-The first runtime slice `MUST` seed exactly these two question types:
+The first runtime slice started with the trigonometry family, but the frozen released-scope contract is now defined by the promoted `9709` question types that pass the released-family evidence gate:
 
 - `9709.trigonometry.identities`
 - `9709.trigonometry.equations`
+- `9709.integration.application`
+- `9709.differential_equations.separable`
 
-The first runtime slice `MAY` attach variant tags such as:
+These promotions stay narrow:
+
+- `Trigonometric manipulation / equations` remains fully released inside the runtime slice
+- `Integration techniques` is released only for `9709.integration.application`
+- `Differential equations` is released only for `9709.differential_equations.separable`
+- broader `9709.integration.*` and `9709.differential_equations.*` variants remain explicit `non_released_fallback` until they earn separate release evidence
+
+The current runtime slice `MAY` attach variant tags such as:
 
 - `paper:p1`
 - `paper:p3`
@@ -123,17 +120,13 @@ The first runtime slice `MAY` attach variant tags such as:
 - `structure:identity_rewrite`
 - `structure:solve_in_domain`
 
-### On-deck families
-
-- `Integration techniques` is the next candidate after the first pilot slice is stable.
-- `Differential equations` remains inside the PRD release envelope but is **not** part of the first runtime scoring slice because local runtime evidence is currently thinner.
-
 ### Important clarification
 
 For this stage:
 
-- authoritative scoring is allowed only for the pilot family
-- `integration` and `differential_equations` still go through the same runtime, but they remain `non-released fallback` until separately promoted by release evidence
+- authoritative scoring is allowed only for the promoted released question types listed above
+- pilot/released-scope membership alone is insufficient; released rubric, confidence, and validated uncertainty gates still apply
+- non-promoted `9709` questions still go through the same runtime, but they remain `non_released_fallback`
 
 This is an execution cutline, not a PRD contradiction.
 
@@ -328,13 +321,13 @@ Rules:
 
 For this stage, authoritative scoring is allowed only when all of the following are true:
 
-- the `question_type_id` is inside the seeded pilot runtime slice
+- the `question_type_id` is inside the promoted released-family runtime slice
 - the question analysis snapshot carries at least one matching `RubricReleaseRef` with `release_state = released`
 - the scoring path has validated uncertainty behavior for that question/rubric path
 
 Additional clarification:
 
-- pilot type match alone is insufficient
+- released-scope type match alone is insufficient
 - draft or validated-but-not-released rubric refs still force `non_released_fallback`
 - missing released rubric coverage, missing gold-set confidence, or missing validated uncertainty behavior all force `non_released_fallback`
 
@@ -1140,7 +1133,7 @@ Frontend code `SHOULD`:
 
 Before implementation fans out, these three things must be frozen and treated as authoritative:
 
-1. pilot family slice
+1. released-scope contract
 2. domain/persistence/API contract
 3. canonical-home and questionless-session semantics
 
@@ -1166,8 +1159,8 @@ The slice is not ready unless all of the following pass:
 1. a user can start sessions from `concept`, `question`, `review_task`, `artifact`, and `workspace_slot`
 2. questionless sessions work without fake IDs
 3. AskAI reads persisted `active_scope_bundle`
-4. the pilot trigonometry family supports end-to-end scoring and post-mark learning effects
-5. imported questions outside pilot scoring scope produce explicit `non-released fallback`
+4. the promoted released `9709` question types support end-to-end scoring and post-mark learning effects
+5. imported questions outside released scoring scope produce explicit `non_released_fallback`
 6. workspace canonical-home behavior does not duplicate long-lived objects
 7. reconciliation can revise derived state without mutating historical attempts/mark runs
 8. legacy Study Hub remains compatibility-only and does not regain canonical logic
@@ -1176,8 +1169,8 @@ The slice is not ready unless all of the following pass:
 
 These items are intentionally deferred until after the first pilot slice is proven:
 
-- promoting `integration` into authoritative runtime scoring
-- promoting `differential_equations` into authoritative runtime scoring
+- widening additional `integration` question types beyond `9709.integration.application`
+- widening additional `differential_equations` question types beyond `9709.differential_equations.separable`
 - widening question-type granularity inside the trigonometry family
 - replacing the old entry surfaces globally
 - expanding beyond `9709`


### PR DESCRIPTION
## Summary
- align `released-scope` with the promoted released-family gate receipt instead of the old trig-only family constant
- route question import and mastery orchestration through the same canonical released-scope helper, and add integration/differential coverage to the learning tests
- update the March contract/plan docs plus regenerated release-gate artifacts so the checked-in docs match the released scoring envelope

## Verification
- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand --runTestsByPath api/learning/__tests__/released-scope.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/review-task-service.test.js api/marking/__tests__/evaluate-v1.test.js --verbose`
- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand --runTestsByPath api/rag/__tests__/ask-service.test.js --testNamePattern "question-type-only ask without released question metadata returns successful fallback posture, not an API error" --verbose`
- `npm run learning:release-gate`

Closes #160