### PR TITLE
fix(learning): stabilize released-scoring repair task projection

### DIFF
--- a/api/learning/__tests__/review-task-service.test.js
+++ b/api/learning/__tests__/review-task-service.test.js
@@ -514,6 +514,93 @@ describe('learning orchestration', () => {
       misconception_tags: ['domain:interval'],
     });
   });
+
+  test('released-scoring outcomes with conservative mapping ambiguity still emit repair tasks', async () => {
+    const reviewTaskService = createSpyService('generateTasksFromOutcome', async (input) => [
+      {
+        review_task_id: 'review-task-ambiguous-1',
+        target_kind: 'question_type',
+        target_topic_id: input.repair_target_topic_id,
+        target_question_type_id: input.repair_target_question_type_id,
+        status: 'open',
+      },
+    ]);
+    const artifactService = createSpyService('buildArtifactCandidates', async () => []);
+    const reconciliationService = createSpyService('reconcileDerivedState', async ({ derivedState }) => ({
+      reconciliation_run_id: 'recon-4',
+      status: 'completed',
+      derived_state: derivedState,
+    }));
+
+    const result = await applyLearningEffects(
+      {
+        user_id: 'student-1',
+        question_id: 'question-4',
+        question_context: {
+          family_id: '9709.integration_techniques',
+          question_type_id: '9709.integration.application',
+          question_type_release_state: 'released',
+          primary_topic_id: 'source-topic',
+          primary_topic_path: '9709/integration/source',
+          classification_confidence: 0.78,
+          candidate_rubric_refs: [
+            {
+              kind: 'rubric_release',
+              rubric_version_id: 'integration-v1',
+              release_state: 'released',
+            },
+          ],
+        },
+        source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-4' },
+        source_mark_run_ref: { kind: 'mark_run', mark_run_id: 'mark-run-4' },
+        decisions: [
+          {
+            awarded: true,
+            awarded_marks: 1,
+            alignment_confidence: 0.74,
+          },
+        ],
+        marking_result: {
+          marking_summary: {
+            coverage_scope: 'question',
+            local_signal_only: false,
+            conservative_part_mapping: true,
+            ambiguous_rubric_point_result_count: 1,
+          },
+        },
+        uncertainty_validated: true,
+        repair_target_topic_id: 'repair-target-topic',
+        repair_target_topic_path: '9709/integration/repair',
+        repair_target_question_type_id: '9709.integration.application',
+      },
+      {
+        reviewTaskService,
+        artifactService,
+        reconciliationService,
+      },
+    );
+
+    expect(result.release_scope_status).toBe('released_scoring');
+    expect(result.authoritative_scoring_allowed).toBe(true);
+    expect(result.review_tasks).toHaveLength(1);
+    expect(result.review_tasks[0]).toMatchObject({
+      review_task_id: 'review-task-ambiguous-1',
+      target_topic_id: 'repair-target-topic',
+      target_question_type_id: '9709.integration.application',
+    });
+    expect(result.mastery_updates.every((item) => item.level !== 'question_type')).toBe(true);
+    expect(reviewTaskService.calls).toHaveLength(1);
+    expect(reviewTaskService.calls[0]).toMatchObject({
+      authoritative_scoring_allowed: true,
+      repair_target_topic_id: 'repair-target-topic',
+      marking_result: {
+        marking_summary: {
+          conservative_part_mapping: true,
+          ambiguous_rubric_point_result_count: 1,
+        },
+      },
+    });
+  });
 });
 
 describe('review task service generation', () => {

--- a/api/learning/__tests__/review-task-service.test.js
+++ b/api/learning/__tests__/review-task-service.test.js
@@ -439,6 +439,81 @@ describe('learning orchestration', () => {
       repair_target_topic_id: 'repair-target-topic',
     });
   });
