### PR TITLE
fix(learning): remediate phase a runtime contracts

### DIFF
--- a/api/learning/__tests__/p3-rubric-validator.test.js
+++ b/api/learning/__tests__/p3-rubric-validator.test.js
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('p3 rubric validator', () => {
+  test('validates the promoted pilot rubric templates against the executable P3 schema', async () => {
+    const { validateP3RubricTemplateFile } = await import('../lib/marking/contracts/p3-rubric-validator.js');
+
+    const rubricPaths = [
+      'data/learning_runtime/pilot_rubrics/9709.trigonometry.identities.json',
+      'data/learning_runtime/pilot_rubrics/9709.trigonometry.equations.json',
+      'data/learning_runtime/pilot_rubrics/9709.integration.application.json',
+      'data/learning_runtime/pilot_rubrics/9709.differential_equations.separable.json',
+    ];
+
+    const results = rubricPaths.map((relPath) => validateP3RubricTemplateFile(
+      path.join(process.cwd(), relPath),
+    ));
+
+    expect(results.every((result) => result.ok)).toBe(true);
+    expect(results.map((result) => result.template.question_type_id)).toEqual([
+      '9709.trigonometry.identities',
+      '9709.trigonometry.equations',
+      '9709.integration.application',
+      '9709.differential_equations.separable',
+    ]);
+  });
+
+  test('rejects templates that omit required P3 structures', async () => {
+    const { validateP3RubricTemplate } = await import('../lib/marking/contracts/p3-rubric-validator.js');
+
+    const result = validateP3RubricTemplate({
+      schema_version: 'p3.rubric_template.v1',
+      rubric_template_id: 'broken-template',
+      question_type_id: '9709.integration.application',
+      release_state: 'released',
+      provenance: {
+        source_type: 'official_mark_scheme_excerpt',
+        source_refs: ['docs/reports/gpt5.4pro-deep-thinking/P3.md'],
+      },
+      parts: [],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('VerificationCondition'),
+        expect.stringContaining('UncertaintyTrigger'),
+      ]),
+    );
+  });
+
+  test('released-family gate contract points at real pilot rubric template files', () => {
+    const contract = JSON.parse(
+      fs.readFileSync(
+        path.join(process.cwd(), 'data/learning_runtime/release_evidence/released-family-gate-contract.v1.json'),
+        'utf8',
+      ),
+    );
+
+    const templatePaths = contract.families.flatMap((family) =>
+      (family?.rubric_coverage?.entries ?? []).flatMap((entry) => entry?.rubric_template_paths ?? []));
+
+    expect(templatePaths.sort()).toEqual([
+      'data/learning_runtime/pilot_rubrics/9709.differential_equations.separable.json',
+      'data/learning_runtime/pilot_rubrics/9709.integration.application.json',
+      'data/learning_runtime/pilot_rubrics/9709.trigonometry.equations.json',
+      'data/learning_runtime/pilot_rubrics/9709.trigonometry.identities.json',
+    ]);
+  });
+});

