### PR TITLE
fix(learning): resolve concept launch 500 by falling back to topic_path

### DIFF
--- a/api/learning/__tests__/session-validator.test.js
+++ b/api/learning/__tests__/session-validator.test.js
@@ -212,6 +212,34 @@ test('resolveCreateSessionAnchor falls back to topic_path when concept topic_id 
   ]);
 });
 
+test('resolveCreateSessionAnchor does not fall back to topic_path when concept topic_id is a missing uuid', async () => {
+  const client = createCurriculumClient([
+    { node_id: TOPIC_UUID, topic_path: TOPIC_PATH },
+  ]);
+
+  await expect(resolveCreateSessionAnchor(client, {
+    anchorKind: 'concept',
+    subjectCode: '9709',
+    anchorRef: {
+      kind: 'concept',
+      topic_id: '22222222-2222-4222-8222-222222222222',
+      topic_path: TOPIC_PATH,
+    },
+    currentQuestionTypeId: '9709.trigonometry.equations',
+  })).rejects.toMatchObject({
+    code: 'anchor_target_not_found',
+    status: 404,
+  });
+
+  expect(client.calls).toEqual([
+    {
+      table: 'curriculum_nodes',
+      columns: 'node_id, topic_path',
+      filters: [{ field: 'node_id', value: '22222222-2222-4222-8222-222222222222' }],
+    },
+  ]);
+});
+
 test('resolveCreateSessionAnchor returns 404 when concept topic is missing by both uuid and topic_path', async () => {
   const client = createCurriculumClient([]);
 

--- a/api/learning/__tests__/session-validator.test.js
+++ b/api/learning/__tests__/session-validator.test.js
@@ -1,4 +1,69 @@
 import { validateCreateSessionInput } from '../lib/validators/session-validator.js';
+import { resolveCreateSessionAnchor } from '../lib/session-runtime/session-anchor-resolution.js';
+
+const TOPIC_UUID = '11111111-1111-4111-8111-111111111111';
+const TOPIC_PATH = '9709.trigonometry.equations';
+
+function isUuidString(value) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    String(value || '').trim(),
+  );
+}
+
+function createCurriculumClient(nodes = []) {
+  const calls = [];
+
+  return {
+    calls,
+    from(table) {
+      const filters = [];
+      let columns = null;
+
+      return {
+        select(value) {
+          columns = value;
+          return this;
+        },
+        eq(field, value) {
+          filters.push({ field, value });
+          return this;
+        },
+        async maybeSingle() {
+          calls.push({
+            table,
+            columns,
+            filters: [...filters],
+          });
+
+          if (table !== 'curriculum_nodes') {
+            throw new Error(`Unhandled test table: ${table}`);
+          }
+
+          const topicId = filters.find((filter) => filter.field === 'node_id')?.value;
+          if (topicId !== undefined) {
+            if (!isUuidString(topicId)) {
+              return {
+                data: null,
+                error: { message: 'invalid input syntax for type uuid' },
+              };
+            }
+
+            return {
+              data: nodes.find((node) => node.node_id === topicId) ?? null,
+              error: null,
+            };
+          }
+
+          const topicPath = filters.find((filter) => filter.field === 'topic_path')?.value;
+          return {
+            data: nodes.find((node) => node.topic_path === topicPath) ?? null,
+            error: null,
+          };
+        },
+      };
+    },
+  };
+}
 
 test('question anchor requires matching current_question_id', () => {
   expect(() => validateCreateSessionInput({
@@ -81,4 +146,94 @@ test('non-review_queue workspace slots cannot start spaced_review', () => {
     current_question_id: null,
     current_question_type_id: null,
   })).toThrow(/unsupported_mode_for_anchor/);
+});
+
+test('resolveCreateSessionAnchor loads concept topic by uuid when topic_id is canonical', async () => {
+  const client = createCurriculumClient([
+    { node_id: TOPIC_UUID, topic_path: TOPIC_PATH },
+  ]);
+
+  await expect(resolveCreateSessionAnchor(client, {
+    anchorKind: 'concept',
+    subjectCode: '9709',
+    anchorRef: {
+      kind: 'concept',
+      topic_id: TOPIC_UUID,
+      topic_path: TOPIC_PATH,
+    },
+    currentQuestionTypeId: '9709.trigonometry.equations',
+  })).resolves.toEqual({
+    currentQuestionId: null,
+    currentQuestionTypeId: '9709.trigonometry.equations',
+    canonicalHome: {
+      topic_id: TOPIC_UUID,
+      topic_path: TOPIC_PATH,
+    },
+  });
+
+  expect(client.calls).toEqual([
+    {
+      table: 'curriculum_nodes',
+      columns: 'node_id, topic_path',
+      filters: [{ field: 'node_id', value: TOPIC_UUID }],
+    },
+  ]);
+});
+
+test('resolveCreateSessionAnchor falls back to topic_path when concept topic_id is a slug', async () => {
+  const client = createCurriculumClient([
+    { node_id: TOPIC_UUID, topic_path: TOPIC_PATH },
+  ]);
+
+  await expect(resolveCreateSessionAnchor(client, {
+    anchorKind: 'concept',
+    subjectCode: '9709',
+    anchorRef: {
+      kind: 'concept',
+      topic_id: 'topic-trig-equations',
+      topic_path: TOPIC_PATH,
+    },
+    currentQuestionTypeId: '9709.trigonometry.equations',
+  })).resolves.toEqual({
+    currentQuestionId: null,
+    currentQuestionTypeId: '9709.trigonometry.equations',
+    canonicalHome: {
+      topic_id: TOPIC_UUID,
+      topic_path: TOPIC_PATH,
+    },
+  });
+
+  expect(client.calls).toEqual([
+    {
+      table: 'curriculum_nodes',
+      columns: 'node_id, topic_path',
+      filters: [{ field: 'topic_path', value: TOPIC_PATH }],
+    },
+  ]);
+});
+
+test('resolveCreateSessionAnchor returns 404 when concept topic is missing by both uuid and topic_path', async () => {
+  const client = createCurriculumClient([]);
+
+  await expect(resolveCreateSessionAnchor(client, {
+    anchorKind: 'concept',
+    subjectCode: '9709',
+    anchorRef: {
+      kind: 'concept',
+      topic_id: 'topic-trig-equations',
+      topic_path: TOPIC_PATH,
+    },
+    currentQuestionTypeId: '9709.trigonometry.equations',
+  })).rejects.toMatchObject({
+    code: 'anchor_target_not_found',
+    status: 404,
+  });
+
+  expect(client.calls).toEqual([
+    {
+      table: 'curriculum_nodes',
+      columns: 'node_id, topic_path',
+      filters: [{ field: 'topic_path', value: TOPIC_PATH }],
+    },
+  ]);
 });

--- a/api/learning/lib/session-runtime/session-anchor-resolution.js
+++ b/api/learning/lib/session-runtime/session-anchor-resolution.js
@@ -21,6 +21,12 @@ function createLearningError(code, {
   return error;
 }
 
+function isUuidString(value) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    String(value || '').trim(),
+  );
+}
+
 async function maybeSingle(query, fallbackMessage) {
   const { data, error } = await query;
   if (error) {
@@ -49,7 +55,22 @@ async function resolveConceptAnchor(client, {
   anchorRef,
   currentQuestionTypeId,
 } = {}) {
-  const topic = await loadTopic(client, anchorRef.topic_id);
+  let topic = null;
+
+  if (isUuidString(anchorRef.topic_id)) {
+    topic = await loadTopic(client, anchorRef.topic_id);
+  }
+
+  if (!topic && anchorRef.topic_path) {
+    topic = await maybeSingle(
+      client
+        .from('curriculum_nodes')
+        .select('node_id, topic_path')
+        .eq('topic_path', anchorRef.topic_path)
+        .maybeSingle(),
+      'Failed to load curriculum node by topic_path.',
+    );
+  }
 
   if (!topic) {
     throw createLearningError('anchor_target_not_found', {

--- a/api/learning/lib/session-runtime/session-anchor-resolution.js
+++ b/api/learning/lib/session-runtime/session-anchor-resolution.js
@@ -55,13 +55,14 @@ async function resolveConceptAnchor(client, {
   anchorRef,
   currentQuestionTypeId,
 } = {}) {
+  const topicIdIsUuid = isUuidString(anchorRef.topic_id);
   let topic = null;
 
-  if (isUuidString(anchorRef.topic_id)) {
+  if (topicIdIsUuid) {
     topic = await loadTopic(client, anchorRef.topic_id);
   }
 
-  if (!topic && anchorRef.topic_path) {
+  if (!topic && !topicIdIsUuid && anchorRef.topic_path) {
     topic = await maybeSingle(
       client
         .from('curriculum_nodes')


### PR DESCRIPTION
## Summary
- guard concept-anchor `topic_id` lookups with a UUID check before querying `curriculum_nodes.node_id`
- fall back to resolving by `topic_path` when the frontend sends a slug instead of a canonical topic UUID
- add regression coverage for canonical UUID hits, slug fallback, and both-miss 404 behavior

## Testing
- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/session-validator.test.js`