+
+  test('incorrect released-scoring outcomes still emit repair tasks without positive type mastery', async () => {
+    const reviewTaskService = createSpyService('generateTasksFromOutcome', async (input) => [
+      {
+        review_task_id: 'review-task-1',
+        target_kind: 'question_type',
+        target_topic_id: input.repair_target_topic_id,
+        target_question_type_id: input.repair_target_question_type_id,
+        status: 'open',
+      },
+    ]);
+    const artifactService = createSpyService('buildArtifactCandidates', async () => []);
+    const reconciliationService = createSpyService('reconcileDerivedState', async ({ derivedState }) => ({
+      reconciliation_run_id: 'recon-3',
+      status: 'completed',
+      derived_state: derivedState,
+    }));
+
+    const result = await applyLearningEffects(
+      {
+        user_id: 'student-1',
+        question_id: 'question-3',
+        question_context: {
+          family_id: '9709.integration_techniques',
+          question_type_id: '9709.integration.application',
+          question_type_release_state: 'released',
+          primary_topic_id: 'source-topic',
+          primary_topic_path: '9709/integration/source',
+          classification_confidence: 0.78,
+          candidate_rubric_refs: [
+            {
+              kind: 'rubric_release',
+              rubric_version_id: 'integration-v1',
+              release_state: 'released',
+            },
+          ],
+        },
+        source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-3' },
+        source_mark_run_ref: { kind: 'mark_run', mark_run_id: 'mark-run-3' },
+        decisions: [
+          {
+            awarded: false,
+            awarded_marks: 0,
+            alignment_confidence: 0.86,
+          },
+        ],
+        uncertainty_validated: true,
+        misconception_tags: ['domain:interval'],
+        repair_target_topic_id: 'repair-target-topic',
+        repair_target_topic_path: '9709/integration/repair',
+        repair_target_question_type_id: '9709.integration.application',
+      },
+      {
+        reviewTaskService,
+        artifactService,
+        reconciliationService,
+      },
+    );
+
+    expect(result.release_scope_status).toBe('released_scoring');
+    expect(result.authoritative_scoring_allowed).toBe(true);
+    expect(result.review_tasks).toHaveLength(1);
+    expect(result.review_tasks[0]).toMatchObject({
+      review_task_id: 'review-task-1',
+      target_topic_id: 'repair-target-topic',
+      target_question_type_id: '9709.integration.application',
+    });
+    expect(result.mastery_updates.every((item) => item.level !== 'question_type')).toBe(true);
+    expect(reviewTaskService.calls).toHaveLength(1);
+    expect(reviewTaskService.calls[0]).toMatchObject({
+      authoritative_scoring_allowed: true,
+      repair_target_topic_id: 'repair-target-topic',
+      misconception_tags: ['domain:interval'],
+    });
+  });
 });
 
 describe('review task service generation', () => {

--- a/api/learning/__tests__/workspace-read-service.test.js
+++ b/api/learning/__tests__/workspace-read-service.test.js
@@ -1249,6 +1249,7 @@ describe('workspace read service', () => {
         question_context: {
           family_id: '9709.integration_techniques',
           question_type_id: '9709.integration.application',
+          question_type_release_state: 'released',
           primary_topic_id: 'source-topic',
           primary_topic_path: '9709.integration.application.source',
           classification_confidence: 0.77,
@@ -1280,6 +1281,9 @@ describe('workspace read service', () => {
         now,
       },
     );
+
+    expect(outcome.release_scope_status).toBe('released_scoring');
+    expect(outcome.authoritative_scoring_allowed).toBe(true);
 
     await patchLearningArtifact({
       client: db,

--- a/api/learning/lib/mastery/mastery-orchestrator.js
+++ b/api/learning/lib/mastery/mastery-orchestrator.js
@@ -1,6 +1,7 @@
 import { buildAttemptRef, buildMarkRunRef } from '../contracts/runtime-contract.js';
 import { createReviewTaskService } from '../review/review-task-service.js';
 import { createDefaultReviewTaskService } from '../review/review-task-service.js';
+import { shouldGenerateReviewTaskFromOutcome } from '../review/review-task-service.js';
 import { createArtifactService } from '../artifacts/artifact-service.js';
 import { createArtifactRepository } from '../repositories/artifact-repository.js';
 import { createReconciliationService } from '../reconciliation/reconciliation-service.js';
@@ -152,8 +153,8 @@ export function createMasteryOrchestrator({
       const masteryUpdates = masteryProjection.masteryUpdates;
       const reviewCapabilityPosture = adapter.meta.capability_posture?.review
         ?? SUBJECT_ADAPTER_CAPABILITY_POSTURES.SUPPORTED;
-      const reviewTasks = releaseScopePosture.authoritative_scoring_allowed
-        || reviewCapabilityPosture !== SUBJECT_ADAPTER_CAPABILITY_POSTURES.SUPPORTED
+      const reviewTasks = reviewCapabilityPosture !== SUBJECT_ADAPTER_CAPABILITY_POSTURES.SUPPORTED
+        || !shouldGenerateReviewTaskFromOutcome(reviewTaskInput)
         ? []
         : await reviewTaskService.generateTasksFromOutcome(reviewTaskInput);
       const artifactCandidates = await artifactService.buildArtifactCandidates(artifactInput);

--- a/api/learning/lib/review/review-scheduler-policy.js
+++ b/api/learning/lib/review/review-scheduler-policy.js
@@ -219,6 +219,10 @@ function summarizeExplainability(task = {}, explainability = {}) {
       ? `${normalizeString(explainability.evidence.coverage_scope)}-level`
       : 'runtime';
 
+  if (normalizeString(explainability?.posture) === 'released_scoring_repair') {
+    return `Queued from ${evidenceLabel} evidence while released scoring stays active.`;
+  }
+
   return `Queued from ${evidenceLabel} evidence while authoritative mastery stays conservative.`;
 }
 
@@ -226,6 +230,8 @@ export function buildReviewTaskExplainabilitySeed({
   sourceQuestionId = null,
   sourceAttemptRef = null,
   targetMisconceptionTags = [],
+  posture = 'conservative_fallback',
+  postureReasonCode = null,
   fallbackReasonCode = null,
   schedulerPolicy = {},
   coverageScope = 'question',
@@ -237,10 +243,11 @@ export function buildReviewTaskExplainabilitySeed({
   const sourceQuestionIds = uniqueStrings(sourceQuestionId ? [sourceQuestionId] : []);
 
   return {
-    posture: 'conservative_fallback',
-    posture_reason_code: fallbackReasonCode ?? null,
+    posture,
+    posture_reason_code: postureReasonCode ?? fallbackReasonCode ?? null,
     creation_reason_codes: uniqueStrings([
       fallbackReasonCode,
+      posture === 'released_scoring_repair' ? 'released_scoring_repair' : null,
       normalizeArray(targetMisconceptionTags).length > 0 ? 'misconception_tag_trigger' : null,
       localSignalOnly ? 'local_signal_only' : null,
     ]),

--- a/api/learning/lib/review/review-task-service.js
+++ b/api/learning/lib/review/review-task-service.js
@@ -308,15 +308,18 @@ function hasRepairSignal(input = {}) {
     return true;
   }
 
+  if (
+    markingSummary.conservative_part_mapping === true
+    || Number(markingSummary.ambiguous_rubric_point_result_count ?? 0) > 0
+  ) {
+    return true;
+  }
+
   if (hasPositiveDecision) {
     return false;
   }
 
-  if (markingSummary.local_signal_only === true || markingSummary.conservative_part_mapping === true) {
-    return true;
-  }
-
-  if (Number(markingSummary.ambiguous_rubric_point_result_count ?? 0) > 0) {
+  if (markingSummary.local_signal_only === true) {
     return true;
   }
 

--- a/api/learning/lib/review/review-task-service.js
+++ b/api/learning/lib/review/review-task-service.js
@@ -286,11 +286,64 @@ function pickTargetKind({ targetQuestionTypeId, familyId } = {}) {
   return 'misconception_tag';
 }
 
+function hasPositiveAwardDecision(decision = {}) {
+  return decision?.awarded === true && Number(decision?.awarded_marks ?? 0) > 0;
+}
+
+function hasRepairSignal(input = {}) {
+  if (input.regression_recovery === true) {
+    return true;
+  }
+
+  if (normalizeArray(input.misconception_tags).length > 0) {
+    return true;
+  }
+
+  const markingSummary = input.marking_result?.marking_summary ?? {};
+  const decisions = normalizeArray(input.decisions);
+  const hasPositiveDecision = decisions.some(hasPositiveAwardDecision);
+
+  if (decisions.some((decision) =>
+    decision?.awarded === false || Number(decision?.awarded_marks ?? 0) <= 0)) {
+    return true;
+  }
+
+  if (hasPositiveDecision) {
+    return false;
+  }
+
+  if (markingSummary.local_signal_only === true || markingSummary.conservative_part_mapping === true) {
+    return true;
+  }
+
+  if (Number(markingSummary.ambiguous_rubric_point_result_count ?? 0) > 0) {
+    return true;
+  }
+
+  return decisions.length > 0 && !hasPositiveDecision;
+}
+
+export function shouldGenerateReviewTaskFromOutcome(input = {}) {
+  if (!input.repair_target_topic_id) {
+    return false;
+  }
+
+  if (!input.authoritative_scoring_allowed) {
+    return true;
+  }
+
+  return hasRepairSignal(input);
+}
+
 function buildReviewTaskPayload(input = {}, now = new Date()) {
   const targetQuestionTypeId =
     input.repair_target_question_type_id
     || input.question_context?.question_type_id
     || null;
+  if (!shouldGenerateReviewTaskFromOutcome(input)) {
+    return null;
+  }
+
   const subjectCode = resolveSubjectCodeFromRuntimeInput(input, input.question_context);
   const adapter = getSubjectAdapter(subjectCode);
   const scheduler = adapter.review.buildSchedulerSeed({
@@ -318,10 +371,15 @@ function buildReviewTaskPayload(input = {}, now = new Date()) {
     input.marking_result?.marking_summary?.ambiguous_rubric_point_result_count ?? 0,
   );
   const schedulerPolicy = scheduler.policy;
+  const reviewTaskPosture = input.authoritative_scoring_allowed
+    ? 'released_scoring_repair'
+    : 'conservative_fallback';
   const explainability = buildReviewTaskExplainabilitySeed({
     sourceQuestionId: input.question_id ?? null,
     sourceAttemptRef: input.source_attempt_ref ?? null,
     targetMisconceptionTags: input.misconception_tags,
+    posture: reviewTaskPosture,
+    postureReasonCode: input.authoritative_scoring_allowed ? 'released_scoring_repair' : null,
     fallbackReasonCode: input.fallback_reason_code ?? null,
     schedulerPolicy,
     coverageScope: input.marking_result?.marking_summary?.coverage_scope ?? 'question',
@@ -346,8 +404,8 @@ function buildReviewTaskPayload(input = {}, now = new Date()) {
     priority: scheduler.priority,
     estimated_minutes: 15,
     success_criteria: {
-      posture: 'conservative_fallback',
-      authoritative_scoring_allowed: false,
+      posture: reviewTaskPosture,
+      authoritative_scoring_allowed: input.authoritative_scoring_allowed === true,
       coverage_scope: input.marking_result?.marking_summary?.coverage_scope ?? 'question',
       local_signal_only: input.marking_result?.marking_summary?.local_signal_only === true,
       ambiguous_part_mapping_count: ambiguousPartMappingCount,
@@ -368,14 +426,6 @@ export function createReviewTaskService({
 } = {}) {
   return {
     async generateTasksFromOutcome(input = {}) {
-      if (input.authoritative_scoring_allowed) {
-        return [];
-      }
-
-      if (!input.repair_target_topic_id) {
-        return [];
-      }
-
       const payload = buildReviewTaskPayload(input, now());
       if (!payload) {
         return [];


### PR DESCRIPTION
## Summary
- keep the review-task repair loop available for released-scoring outcomes when the marking result still carries real repair signals
- preserve positive authoritative scoring behavior by skipping repair task generation for clearly positive released outcomes
- lock the released-scoring repair lifecycle in workspace/read tests so complete and reopen keep `review_queue` projections aligned

## Verification
- npm test -- --runInBand --runTestsByPath api/learning/__tests__/review-task-service.test.js api/learning/__tests__/workspace-read-service.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/artifact-api.test.js api/learning/__tests__/mastery-orchestrator.test.js --verbose

Closes #161