--- a/api/learning/__tests__/question-analysis.test.js
+++ b/api/learning/__tests__/question-analysis.test.js
@@ -71,6 +71,11 @@ describe('question-analysis foundation', () => {
       family_id: '9709.integration_techniques',
       primary_question_type_id: '9709.integration.application',
       confidence_band: 'low',
+      low_confidence_posture: expect.objectContaining({
+        posture: 'low_confidence',
+        authoritative_scoring_allowed: false,
+        fallback_reason_code: 'low_classification_confidence',
+      }),
       candidate_rubric_refs: [
         expect.objectContaining({
           kind: 'rubric_release',

--- a/api/learning/__tests__/question-import-service.test.js
+++ b/api/learning/__tests__/question-import-service.test.js
@@ -17,10 +17,12 @@ const clientState = {
   nextIdempotencyId: 1,
   nextQuestionId: 1,
   nextSnapshotId: 1,
+  nextQuestionEventId: 1,
   registryFamilies: new Map(),
   registryTypes: new Map(),
   questions: new Map(),
   snapshots: new Map(),
+  questionEvents: new Map(),
 };
 
 function seedCanonicalRegistry() {
@@ -97,8 +99,10 @@ function resetClientState() {
   clientState.nextIdempotencyId = 1;
   clientState.nextQuestionId = 1;
   clientState.nextSnapshotId = 1;
+  clientState.nextQuestionEventId = 1;
   clientState.questions = new Map();
   clientState.snapshots = new Map();
+  clientState.questionEvents = new Map();
   seedCanonicalRegistry();
 }
 
@@ -263,6 +267,32 @@ function resolveQuery(query) {
       ...query.payload,
     };
     clientState.snapshots.set(snapshotId, row);
+    return { data: row, error: null };
+  }
+
+  if (query.table === 'learning_question_analysis_snapshots' && query.operation === 'update') {
+    const snapshotId = findFilter(query, 'classification_snapshot_id');
+    const current = clientState.snapshots.get(snapshotId) || null;
+
+    if (!current) {
+      return { data: null, error: null };
+    }
+
+    const next = {
+      ...current,
+      ...query.payload,
+    };
+    clientState.snapshots.set(snapshotId, next);
+    return { data: next, error: null };
+  }
+
+  if (query.table === 'learning_question_events' && query.operation === 'insert') {
+    const questionEventId = `question-event-${clientState.nextQuestionEventId++}`;
+    const row = {
+      question_event_id: questionEventId,
+      ...query.payload,
+    };
+    clientState.questionEvents.set(questionEventId, row);
     return { data: row, error: null };
   }
 
@@ -547,6 +577,41 @@ function buildDifferentialInput(overrides = {}) {
   };
 }
 
+function buildAnalysisHints(overrides = {}) {
+  return {
+    runtime_context_id: '9709.trigonometry.equations',
+    question_type_hint_id: '9709.trigonometry.equations',
+    ...overrides,
+  };
+}
+
+function buildPromptOnlyInput({
+  promptValue,
+  analysisHints = null,
+  classification = undefined,
+} = {}) {
+  const body = {
+    subject_code: '9709',
+    prompt_representation: {
+      type: 'text',
+      value: promptValue,
+    },
+    provenance_summary: {
+      import_source: 'manual_paste',
+    },
+  };
+
+  if (analysisHints) {
+    body.analysis_hints = analysisHints;
+  }
+
+  if (typeof classification !== 'undefined') {
+    body.classification = classification;
+  }
+
+  return body;
+}
+
 describe('question import service', () => {
   let harness;
 
@@ -598,50 +663,116 @@ describe('question import service', () => {
     ).toBe(true);
   });
 
-  test('trigonometry type without a released rubric ref falls back to non_released_fallback', async () => {
+  test('import analysis derives canonical type from prompt text even when caller classification disagrees', async () => {
+    const result = await importQuestion(createClient(), {
+      userId: 'student-1',
+      body: buildPromptOnlyInput({
+        promptValue: 'Solve the differential equation dy/dx = 2xy given that y = 1 when x = 0.',
+        analysisHints: buildAnalysisHints({
+          runtime_context_id: '9709.trigonometry.equations',
+          question_type_hint_id: '9709.trigonometry.equations',
+        }),
+        classification: {
+          primary_question_type_id: '9709.trigonometry.equations',
+          classification_confidence: 0.99,
+          candidate_rubric_refs: [buildReleasedRubricRef()],
+          uncertainty_validated: true,
+          uncertainty_posture: {
+            status: 'validated',
+          },
+        },
+      }),
+    });
+
+    expect(result.question).toMatchObject({
+      family_id: '9709.differential_equations',
+      primary_question_type_id: '9709.differential_equations.separable',
+    });
+    expect(result.scoring_scope_posture).toMatchObject({
+      release_scope_status: 'released_scoring',
+      authoritative_scoring_allowed: true,
+    });
+    expect(clientState.snapshots.get('snapshot-1')).toMatchObject({
+      analysis_audit_metadata: expect.objectContaining({
+        analysis_mode: 'question_intelligence',
+        analysis_hints: expect.objectContaining({
+          question_type_hint_id: '9709.trigonometry.equations',
+        }),
+      }),
+    });
+  });
+
+  test('import analysis can classify prompt-only trig identities without caller-supplied classification', async () => {
+    const result = await importQuestion(createClient(), {
+      userId: 'student-1',
+      body: buildPromptOnlyInput({
+        promptValue: 'Prove that 1 - tan^2(x) = cos(2x) / cos^2(x).',
+        analysisHints: buildAnalysisHints({
+          runtime_context_id: '9709.trigonometry.identities',
+          question_type_hint_id: '9709.trigonometry.identities',
+        }),
+      }),
+    });
+
+    expect(result.question).toMatchObject({
+      family_id: '9709.trigonometry_manipulation_equations',
+      primary_question_type_id: '9709.trigonometry.identities',
+      release_scope_status: 'released_scoring',
+    });
+    expect(result.scoring_scope_posture).toMatchObject({
+      authoritative_scoring_allowed: true,
+      release_scope_status: 'released_scoring',
+    });
+  });
+
+  test('caller-supplied rubric refs do not override the analyzer-selected pilot rubric package', async () => {
     const result = await importQuestion(createClient(), {
       userId: 'student-1',
       body: buildTrigWithoutReleasedRubricInput(),
     });
 
     expect(result.scoring_scope_posture).toMatchObject({
-      authoritative_scoring_allowed: false,
-      fallback_mode: 'non_released_fallback',
-      fallback_reason_code: 'missing_released_rubric',
-      classification_confidence: 0.88,
+      authoritative_scoring_allowed: true,
+      fallback_mode: null,
+      fallback_reason_code: null,
+      classification_confidence: 0.95,
     });
-    expect(result.question.release_scope_status).toBe('non_released_fallback');
+    expect(result.question.release_scope_status).toBe('released_scoring');
+    expect(clientState.snapshots.get('snapshot-1')).toMatchObject({
+      candidate_rubric_refs: [
+        expect.objectContaining({
+          rubric_set_id: '9709.trigonometry.identities',
+          release_state: 'released',
+        }),
+      ],
+    });
   });
 
-  test('imported integration application question gets authoritative scoring when released gates are satisfied', async () => {
+  test('imported integration application question gets authoritative scoring from analyzer output when released gates are satisfied', async () => {
     const result = await importQuestion(createClient(), {
       userId: 'student-1',
       body: buildIntegrationInput(),
     });
 
     expect(result.scoring_scope_posture).toMatchObject({
-      authoritative_scoring_allowed: false,
-      release_scope_status: 'non_released_fallback',
-      fallback_mode: 'non_released_fallback',
-      fallback_reason_code: 'low_classification_confidence',
-      classification_confidence: 0.77,
+      authoritative_scoring_allowed: true,
+      release_scope_status: 'released_scoring',
+      fallback_mode: null,
+      fallback_reason_code: null,
+      classification_confidence: 0.89,
     });
     expect(result.question).toMatchObject({
       family_id: '9709.integration_techniques',
       primary_question_type_id: '9709.integration.application',
-      release_scope_status: 'non_released_fallback',
+      release_scope_status: 'released_scoring',
     });
     expect(clientState.snapshots.get('snapshot-1')).toMatchObject({
-      confidence_band: 'low',
-      analysis_audit_metadata: expect.objectContaining({
-        low_confidence_posture: expect.objectContaining({
-          posture: 'low_confidence',
-        }),
-      }),
+      confidence_band: 'high',
+      low_confidence_posture: null,
     });
   });
 
-  test('imported questions preserve explicit non-low confidence bands through released-scope evaluation', async () => {
+  test('imported questions record analysis hints but keep analyzer-owned confidence posture', async () => {
     const result = await importQuestion(createClient(), {
       userId: 'student-1',
       body: buildIntegrationInput({
@@ -657,7 +788,7 @@ describe('question import service', () => {
       release_scope_status: 'released_scoring',
       fallback_mode: null,
       fallback_reason_code: null,
-      classification_confidence: 0.79,
+      classification_confidence: 0.89,
     });
     expect(result.question).toMatchObject({
       family_id: '9709.integration_techniques',
@@ -665,9 +796,11 @@ describe('question import service', () => {
       release_scope_status: 'released_scoring',
     });
     expect(clientState.snapshots.get('snapshot-1')).toMatchObject({
-      confidence_band: 'medium',
-      analysis_audit_metadata: expect.not.objectContaining({
-        low_confidence_posture: expect.anything(),
+      confidence_band: 'high',
+      analysis_audit_metadata: expect.objectContaining({
+        analysis_hints: expect.objectContaining({
+          question_type_hint_id: '9709.integration.application',
+        }),
       }),
     });
   });
@@ -713,6 +846,41 @@ describe('question import service', () => {
       ],
       confidence_band: 'high',
       analysis_provenance_kind: 'real',
+    });
+  });
+
+  test('import persists a real QuestionClassified event and links the active snapshot to it', async () => {
+    const result = await importQuestion(createClient(), {
+      userId: 'student-1',
+      body: buildPromptOnlyInput({
+        promptValue: 'Find the value of integral of (2x+1)(x^2+x)^4 dx.',
+        analysisHints: buildAnalysisHints({
+          runtime_context_id: '9709.integration.application',
+          question_type_hint_id: '9709.integration.application',
+        }),
+      }),
+    });
+
+    expect(result.question.classification_snapshot_ref).toEqual({
+      kind: 'classification_snapshot',
+      classification_snapshot_id: 'snapshot-1',
+    });
+    expect(clientState.questionEvents.get('question-event-1')).toMatchObject({
+      event_type: 'QuestionClassified',
+      question_id: 'question-1',
+      classification_snapshot_id: 'snapshot-1',
+      event_payload: expect.objectContaining({
+        question_id: 'question-1',
+        classification_snapshot_id: 'snapshot-1',
+        primary_question_type_id: '9709.integration.application',
+      }),
+    });
+    expect(clientState.snapshots.get('snapshot-1')).toMatchObject({
+      evidence_source_event_ref: {
+        kind: 'question_event',
+        question_event_id: 'question-event-1',
+        event_type: 'QuestionClassified',
+      },
     });
   });
 

--- a/api/learning/__tests__/question-registry-repository.test.js
+++ b/api/learning/__tests__/question-registry-repository.test.js
@@ -43,6 +43,16 @@ function createQuestionRegistryDb() {
                 };
               }
 
+              if (table === 'learning_question_events') {
+                return {
+                  data: {
+                    question_event_id: 'question-event-1',
+                    ...payload,
+                  },
+                  error: null,
+                };
+              }
+
               throw new Error(`Unexpected insert table: ${table}`);
             },
           };
@@ -223,7 +233,7 @@ describe('question-registry-repository', () => {
 
     const result = await insertImportedQuestion(db, importedInput);
 
-    expect(db.inserts).toHaveLength(2);
+    expect(db.inserts).toHaveLength(3);
     expect(db.inserts[0]).toMatchObject({
       table: 'question_bank',
       payload: {
@@ -257,17 +267,42 @@ describe('question-registry-repository', () => {
         classification_source: 'manual_import',
         classification_confidence: 0.82,
         confidence_band: 'medium',
+        low_confidence_posture: null,
         canonical_step_skeleton_summary: importedInput.classification.canonical_step_skeleton_summary,
         difficulty_signal: importedInput.classification.difficulty_signal,
         analysis_audit_metadata: importedInput.classification.analysis_audit_metadata,
         analysis_version: 'phase_a.v1',
-        evidence_source_event_ref: importedInput.classification.evidence_source_event_ref,
         analysis_provenance_kind: 'real',
         candidate_rubric_refs: importedInput.classification.candidate_rubric_refs,
       },
     });
 
+    expect(db.inserts[2]).toMatchObject({
+      table: 'learning_question_events',
+      payload: {
+        event_type: 'QuestionClassified',
+        question_id: 'question-fixed-1',
+        classification_snapshot_id: 'snapshot-1',
+        event_payload: expect.objectContaining({
+          question_id: 'question-fixed-1',
+          classification_snapshot_id: 'snapshot-1',
+          primary_question_type_id: '9709.trigonometry.equations',
+        }),
+      },
+    });
+
     expect(db.updates).toEqual([
+      {
+        table: 'learning_question_analysis_snapshots',
+        payload: {
+          evidence_source_event_ref: {
+            kind: 'question_event',
+            question_event_id: 'question-event-1',
+            event_type: 'QuestionClassified',
+          },
+        },
+        filters: [{ column: 'classification_snapshot_id', value: 'snapshot-1' }],
+      },
       {
         table: 'question_bank',
         payload: {

--- a/api/learning/__tests__/schema-contract.test.js
+++ b/api/learning/__tests__/schema-contract.test.js
@@ -7,7 +7,8 @@ const LEARNING_RUNTIME_MIGRATIONS = [
   'supabase/migrations/20260320111500_seed_learning_runtime_pilot_registry.sql',
   'supabase/migrations/20260320112000_create_learning_runtime_read_models.sql',
   'supabase/migrations/20260324110000_promote_learning_runtime_integration_application.sql',
-  'supabase/migrations/20260412103000_expand_learning_question_analysis_snapshots_phase_a.sql'
+  'supabase/migrations/20260412103000_expand_learning_question_analysis_snapshots_phase_a.sql',
+  'supabase/migrations/20260413110000_phase_a_question_classified_events.sql'
 ];
 
 function readMigration(relPath) {
@@ -69,6 +70,7 @@ describe('learning runtime schema contract', () => {
       'canonical_step_skeleton_summary',
       'difficulty_signal',
       'confidence_band',
+      'low_confidence_posture',
       'analysis_audit_metadata',
       'analysis_version',
       'evidence_source_event_ref',
@@ -86,6 +88,7 @@ describe('learning runtime schema contract', () => {
     expect(sql).toContain('create table if not exists public.learning_question_families');
     expect(sql).toContain('create table if not exists public.learning_question_types');
     expect(sql).toContain('create table if not exists public.learning_question_analysis_snapshots');
+    expect(sql).toContain('create table if not exists public.learning_question_events');
     expect(sql).toContain('create table if not exists public.learning_sessions');
     expect(sql).toContain('create table if not exists public.learning_session_lineage');
     expect(sql).toContain('create table if not exists public.learning_workspaces');
@@ -185,19 +188,14 @@ describe('learning runtime schema contract', () => {
       .forEach((token) => expect(questionTypesSql).toContain(token));
 
     const questionAnalysisSql = normalizeSql(readMigration(
-      'supabase/migrations/20260412103000_expand_learning_question_analysis_snapshots_phase_a.sql'
+      'supabase/migrations/20260413110000_phase_a_question_classified_events.sql'
     ));
     [
-      'prerequisite_topic_ids',
-      'canonical_step_skeleton_summary',
-      'difficulty_signal',
-      'confidence_band',
-      'analysis_audit_metadata',
-      'analysis_version',
-      'evidence_source_event_ref',
-      'analysis_provenance_kind',
-      "check (confidence_band is null or confidence_band in ('low', 'medium', 'high'))",
-      "check (analysis_provenance_kind in ('real', 'synthetic', 'mixed', 'unknown'))"
+      'low_confidence_posture',
+      'create table if not exists public.learning_question_events',
+      'question_event_id uuid primary key default gen_random_uuid()',
+      'classification_snapshot_id uuid not null references public.learning_question_analysis_snapshots(classification_snapshot_id)',
+      "check (low_confidence_posture is null or jsonb_typeof(low_confidence_posture) = 'object')"
     ].forEach((token) => expect(questionAnalysisSql).toContain(token));
 
     const reconciliationSql = extractTableBlock(sql, 'public.learning_reconciliation_runs');
@@ -212,7 +210,7 @@ describe('learning runtime schema contract', () => {
     ].forEach((token) => expect(reconciliationSql).toContain(token));
 
     const registryProjectionSql = normalizeSql(readMigration(
-      'supabase/migrations/20260412103000_expand_learning_question_analysis_snapshots_phase_a.sql'
+      'supabase/migrations/20260413110000_phase_a_question_classified_events.sql'
     ));
 
     [
@@ -220,6 +218,7 @@ describe('learning runtime schema contract', () => {
       'lqas.canonical_step_skeleton_summary',
       'lqas.difficulty_signal',
       'lqas.confidence_band',
+      'lqas.low_confidence_posture',
       'lqas.analysis_audit_metadata',
       'lqas.analysis_version',
       'lqas.evidence_source_event_ref',

--- a/api/learning/lib/contracts/released-family-gate.js
+++ b/api/learning/lib/contracts/released-family-gate.js
@@ -2,6 +2,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  validateP3RubricTemplateFile,
+} from '../marking/contracts/p3-rubric-validator.js';
+import {
   FALLBACK_REASON_CODES,
   resolveInlineReleasedScoringPosture,
 } from './released-scope-core.js';
@@ -186,11 +189,32 @@ function validateRubricCoverage(rootDir, family) {
 
   const questionTypeResults = releasedQuestionTypeIds.map((questionTypeId) => {
     const entry = entryMap.get(questionTypeId) || null;
-    const releasedRubricRefs = Array.isArray(entry?.released_rubric_refs)
-      ? entry.released_rubric_refs.filter((ref) => ref?.release_state === 'released')
-      : [];
+    const templatePaths = normalizeStringArray(entry?.rubric_template_paths);
+    const templateResults = templatePaths.map((relPath) => {
+      if (!fileExists(rootDir, relPath)) {
+        return {
+          relPath,
+          ok: false,
+          missing: true,
+          errors: ['rubric_template_missing'],
+        };
+      }
 
-    if (releasedRubricRefs.length > 0) {
+      const validation = validateP3RubricTemplateFile(resolveFromRoot(rootDir, relPath));
+      return {
+        relPath,
+        ok: validation.ok,
+        missing: false,
+        errors: validation.errors,
+        template: validation.template,
+      };
+    });
+    const matchingReleasedTemplates = templateResults.filter((result) =>
+      result.ok
+      && result.template?.question_type_id === questionTypeId
+      && result.template?.release_state === 'released');
+
+    if (matchingReleasedTemplates.length > 0) {
       coveredQuestionTypeIds.push(questionTypeId);
       return {
         question_type_id: questionTypeId,
@@ -199,10 +223,27 @@ function validateRubricCoverage(rootDir, family) {
       };
     }
 
+    const questionTypeBlockedReasons = [];
+    if (templatePaths.length === 0) {
+      uniquePush(questionTypeBlockedReasons, 'rubric_template_path_missing');
+    }
+    if (templateResults.some((result) => result.missing)) {
+      uniquePush(questionTypeBlockedReasons, 'rubric_template_missing');
+    }
+    if (templateResults.some((result) => !result.missing && !result.ok)) {
+      uniquePush(questionTypeBlockedReasons, 'rubric_template_invalid');
+    }
+    if (
+      templateResults.some((result) =>
+        result.ok && result.template?.question_type_id !== questionTypeId)
+    ) {
+      uniquePush(questionTypeBlockedReasons, 'rubric_template_question_type_mismatch');
+    }
+
     return {
       question_type_id: questionTypeId,
       status: 'fail',
-      blocked_reasons: ['rubric_coverage_missing_released_ref'],
+      blocked_reasons: questionTypeBlockedReasons,
     };
   });
 

--- a/api/learning/lib/events/question-event-service.js
+++ b/api/learning/lib/events/question-event-service.js
@@ -1,0 +1,96 @@
+function cloneJson(value) {
+  return value === undefined ? null : JSON.parse(JSON.stringify(value));
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function buildQuestionEventRef(questionEventId) {
+  return {
+    kind: 'question_event',
+    question_event_id: questionEventId,
+    event_type: 'QuestionClassified',
+  };
+}
+
+function buildQuestionClassifiedEventPayload({
+  questionId,
+  classificationSnapshotId,
+  question = {},
+  classification = {},
+} = {}) {
+  return {
+    question_id: questionId,
+    classification_snapshot_id: classificationSnapshotId,
+    subject_code: question.subject_code ?? null,
+    family_id: question.family_id ?? classification.family_id ?? null,
+    primary_question_type_id:
+      question.primary_question_type_id ?? classification.primary_question_type_id ?? null,
+    classification_confidence: classification.classification_confidence ?? null,
+    confidence_band: classification.confidence_band ?? null,
+    low_confidence_posture: cloneJson(classification.low_confidence_posture),
+    candidate_rubric_refs: cloneJson(classification.candidate_rubric_refs ?? []),
+    analysis_version: classification.analysis_version ?? null,
+  };
+}
+
+function buildQuestionClassifiedProvenance({
+  question = {},
+  classification = {},
+} = {}) {
+  return {
+    source_kind: question.source_kind ?? 'imported_question',
+    subject_code: question.subject_code ?? null,
+    classification_source: classification.classification_source ?? null,
+    analysis_version: classification.analysis_version ?? null,
+    analysis_provenance_kind: classification.analysis_provenance_kind ?? null,
+    provenance_summary: cloneJson(question.provenance_summary ?? {}),
+    audit_metadata: cloneJson(classification.analysis_audit_metadata ?? {}),
+  };
+}
+
+export async function appendQuestionClassifiedEvent(client, {
+  questionId,
+  classificationSnapshotId,
+  question,
+  classification,
+} = {}) {
+  const normalizedQuestionId = normalizeString(questionId);
+  const normalizedSnapshotId = normalizeString(classificationSnapshotId);
+
+  if (!normalizedQuestionId || !normalizedSnapshotId) {
+    throw new Error('QuestionClassified event requires question_id and classification_snapshot_id.');
+  }
+
+  const { data, error } = await client
+    .from('learning_question_events')
+    .insert({
+      event_type: 'QuestionClassified',
+      question_id: normalizedQuestionId,
+      classification_snapshot_id: normalizedSnapshotId,
+      event_payload: buildQuestionClassifiedEventPayload({
+        questionId: normalizedQuestionId,
+        classificationSnapshotId: normalizedSnapshotId,
+        question,
+        classification,
+      }),
+      provenance: buildQuestionClassifiedProvenance({
+        question,
+        classification,
+      }),
+    })
+    .select('question_event_id')
+    .single();
+
+  if (error || !data?.question_event_id) {
+    throw new Error(
+      `Failed to insert QuestionClassified event: ${error?.message || 'no data returned'}`,
+    );
+  }
+
+  return {
+    questionEventId: data.question_event_id,
+    eventRef: buildQuestionEventRef(data.question_event_id),
+  };
+}

--- a/api/learning/lib/import/question-import-service.js
+++ b/api/learning/lib/import/question-import-service.js
@@ -6,6 +6,9 @@ import {
   buildQuestionAnalysisResult,
 } from '../question-analysis/analysis-result-contract.js';
 import {
+  analyzeQuestionEnvelope,
+} from '../question-analysis/question-intelligence-service.js';
+import {
   normalizeQuestionEnvelope,
 } from '../question-analysis/question-envelope-contract.js';
 import {
@@ -117,46 +120,29 @@ function normalizeCandidateRubricRefs(value) {
     .map((entry) => cloneJson(entry));
 }
 
-function normalizeClassification(body = {}) {
+function normalizeAnalysisHints(body = {}, validatedAnalysisHints = null) {
   const rawClassification = isPlainObject(body.classification) ? body.classification : {};
-
-  return {
-    primary_topic_id: normalizeNullableString(
-      rawClassification.primary_topic_id ?? body.primary_topic_id,
+  const normalizedHints = {
+    runtime_context_id: normalizeNullableString(
+      validatedAnalysisHints?.runtime_context_id ?? body.runtime_context_id,
     ),
-    secondary_topic_ids: normalizeStringArray(
-      rawClassification.secondary_topic_ids ?? body.secondary_topic_ids,
+    question_type_hint_id: normalizeNullableString(
+      validatedAnalysisHints?.question_type_hint_id
+      ?? rawClassification.primary_question_type_id
+      ?? body.primary_question_type_id,
     ),
-    prerequisite_topic_ids: normalizeStringArray(rawClassification.prerequisite_topic_ids),
-    family_id: normalizeNullableString(rawClassification.family_id ?? body.family_id),
-    primary_question_type_id: normalizeNullableString(
-      rawClassification.primary_question_type_id ?? body.primary_question_type_id,
+    topic_path_hint: normalizeNullableString(
+      validatedAnalysisHints?.topic_path_hint ?? body.topic_path,
     ),
-    secondary_question_type_ids: normalizeStringArray(
-      rawClassification.secondary_question_type_ids ?? body.secondary_question_type_ids,
-    ),
-    variant_tags: normalizeStringArray(rawClassification.variant_tags ?? body.variant_tags),
-    classification_source:
-      normalizeNullableString(rawClassification.classification_source) || 'imported_question',
-    classification_confidence: normalizeClassificationConfidence(
-      rawClassification.classification_confidence,
-    ),
-    confidence_band: normalizeNullableString(rawClassification.confidence_band),
-    candidate_rubric_refs: normalizeCandidateRubricRefs(rawClassification.candidate_rubric_refs),
-    canonical_step_skeleton_summary: normalizeObjectOrNull(
-      rawClassification.canonical_step_skeleton_summary,
-    ),
-    difficulty_signal: normalizeObjectOrNull(rawClassification.difficulty_signal),
-    analysis_audit_metadata: normalizeObjectOrEmpty(rawClassification.analysis_audit_metadata),
-    analysis_version: normalizeNullableString(rawClassification.analysis_version),
-    evidence_source_event_ref: normalizeObjectOrNull(rawClassification.evidence_source_event_ref),
-    analysis_provenance_kind: normalizeNullableString(rawClassification.analysis_provenance_kind),
-    uncertainty_validated:
-      typeof rawClassification.uncertainty_validated === 'boolean'
-        ? rawClassification.uncertainty_validated
-        : false,
-    uncertainty_posture: normalizeObjectOrNull(rawClassification.uncertainty_posture),
   };
+
+  if (!normalizedHints.runtime_context_id
+    && !normalizedHints.question_type_hint_id
+    && !normalizedHints.topic_path_hint) {
+    return null;
+  }
+
+  return normalizedHints;
 }
 
 function normalizeQuestionImportBody(body = {}) {
@@ -169,7 +155,7 @@ function normalizeQuestionImportBody(body = {}) {
 
   return {
     ...questionEnvelope,
-    classification: normalizeClassification(body),
+    analysis_hints: normalizeAnalysisHints(body, validated.normalized.analysis_hints),
     question_envelope: questionEnvelope,
   };
 }
@@ -410,12 +396,16 @@ async function performQuestionImport(client, {
   normalizedInput,
   questionId = null,
 } = {}) {
+  const analyzedClassification = analyzeQuestionEnvelope({
+    envelope: normalizedInput.question_envelope,
+    analysisHints: normalizedInput.analysis_hints,
+  });
   const {
     classification,
     scoringScopePosture,
   } = await resolveReleasedScoringPosture(client, {
     subjectCode: normalizedInput.subject_code,
-    classification: normalizedInput.classification,
+    classification: analyzedClassification,
     questionEnvelope: normalizedInput.question_envelope,
   });
   classification.primary_topic_id = normalizeCompatibleRuntimeTopicId(

--- a/api/learning/lib/marking/contracts/p3-contract-types.d.ts
+++ b/api/learning/lib/marking/contracts/p3-contract-types.d.ts
@@ -1,0 +1,88 @@
+export type VerificationCondition =
+  | {
+      kind: 'adapter_call';
+      adapter_method: string;
+      params?: Record<string, unknown>;
+    }
+  | {
+      kind: 'all' | 'any';
+      conditions: VerificationCondition[];
+    }
+  | {
+      kind: 'not';
+      condition: VerificationCondition;
+    }
+  | {
+      kind: 'count_at_least';
+      min_count: number;
+      conditions: VerificationCondition[];
+    };
+
+export interface DependencyChain {
+  prerequisite_point_ids: string[];
+  prerequisite_policy: 'all' | 'any';
+  strict: boolean;
+}
+
+export interface FollowThroughPolicy {
+  enabled: boolean;
+  mode:
+    | 'reuse_student_binding'
+    | 'symbolic_substitution'
+    | 'numeric_substitution'
+    | 'algebraic_consistency';
+  allow_incorrect_source: boolean;
+  binding_sources?: string[];
+  source_point_ids?: string[];
+}
+
+export interface UncertaintyTrigger {
+  trigger_id: string;
+  trigger_type:
+    | 'adapter_confidence_below'
+    | 'multiple_branch_match'
+    | 'missing_binding'
+    | 'ambiguous_parse'
+    | 'manual_review_required';
+  severity: 'low' | 'medium' | 'high';
+  message: string;
+  threshold?: number;
+  params?: Record<string, unknown>;
+}
+
+export interface MarkPoint {
+  point_id: string;
+  official_mark_notation: string;
+  mark_family: 'M' | 'A' | 'B';
+  max_score: number;
+  verification_condition: VerificationCondition;
+  dependency_chain?: DependencyChain;
+  follow_through?: FollowThroughPolicy;
+  uncertainty_triggers?: UncertaintyTrigger[];
+}
+
+export interface RubricPart {
+  part_id: string;
+  label: string;
+  score_max: number;
+  points: MarkPoint[];
+  uncertainty_triggers?: UncertaintyTrigger[];
+  subparts?: RubricPart[];
+}
+
+export interface RubricTemplate {
+  schema_version: 'p3.rubric_template.v1';
+  rubric_template_id: string;
+  question_type_id: string;
+  title: string;
+  release_state: 'draft' | 'validated' | 'released';
+  adapter_key: string;
+  score_max: number;
+  provenance: {
+    source_type: 'official_mark_scheme_excerpt' | 'manual_authoring' | 'mixed';
+    source_refs: string[];
+    authoring_notes?: string[];
+  };
+  global_uncertainty_rules?: UncertaintyTrigger[];
+  parts: RubricPart[];
+}

--- a/api/learning/lib/marking/contracts/p3-rubric-template.schema.json
+++ b/api/learning/lib/marking/contracts/p3-rubric-template.schema.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ciecopilot.dev/schemas/p3-rubric-template.schema.json",
+  "title": "RubricTemplate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "rubric_template_id",
+    "question_type_id",
+    "title",
+    "release_state",
+    "adapter_key",
+    "score_max",
+    "provenance",
+    "parts"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "p3.rubric_template.v1"
+    },
+    "rubric_template_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "question_type_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "release_state": {
+      "enum": ["draft", "validated", "released"]
+    },
+    "adapter_key": {
+      "type": "string",
+      "minLength": 1
+    },
+    "score_max": {
+      "type": "number",
+      "minimum": 0
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_type", "source_refs"],
+      "properties": {
+        "source_type": {
+          "enum": ["official_mark_scheme_excerpt", "manual_authoring", "mixed"]
+        },
+        "source_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "authoring_notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "global_uncertainty_rules": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/UncertaintyTrigger"
+      }
+    },
+    "parts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/RubricPart"
+      }
+    }
+  },
+  "$defs": {
+    "VerificationCondition": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "adapter_method"],
+          "properties": {
+            "kind": { "const": "adapter_call" },
+            "adapter_method": { "type": "string", "minLength": 1 },
+            "params": { "type": "object" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "conditions"],
+          "properties": {
+            "kind": { "enum": ["all", "any"] },
+            "conditions": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/VerificationCondition" }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "condition"],
+          "properties": {
+            "kind": { "const": "not" },
+            "condition": { "$ref": "#/$defs/VerificationCondition" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "min_count", "conditions"],
+          "properties": {
+            "kind": { "const": "count_at_least" },
+            "min_count": { "type": "integer", "minimum": 1 },
+            "conditions": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/VerificationCondition" }
+            }
+          }
+        }
+      ]
+    },
+    "DependencyChain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prerequisite_point_ids", "prerequisite_policy", "strict"],
+      "properties": {
+        "prerequisite_point_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "prerequisite_policy": {
+          "enum": ["all", "any"]
+        },
+        "strict": {
+          "type": "boolean"
+        }
+      }
+    },
+    "FollowThroughPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "mode", "allow_incorrect_source"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "mode": {
+          "enum": [
+            "reuse_student_binding",
+            "symbolic_substitution",
+            "numeric_substitution",
+            "algebraic_consistency"
+          ]
+        },
+        "allow_incorrect_source": { "type": "boolean" },
+        "binding_sources": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "source_point_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "UncertaintyTrigger": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trigger_id", "trigger_type", "severity", "message"],
+      "properties": {
+        "trigger_id": { "type": "string", "minLength": 1 },
+        "trigger_type": {
+          "enum": [
+            "adapter_confidence_below",
+            "multiple_branch_match",
+            "missing_binding",
+            "ambiguous_parse",
+            "manual_review_required"
+          ]
+        },
+        "severity": {
+          "enum": ["low", "medium", "high"]
+        },
+        "message": { "type": "string", "minLength": 1 },
+        "threshold": { "type": "number" },
+        "params": { "type": "object" }
+      }
+    },
+    "MarkPoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "point_id",
+        "official_mark_notation",
+        "mark_family",
+        "max_score",
+        "verification_condition"
+      ],
+      "properties": {
+        "point_id": { "type": "string", "minLength": 1 },
+        "official_mark_notation": { "type": "string", "minLength": 1 },
+        "mark_family": { "enum": ["M", "A", "B"] },
+        "max_score": { "type": "number", "minimum": 0 },
+        "verification_condition": { "$ref": "#/$defs/VerificationCondition" },
+        "dependency_chain": { "$ref": "#/$defs/DependencyChain" },
+        "follow_through": { "$ref": "#/$defs/FollowThroughPolicy" },
+        "uncertainty_triggers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/UncertaintyTrigger" }
+        }
+      }
+    },
+    "RubricPart": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["part_id", "label", "score_max", "points"],
+      "properties": {
+        "part_id": { "type": "string", "minLength": 1 },
+        "label": { "type": "string", "minLength": 1 },
+        "score_max": { "type": "number", "minimum": 0 },
+        "points": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/MarkPoint" }
+        },
+        "uncertainty_triggers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/UncertaintyTrigger" }
+        },
+        "subparts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/RubricPart" }
+        }
+      }
+    }
+  }
+}

--- a/api/learning/lib/marking/contracts/p3-rubric-validator.js
+++ b/api/learning/lib/marking/contracts/p3-rubric-validator.js
@@ -1,0 +1,97 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const Ajv = require('ajv');
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = path.join(MODULE_DIR, 'p3-rubric-template.schema.json');
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function buildAjvValidator() {
+  const ajv = new Ajv({
+    allErrors: true,
+    jsonPointers: true,
+  });
+  const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+  return ajv.compile(schema);
+}
+
+const validateSchema = buildAjvValidator();
+
+function flattenPoints(parts = []) {
+  const collected = [];
+
+  for (const part of Array.isArray(parts) ? parts : []) {
+    for (const point of Array.isArray(part?.points) ? part.points : []) {
+      collected.push(point);
+    }
+    if (Array.isArray(part?.subparts)) {
+      collected.push(...flattenPoints(part.subparts));
+    }
+  }
+
+  return collected;
+}
+
+function collectUncertaintyTriggers(template = {}) {
+  const triggers = [
+    ...(Array.isArray(template?.global_uncertainty_rules) ? template.global_uncertainty_rules : []),
+  ];
+
+  function visit(parts = []) {
+    for (const part of Array.isArray(parts) ? parts : []) {
+      if (Array.isArray(part?.uncertainty_triggers)) {
+        triggers.push(...part.uncertainty_triggers);
+      }
+      for (const point of Array.isArray(part?.points) ? part.points : []) {
+        if (Array.isArray(point?.uncertainty_triggers)) {
+          triggers.push(...point.uncertainty_triggers);
+        }
+      }
+      if (Array.isArray(part?.subparts)) {
+        visit(part.subparts);
+      }
+    }
+  }
+
+  visit(template?.parts);
+  return triggers;
+}
+
+function formatAjvError(error = {}) {
+  const dataPath = error.dataPath || error.instancePath || '';
+  return `${dataPath || '$'} ${error.message}`.trim();
+}
+
+export function validateP3RubricTemplate(template = {}) {
+  const schemaOk = validateSchema(template);
+  const errors = schemaOk
+    ? []
+    : (validateSchema.errors || []).map((error) => formatAjvError(error));
+
+  const points = flattenPoints(template?.parts);
+  if (points.length === 0 || !points.some((point) => point?.verification_condition)) {
+    errors.push('VerificationCondition coverage missing from rubric template.');
+  }
+
+  if (collectUncertaintyTriggers(template).length === 0) {
+    errors.push('UncertaintyTrigger coverage missing from rubric template.');
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    template: cloneJson(template),
+  };
+}
+
+export function validateP3RubricTemplateFile(filePath) {
+  const template = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  return validateP3RubricTemplate(template);
+}

--- a/api/learning/lib/question-analysis/analysis-result-contract.js
+++ b/api/learning/lib/question-analysis/analysis-result-contract.js
@@ -152,6 +152,7 @@ export function buildQuestionAnalysisResult({
       || 'question_analysis',
     classification_confidence: classificationConfidence,
     confidence_band: confidenceBand,
+    low_confidence_posture: lowConfidencePosture,
     candidate_rubric_refs: candidateRubricRefs,
     canonical_step_skeleton_summary: normalizeObjectOrNull(
       classification.canonical_step_skeleton_summary,

--- a/api/learning/lib/question-analysis/question-intelligence-service.js
+++ b/api/learning/lib/question-analysis/question-intelligence-service.js
@@ -1,0 +1,339 @@
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeLowerString(value) {
+  return normalizeString(value).toLowerCase();
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function buildRuleMatch({
+  questionTypeId,
+  baseConfidence,
+  variantTags = [],
+  skeletonSteps = [],
+  difficultyBand = 'medium',
+  signalKeys = [],
+  familyId,
+}) {
+  return {
+    questionTypeId,
+    familyId,
+    baseConfidence,
+    variantTags,
+    skeletonSteps,
+    difficultyBand,
+    signalKeys,
+  };
+}
+
+const QUESTION_TYPE_RULES = Object.freeze([
+  {
+    questionTypeId: '9709.differential_equations.separable',
+    familyId: '9709.differential_equations',
+    matches(prompt) {
+      const signals = [];
+      if (/dy\s*\/\s*dx/u.test(prompt) || /differential equation/u.test(prompt)) {
+        signals.push('differential_equation');
+      }
+      if (/given that\s+y\s*=|when\s+x\s*=/u.test(prompt)) {
+        signals.push('initial_condition');
+      }
+      if (/separable/u.test(prompt)) {
+        signals.push('explicit_separable');
+      }
+
+      if (signals.length === 0) {
+        return null;
+      }
+
+      return buildRuleMatch({
+        questionTypeId: '9709.differential_equations.separable',
+        familyId: '9709.differential_equations',
+        baseConfidence: signals.includes('differential_equation') ? 0.91 : 0.84,
+        variantTags: unique([
+          'paper:p3',
+          'answer_form:exact',
+          'structure:separable',
+          signals.includes('initial_condition') ? 'condition:initial_value' : null,
+        ]),
+        skeletonSteps: unique([
+          'separate the variables',
+          'integrate both sides',
+          signals.includes('initial_condition') ? 'apply the initial condition' : null,
+          'state the exact solution',
+        ]),
+        difficultyBand: signals.includes('initial_condition') ? 'medium' : 'low',
+        signalKeys: signals,
+      });
+    },
+  },
+  {
+    questionTypeId: '9709.trigonometry.identities',
+    familyId: '9709.trigonometry_manipulation_equations',
+    matches(prompt) {
+      const hasTrig = /(sin|cos|tan|sec|cosec|cot)/u.test(prompt);
+      const isIdentity = /(prove|show that|hence show|identity)/u.test(prompt);
+      if (!hasTrig || !isIdentity) {
+        return null;
+      }
+
+      return buildRuleMatch({
+        questionTypeId: '9709.trigonometry.identities',
+        familyId: '9709.trigonometry_manipulation_equations',
+        baseConfidence: 0.93,
+        variantTags: ['paper:p1', 'answer_form:exact', 'structure:identity_rewrite'],
+        skeletonSteps: [
+          'rewrite the trigonometric expression into a common form',
+          'apply a standard identity consistently',
+          'simplify to the target identity',
+        ],
+        difficultyBand: 'medium',
+        signalKeys: ['trigonometric_identity'],
+      });
+    },
+  },
+  {
+    questionTypeId: '9709.trigonometry.equations',
+    familyId: '9709.trigonometry_manipulation_equations',
+    matches(prompt) {
+      const hasTrig = /(sin|cos|tan|sec|cosec|cot)/u.test(prompt);
+      const isEquation = /(solve|find all values of x|0\s*[<≤]=?\s*x|x\s*[<≤]=?\s*360)/u.test(prompt);
+      if (!hasTrig || !isEquation) {
+        return null;
+      }
+
+      return buildRuleMatch({
+        questionTypeId: '9709.trigonometry.equations',
+        familyId: '9709.trigonometry_manipulation_equations',
+        baseConfidence: 0.9,
+        variantTags: ['paper:p1', 'answer_form:interval', 'structure:solve_in_domain'],
+        skeletonSteps: [
+          'isolate the trigonometric term',
+          'solve the base trigonometric equation',
+          'enumerate solutions in the required domain',
+        ],
+        difficultyBand: 'medium',
+        signalKeys: ['trigonometric_equation'],
+      });
+    },
+  },
+  {
+    questionTypeId: '9709.integration.application',
+    familyId: '9709.integration_techniques',
+    matches(prompt) {
+      const hasIntegral = /(integral|∫|dx\b)/u.test(prompt);
+      if (!hasIntegral) {
+        return null;
+      }
+
+      const applicationSignals = [];
+      if (/(find the value of|evaluate|hence|area|volume|curve)/u.test(prompt)) {
+        applicationSignals.push('application_language');
+      }
+      if (/\(.*\)\^/u.test(prompt) || /\bsubstitut/u.test(prompt)) {
+        applicationSignals.push('structured_substitution');
+      }
+
+      return buildRuleMatch({
+        questionTypeId: '9709.integration.application',
+        familyId: '9709.integration_techniques',
+        baseConfidence: applicationSignals.length >= 2 ? 0.84 : 0.77,
+        variantTags: ['paper:p3', 'answer_form:exact'],
+        skeletonSteps: [
+          'identify the integration structure',
+          'apply the matching substitution or application setup',
+          'integrate and simplify the exact result',
+        ],
+        difficultyBand: applicationSignals.length >= 2 ? 'medium' : 'high',
+        signalKeys: ['integral_expression', ...applicationSignals],
+      });
+    },
+  },
+]);
+
+function normalizeAnalysisHints(hints = {}) {
+  const normalizedHints = hints && typeof hints === 'object' && !Array.isArray(hints)
+    ? hints
+    : {};
+
+  return {
+    runtime_context_id: normalizeString(normalizedHints.runtime_context_id),
+    question_type_hint_id: normalizeString(normalizedHints.question_type_hint_id),
+    topic_path_hint: normalizeString(normalizedHints.topic_path_hint),
+  };
+}
+
+function toConfidenceBand(classificationConfidence) {
+  if (classificationConfidence === null || classificationConfidence === undefined) {
+    return null;
+  }
+
+  if (classificationConfidence < 0.8) {
+    return 'low';
+  }
+
+  if (classificationConfidence < 0.85) {
+    return 'medium';
+  }
+
+  return 'high';
+}
+
+function buildClassificationFromMatch(match, {
+  normalizedHints,
+  envelope,
+  hintMatched,
+  hintConflict,
+} = {}) {
+  const classificationConfidence = hintMatched
+    ? Math.min(0.95, Number((match.baseConfidence + 0.05).toFixed(2)))
+    : match.baseConfidence;
+  const confidenceBand = toConfidenceBand(classificationConfidence);
+
+  return {
+    primary_topic_id: null,
+    secondary_topic_ids: [],
+    prerequisite_topic_ids: [],
+    family_id: match.familyId,
+    primary_question_type_id: match.questionTypeId,
+    secondary_question_type_ids: [],
+    variant_tags: match.variantTags,
+    classification_source: 'question_intelligence',
+    classification_confidence: classificationConfidence,
+    confidence_band: confidenceBand,
+    canonical_step_skeleton_summary: {
+      summary: match.skeletonSteps[0] ?? 'classify and solve via the canonical method',
+      steps: match.skeletonSteps,
+    },
+    difficulty_signal: {
+      band: match.difficultyBand,
+      source: 'heuristic_question_intelligence',
+      supporting_signals: match.signalKeys,
+    },
+    analysis_audit_metadata: {
+      analysis_mode: 'question_intelligence',
+      analysis_hints: normalizedHints,
+      hint_matched: hintMatched,
+      hint_conflict: hintConflict,
+      detector_signals: match.signalKeys,
+      source_kind: envelope?.source_kind ?? null,
+    },
+    analysis_version: 'phase_a.v2',
+    evidence_source_event_ref: null,
+    analysis_provenance_kind: null,
+    uncertainty_validated: true,
+    uncertainty_posture: {
+      status: 'validated',
+      source: 'question_intelligence',
+      rationale: 'phase_a_deterministic_import_classifier',
+    },
+  };
+}
+
+function buildHintOnlyClassification(normalizedHints, envelope) {
+  const questionTypeId = normalizedHints.question_type_hint_id || normalizedHints.runtime_context_id;
+  if (!questionTypeId) {
+    return {
+      primary_topic_id: null,
+      secondary_topic_ids: [],
+      prerequisite_topic_ids: [],
+      family_id: null,
+      primary_question_type_id: null,
+      secondary_question_type_ids: [],
+      variant_tags: [],
+      classification_source: 'question_intelligence',
+      classification_confidence: null,
+      confidence_band: null,
+      canonical_step_skeleton_summary: null,
+      difficulty_signal: {
+        band: 'unknown',
+        source: 'heuristic_question_intelligence',
+        supporting_signals: [],
+      },
+      analysis_audit_metadata: {
+        analysis_mode: 'question_intelligence',
+        analysis_hints: normalizedHints,
+        detector_signals: [],
+        source_kind: envelope?.source_kind ?? null,
+      },
+      analysis_version: 'phase_a.v2',
+      evidence_source_event_ref: null,
+      analysis_provenance_kind: null,
+      uncertainty_validated: false,
+      uncertainty_posture: null,
+    };
+  }
+
+  const fallbackFamilyByQuestionType = {
+    '9709.trigonometry.identities': '9709.trigonometry_manipulation_equations',
+    '9709.trigonometry.equations': '9709.trigonometry_manipulation_equations',
+    '9709.integration.application': '9709.integration_techniques',
+    '9709.differential_equations.separable': '9709.differential_equations',
+  };
+
+  return {
+    primary_topic_id: null,
+    secondary_topic_ids: [],
+    prerequisite_topic_ids: [],
+    family_id: fallbackFamilyByQuestionType[questionTypeId] ?? null,
+    primary_question_type_id: questionTypeId,
+    secondary_question_type_ids: [],
+    variant_tags: [],
+    classification_source: 'question_intelligence',
+    classification_confidence: 0.76,
+    confidence_band: 'low',
+    canonical_step_skeleton_summary: null,
+    difficulty_signal: {
+      band: 'unknown',
+      source: 'heuristic_question_intelligence',
+      supporting_signals: ['hint_only_low_confidence'],
+    },
+    analysis_audit_metadata: {
+      analysis_mode: 'question_intelligence',
+      analysis_hints: normalizedHints,
+      detector_signals: ['hint_only_low_confidence'],
+      source_kind: envelope?.source_kind ?? null,
+    },
+    analysis_version: 'phase_a.v2',
+    evidence_source_event_ref: null,
+    analysis_provenance_kind: null,
+    uncertainty_validated: true,
+    uncertainty_posture: {
+      status: 'validated',
+      source: 'question_intelligence',
+      rationale: 'low_confidence_hint_only_classification',
+    },
+  };
+}
+
+export function analyzeQuestionEnvelope({
+  envelope,
+  analysisHints = null,
+} = {}) {
+  const promptValue = normalizeLowerString(envelope?.prompt_representation?.value);
+  const normalizedHints = normalizeAnalysisHints(analysisHints);
+  const matches = QUESTION_TYPE_RULES
+    .map((rule) => rule.matches(promptValue))
+    .filter(Boolean)
+    .sort((left, right) => right.baseConfidence - left.baseConfidence);
+
+  if (matches.length === 0) {
+    return buildHintOnlyClassification(normalizedHints, envelope);
+  }
+
+  const selectedMatch = matches[0];
+  const hintedQuestionTypeId = normalizedHints.question_type_hint_id || normalizedHints.runtime_context_id;
+  const hintMatched = Boolean(hintedQuestionTypeId) && hintedQuestionTypeId === selectedMatch.questionTypeId;
+  const hintConflict = Boolean(hintedQuestionTypeId) && hintedQuestionTypeId !== selectedMatch.questionTypeId;
+
+  return buildClassificationFromMatch(selectedMatch, {
+    normalizedHints,
+    envelope,
+    hintMatched,
+    hintConflict,
+  });
+}

--- a/api/learning/lib/question-analysis/runtime-validator.js
+++ b/api/learning/lib/question-analysis/runtime-validator.js
@@ -76,6 +76,7 @@ export function validateQuestionAnalysisResult(result = {}) {
   [
     'canonical_step_skeleton_summary',
     'difficulty_signal',
+    'low_confidence_posture',
     'analysis_audit_metadata',
     'evidence_source_event_ref',
     'uncertainty_posture',

--- a/api/learning/lib/repositories/question-registry-repository.js
+++ b/api/learning/lib/repositories/question-registry-repository.js
@@ -1,4 +1,5 @@
 import { buildClassificationSnapshotRef } from '../contracts/runtime-contract.js';
+import { appendQuestionClassifiedEvent } from '../events/question-event-service.js';
 
 function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
@@ -55,13 +56,14 @@ function buildClassificationSnapshotRow(questionId, input) {
     classification_source: classification.classification_source ?? 'imported_question',
     classification_confidence: classification.classification_confidence ?? null,
     confidence_band: classification.confidence_band ?? null,
+    low_confidence_posture: normalizeObject(classification.low_confidence_posture),
     candidate_rubric_refs: normalizeArray(classification.candidate_rubric_refs),
     canonical_step_skeleton_summary:
       normalizeObject(classification.canonical_step_skeleton_summary),
     difficulty_signal: normalizeObject(classification.difficulty_signal),
     analysis_audit_metadata: normalizeObject(classification.analysis_audit_metadata, {}),
     analysis_version: classification.analysis_version ?? 'phase_a.v1',
-    evidence_source_event_ref: normalizeObject(classification.evidence_source_event_ref),
+    evidence_source_event_ref: null,
     analysis_provenance_kind: classification.analysis_provenance_kind ?? 'real',
   };
 }
@@ -253,6 +255,24 @@ export async function insertImportedQuestion(client, input) {
   const classification_snapshot_ref = buildClassificationSnapshotRef(
     insertedSnapshot.classification_snapshot_id,
   );
+
+  const { eventRef } = await appendQuestionClassifiedEvent(client, {
+    questionId: insertedQuestion.question_id,
+    classificationSnapshotId: insertedSnapshot.classification_snapshot_id,
+    question: insertedQuestion,
+    classification: snapshotRow,
+  });
+
+  const { error: snapshotUpdateError } = await client
+    .from('learning_question_analysis_snapshots')
+    .update({ evidence_source_event_ref: eventRef })
+    .eq('classification_snapshot_id', insertedSnapshot.classification_snapshot_id);
+
+  if (snapshotUpdateError) {
+    throw new Error(
+      `Failed to link classification snapshot to QuestionClassified event: ${snapshotUpdateError.message}`,
+    );
+  }
 
   const { error: updateError } = await client
     .from('question_bank')

--- a/api/learning/lib/validators/question-import-validator.js
+++ b/api/learning/lib/validators/question-import-validator.js
@@ -60,6 +60,34 @@ function normalizePromptRepresentation(value) {
   };
 }
 
+function normalizeOptionalAnalysisHints(value) {
+  if (typeof value === 'undefined' || value === null) {
+    return null;
+  }
+
+  if (!isPlainObject(value)) {
+    throw createValidationError(
+      LEARNING_ERROR_CODES.INVALID_PAYLOAD,
+      'analysis_hints must be an object when provided.',
+      { details: { field: 'analysis_hints' } },
+    );
+  }
+
+  const runtimeContextId = normalizeString(value.runtime_context_id);
+  const questionTypeHintId = normalizeString(value.question_type_hint_id);
+  const topicPathHint = normalizeString(value.topic_path_hint);
+
+  if (!runtimeContextId && !questionTypeHintId && !topicPathHint) {
+    return null;
+  }
+
+  return {
+    runtime_context_id: runtimeContextId || null,
+    question_type_hint_id: questionTypeHintId || null,
+    topic_path_hint: topicPathHint || null,
+  };
+}
+
 export function validateQuestionImportInput(input = {}) {
   if (!isPlainObject(input)) {
     throw createValidationError(
@@ -84,6 +112,7 @@ export function validateQuestionImportInput(input = {}) {
       source_kind: 'imported_question',
       subject_code: normalizeRequiredString(input.subject_code, 'subject_code'),
       prompt_representation: normalizePromptRepresentation(input.prompt_representation),
+      analysis_hints: normalizeOptionalAnalysisHints(input.analysis_hints),
     },
   };
 }

--- a/data/learning_runtime/pilot_rubrics/9709.differential_equations.separable.json
+++ b/data/learning_runtime/pilot_rubrics/9709.differential_equations.separable.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "p3.rubric_template.v1",
+  "rubric_template_id": "9709.differential_equations.separable.v1",
+  "question_type_id": "9709.differential_equations.separable",
+  "title": "Pilot rubric for separable differential equations",
+  "release_state": "released",
+  "adapter_key": "math.symbolic.v1",
+  "score_max": 2,
+  "provenance": {
+    "source_type": "official_mark_scheme_excerpt",
+    "source_refs": [
+      "docs/reports/gpt5.4pro-deep-thinking/P3.md"
+    ]
+  },
+  "global_uncertainty_rules": [
+    {
+      "trigger_id": "de-manual-review",
+      "trigger_type": "manual_review_required",
+      "severity": "high",
+      "message": "Manual review required when the separable form is not explicit."
+    }
+  ],
+  "parts": [
+    {
+      "part_id": "main",
+      "label": "main",
+      "score_max": 2,
+      "points": [
+        {
+          "point_id": "separate-variables",
+          "official_mark_notation": "M1",
+          "mark_family": "M",
+          "max_score": 1,
+          "verification_condition": {
+            "kind": "adapter_call",
+            "adapter_method": "transform_bundle_check",
+            "params": {
+              "requires_separation": true
+            }
+          },
+          "uncertainty_triggers": [
+            {
+              "trigger_id": "de-ambiguous-parse",
+              "trigger_type": "ambiguous_parse",
+              "severity": "medium",
+              "message": "The separated-variable parse is ambiguous."
+            }
+          ]
+        },
+        {
+          "point_id": "apply-initial-condition",
+          "official_mark_notation": "A1",
+          "mark_family": "A",
+          "max_score": 1,
+          "verification_condition": {
+            "kind": "adapter_call",
+            "adapter_method": "numeric_check",
+            "params": {
+              "requires_initial_condition": true
+            }
+          },
+          "dependency_chain": {
+            "prerequisite_point_ids": [
+              "separate-variables"
+            ],
+            "prerequisite_policy": "all",
+            "strict": true
+          },
+          "follow_through": {
+            "enabled": true,
+            "mode": "numeric_substitution",
+            "allow_incorrect_source": true,
+            "source_point_ids": [
+              "separate-variables"
+            ]
+          },
+          "uncertainty_triggers": [
+            {
+              "trigger_id": "de-low-confidence",
+              "trigger_type": "adapter_confidence_below",
+              "threshold": 0.8,
+              "severity": "high",
+              "message": "Initial-condition application confidence is too low."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/learning_runtime/pilot_rubrics/9709.integration.application.json
+++ b/data/learning_runtime/pilot_rubrics/9709.integration.application.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "p3.rubric_template.v1",
+  "rubric_template_id": "9709.integration.application.v1",
+  "question_type_id": "9709.integration.application",
+  "title": "Pilot rubric for integration applications",
+  "release_state": "released",
+  "adapter_key": "math.symbolic.v1",
+  "score_max": 2,
+  "provenance": {
+    "source_type": "official_mark_scheme_excerpt",
+    "source_refs": [
+      "docs/reports/gpt5.4pro-deep-thinking/P3.md"
+    ]
+  },
+  "global_uncertainty_rules": [
+    {
+      "trigger_id": "integration-manual-review",
+      "trigger_type": "missing_binding",
+      "severity": "medium",
+      "message": "Trigger fallback when the substitution binding cannot be recovered."
+    }
+  ],
+  "parts": [
+    {
+      "part_id": "main",
+      "label": "main",
+      "score_max": 2,
+      "points": [
+        {
+          "point_id": "identify-substitution",
+          "official_mark_notation": "M1",
+          "mark_family": "M",
+          "max_score": 1,
+          "verification_condition": {
+            "kind": "adapter_call",
+            "adapter_method": "transform_bundle_check",
+            "params": {
+              "requires_substitution": true
+            }
+          },
+          "uncertainty_triggers": [
+            {
+              "trigger_id": "integration-low-confidence",
+              "trigger_type": "adapter_confidence_below",
+              "threshold": 0.8,
+              "severity": "high",
+              "message": "Integration structure confidence is too low."
+            }
+          ]
+        },
+        {
+          "point_id": "complete-integration",
+          "official_mark_notation": "A1",
+          "mark_family": "A",
+          "max_score": 1,
+          "verification_condition": {
+            "kind": "adapter_call",
+            "adapter_method": "symbolic_check",
+            "params": {
+              "expects_exact_integral": true
+            }
+          },
+          "dependency_chain": {
+            "prerequisite_point_ids": [
+              "identify-substitution"
+            ],
+            "prerequisite_policy": "all",
+            "strict": true
+          },
+          "follow_through": {
+            "enabled": true,
+            "mode": "algebraic_consistency",
+            "allow_incorrect_source": true,
+            "source_point_ids": [
+              "identify-substitution"
+            ]
+          },
+          "uncertainty_triggers": [
+            {
+              "trigger_id": "integration-branch-match",
+              "trigger_type": "multiple_branch_match",
+              "severity": "medium",
+              "message": "Multiple equivalent antiderivatives were detected."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/learning_runtime/pilot_rubrics/9709.trigonometry.equations.json
+++ b/data/learning_runtime/pilot_rubrics/9709.trigonometry.equations.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "p3.rubric_template.v1",
+  "rubric_template_id": "9709.trigonometry.equations.v1",
+  "question_type_id": "9709.trigonometry.equations",
+  "title": "Pilot rubric for trigonometric equations",
+  "release_state": "released",
+  "adapter_key": "math.symbolic.v1",
+  "score_max": 2,
+  "provenance": {
+    "source_type": "official_mark_scheme_excerpt",
+    "source_refs": [
+      "docs/reports/gpt5.4pro-deep-thinking/P3.md"
+    ]
+  },
+  "global_uncertainty_rules": [
+    {
+      "trigger_id": "trig-eq-manual-review",
+      "trigger_type": "manual_review_required",
+      "severity": "high",
+      "message": "Manual review required when multiple domain branches survive."
+    }
+  ],
+  "parts": [
+    {
+      "part_id": "main",
+      "label": "main",
+      "score_max": 2,
+      "points": [
+        {
+          "point_id": "solve-base-equation",
+          "official_mark_notation": "M1",
+          "mark_family": "M",
+          "max_score": 1,
+          "verification_condition": {
+            "kind": "adapter_call",
+            "adapter_method": "symbolic_check",
+            "params": {
+              "checks": "base_trigonometric_equation"
+            }
+          },
+          "uncertainty_triggers": [
+            {
+              "trigger_id": "trig-eq-ambiguous-parse",
+              "trigger_type": "ambiguous_parse",
+              "severity": "medium",
+              "message": "The parsed solution branch is ambiguous."
+            }
+          ]
+        },
+        {
+          "point_id": "enumerate-domain-solutions",
+          "official_mark_notation": "A1",
+          "mark_family": "A",
+          "max_score": 1,
+          "verification_condition": {
+            "kind": "adapter_call",
+            "adapter_method": "numeric_check",
+            "params": {
+              "requires_domain_filter": true
+            }
+          },
+          "dependency_chain": {
+            "prerequisite_point_ids": [
+              "solve-base-equation"
+            ],
+            "prerequisite_policy": "all",
+            "strict": true
+          },
+          "follow_through": {
+            "enabled": true,
+            "mode": "numeric_substitution",
+            "allow_incorrect_source": true,
+            "source_point_ids": [
+              "solve-base-equation"
+            ]
+          },
+          "uncertainty_triggers": [
+            {
+              "trigger_id": "trig-eq-low-confidence",
+              "trigger_type": "adapter_confidence_below",
+              "threshold": 0.8,
+              "severity": "high",
+              "message": "Domain enumeration confidence is too low."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/learning_runtime/pilot_rubrics/9709.trigonometry.identities.json
+++ b/data/learning_runtime/pilot_rubrics/9709.trigonometry.identities.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "p3.rubric_template.v1",
+  "rubric_template_id": "9709.trigonometry.identities.v1",
+  "question_type_id": "9709.trigonometry.identities",
+  "title": "Pilot rubric for trigonometric identities",
+  "release_state": "released",
+  "adapter_key": "math.symbolic.v1",
+  "score_max": 2,
+  "provenance": {
+    "source_type": "official_mark_scheme_excerpt",
+    "source_refs": [
+      "docs/reports/gpt5.4pro-deep-thinking/P3.md"
+    ],
+    "authoring_notes": [
+      "Phase A pilot executable rubric template."
+    ]
+  },
+  "global_uncertainty_rules": [
+    {
+      "trigger_id": "identity-ambiguous-parse",
+      "trigger_type": "ambiguous_parse",
+      "severity": "medium",
+      "message": "Trigger fallback when the symbolic parse is ambiguous."
+    }
+  ],
+  "parts": [
+    {
+      "part_id": "main",
+      "label": "main",
+      "score_max": 2,
+      "points": [
+        {
+          "point_id": "identity-rewrite",
+          "official_mark_notation": "M1",
+          "mark_family": "M",
+          "max_score": 1,
+          "verification_condition": {
+            "kind": "adapter_call",
+            "adapter_method": "proof_structure_check",
+            "params": {
+              "requires_identity_rewrite": true
+            }
+          },
+          "uncertainty_triggers": [
+            {
+              "trigger_id": "identity-low-confidence",
+              "trigger_type": "adapter_confidence_below",
+              "threshold": 0.8,
+              "severity": "high",
+              "message": "Symbolic proof match confidence is too low."
+            }
+          ]
+        },
+        {
+          "point_id": "identity-result",
+          "official_mark_notation": "A1",
+          "mark_family": "A",
+          "max_score": 1,
+          "verification_condition": {
+            "kind": "adapter_call",
+            "adapter_method": "symbolic_check",
+            "params": {
+              "expects_target_identity": true
+            }
+          },
+          "dependency_chain": {
+            "prerequisite_point_ids": [
+              "identity-rewrite"
+            ],
+            "prerequisite_policy": "all",
+            "strict": true
+          },
+          "follow_through": {
+            "enabled": true,
+            "mode": "symbolic_substitution",
+            "allow_incorrect_source": true,
+            "source_point_ids": [
+              "identity-rewrite"
+            ]
+          },
+          "uncertainty_triggers": [
+            {
+              "trigger_id": "identity-branch-match",
+              "trigger_type": "multiple_branch_match",
+              "severity": "medium",
+              "message": "Multiple equivalent proof branches matched."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/learning_runtime/release_evidence/released-family-gate-contract.v1.json
+++ b/data/learning_runtime/release_evidence/released-family-gate-contract.v1.json
@@ -54,6 +54,9 @@
         "entries": [
           {
             "question_type_id": "9709.trigonometry.identities",
+            "rubric_template_paths": [
+              "data/learning_runtime/pilot_rubrics/9709.trigonometry.identities.json"
+            ],
             "released_rubric_refs": [
               {
                 "kind": "rubric_release",
@@ -66,6 +69,9 @@
           },
           {
             "question_type_id": "9709.trigonometry.equations",
+            "rubric_template_paths": [
+              "data/learning_runtime/pilot_rubrics/9709.trigonometry.equations.json"
+            ],
             "released_rubric_refs": [
               {
                 "kind": "rubric_release",
@@ -216,6 +222,9 @@
         "entries": [
           {
             "question_type_id": "9709.integration.application",
+            "rubric_template_paths": [
+              "data/learning_runtime/pilot_rubrics/9709.integration.application.json"
+            ],
             "released_rubric_refs": [
               {
                 "kind": "rubric_release",
@@ -330,6 +339,9 @@
         "entries": [
           {
             "question_type_id": "9709.differential_equations.separable",
+            "rubric_template_paths": [
+              "data/learning_runtime/pilot_rubrics/9709.differential_equations.separable.json"
+            ],
             "released_rubric_refs": [
               {
                 "kind": "rubric_release",

--- a/data/learning_runtime/release_evidence/released-family-gate-receipt.v1.json
+++ b/data/learning_runtime/release_evidence/released-family-gate-receipt.v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "learning_runtime_released_family_gate_receipt_v1",
-  "generated_at": "2026-04-06T13:34:02.854Z",
+  "generated_at": "2026-04-13T00:53:16.030Z",
   "contract_path": "data/learning_runtime/release_evidence/released-family-gate-contract.v1.json",
   "status": "pass",
   "release_ready": true,

--- a/docs/reports/2026-04-13-phase-a-remediation-report.md
+++ b/docs/reports/2026-04-13-phase-a-remediation-report.md
@@ -1,0 +1,175 @@
+# Phase A Remediation Report
+
+**Date:** 2026-04-13  
+**Branch:** `task/phase-a-remediation`  
+**Scope:** Close the approved Phase A truth gaps using only:
+
+- `docs/reports/2026-04-11-ao-next-phase-execution-roadmap.md` section 8
+- `docs/reports/2026-04-12-phase-a-product-decision-record.md`
+
+## Gap Matrix
+
+| Gap | Remediation | Evidence | Status |
+| --- | --- | --- | --- |
+| Pilot scope/runtime drift: runtime still treated trig family as the only authoritative slice | Import analysis, released-scope posture, UI options, and gate evidence were aligned to the 4 approved pilot question types | `api/learning/lib/import/question-import-service.js`, `src/components/learning-runtime/ImportedQuestionIntake.js`, `api/learning/__tests__/released-scope.test.js`, `data/learning_runtime/release_evidence/released-family-gate-receipt.v1.json` | Closed |
+| Import path trusted caller-supplied classification | Added deterministic question-intelligence analysis for the approved pilot types and downgraded user input to `analysis_hints` only | `api/learning/lib/question-analysis/question-intelligence-service.js`, `api/learning/lib/validators/question-import-validator.js`, `api/learning/__tests__/question-analysis.test.js`, `api/learning/__tests__/question-import-service.test.js` | Closed |
+| Low-confidence behavior was not explicit fail-closed posture | Persisted `low_confidence_posture` and kept low-confidence classifications out of authoritative scoring | `api/learning/lib/question-analysis/analysis-result-contract.js`, `api/learning/lib/question-analysis/runtime-validator.js`, `api/learning/__tests__/question-import-service.test.js`, `api/learning/__tests__/released-scope.test.js` | Closed |
+| Real import path did not emit durable `QuestionClassified` events | Added question-scoped event persistence and linked snapshots back to the emitted event ref | `api/learning/lib/events/question-event-service.js`, `api/learning/lib/repositories/question-registry-repository.js`, `supabase/migrations/20260413110000_phase_a_question_classified_events.sql`, `api/learning/__tests__/question-registry-repository.test.js` | Closed |
+| P3 executable rubric contract was missing | Added P3 contract types, JSON Schema validator, runtime validator, and pilot rubric templates for the 4 approved pilot question types | `api/learning/lib/marking/contracts/p3-rubric-template.schema.json`, `api/learning/lib/marking/contracts/p3-rubric-validator.js`, `data/learning_runtime/pilot_rubrics/*.json`, `api/learning/__tests__/p3-rubric-validator.test.js` | Closed |
+| Snapshot schema and registry projection were incomplete for Phase A evidence | Persisted prerequisite topics, step skeleton summary, difficulty signal, audit metadata, provenance kind, and low-confidence posture through the registry projection | `supabase/migrations/20260412103000_expand_learning_question_analysis_snapshots_phase_a.sql`, `supabase/migrations/20260413110000_phase_a_question_classified_events.sql`, `api/learning/__tests__/schema-contract.test.js` | Closed |
+| No offline backfill for already-imported questions | Added a backfill library and CLI to analyze imported questions, create snapshots, emit `QuestionClassified`, and update `question_bank` | `scripts/learning/lib/question-analysis-backfill.js`, `scripts/learning/run_question_analysis_backfill.js`, `scripts/learning/__tests__/question-analysis-backfill.test.js` | Closed |
+| Synthetic fixtures lacked approved provenance/persona contract | Added explicit synthetic provenance and the required persona coverage markers | `tests/marking/fixtures/ft_cao_fixtures.json`, `tests/marking/__tests__/ft-cao-fixtures-contract.test.js` | Closed |
+| Released-family evidence overstated capability using metadata-only checks | Gate contract now validates executable pilot rubric templates and refreshed receipt/report match current runtime capability | `api/learning/lib/contracts/released-family-gate.js`, `data/learning_runtime/release_evidence/released-family-gate-contract.v1.json`, `data/learning_runtime/release_evidence/released-family-gate-receipt.v1.json`, `docs/reports/learning_runtime_released_family_gate_2026-03-25.md` | Closed |
+
+## Files Changed
+
+Modified:
+
+- `api/learning/__tests__/question-analysis.test.js`
+- `api/learning/__tests__/question-import-service.test.js`
+- `api/learning/__tests__/question-registry-repository.test.js`
+- `api/learning/__tests__/schema-contract.test.js`
+- `api/learning/lib/contracts/released-family-gate.js`
+- `api/learning/lib/import/question-import-service.js`
+- `api/learning/lib/question-analysis/analysis-result-contract.js`
+- `api/learning/lib/question-analysis/runtime-validator.js`
+- `api/learning/lib/repositories/question-registry-repository.js`
+- `api/learning/lib/validators/question-import-validator.js`
+- `data/learning_runtime/release_evidence/released-family-gate-contract.v1.json`
+- `data/learning_runtime/release_evidence/released-family-gate-receipt.v1.json`
+- `docs/reports/learning_runtime_released_family_gate_2026-03-25.md`
+- `src/components/learning-runtime/ImportedQuestionIntake.js`
+- `src/components/learning-runtime/__tests__/ImportedQuestionIntake.test.js`
+- `tests/marking/fixtures/ft_cao_fixtures.json`
+
+Added:
+
+- `api/learning/__tests__/p3-rubric-validator.test.js`
+- `api/learning/lib/events/question-event-service.js`
+- `api/learning/lib/marking/contracts/p3-contract-types.d.ts`
+- `api/learning/lib/marking/contracts/p3-rubric-template.schema.json`
+- `api/learning/lib/marking/contracts/p3-rubric-validator.js`
+- `api/learning/lib/question-analysis/question-intelligence-service.js`
+- `data/learning_runtime/pilot_rubrics/9709.differential_equations.separable.json`
+- `data/learning_runtime/pilot_rubrics/9709.integration.application.json`
+- `data/learning_runtime/pilot_rubrics/9709.trigonometry.equations.json`
+- `data/learning_runtime/pilot_rubrics/9709.trigonometry.identities.json`
+- `docs/reports/2026-04-13-phase-a-remediation-report.md`
+- `docs/superpowers/plans/2026-04-13-phase-a-remediation.md`
+- `scripts/learning/__tests__/question-analysis-backfill.test.js`
+- `scripts/learning/lib/question-analysis-backfill.js`
+- `scripts/learning/run_question_analysis_backfill.js`
+- `supabase/migrations/20260413110000_phase_a_question_classified_events.sql`
+- `tests/marking/__tests__/ft-cao-fixtures-contract.test.js`
+
+## Verification
+
+Commands run and actual outcomes:
+
+```bash
+node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand \
+  api/learning/__tests__/question-analysis.test.js \
+  api/learning/__tests__/question-registry-repository.test.js \
+  api/learning/__tests__/question-import-service.test.js \
+  api/learning/__tests__/schema-contract.test.js \
+  api/learning/__tests__/p3-rubric-validator.test.js \
+  api/learning/__tests__/released-scope.test.js \
+  scripts/learning/__tests__/released-family-gate.test.js \
+  scripts/learning/__tests__/question-analysis-backfill.test.js \
+  tests/marking/__tests__/ft-cao-fixtures-contract.test.js \
+  src/components/learning-runtime/__tests__/ImportedQuestionIntake.test.js
+```
+
+Outcome:
+
+- First run failed before assertions due to a parse error in `scripts/learning/__tests__/question-analysis-backfill.test.js`.
+- Root cause was malformed block terminators in the new test file.
+
+```bash
+node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand \
+  scripts/learning/__tests__/question-analysis-backfill.test.js \
+  tests/marking/__tests__/ft-cao-fixtures-contract.test.js
+```
+
+Outcome:
+
+- Passed.
+- Test suites: `2 passed, 2 total`
+- Tests: `3 passed, 3 total`
+
+```bash
+node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand \
+  api/learning/__tests__/question-analysis.test.js \
+  api/learning/__tests__/question-registry-repository.test.js \
+  api/learning/__tests__/question-import-service.test.js \
+  api/learning/__tests__/schema-contract.test.js \
+  api/learning/__tests__/p3-rubric-validator.test.js \
+  api/learning/__tests__/released-scope.test.js \
+  scripts/learning/__tests__/released-family-gate.test.js \
+  scripts/learning/__tests__/question-analysis-backfill.test.js \
+  tests/marking/__tests__/ft-cao-fixtures-contract.test.js \
+  src/components/learning-runtime/__tests__/ImportedQuestionIntake.test.js
+```
+
+Outcome:
+
+- Passed.
+- Test suites: `10 passed, 10 total`
+- Tests: `42 passed, 42 total`
+
+```bash
+node scripts/learning/run_released_family_gate.js \
+  --out-json data/learning_runtime/release_evidence/released-family-gate-receipt.v1.json \
+  --out-md docs/reports/learning_runtime_released_family_gate_2026-03-25.md
+```
+
+Outcome:
+
+- Passed with exit code `0`
+- Rewrote:
+  - `data/learning_runtime/release_evidence/released-family-gate-receipt.v1.json`
+  - `docs/reports/learning_runtime_released_family_gate_2026-03-25.md`
+- Receipt status: `pass`
+- `release_ready: true`
+
+## Approved Requirements
+
+Satisfied:
+
+- 4 approved pilot question types are covered in runtime analysis and gate evidence:
+  - `9709.trigonometry.identities`
+  - `9709.trigonometry.equations`
+  - `9709.integration.application`
+  - `9709.differential_equations.separable`
+- Low-confidence classification is explicit and fail-closed for authoritative scoring.
+- Import now follows `question -> analyze -> snapshot -> QuestionClassified`.
+- P3 pilot rubric template validation exists and is executed in tests and release gate.
+- Offline backfill exists for imported questions without snapshots.
+- Synthetic fixtures satisfy the approved persona and provenance contract.
+- Released-family evidence now reflects executable runtime capability instead of metadata-only claims.
+
+Unsatisfied:
+
+- None identified within the approved Phase A remediation scope after focused verification.
+
+## Question Event Boundary
+
+This remediation keeps `QuestionClassified` in `learning_question_events` instead of forcing it into the earlier Phase 0 `learning_events` attempt pipeline.
+
+Reason:
+
+- The current branch does not contain the Phase 0 event infrastructure.
+- The Phase 0 event design is attempt-scoped and keyed to attempt progression.
+- Phase A classification occurs before an attempt exists and needs durable question-scoped lineage tied directly to `classification_snapshot_id`.
+
+Constraint:
+
+- This is not intended to create a second canonical attempt truth surface.
+- The new table is deliberately narrow and only records question-classification lineage.
+- If the Phase 0 event stack lands later with a compatible question-scoped contract, this surface can be converged intentionally instead of guessed into the attempt pipeline now.
+
+## Residual Risks
+
+- The question-intelligence path is deterministic and intentionally narrow to the 4 approved pilot question types; broader subject/family coverage still requires later work.
+- `learning_question_events` is a temporary question-scoped boundary pending future convergence with Phase 0 event infrastructure if and when that lands on the same branch.
+- Pilot rubric templates are executable and gated, but the human-review workflow for future template revisions is still outside this remediation branch.

--- a/docs/reports/learning_runtime_released_family_gate_2026-03-25.md
+++ b/docs/reports/learning_runtime_released_family_gate_2026-03-25.md
@@ -2,7 +2,7 @@
 
 - status: `pass`
 - release_ready: `true`
-- generated_at: `2026-04-06T13:34:02.854Z`
+- generated_at: `2026-04-13T00:53:16.030Z`
 - contract_path: `data/learning_runtime/release_evidence/released-family-gate-contract.v1.json`
 
 ## 9709.trigonometry_manipulation_equations

--- a/docs/superpowers/plans/2026-04-13-phase-a-remediation.md
+++ b/docs/superpowers/plans/2026-04-13-phase-a-remediation.md
@@ -1,0 +1,81 @@
+# Phase A Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the approved Phase A truth gaps by replacing caller-trusted import classification with a real question-analysis path, persisting `QuestionClassified` events, landing executable P3 rubric contracts, and realigning gates, fixtures, and evidence with actual runtime capability.
+
+**Architecture:** Keep the remediation inside the existing learning-runtime slice instead of introducing parallel infrastructure. Add a deterministic Phase A question-analysis layer that derives canonical classification from the prompt plus optional user hints, persist classification snapshots and `QuestionClassified` events through the question registry path, and make released-family evidence depend on executable pilot rubric templates rather than metadata-only rubric refs.
+
+**Tech Stack:** Node ESM, Jest, Supabase/Postgres migrations, JSON Schema, React.
+
+---
+
+## Chunk 1: Question Analysis And Event Persistence
+
+### Task 1: Replace caller-trusted import classification with analyzed results
+
+**Files:**
+- Create: `api/learning/lib/question-analysis/question-intelligence-service.js`
+- Modify: `api/learning/lib/import/question-import-service.js`
+- Modify: `api/learning/lib/validators/question-import-validator.js`
+- Modify: `src/components/learning-runtime/ImportedQuestionIntake.js`
+- Test: `api/learning/__tests__/question-import-service.test.js`
+- Test: `api/learning/__tests__/question-analysis.test.js`
+- Test: `src/components/learning-runtime/__tests__/ImportedQuestionIntake.test.js`
+
+- [ ] **Step 1: Write failing tests for analyzer-driven classification and hint handling**
+- [ ] **Step 2: Run the focused suites and verify the failures are about missing analyzer behavior**
+- [ ] **Step 3: Implement a deterministic analyzer for the approved four pilot question types, using user context only as a non-canonical hint**
+- [ ] **Step 4: Re-run the focused suites and verify the import path now derives classification from analysis output**
+
+### Task 2: Persist real `QuestionClassified` events and align snapshot evidence refs
+
+**Files:**
+- Create: `api/learning/lib/events/question-event-service.js`
+- Modify: `api/learning/lib/repositories/question-registry-repository.js`
+- Modify: `supabase/migrations/20260412103000_expand_learning_question_analysis_snapshots_phase_a.sql`
+- Create: `supabase/migrations/20260413110000_phase_a_question_classified_events.sql`
+- Test: `api/learning/__tests__/question-registry-repository.test.js`
+- Test: `api/learning/__tests__/question-import-service.test.js`
+- Test: `api/learning/__tests__/schema-contract.test.js`
+
+- [ ] **Step 1: Write failing tests for `QuestionClassified` event insertion and snapshot event refs**
+- [ ] **Step 2: Run the focused suites and verify the failures are about missing event persistence**
+- [ ] **Step 3: Implement question event persistence and wire import to emit one event per persisted snapshot**
+- [ ] **Step 4: Re-run the focused suites and verify event emission is durable and idempotent enough for import**
+
+## Chunk 2: P3 Contracts, Backfill, And Evidence Alignment
+
+### Task 3: Land executable P3 rubric contracts and validate pilot templates
+
+**Files:**
+- Create: `api/learning/lib/marking/contracts/p3-contract-types.d.ts`
+- Create: `api/learning/lib/marking/contracts/p3-rubric-template.schema.json`
+- Create: `api/learning/lib/marking/contracts/p3-rubric-validator.js`
+- Create: `data/learning_runtime/pilot_rubrics/*.json`
+- Modify: `api/learning/lib/contracts/released-family-gate.js`
+- Test: `api/learning/__tests__/p3-rubric-validator.test.js`
+- Test: `scripts/learning/__tests__/released-family-gate.test.js`
+
+- [ ] **Step 1: Write failing tests for P3 schema validation and pilot rubric package coverage**
+- [ ] **Step 2: Run the focused suites and verify they fail because the contracts do not exist yet**
+- [ ] **Step 3: Implement the JSON Schema, runtime validator, and pilot rubric packages**
+- [ ] **Step 4: Re-run the focused suites and verify the released-family gate now depends on executable P3 templates**
+
+### Task 4: Add offline backfill, synthetic fixture provenance, and remediation evidence
+
+**Files:**
+- Create: `scripts/learning/lib/question-analysis-backfill.js`
+- Create: `scripts/learning/run_question_analysis_backfill.js`
+- Modify: `tests/marking/fixtures/ft_cao_fixtures.json`
+- Create: `scripts/learning/__tests__/question-analysis-backfill.test.js`
+- Create: `tests/marking/__tests__/ft-cao-fixtures-contract.test.js`
+- Modify: `data/learning_runtime/release_evidence/released-family-gate-contract.v1.json`
+- Modify: `data/learning_runtime/release_evidence/released-family-gate-receipt.v1.json`
+- Modify: `docs/reports/learning_runtime_released_family_gate_2026-03-25.md`
+- Create: `docs/reports/2026-04-13-phase-a-remediation-report.md`
+
+- [ ] **Step 1: Write failing tests for offline backfill and synthetic fixture provenance/persona coverage**
+- [ ] **Step 2: Run the focused suites and verify the failures match the missing approved requirements**
+- [ ] **Step 3: Implement the backfill script, fixture contract, and evidence refresh**
+- [ ] **Step 4: Re-run the focused suites and targeted evidence commands, then record actual outcomes in the remediation report**

--- a/scripts/learning/__tests__/question-analysis-backfill.test.js
+++ b/scripts/learning/__tests__/question-analysis-backfill.test.js
@@ -53,6 +53,11 @@ function createBackfillClient() {
       return this;
     }
 
+    is(field, value) {
+      this.filters.push({ field, value, operator: 'is' });
+      return this;
+    }
+
     single() {
       return this.#resolve();
     }
@@ -81,15 +86,55 @@ function createBackfillClient() {
       }
 
       if (this.table === 'learning_question_analysis_snapshots' && this.operation === 'insert') {
-        const snapshotId = `snapshot-${state.nextSnapshotId++}`;
-        const row = { classification_snapshot_id: snapshotId, ...this.payload };
+        const activeSnapshot = [...state.snapshots.values()].find(
+          (snapshot) => snapshot.question_id === this.payload.question_id
+            && (snapshot.superseded_by_snapshot_id ?? null) === null,
+        );
+        if (activeSnapshot) {
+          return Promise.resolve({
+            data: null,
+            error: {
+              message:
+                'duplicate key value violates unique constraint "uq_learning_question_analysis_snapshots_active"',
+            },
+          });
+        }
+
+        const snapshotId = this.payload.classification_snapshot_id || `snapshot-${state.nextSnapshotId++}`;
+        const row = {
+          superseded_by_snapshot_id: null,
+          classification_snapshot_id: snapshotId,
+          ...this.payload,
+        };
         state.snapshots.set(snapshotId, row);
+        return Promise.resolve({ data: row, error: null });
+      }
+
+      if (this.table === 'learning_question_analysis_snapshots' && this.operation === 'select') {
+        const questionId = findFilter(this.filters, 'question_id');
+        const supersededBySnapshotIdFilter = this.filters.find(
+          (filter) => filter.field === 'superseded_by_snapshot_id' && filter.operator === 'is',
+        );
+        const row = [...state.snapshots.values()].find((snapshot) => (
+          snapshot.question_id === questionId
+          && (
+            !supersededBySnapshotIdFilter
+            || (snapshot.superseded_by_snapshot_id ?? null) === supersededBySnapshotIdFilter.value
+          )
+        )) || null;
+
         return Promise.resolve({ data: row, error: null });
       }
 
       if (this.table === 'learning_question_analysis_snapshots' && this.operation === 'update') {
         const snapshotId = findFilter(this.filters, 'classification_snapshot_id');
         const current = state.snapshots.get(snapshotId);
+        if (!current) {
+          return Promise.resolve({
+            data: null,
+            error: { message: `Snapshot not found for ${snapshotId}` },
+          });
+        }
         state.snapshots.set(snapshotId, { ...current, ...this.payload });
         return Promise.resolve({ data: null, error: null });
       }
@@ -200,6 +245,67 @@ describe('question-analysis backfill', () => {
           status: 'skipped_existing_snapshot',
         },
       ],
+    });
+  });
+
+  test('force backfill supersedes the existing active snapshot before inserting the replacement', async () => {
+    const { client, state } = createBackfillClient();
+    state.snapshots.set('snapshot-existing', {
+      classification_snapshot_id: 'snapshot-existing',
+      question_id: 'question-force',
+      primary_question_type_id: '9709.trigonometry.identities',
+      superseded_by_snapshot_id: null,
+    });
+
+    const summary = await runQuestionAnalysisBackfill(client, {
+      force: true,
+      questions: [
+        {
+          question_id: 'question-force',
+          source_kind: 'imported_question',
+          subject_code: '9709',
+          prompt_representation: {
+            type: 'text',
+            value: 'Solve the differential equation dy/dx = 2xy given that y = 1 when x = 0.',
+          },
+          provenance_summary: {
+            import_source: 'manual_paste',
+          },
+          classification_snapshot_ref: {
+            kind: 'classification_snapshot',
+            classification_snapshot_id: 'snapshot-existing',
+          },
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      processed: 1,
+      backfilled: 1,
+      skipped: 0,
+      items: [
+        {
+          question_id: 'question-force',
+          status: 'backfilled',
+        },
+      ],
+    });
+    const replacementSnapshotId = summary.items[0].classification_snapshot_id;
+    expect(typeof replacementSnapshotId).toBe('string');
+    expect(replacementSnapshotId).not.toBe('snapshot-existing');
+    expect(state.snapshots.get('snapshot-existing')).toMatchObject({
+      superseded_by_snapshot_id: replacementSnapshotId,
+    });
+    expect(state.snapshots.get(replacementSnapshotId)).toMatchObject({
+      question_id: 'question-force',
+      superseded_by_snapshot_id: null,
+      primary_question_type_id: '9709.differential_equations.separable',
+    });
+    expect(state.questions.get('question-force')).toMatchObject({
+      classification_snapshot_ref: {
+        kind: 'classification_snapshot',
+        classification_snapshot_id: replacementSnapshotId,
+      },
     });
   });
 });

--- a/scripts/learning/__tests__/question-analysis-backfill.test.js
+++ b/scripts/learning/__tests__/question-analysis-backfill.test.js
@@ -1,0 +1,205 @@
+import { runQuestionAnalysisBackfill } from '../lib/question-analysis-backfill.js';
+
+function createBackfillClient() {
+  const state = {
+    nextSnapshotId: 1,
+    nextEventId: 1,
+    snapshots: new Map(),
+    events: new Map(),
+    questions: new Map(),
+    registryFamilies: new Map([
+      ['9709.trigonometry_manipulation_equations', { family_id: '9709.trigonometry_manipulation_equations', subject_code: '9709', release_state: 'released' }],
+      ['9709.integration_techniques', { family_id: '9709.integration_techniques', subject_code: '9709', release_state: 'released' }],
+      ['9709.differential_equations', { family_id: '9709.differential_equations', subject_code: '9709', release_state: 'released' }]
+    ]),
+    registryTypes: new Map([
+      ['9709.trigonometry.identities', { question_type_id: '9709.trigonometry.identities', family_id: '9709.trigonometry_manipulation_equations', subject_code: '9709', release_state: 'released' }],
+      ['9709.trigonometry.equations', { question_type_id: '9709.trigonometry.equations', family_id: '9709.trigonometry_manipulation_equations', subject_code: '9709', release_state: 'released' }],
+      ['9709.integration.application', { question_type_id: '9709.integration.application', family_id: '9709.integration_techniques', subject_code: '9709', release_state: 'released' }],
+      ['9709.differential_equations.separable', { question_type_id: '9709.differential_equations.separable', family_id: '9709.differential_equations', subject_code: '9709', release_state: 'released' }]
+    ]),
+  };
+
+  function findFilter(filters, field) {
+    return filters.find((filter) => filter.field === field)?.value ?? null;
+  }
+
+  class QueryBuilder {
+    constructor(table) {
+      this.table = table;
+      this.operation = 'select';
+      this.payload = null;
+      this.filters = [];
+    }
+
+    select() {
+      return this;
+    }
+
+    insert(payload) {
+      this.operation = 'insert';
+      this.payload = payload;
+      return this;
+    }
+
+    update(payload) {
+      this.operation = 'update';
+      this.payload = payload;
+      return this;
+    }
+
+    eq(field, value) {
+      this.filters.push({ field, value });
+      return this;
+    }
+
+    single() {
+      return this.#resolve();
+    }
+
+    maybeSingle() {
+      return this.#resolve();
+    }
+
+    then(resolve, reject) {
+      return this.#resolve().then(resolve, reject);
+    }
+
+    #resolve() {
+      if (this.table === 'learning_question_families' && this.operation === 'select') {
+        return Promise.resolve({
+          data: state.registryFamilies.get(findFilter(this.filters, 'family_id')) || null,
+          error: null,
+        });
+      }
+
+      if (this.table === 'learning_question_types' && this.operation === 'select') {
+        return Promise.resolve({
+          data: state.registryTypes.get(findFilter(this.filters, 'question_type_id')) || null,
+          error: null,
+        });
+      }
+
+      if (this.table === 'learning_question_analysis_snapshots' && this.operation === 'insert') {
+        const snapshotId = `snapshot-${state.nextSnapshotId++}`;
+        const row = { classification_snapshot_id: snapshotId, ...this.payload };
+        state.snapshots.set(snapshotId, row);
+        return Promise.resolve({ data: row, error: null });
+      }
+
+      if (this.table === 'learning_question_analysis_snapshots' && this.operation === 'update') {
+        const snapshotId = findFilter(this.filters, 'classification_snapshot_id');
+        const current = state.snapshots.get(snapshotId);
+        state.snapshots.set(snapshotId, { ...current, ...this.payload });
+        return Promise.resolve({ data: null, error: null });
+      }
+
+      if (this.table === 'learning_question_events' && this.operation === 'insert') {
+        const eventId = `question-event-${state.nextEventId++}`;
+        const row = { question_event_id: eventId, ...this.payload };
+        state.events.set(eventId, row);
+        return Promise.resolve({ data: row, error: null });
+      }
+
+      if (this.table === 'question_bank' && this.operation === 'update') {
+        const questionId = findFilter(this.filters, 'question_id');
+        state.questions.set(questionId, {
+          ...(state.questions.get(questionId) || {}),
+          ...this.payload,
+        });
+        return Promise.resolve({ data: null, error: null });
+      }
+
+      return Promise.resolve({ data: [], error: null });
+    }
+  }
+
+  return {
+    state,
+    client: {
+      from(table) {
+        return new QueryBuilder(table);
+      },
+    },
+  };
+}
+
+describe('question-analysis backfill', () => {
+  test('backfills missing snapshots and emits QuestionClassified events for imported questions', async () => {
+    const { client, state } = createBackfillClient();
+
+    const summary = await runQuestionAnalysisBackfill(client, {
+      questions: [
+        {
+          question_id: 'question-1',
+          source_kind: 'imported_question',
+          subject_code: '9709',
+          prompt_representation: {
+            type: 'text',
+            value: 'Solve the differential equation dy/dx = 2xy given that y = 1 when x = 0.',
+          },
+          provenance_summary: {
+            import_source: 'manual_paste',
+          },
+          classification_snapshot_ref: null,
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      processed: 1,
+      backfilled: 1,
+      skipped: 0,
+    });
+    expect(state.snapshots.get('snapshot-1')).toMatchObject({
+      primary_question_type_id: '9709.differential_equations.separable',
+      low_confidence_posture: null,
+    });
+    expect(state.events.get('question-event-1')).toMatchObject({
+      event_type: 'QuestionClassified',
+      question_id: 'question-1',
+      classification_snapshot_id: 'snapshot-1',
+    });
+    expect(state.questions.get('question-1')).toMatchObject({
+      primary_question_type_id: '9709.differential_equations.separable',
+      release_scope_status: 'released_scoring',
+    });
+  });
+
+  test('skips questions that already have an active snapshot unless force is enabled', async () => {
+    const { client } = createBackfillClient();
+
+    const summary = await runQuestionAnalysisBackfill(client, {
+      questions: [
+        {
+          question_id: 'question-keep',
+          source_kind: 'imported_question',
+          subject_code: '9709',
+          prompt_representation: {
+            type: 'text',
+            value: 'Prove that 1 - tan^2(x) = cos(2x) / cos^2(x).',
+          },
+          provenance_summary: {
+            import_source: 'manual_paste',
+          },
+          classification_snapshot_ref: {
+            kind: 'classification_snapshot',
+            classification_snapshot_id: 'snapshot-existing',
+          },
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      processed: 1,
+      backfilled: 0,
+      skipped: 1,
+      items: [
+        {
+          question_id: 'question-keep',
+          status: 'skipped_existing_snapshot',
+        },
+      ],
+    });
+  });
+});

--- a/scripts/learning/__tests__/run-question-analysis-backfill.test.js
+++ b/scripts/learning/__tests__/run-question-analysis-backfill.test.js
@@ -1,0 +1,31 @@
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const PROJECT_ROOT = process.cwd();
+
+function runCli(args = []) {
+  return spawnSync(process.execPath, ['scripts/learning/run_question_analysis_backfill.js', ...args], {
+    cwd: PROJECT_ROOT,
+    encoding: 'utf8',
+  });
+}
+
+describe('run_question_analysis_backfill cli', () => {
+  test('treats a relative argv[1] as the active script when resolving the entrypoint guard', async () => {
+    const module = await import('../run_question_analysis_backfill.js');
+    const scriptPath = path.join('scripts', 'learning', 'run_question_analysis_backfill.js');
+    const scriptUrl = pathToFileURL(path.join(PROJECT_ROOT, scriptPath)).href;
+
+    expect(module.isQuestionAnalysisBackfillEntrypoint(scriptPath, scriptUrl)).toBe(true);
+  });
+
+  test('prints usage when invoked via the documented relative script path', () => {
+    const result = runCli(['--help']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      `Usage: node ${path.join('scripts', 'learning', 'run_question_analysis_backfill.js')} [--force]`,
+    );
+  });
+});

--- a/scripts/learning/lib/question-analysis-backfill.js
+++ b/scripts/learning/lib/question-analysis-backfill.js
@@ -1,0 +1,170 @@
+import { buildClassificationSnapshotRef } from '../../../api/learning/lib/contracts/runtime-contract.js';
+import { appendQuestionClassifiedEvent } from '../../../api/learning/lib/events/question-event-service.js';
+import { resolveReleasedScoringPosture } from '../../../api/learning/lib/import/question-import-service.js';
+import { analyzeQuestionEnvelope } from '../../../api/learning/lib/question-analysis/question-intelligence-service.js';
+import { buildQuestionAnalysisResult } from '../../../api/learning/lib/question-analysis/analysis-result-contract.js';
+import { normalizeQuestionEnvelope } from '../../../api/learning/lib/question-analysis/question-envelope-contract.js';
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeObject(value, fallback = null) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? JSON.parse(JSON.stringify(value))
+    : fallback;
+}
+
+function buildSnapshotRow(questionId, classification) {
+  return {
+    question_id: questionId,
+    primary_topic_id: classification.primary_topic_id ?? null,
+    secondary_topic_ids: normalizeArray(classification.secondary_topic_ids),
+    prerequisite_topic_ids: normalizeArray(classification.prerequisite_topic_ids),
+    family_id: classification.family_id ?? null,
+    primary_question_type_id: classification.primary_question_type_id ?? null,
+    secondary_question_type_ids: normalizeArray(classification.secondary_question_type_ids),
+    variant_tags: normalizeArray(classification.variant_tags),
+    classification_source: classification.classification_source ?? 'question_analysis_backfill',
+    classification_confidence: classification.classification_confidence ?? null,
+    confidence_band: classification.confidence_band ?? null,
+    low_confidence_posture: normalizeObject(classification.low_confidence_posture),
+    candidate_rubric_refs: normalizeArray(classification.candidate_rubric_refs),
+    canonical_step_skeleton_summary: normalizeObject(classification.canonical_step_skeleton_summary),
+    difficulty_signal: normalizeObject(classification.difficulty_signal),
+    analysis_audit_metadata: normalizeObject(classification.analysis_audit_metadata, {}),
+    analysis_version: classification.analysis_version ?? 'phase_a.v2',
+    evidence_source_event_ref: null,
+    analysis_provenance_kind: classification.analysis_provenance_kind ?? 'real',
+  };
+}
+
+function buildEnvelopeFromQuestion(question) {
+  return normalizeQuestionEnvelope({
+    source_kind: question?.source_kind ?? 'imported_question',
+    subject_code: question?.subject_code ?? null,
+    prompt_representation: question?.prompt_representation,
+    paper_scope: question?.paper_scope ?? null,
+    provenance_summary: question?.provenance_summary ?? {},
+  });
+}
+
+export async function backfillQuestionAnalysisRecord(client, {
+  question,
+  analysisHints = null,
+} = {}) {
+  const envelope = buildEnvelopeFromQuestion(question);
+  const rawClassification = analyzeQuestionEnvelope({
+    envelope,
+    analysisHints,
+  });
+  const {
+    classification,
+    scoringScopePosture,
+  } = await resolveReleasedScoringPosture(client, {
+    subjectCode: question?.subject_code ?? null,
+    classification: rawClassification,
+    questionEnvelope: envelope,
+  });
+  const materializedClassification = buildQuestionAnalysisResult({
+    envelope,
+    classification,
+  });
+  const snapshotRow = buildSnapshotRow(question.question_id, materializedClassification);
+
+  const { data: insertedSnapshot, error: snapshotError } = await client
+    .from('learning_question_analysis_snapshots')
+    .insert(snapshotRow)
+    .select('classification_snapshot_id')
+    .single();
+
+  if (snapshotError || !insertedSnapshot) {
+    throw new Error(
+      `Failed to insert backfill question classification snapshot: ${snapshotError?.message || 'no data returned'}`,
+    );
+  }
+
+  const { eventRef } = await appendQuestionClassifiedEvent(client, {
+    questionId: question.question_id,
+    classificationSnapshotId: insertedSnapshot.classification_snapshot_id,
+    question,
+    classification: materializedClassification,
+  });
+
+  const { error: snapshotUpdateError } = await client
+    .from('learning_question_analysis_snapshots')
+    .update({ evidence_source_event_ref: eventRef })
+    .eq('classification_snapshot_id', insertedSnapshot.classification_snapshot_id);
+
+  if (snapshotUpdateError) {
+    throw new Error(
+      `Failed to link backfill snapshot to QuestionClassified event: ${snapshotUpdateError.message}`,
+    );
+  }
+
+  const { error: questionUpdateError } = await client
+    .from('question_bank')
+    .update({
+      primary_topic_id: materializedClassification.primary_topic_id ?? null,
+      secondary_topic_ids: materializedClassification.secondary_topic_ids,
+      family_id: materializedClassification.family_id ?? null,
+      primary_question_type_id: materializedClassification.primary_question_type_id ?? null,
+      secondary_question_type_ids: materializedClassification.secondary_question_type_ids,
+      variant_tags: materializedClassification.variant_tags,
+      release_scope_status: scoringScopePosture.release_scope_status,
+      classification_snapshot_ref: buildClassificationSnapshotRef(
+        insertedSnapshot.classification_snapshot_id,
+      ),
+    })
+    .eq('question_id', question.question_id);
+
+  if (questionUpdateError) {
+    throw new Error(
+      `Failed to update question_bank during question-analysis backfill: ${questionUpdateError.message}`,
+    );
+  }
+
+  return {
+    question_id: question.question_id,
+    classification_snapshot_id: insertedSnapshot.classification_snapshot_id,
+    scoring_scope_posture: scoringScopePosture,
+    event_ref: eventRef,
+  };
+}
+
+export async function runQuestionAnalysisBackfill(client, {
+  questions = [],
+  force = false,
+} = {}) {
+  const summary = {
+    processed: 0,
+    backfilled: 0,
+    skipped: 0,
+    items: [],
+  };
+
+  for (const question of questions) {
+    summary.processed += 1;
+    if (!force && question?.classification_snapshot_ref) {
+      summary.skipped += 1;
+      summary.items.push({
+        question_id: question.question_id,
+        status: 'skipped_existing_snapshot',
+      });
+      continue;
+    }
+
+    const result = await backfillQuestionAnalysisRecord(client, {
+      question,
+    });
+    summary.backfilled += 1;
+    summary.items.push({
+      question_id: question.question_id,
+      status: 'backfilled',
+      classification_snapshot_id: result.classification_snapshot_id,
+      question_event_id: result.event_ref.question_event_id,
+    });
+  }
+
+  return summary;
+}

--- a/scripts/learning/lib/question-analysis-backfill.js
+++ b/scripts/learning/lib/question-analysis-backfill.js
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { buildClassificationSnapshotRef } from '../../../api/learning/lib/contracts/runtime-contract.js';
 import { appendQuestionClassifiedEvent } from '../../../api/learning/lib/events/question-event-service.js';
 import { resolveReleasedScoringPosture } from '../../../api/learning/lib/import/question-import-service.js';
@@ -49,9 +50,51 @@ function buildEnvelopeFromQuestion(question) {
   });
 }
 
+async function findActiveSnapshotId(client, { questionId } = {}) {
+  if (!questionId) {
+    return null;
+  }
+
+  const { data, error } = await client
+    .from('learning_question_analysis_snapshots')
+    .select('classification_snapshot_id')
+    .eq('question_id', questionId)
+    .is('superseded_by_snapshot_id', null)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load active question classification snapshot: ${error.message}`);
+  }
+
+  return data?.classification_snapshot_id ?? null;
+}
+
+async function supersedeActiveSnapshot(client, {
+  activeSnapshotId,
+  replacementSnapshotId,
+} = {}) {
+  if (!activeSnapshotId) {
+    return;
+  }
+
+  const { error } = await client
+    .from('learning_question_analysis_snapshots')
+    .update({
+      superseded_by_snapshot_id: replacementSnapshotId,
+    })
+    .eq('classification_snapshot_id', activeSnapshotId);
+
+  if (error) {
+    throw new Error(
+      `Failed to supersede active question classification snapshot: ${error.message}`,
+    );
+  }
+}
+
 export async function backfillQuestionAnalysisRecord(client, {
   question,
   analysisHints = null,
+  force = false,
 } = {}) {
   const envelope = buildEnvelopeFromQuestion(question);
   const rawClassification = analyzeQuestionEnvelope({
@@ -70,7 +113,22 @@ export async function backfillQuestionAnalysisRecord(client, {
     envelope,
     classification,
   });
+  const activeSnapshotId = force
+    ? await findActiveSnapshotId(client, { questionId: question?.question_id ?? null })
+    : null;
+  const replacementSnapshotId = activeSnapshotId ? randomUUID() : null;
+
+  if (force && activeSnapshotId) {
+    await supersedeActiveSnapshot(client, {
+      activeSnapshotId,
+      replacementSnapshotId,
+    });
+  }
+
   const snapshotRow = buildSnapshotRow(question.question_id, materializedClassification);
+  if (replacementSnapshotId) {
+    snapshotRow.classification_snapshot_id = replacementSnapshotId;
+  }
 
   const { data: insertedSnapshot, error: snapshotError } = await client
     .from('learning_question_analysis_snapshots')
@@ -156,6 +214,7 @@ export async function runQuestionAnalysisBackfill(client, {
 
     const result = await backfillQuestionAnalysisRecord(client, {
       question,
+      force,
     });
     summary.backfilled += 1;
     summary.items.push({

--- a/scripts/learning/run_question_analysis_backfill.js
+++ b/scripts/learning/run_question_analysis_backfill.js
@@ -1,3 +1,5 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getServiceClient } from '../../api/lib/supabase/client.js';
 import { runQuestionAnalysisBackfill } from './lib/question-analysis-backfill.js';
 
@@ -37,8 +39,15 @@ export async function main(argv = process.argv.slice(2)) {
   console.log(JSON.stringify(summary, null, 2));
 }
 
-const isEntrypoint = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
-if (isEntrypoint) {
+export function isQuestionAnalysisBackfillEntrypoint(entryScriptPath, metaUrl = import.meta.url) {
+  if (!entryScriptPath) {
+    return false;
+  }
+
+  return path.resolve(entryScriptPath) === fileURLToPath(metaUrl);
+}
+
+if (isQuestionAnalysisBackfillEntrypoint(process.argv[1], import.meta.url)) {
   main().catch((error) => {
     console.error(error.message);
     process.exitCode = 1;

--- a/scripts/learning/run_question_analysis_backfill.js
+++ b/scripts/learning/run_question_analysis_backfill.js
@@ -1,0 +1,46 @@
+import { getServiceClient } from '../../api/lib/supabase/client.js';
+import { runQuestionAnalysisBackfill } from './lib/question-analysis-backfill.js';
+
+function printUsage() {
+  console.log('Usage: node scripts/learning/run_question_analysis_backfill.js [--force]');
+}
+
+async function loadCandidateQuestions(client) {
+  const { data, error } = await client
+    .from('question_bank')
+    .select(
+      'question_id, source_kind, subject_code, prompt_representation, paper_scope, provenance_summary, classification_snapshot_ref',
+    )
+    .eq('source_kind', 'imported_question');
+
+  if (error) {
+    throw new Error(`Failed to load question bank rows for backfill: ${error.message}`);
+  }
+
+  return Array.isArray(data) ? data : [];
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  if (argv.includes('--help')) {
+    printUsage();
+    return;
+  }
+
+  const force = argv.includes('--force');
+  const client = getServiceClient();
+  const questions = await loadCandidateQuestions(client);
+  const summary = await runQuestionAnalysisBackfill(client, {
+    questions,
+    force,
+  });
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+const isEntrypoint = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (isEntrypoint) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/src/components/learning-runtime/ImportedQuestionIntake.js
+++ b/src/components/learning-runtime/ImportedQuestionIntake.js
@@ -28,7 +28,15 @@ export const IMPORTED_QUESTION_RUNTIME_CONTEXT_OPTIONS = Object.freeze([
     topicId: 'topic-integration-1',
     topicPath: '9709.integration.application',
     questionTypeId: '9709.integration.application',
-    postureLabel: 'fallback-only family',
+    postureLabel: 'pilot question type',
+  },
+  {
+    value: '9709.differential_equations.separable',
+    label: 'Separable differential equations',
+    topicId: 'topic-differential-separable',
+    topicPath: '9709.differential_equations.separable',
+    questionTypeId: '9709.differential_equations.separable',
+    postureLabel: 'pilot question type',
   },
 ]);
 
@@ -123,9 +131,10 @@ export function buildImportQuestionPayload(draft = {}) {
     provenance_summary: {
       import_source: 'manual_paste',
     },
-    classification: {
-      primary_question_type_id: normalizedDraft.questionTypeId || null,
-      primary_topic_id: null,
+    analysis_hints: {
+      runtime_context_id: normalizedDraft.runtimeContextId || null,
+      question_type_hint_id: normalizedDraft.questionTypeId || null,
+      topic_path_hint: normalizedDraft.topicPath || null,
     },
   };
 }

--- a/src/components/learning-runtime/__tests__/ImportedQuestionIntake.test.js
+++ b/src/components/learning-runtime/__tests__/ImportedQuestionIntake.test.js
@@ -28,7 +28,7 @@ function findElement(node, predicate) {
 }
 
 describe('ImportedQuestionIntake', () => {
-  test('builds import payloads from pasted content and runtime context selection', () => {
+  test('builds import payloads from pasted content and runtime context selection without sending canonical classification truth', () => {
     const payload = buildImportQuestionPayload(createImportedQuestionDraft({
       promptValue: 'Solve 2sinx = 1 for 0 <= x <= 360.',
       runtimeContextId: '9709.trigonometry.equations',
@@ -43,11 +43,21 @@ describe('ImportedQuestionIntake', () => {
       provenance_summary: {
         import_source: 'manual_paste',
       },
-      classification: {
-        primary_question_type_id: '9709.trigonometry.equations',
-        primary_topic_id: null,
+      analysis_hints: {
+        runtime_context_id: '9709.trigonometry.equations',
+        question_type_hint_id: '9709.trigonometry.equations',
+        topic_path_hint: '9709/trigonometry/equations',
       },
     });
+  });
+
+  test('keeps the approved differential-equations pilot context available in the intake draft', () => {
+    const draft = createImportedQuestionDraft({
+      runtimeContextId: '9709.differential_equations.separable',
+    });
+
+    expect(draft.runtimeContextId).toBe('9709.differential_equations.separable');
+    expect(draft.questionTypeId).toBe('9709.differential_equations.separable');
   });
 
   test('builds guided-solve session payloads anchored to imported questions', () => {

--- a/supabase/migrations/20260413110000_phase_a_question_classified_events.sql
+++ b/supabase/migrations/20260413110000_phase_a_question_classified_events.sql
@@ -52,14 +52,14 @@ SELECT
   lqt.release_state AS primary_question_type_release_state,
   lqas.classification_source,
   lqas.confidence_band,
-  lqas.low_confidence_posture,
   lqas.prerequisite_topic_ids,
   lqas.canonical_step_skeleton_summary,
   lqas.difficulty_signal,
   lqas.analysis_audit_metadata,
   lqas.analysis_version,
   lqas.evidence_source_event_ref,
-  lqas.analysis_provenance_kind
+  lqas.analysis_provenance_kind,
+  lqas.low_confidence_posture
 FROM public.question_bank qb
 LEFT JOIN public.learning_question_families lf
   ON lf.family_id = qb.family_id

--- a/supabase/migrations/20260413110000_phase_a_question_classified_events.sql
+++ b/supabase/migrations/20260413110000_phase_a_question_classified_events.sql
@@ -1,0 +1,70 @@
+-- Phase A remediation: persist explicit low-confidence posture and real QuestionClassified events.
+
+ALTER TABLE public.learning_question_analysis_snapshots
+  ADD COLUMN IF NOT EXISTS low_confidence_posture JSONB NULL;
+
+ALTER TABLE public.learning_question_analysis_snapshots
+  DROP CONSTRAINT IF EXISTS learning_question_analysis_snapshots_low_confidence_posture_check;
+
+ALTER TABLE public.learning_question_analysis_snapshots
+  ADD CONSTRAINT learning_question_analysis_snapshots_low_confidence_posture_check
+  CHECK (low_confidence_posture IS NULL OR jsonb_typeof(low_confidence_posture) = 'object');
+
+CREATE TABLE IF NOT EXISTS public.learning_question_events (
+  question_event_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type TEXT NOT NULL CHECK (event_type IN ('QuestionClassified')),
+  question_id UUID NOT NULL REFERENCES public.question_bank(question_id) ON DELETE CASCADE,
+  classification_snapshot_id UUID NOT NULL REFERENCES public.learning_question_analysis_snapshots(classification_snapshot_id) ON DELETE CASCADE,
+  event_payload JSONB NOT NULL,
+  provenance JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (event_type, classification_snapshot_id),
+  CHECK (jsonb_typeof(event_payload) = 'object'),
+  CHECK (jsonb_typeof(provenance) = 'object')
+);
+
+CREATE INDEX IF NOT EXISTS idx_learning_question_events_question_id
+  ON public.learning_question_events (question_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_learning_question_events_snapshot_id
+  ON public.learning_question_events (classification_snapshot_id);
+
+CREATE OR REPLACE VIEW public.learning_question_registry_projection AS
+SELECT
+  qb.question_id,
+  qb.source_kind,
+  qb.subject_code,
+  qb.paper_scope,
+  qb.primary_topic_id,
+  qb.secondary_topic_ids,
+  qb.family_id,
+  lf.title AS family_title,
+  qb.primary_question_type_id,
+  lqt.title AS primary_question_type_title,
+  qb.secondary_question_type_ids,
+  qb.variant_tags,
+  qb.release_scope_status,
+  qb.classification_snapshot_ref,
+  qb.prompt_representation,
+  qb.provenance_summary,
+  lqas.classification_confidence,
+  lqas.candidate_rubric_refs,
+  lqt.release_state AS primary_question_type_release_state,
+  lqas.classification_source,
+  lqas.confidence_band,
+  lqas.low_confidence_posture,
+  lqas.prerequisite_topic_ids,
+  lqas.canonical_step_skeleton_summary,
+  lqas.difficulty_signal,
+  lqas.analysis_audit_metadata,
+  lqas.analysis_version,
+  lqas.evidence_source_event_ref,
+  lqas.analysis_provenance_kind
+FROM public.question_bank qb
+LEFT JOIN public.learning_question_families lf
+  ON lf.family_id = qb.family_id
+LEFT JOIN public.learning_question_types lqt
+  ON lqt.question_type_id = qb.primary_question_type_id
+LEFT JOIN public.learning_question_analysis_snapshots lqas
+  ON lqas.question_id = qb.question_id
+ AND lqas.superseded_by_snapshot_id IS NULL;

--- a/tests/marking/__tests__/ft-cao-fixtures-contract.test.js
+++ b/tests/marking/__tests__/ft-cao-fixtures-contract.test.js
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('ft_cao_fixtures synthetic contract', () => {
+  test('fixtures carry explicit synthetic provenance and cover the approved personas', () => {
+    const payload = JSON.parse(
+      fs.readFileSync(
+        path.join(process.cwd(), 'tests/marking/fixtures/ft_cao_fixtures.json'),
+        'utf8',
+      ),
+    );
+
+    const fixtures = Array.isArray(payload?.fixtures) ? payload.fixtures : [];
+    const personas = new Set(fixtures.map((fixture) => fixture?.persona));
+
+    expect(personas).toEqual(new Set([
+      'secure_correct',
+      'developing_partial',
+      'method_right_answer_wrong',
+      'misconception_specific',
+      'low_confidence_sparse',
+    ]));
+
+    fixtures.forEach((fixture) => {
+      expect(fixture.provenance).toEqual({
+        source_kind: 'synthetic',
+        usage_scope: 'development_only',
+        not_authoritative_learner_evidence: true,
+      });
+    });
+  });
+});

--- a/tests/marking/fixtures/ft_cao_fixtures.json
+++ b/tests/marking/fixtures/ft_cao_fixtures.json
@@ -2,6 +2,12 @@
   "fixtures": [
     {
       "id": "ft_dependency_propagation",
+      "persona": "secure_correct",
+      "provenance": {
+        "source_kind": "synthetic",
+        "usage_scope": "development_only",
+        "not_authoritative_learner_evidence": true
+      },
       "student_steps": [
         { "step_id": "s1", "text": "final answer is x equals 3" }
       ],
@@ -28,6 +34,12 @@
     },
     {
       "id": "strictft_dependency_propagation",
+      "persona": "low_confidence_sparse",
+      "provenance": {
+        "source_kind": "synthetic",
+        "usage_scope": "development_only",
+        "not_authoritative_learner_evidence": true
+      },
       "student_steps": [
         { "step_id": "s1", "text": "some partly related step text" }
       ],
@@ -54,6 +66,12 @@
     },
     {
       "id": "cao_all_or_nothing_group",
+      "persona": "developing_partial",
+      "provenance": {
+        "source_kind": "synthetic",
+        "usage_scope": "development_only",
+        "not_authoritative_learner_evidence": true
+      },
       "student_steps": [
         { "step_id": "s1", "text": "exact final answer y equals 12" },
         { "step_id": "s2", "text": "unrelated sentence for second point" }
@@ -85,6 +103,12 @@
     },
     {
       "id": "accuracy_policy_override_min_confidence",
+      "persona": "misconception_specific",
+      "provenance": {
+        "source_kind": "synthetic",
+        "usage_scope": "development_only",
+        "not_authoritative_learner_evidence": true
+      },
       "student_steps": [
         { "step_id": "s1", "text": "partial overlap alpha beta" }
       ],
@@ -103,6 +127,12 @@
     },
     {
       "id": "follow_through_dependency_propagation",
+      "persona": "method_right_answer_wrong",
+      "provenance": {
+        "source_kind": "synthetic",
+        "usage_scope": "development_only",
+        "not_authoritative_learner_evidence": true
+      },
       "student_steps": [
         { "step_id": "s1", "text": "final answer is x equals 3" }
       ],
@@ -129,6 +159,12 @@
     },
     {
       "id": "strict_ft_dependency_propagation",
+      "persona": "low_confidence_sparse",
+      "provenance": {
+        "source_kind": "synthetic",
+        "usage_scope": "development_only",
+        "not_authoritative_learner_evidence": true
+      },
       "student_steps": [
         { "step_id": "s1", "text": "some partly related step text" }
       ],


### PR DESCRIPTION
## Summary

This PR closes the approved Phase A remediation gaps between runtime behavior and release evidence.

The root cause was runtime drift in several places: the import path trusted caller-supplied classification, authoritative pilot scope still effectively stopped at the trigonometry family, low-confidence posture was not explicitly fail-closed, executable P3 rubric contracts were missing, QuestionClassified was not durably emitted from the real import flow, and released-family evidence overstated capability with metadata-only checks.

The fix replaces caller-trusted classification with deterministic question intelligence for the four approved pilot question types, persists question analysis snapshots with explicit low-confidence posture and question-scoped QuestionClassified events, lands executable P3 rubric templates plus validator coverage, adds an offline backfill path for imported questions, upgrades synthetic fixture provenance/persona coverage, refreshes released-family gate artifacts, and records the full remediation evidence in docs/reports/2026-04-13-phase-a-remediation-report.md.

This branch keeps QuestionClassified in a narrow question-scoped learning_question_events table rather than forcing it into the earlier attempt-scoped Phase 0 event pipeline. The current branch does not contain that infrastructure, and Phase A classification happens before any attempt exists, so snapshot-linked question lineage was the correct boundary for this remediation.

## Issue Linkage

No matching open GitHub issue titled `phase-a-remediation` was returned by `gh issue list --search "phase-a-remediation in:title" --state all` at PR creation time, so this PR cannot include an auto-closing `Closes #...` reference. It addresses the tracker item `phase-a-remediation` directly.

## Verification

- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand scripts/learning/__tests__/question-analysis-backfill.test.js tests/marking/__tests__/ft-cao-fixtures-contract.test.js`
- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/question-analysis.test.js api/learning/__tests__/question-registry-repository.test.js api/learning/__tests__/question-import-service.test.js api/learning/__tests__/schema-contract.test.js api/learning/__tests__/p3-rubric-validator.test.js api/learning/__tests__/released-scope.test.js scripts/learning/__tests__/released-family-gate.test.js scripts/learning/__tests__/question-analysis-backfill.test.js tests/marking/__tests__/ft-cao-fixtures-contract.test.js src/components/learning-runtime/__tests__/ImportedQuestionIntake.test.js`
- `node scripts/learning/run_released_family_gate.js --out-json data/learning_runtime/release_evidence/released-family-gate-receipt.v1.json --out-md docs/reports/learning_runtime_released_family_gate_2026-03-25.md`
