### PR TITLE
fix(learning): extract browser-safe workspace contract subset

### DIFF
--- a/src/components/learning-runtime/WorkspaceShell.js
+++ b/src/components/learning-runtime/WorkspaceShell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isCompatibleArtifactKindForSlot } from '../../../api/learning/lib/contracts/runtime-contract.js';
+import { isCompatibleArtifactKindForSlot } from '../../lib/contracts/runtime-contract-client.js';
 import {
   markArtifactContested,
   pinArtifact,

--- a/src/components/learning-runtime/__tests__/workspace-contract-boundary.test.js
+++ b/src/components/learning-runtime/__tests__/workspace-contract-boundary.test.js
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+
+const workspaceShellPath = new URL('../WorkspaceShell.js', import.meta.url);
+const workspaceViewModelPath = new URL('../view-models/workspace-view-model.js', import.meta.url);
+
+describe('workspace runtime contract boundary', () => {
+  test('workspace client modules do not import runtime contracts from api/', () => {
+    const workspaceShellSource = fs.readFileSync(workspaceShellPath, 'utf8');
+    const workspaceViewModelSource = fs.readFileSync(workspaceViewModelPath, 'utf8');
+
+    expect(workspaceShellSource).not.toMatch(/from\s+['"].*api\/learning\/lib\/contracts\/runtime-contract\.js['"]/);
+    expect(workspaceViewModelSource).not.toMatch(/from\s+['"].*api\/learning\/lib\/contracts\/runtime-contract\.js['"]/);
+  });
+
+  test('browser-safe runtime contract client mirrors the server subset used by workspace code', async () => {
+    const clientContracts = await import('../../../lib/contracts/runtime-contract-client.js');
+    const serverContracts = await import('../../../../api/learning/lib/contracts/runtime-contract.js');
+
+    expect(clientContracts.STABLE_SLOT_KEYS).toEqual(serverContracts.STABLE_SLOT_KEYS);
+    expect(clientContracts.ARTIFACT_KINDS).toEqual(serverContracts.ARTIFACT_KINDS);
+    expect(clientContracts.SLOT_COMPATIBILITY).toEqual(serverContracts.SLOT_COMPATIBILITY);
+
+    for (const slotKey of serverContracts.STABLE_SLOT_KEYS) {
+      expect(clientContracts.isStableSlotKey(slotKey)).toBe(serverContracts.isStableSlotKey(slotKey));
+    }
+
+    expect(clientContracts.isStableSlotKey('not_a_slot')).toBe(false);
+
+    for (const artifactKind of serverContracts.ARTIFACT_KINDS) {
+      expect(clientContracts.isArtifactKind(artifactKind)).toBe(serverContracts.isArtifactKind(artifactKind));
+    }
+
+    expect(clientContracts.isArtifactKind('not_an_artifact')).toBe(false);
+
+    for (const slotKey of serverContracts.STABLE_SLOT_KEYS) {
+      for (const artifactKind of serverContracts.ARTIFACT_KINDS) {
+        expect(clientContracts.isCompatibleArtifactKindForSlot(slotKey, artifactKind)).toBe(
+          serverContracts.isCompatibleArtifactKindForSlot(slotKey, artifactKind),
+        );
+      }
+    }
+
+    expect(clientContracts.isCompatibleArtifactKindForSlot('not_a_slot', 'summary_card')).toBe(false);
+    expect(clientContracts.isCompatibleArtifactKindForSlot('overview_map', 'not_an_artifact')).toBe(false);
+  });
+});

--- a/src/components/learning-runtime/view-models/workspace-view-model.js
+++ b/src/components/learning-runtime/view-models/workspace-view-model.js
@@ -1,4 +1,4 @@
-import { isCompatibleArtifactKindForSlot } from '../../../../api/learning/lib/contracts/runtime-contract.js';
+import { isCompatibleArtifactKindForSlot } from '../../../lib/contracts/runtime-contract-client.js';
 import { buildReviewQueueViewModel } from './review-queue-view-model.js';
 
 const SLOT_DEFINITIONS = Object.freeze([

--- a/src/lib/contracts/runtime-contract-client.js
+++ b/src/lib/contracts/runtime-contract-client.js
@@ -1,0 +1,51 @@
+// Browser-safe subset copied from api/learning/lib/contracts/runtime-contract.js.
+function freezeList(values) {
+  return Object.freeze([...values]);
+}
+
+function freezeCompatibilityMap(map) {
+  return Object.freeze(
+    Object.fromEntries(
+      Object.entries(map).map(([slotKey, artifactKinds]) => [slotKey, freezeList(artifactKinds)]),
+    ),
+  );
+}
+
+export const STABLE_SLOT_KEYS = freezeList([
+  'overview_map',
+  'core_method_derivation',
+  'canonical_worked_example',
+  'common_traps',
+  'my_notes',
+  'review_queue',
+]);
+
+export const ARTIFACT_KINDS = freezeList([
+  'summary_card',
+  'derivation_card',
+  'worked_example_card',
+  'misconception_card',
+  'formula_card',
+  'free_note',
+]);
+
+export const SLOT_COMPATIBILITY = freezeCompatibilityMap({
+  overview_map: ['summary_card'],
+  core_method_derivation: ['derivation_card', 'formula_card'],
+  canonical_worked_example: ['worked_example_card'],
+  common_traps: ['misconception_card'],
+  my_notes: ['free_note'],
+  review_queue: [],
+});
+
+export function isStableSlotKey(value) {
+  return STABLE_SLOT_KEYS.includes(value);
+}
+
+export function isArtifactKind(value) {
+  return ARTIFACT_KINDS.includes(value);
+}
+
+export function isCompatibleArtifactKindForSlot(slotKey, artifactKind) {
+  return Boolean(SLOT_COMPATIBILITY[slotKey]?.includes(artifactKind));
+}


### PR DESCRIPTION
## Summary
- move workspace frontend consumers off the server-only `api/learning/lib/contracts/runtime-contract.js` import
- add `src/lib/contracts/runtime-contract-client.js` as the browser-safe subset used by workspace code
- lock the boundary with a focused parity test against the server contract subset

## Why
Fresh workspace loads could crash in the browser because Vite treated the frontend import of the server-side contract as an app request path and proxied it to `/api/learning/lib/contracts/runtime-contract.js`, which returns `404`. This PR keeps the frontend on a browser-safe contract subset without changing runtime semantics.

## Scope
- `src/components/learning-runtime/WorkspaceShell.js`
- `src/components/learning-runtime/view-models/workspace-view-model.js`
- `src/lib/contracts/runtime-contract-client.js`
- `src/components/learning-runtime/__tests__/workspace-contract-boundary.test.js`

## Verification
- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand src/components/learning-runtime/__tests__/workspace-contract-boundary.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js src/components/learning-runtime/__tests__/view-models.test.js`
  - PASS (`3` suites, `25` tests)
