### PR TITLE
[codex] add phase0 event pipeline gate

### DIFF
--- a/api/learning/__tests__/event-service.test.js
+++ b/api/learning/__tests__/event-service.test.js
@@ -135,6 +135,49 @@ describe('learning event service', () => {
     expect(store.effects).toHaveLength(1);
   });
 
+  test('replay can append a new truth revision that restarts sequence numbering', async () => {
+    const {
+      appendLearningEvent,
+      buildReplayLearningEvent,
+      buildSyntheticAttemptEventFlow,
+      createEmptyLearningEventStore,
+    } = await import('../lib/events/event-service.js');
+
+    const store = createEmptyLearningEventStore();
+    const flow = buildSyntheticAttemptEventFlow({
+      attemptId: 'attempt-revision-replay',
+      learnerId: 'learner-1',
+      sessionId: 'session-1',
+      subjectCode: '9709',
+      emittedBy: 'jest',
+    });
+
+    flow.forEach((event) => appendLearningEvent(store, event));
+
+    const replayFlow = flow.map((sourceEvent) => buildReplayLearningEvent(sourceEvent, {
+      truthRevision: 2,
+      sequenceNo: sourceEvent.sequence_no,
+      emittedBy: 'jest-replay',
+      replayOfEventId: sourceEvent.event_id,
+      supersedesEventId: sourceEvent.event_id,
+      causationEventId: sourceEvent.event_id,
+      reconciliationId: 'reconciliation-run-1',
+      dedupeKey: `${sourceEvent.aggregate_id}:2:${sourceEvent.event_type}:replay`,
+    }));
+
+    const replayResults = replayFlow.map((event) => appendLearningEvent(store, event));
+
+    expect(replayResults.every((result) => result.inserted)).toBe(true);
+    expect(store.pipelineStateByAttempt.get('attempt-revision-replay')).toMatchObject({
+      attempt_id: 'attempt-revision-replay',
+      current_truth_revision: 2,
+      current_stage: 'ArtifactSuggestionsCreated',
+      current_status: 'completed',
+      last_sequence_no: 7,
+    });
+    expect(store.events).toHaveLength(14);
+  });
+
   test('attempt stream lock rejects re-entry and can be acquired again after release', async () => {
     const {
       acquireAttemptStreamLock,

--- a/api/learning/__tests__/event-service.test.js
+++ b/api/learning/__tests__/event-service.test.js
@@ -1,0 +1,164 @@
+describe('learning event service', () => {
+  test('synthetic pipeline preserves strict phase ordering and completes attempt state', async () => {
+    const {
+      appendLearningEvent,
+      buildSyntheticAttemptEventFlow,
+      createEmptyLearningEventStore,
+    } = await import('../lib/events/event-service.js');
+
+    const store = createEmptyLearningEventStore();
+    const flow = buildSyntheticAttemptEventFlow({
+      attemptId: 'attempt-1',
+      learnerId: 'learner-1',
+      sessionId: 'session-1',
+      subjectCode: '9709',
+      emittedBy: 'jest',
+    });
+
+    const results = flow.map((event) => appendLearningEvent(store, event));
+
+    expect(results.every((result) => result.inserted)).toBe(true);
+    expect(store.pipelineStateByAttempt.get('attempt-1')).toMatchObject({
+      attempt_id: 'attempt-1',
+      current_stage: 'ArtifactSuggestionsCreated',
+      current_status: 'completed',
+      last_sequence_no: 7,
+    });
+  });
+
+  test('dedupe blocks duplicate emissions for the same event_type and dedupe_key', async () => {
+    const {
+      appendLearningEvent,
+      buildSyntheticAttemptEventFlow,
+      createEmptyLearningEventStore,
+    } = await import('../lib/events/event-service.js');
+
+    const store = createEmptyLearningEventStore();
+    const [attemptSubmitted] = buildSyntheticAttemptEventFlow({
+      attemptId: 'attempt-dup',
+      learnerId: 'learner-1',
+      sessionId: 'session-1',
+      subjectCode: '9709',
+      emittedBy: 'jest',
+    });
+
+    expect(appendLearningEvent(store, attemptSubmitted)).toMatchObject({ inserted: true });
+    expect(appendLearningEvent(store, attemptSubmitted)).toMatchObject({
+      inserted: false,
+      reason_code: 'duplicate_dedupe_key',
+    });
+  });
+
+  test('out-of-order append is rejected inside the same attempt stream', async () => {
+    const {
+      appendLearningEvent,
+      buildSyntheticAttemptEventFlow,
+      createEmptyLearningEventStore,
+    } = await import('../lib/events/event-service.js');
+
+    const store = createEmptyLearningEventStore();
+    const [attemptSubmitted, , markingCompleted] = buildSyntheticAttemptEventFlow({
+      attemptId: 'attempt-order',
+      learnerId: 'learner-1',
+      sessionId: 'session-1',
+      subjectCode: '9709',
+      emittedBy: 'jest',
+    });
+
+    appendLearningEvent(store, attemptSubmitted);
+
+    expect(() => appendLearningEvent(store, markingCompleted)).toThrow(
+      'out_of_order_event',
+    );
+  });
+
+  test('replay with the same effect_key stays idempotent in the effect ledger', async () => {
+    const {
+      buildReplayLearningEvent,
+      buildSyntheticAttemptEventFlow,
+      createEmptyLearningEventStore,
+      markLearningEventEffectStatus,
+      tryStartLearningEventEffect,
+    } = await import('../lib/events/event-service.js');
+
+    const store = createEmptyLearningEventStore();
+    const flow = buildSyntheticAttemptEventFlow({
+      attemptId: 'attempt-replay',
+      learnerId: 'learner-1',
+      sessionId: 'session-1',
+      subjectCode: '9709',
+      emittedBy: 'jest',
+    });
+    const originalEvent = flow.at(-1);
+    const replayEvent = buildReplayLearningEvent(originalEvent, {
+      truthRevision: 2,
+      sequenceNo: 8,
+      emittedBy: 'jest-replay',
+    });
+
+    const first = tryStartLearningEventEffect(store, {
+      eventId: originalEvent.event_id,
+      handlerName: 'project:artifact-suggestions',
+      effectKey: 'artifact-slot:review_queue:stable-output',
+      aggregateId: originalEvent.aggregate_id,
+      truthRevision: originalEvent.truth_revision,
+    });
+    const completed = markLearningEventEffectStatus(store, {
+      handlerName: 'project:artifact-suggestions',
+      effectKey: 'artifact-slot:review_queue:stable-output',
+      status: 'succeeded',
+      resultRefType: 'artifact_suggestion_version',
+      resultRefId: 'artifact-suggestion-1',
+    });
+    const replay = tryStartLearningEventEffect(store, {
+      eventId: replayEvent.event_id,
+      handlerName: 'project:artifact-suggestions',
+      effectKey: 'artifact-slot:review_queue:stable-output',
+      aggregateId: replayEvent.aggregate_id,
+      truthRevision: replayEvent.truth_revision,
+    });
+
+    expect(first).toMatchObject({ inserted: true, reason_code: null });
+    expect(completed).toMatchObject({
+      status: 'succeeded',
+      result_ref_type: 'artifact_suggestion_version',
+      result_ref_id: 'artifact-suggestion-1',
+    });
+    expect(replay).toMatchObject({
+      inserted: false,
+      reason_code: 'duplicate_effect_key',
+      effect: {
+        status: 'succeeded',
+        result_ref_id: 'artifact-suggestion-1',
+      },
+    });
+    expect(store.effects).toHaveLength(1);
+  });
+
+  test('attempt stream lock rejects re-entry and can be acquired again after release', async () => {
+    const {
+      acquireAttemptStreamLock,
+      createEmptyLearningEventStore,
+      releaseAttemptStreamLock,
+    } = await import('../lib/events/event-service.js');
+
+    const store = createEmptyLearningEventStore();
+
+    expect(acquireAttemptStreamLock(store, 'attempt-lock')).toMatchObject({
+      acquired: true,
+      reason_code: null,
+      attempt_id: 'attempt-lock',
+    });
+    expect(acquireAttemptStreamLock(store, 'attempt-lock')).toMatchObject({
+      acquired: false,
+      reason_code: 'attempt_stream_locked',
+      attempt_id: 'attempt-lock',
+    });
+    expect(releaseAttemptStreamLock(store, 'attempt-lock')).toBe(true);
+    expect(acquireAttemptStreamLock(store, 'attempt-lock')).toMatchObject({
+      acquired: true,
+      reason_code: null,
+      attempt_id: 'attempt-lock',
+    });
+  });
+});

--- a/api/learning/__tests__/event-service.test.js
+++ b/api/learning/__tests__/event-service.test.js
@@ -74,6 +74,7 @@ describe('learning event service', () => {
 
   test('replay with the same effect_key stays idempotent in the effect ledger', async () => {
     const {
+      appendLearningEvent,
       buildReplayLearningEvent,
       buildSyntheticAttemptEventFlow,
       createEmptyLearningEventStore,
@@ -89,6 +90,7 @@ describe('learning event service', () => {
       subjectCode: '9709',
       emittedBy: 'jest',
     });
+    flow.forEach((event) => appendLearningEvent(store, event));
     const originalEvent = flow.at(-1);
     const replayEvent = buildReplayLearningEvent(originalEvent, {
       truthRevision: 2,
@@ -203,5 +205,22 @@ describe('learning event service', () => {
       reason_code: null,
       attempt_id: 'attempt-lock',
     });
+  });
+
+  test('effect start rejects unknown event ids that are not present in the stream', async () => {
+    const {
+      createEmptyLearningEventStore,
+      tryStartLearningEventEffect,
+    } = await import('../lib/events/event-service.js');
+
+    const store = createEmptyLearningEventStore();
+
+    expect(() => tryStartLearningEventEffect(store, {
+      eventId: 'missing-event-id',
+      handlerName: 'project:artifact-suggestions',
+      effectKey: 'artifact-slot:review_queue:stable-output',
+      aggregateId: 'attempt-missing-event',
+      truthRevision: 1,
+    })).toThrow('unknown_effect_event_id');
   });
 });

--- a/api/learning/lib/events/event-contract.js
+++ b/api/learning/lib/events/event-contract.js
@@ -1,0 +1,55 @@
+export const LEARNING_EVENT_TYPES = Object.freeze([
+  'AttemptSubmitted',
+  'QuestionClassified',
+  'MarkingCompleted',
+  'LearningUpdateProposed',
+  'MasteryUpdated',
+  'ReviewTasksCreated',
+  'ArtifactSuggestionsCreated',
+]);
+
+export const LEARNING_EVENT_STAGE_ORDINAL = Object.freeze(
+  LEARNING_EVENT_TYPES.reduce((accumulator, eventType, index) => ({
+    ...accumulator,
+    [eventType]: index + 1,
+  }), {}),
+);
+
+export const ATTEMPT_PIPELINE_STATUSES = Object.freeze([
+  'running',
+  'completed',
+  'failed',
+  'blocked',
+  'reconciling',
+]);
+
+export const LEARNING_EVENT_EFFECT_STATUSES = Object.freeze([
+  'started',
+  'succeeded',
+  'failed',
+  'noop',
+  'superseded',
+]);
+
+export const ACTIVE_EVENT_POINTER_FIELD_BY_TYPE = Object.freeze({
+  QuestionClassified: 'active_classification_event_id',
+  MarkingCompleted: 'active_marking_event_id',
+  LearningUpdateProposed: 'active_learning_update_event_id',
+  MasteryUpdated: 'active_mastery_event_id',
+  ReviewTasksCreated: 'active_review_tasks_event_id',
+  ArtifactSuggestionsCreated: 'active_artifact_suggestions_event_id',
+});
+
+export const TERMINAL_LEARNING_EVENT_TYPE = 'ArtifactSuggestionsCreated';
+
+export function isLearningEventType(value) {
+  return LEARNING_EVENT_TYPES.includes(value);
+}
+
+export function getLearningEventStageOrdinal(eventType) {
+  if (!isLearningEventType(eventType)) {
+    throw new Error(`unknown_learning_event_type:${String(eventType)}`);
+  }
+
+  return LEARNING_EVENT_STAGE_ORDINAL[eventType];
+}

--- a/api/learning/lib/events/event-service.js
+++ b/api/learning/lib/events/event-service.js
@@ -1,0 +1,554 @@
+import { randomUUID } from 'node:crypto';
+import {
+  ACTIVE_EVENT_POINTER_FIELD_BY_TYPE,
+  ATTEMPT_PIPELINE_STATUSES,
+  LEARNING_EVENT_EFFECT_STATUSES,
+  getLearningEventStageOrdinal,
+  LEARNING_EVENT_TYPES,
+  TERMINAL_LEARNING_EVENT_TYPE,
+} from './event-contract.js';
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function dedupeRef(eventType, dedupeKey) {
+  return `${eventType}::${dedupeKey}`;
+}
+
+function streamRef(aggregateId, sequenceNo) {
+  return `${aggregateId}::${sequenceNo}`;
+}
+
+function revisionStageRef(aggregateId, truthRevision, eventType) {
+  return `${aggregateId}::${truthRevision}::${eventType}`;
+}
+
+function effectRef(handlerName, effectKey) {
+  return `${handlerName}::${effectKey}`;
+}
+
+function getNowIso() {
+  return new Date().toISOString();
+}
+
+function createDefaultPayload(eventType, attemptId) {
+  const proposalKey = `proposal:${attemptId}`;
+
+  switch (eventType) {
+    case 'AttemptSubmitted':
+      return {
+        attempt_id: attemptId,
+        attempt_mode: 'guided_solve',
+        submitted_at: '2026-04-12T00:00:00.000Z',
+        submission: {
+          question_ref: { source_kind: 'typed', prompt_hash: `prompt:${attemptId}` },
+          answer_parts: [{ part_ref: 'part-a', raw_text: 'synthetic answer' }],
+        },
+      };
+    case 'QuestionClassified':
+      return {
+        attempt_id: attemptId,
+        classification_version: 'phase0.v1',
+        classification_confidence: 0.93,
+        subject_adapter: { key: 'subject-adapter.synthetic', version: 'phase0.v1' },
+        classification: {
+          family_key: '9709.synthetic.family',
+          type_key: '9709.synthetic.type',
+          variant_tags: ['synthetic'],
+          question_analysis_ref: 'analysis.synthetic.snapshot',
+        },
+        uncertain_flags: [],
+      };
+    case 'MarkingCompleted':
+      return {
+        attempt_id: attemptId,
+        marking_mode: 'authoritative',
+        released_scope: false,
+        rubric_ref: { rubric_id: 'rubric.synthetic', rubric_version: 'phase0.v1' },
+        diagnostics: {
+          misconception_tags: [],
+          missing_steps: [],
+          strengths: ['synthetic-check'],
+        },
+        uncertain_flags: [],
+      };
+    case 'LearningUpdateProposed':
+      return {
+        attempt_id: attemptId,
+        proposal_key: proposalKey,
+        guardrail_decisions: {
+          allow_family_mastery: true,
+          allow_type_mastery: false,
+          allow_positive_mastery: false,
+          reasons: ['synthetic-phase0'],
+        },
+        proposed_mastery_effects: [],
+        proposed_review_tasks: [],
+        proposed_artifact_suggestions: [],
+      };
+    case 'MasteryUpdated':
+      return {
+        attempt_id: attemptId,
+        proposal_key: proposalKey,
+        applied_effects: [],
+      };
+    case 'ReviewTasksCreated':
+      return {
+        attempt_id: attemptId,
+        proposal_key: proposalKey,
+        tasks: [],
+      };
+    case 'ArtifactSuggestionsCreated':
+      return {
+        attempt_id: attemptId,
+        proposal_key: proposalKey,
+        suggestions: [],
+      };
+    default:
+      throw new Error(`unsupported_synthetic_event_type:${eventType}`);
+  }
+}
+
+function createDefaultProvenance(subjectCode, correlationId) {
+  return {
+    subject_code: subjectCode,
+    subject_adapter: {
+      key: `subject-adapter:${subjectCode}`,
+      version: 'phase0.v1',
+    },
+    evidence_refs: [],
+    lineage: {
+      correlation_id: correlationId,
+    },
+    trust: {
+      level: 'provisional',
+      reasons: ['synthetic-phase0-gate'],
+    },
+    source: {
+      kind: 'system',
+      system: 'phase0-event-gate',
+    },
+  };
+}
+
+function assertPayloadAndProvenance(event) {
+  if (!isPlainObject(event.payload)) {
+    throw new Error('invalid_payload_shape');
+  }
+
+  if (!isPlainObject(event.provenance)) {
+    throw new Error('invalid_provenance_shape');
+  }
+
+  if (normalizeString(event.payload.attempt_id) !== normalizeString(event.aggregate_id)) {
+    throw new Error('payload_attempt_id_mismatch');
+  }
+
+  if (normalizeString(event.provenance.subject_code) !== normalizeString(event.subject_code)) {
+    throw new Error('provenance_subject_code_mismatch');
+  }
+
+  if (!isPlainObject(event.provenance.subject_adapter)) {
+    throw new Error('invalid_subject_adapter_ref');
+  }
+
+  if (!Array.isArray(event.provenance.evidence_refs)) {
+    throw new Error('invalid_evidence_refs');
+  }
+
+  if (!isPlainObject(event.provenance.lineage)) {
+    throw new Error('invalid_lineage_ref');
+  }
+
+  if (!isPlainObject(event.provenance.trust)) {
+    throw new Error('invalid_trust_envelope');
+  }
+}
+
+function assertOrderedAppend(store, event) {
+  const state = store.pipelineStateByAttempt.get(event.aggregate_id) ?? null;
+  const eventStageOrdinal = getLearningEventStageOrdinal(event.event_type);
+
+  if (!state) {
+    if (event.event_type !== 'AttemptSubmitted' || event.sequence_no !== 1 || event.truth_revision !== 1) {
+      throw new Error('out_of_order_event');
+    }
+    return;
+  }
+
+  if (event.truth_revision !== state.current_truth_revision) {
+    throw new Error('out_of_order_event');
+  }
+
+  const expectedStageOrdinal = getLearningEventStageOrdinal(state.current_stage) + 1;
+  const expectedSequenceNo = state.last_sequence_no + 1;
+  if (eventStageOrdinal !== expectedStageOrdinal || event.sequence_no !== expectedSequenceNo) {
+    throw new Error('out_of_order_event');
+  }
+}
+
+function buildNextPipelineState(previousState, event) {
+  const nextState = previousState
+    ? { ...previousState }
+    : {
+      attempt_id: event.aggregate_id,
+      learner_id: event.learner_id,
+      session_id: event.session_id ?? null,
+      subject_code: event.subject_code,
+      current_truth_revision: 1,
+      last_sequence_no: 0,
+      current_stage: 'AttemptSubmitted',
+      current_status: 'running',
+      last_event_id: null,
+      active_classification_event_id: null,
+      active_marking_event_id: null,
+      active_learning_update_event_id: null,
+      active_mastery_event_id: null,
+      active_review_tasks_event_id: null,
+      active_artifact_suggestions_event_id: null,
+      last_error_code: null,
+      last_error_message: null,
+      updated_at: null,
+    };
+
+  nextState.learner_id = event.learner_id;
+  nextState.session_id = event.session_id ?? null;
+  nextState.subject_code = event.subject_code;
+  nextState.current_truth_revision = event.truth_revision;
+  nextState.last_sequence_no = event.sequence_no;
+  nextState.current_stage = event.event_type;
+  nextState.current_status = event.event_type === TERMINAL_LEARNING_EVENT_TYPE ? 'completed' : 'running';
+  nextState.last_event_id = event.event_id;
+  nextState.updated_at = event.emitted_at;
+
+  const pointerField = ACTIVE_EVENT_POINTER_FIELD_BY_TYPE[event.event_type];
+  if (pointerField) {
+    nextState[pointerField] = event.event_id;
+  }
+
+  return nextState;
+}
+
+function assertEffectInput(input) {
+  const handlerName = normalizeString(input.handlerName ?? input.handler_name);
+  const effectKey = normalizeString(input.effectKey ?? input.effect_key);
+  const aggregateId = normalizeString(input.aggregateId ?? input.aggregate_id);
+  const eventId = normalizeString(input.eventId ?? input.event_id);
+  const truthRevision = Number(input.truthRevision ?? input.truth_revision);
+
+  if (!handlerName) {
+    throw new Error('missing_handler_name');
+  }
+  if (!effectKey) {
+    throw new Error('missing_effect_key');
+  }
+  if (!aggregateId) {
+    throw new Error('missing_effect_aggregate_id');
+  }
+  if (!eventId) {
+    throw new Error('missing_effect_event_id');
+  }
+  if (!Number.isInteger(truthRevision) || truthRevision < 1) {
+    throw new Error('invalid_effect_truth_revision');
+  }
+
+  return {
+    event_id: eventId,
+    handler_name: handlerName,
+    effect_key: effectKey,
+    aggregate_id: aggregateId,
+    truth_revision: truthRevision,
+    reconciliation_id: normalizeString(input.reconciliationId ?? input.reconciliation_id) || null,
+  };
+}
+
+function cloneEffect(effect) {
+  return cloneJson(effect);
+}
+
+export function createEmptyLearningEventStore() {
+  return {
+    events: [],
+    effects: [],
+    dedupeRefs: new Set(),
+    streamRefs: new Set(),
+    revisionStageRefs: new Set(),
+    effectRefs: new Map(),
+    attemptLockRefs: new Set(),
+    pipelineStateByAttempt: new Map(),
+  };
+}
+
+export function buildSyntheticAttemptEventFlow({
+  attemptId,
+  learnerId,
+  sessionId = null,
+  subjectCode,
+  emittedBy = 'phase0-event-gate',
+  correlationId = randomUUID(),
+  truthRevision = 1,
+} = {}) {
+  const normalizedAttemptId = normalizeString(attemptId) || randomUUID();
+  const normalizedLearnerId = normalizeString(learnerId) || randomUUID();
+  const normalizedSubjectCode = normalizeString(subjectCode) || '9709';
+  const normalizedSessionId = normalizeString(sessionId) || null;
+  const emittedAt = '2026-04-12T00:00:00.000Z';
+
+  return LEARNING_EVENT_TYPES.map((eventType, index) => ({
+    event_id: randomUUID(),
+    event_type: eventType,
+    aggregate_type: 'attempt',
+    aggregate_id: normalizedAttemptId,
+    learner_id: normalizedLearnerId,
+    session_id: normalizedSessionId,
+    subject_code: normalizedSubjectCode,
+    truth_revision: truthRevision,
+    sequence_no: index + 1,
+    correlation_id: correlationId,
+    causation_event_id: index === 0 ? null : undefined,
+    replay_of_event_id: null,
+    supersedes_event_id: null,
+    reconciliation_id: null,
+    dedupe_key: `${normalizedAttemptId}:${truthRevision}:${eventType}`,
+    basis_hash: `basis:${normalizedAttemptId}:${eventType}`,
+    emitted_by: emittedBy,
+    payload: createDefaultPayload(eventType, normalizedAttemptId),
+    provenance: createDefaultProvenance(normalizedSubjectCode, correlationId),
+    emitted_at: emittedAt,
+  }));
+}
+
+export function buildReplayLearningEvent(sourceEvent, {
+  eventId = randomUUID(),
+  truthRevision = Number(sourceEvent?.truth_revision ?? 0) + 1,
+  sequenceNo = Number(sourceEvent?.sequence_no ?? 0) + 1,
+  emittedBy = 'phase0-event-replay',
+  replayOfEventId = sourceEvent?.event_id ?? null,
+  supersedesEventId = sourceEvent?.event_id ?? null,
+  causationEventId = sourceEvent?.event_id ?? null,
+  reconciliationId = null,
+  dedupeKey,
+  basisHash,
+  payload,
+  provenance,
+  emittedAt = getNowIso(),
+} = {}) {
+  if (!sourceEvent || !sourceEvent.event_type) {
+    throw new Error('missing_replay_source_event');
+  }
+
+  const replayPayload = cloneJson(payload ?? sourceEvent.payload);
+  const replayProvenance = cloneJson(provenance ?? sourceEvent.provenance) ?? {};
+  const lineage = isPlainObject(replayProvenance.lineage) ? replayProvenance.lineage : {};
+  replayProvenance.lineage = {
+    ...lineage,
+    replay_of_event_id: replayOfEventId,
+    supersedes_event_id: supersedesEventId,
+    causation_event_id: causationEventId,
+  };
+
+  return {
+    event_id: eventId,
+    event_type: sourceEvent.event_type,
+    aggregate_type: sourceEvent.aggregate_type ?? 'attempt',
+    aggregate_id: sourceEvent.aggregate_id,
+    learner_id: sourceEvent.learner_id,
+    session_id: sourceEvent.session_id ?? null,
+    subject_code: sourceEvent.subject_code,
+    truth_revision: truthRevision,
+    sequence_no: sequenceNo,
+    correlation_id: sourceEvent.correlation_id,
+    causation_event_id: causationEventId,
+    replay_of_event_id: replayOfEventId,
+    supersedes_event_id: supersedesEventId,
+    reconciliation_id: reconciliationId,
+    dedupe_key: dedupeKey ?? `${sourceEvent.aggregate_id}:${truthRevision}:${sourceEvent.event_type}:replay:${sourceEvent.event_id}`,
+    basis_hash: basisHash ?? sourceEvent.basis_hash,
+    emitted_by: emittedBy,
+    payload: replayPayload,
+    provenance: replayProvenance,
+    emitted_at: emittedAt,
+  };
+}
+
+export function appendLearningEvent(store, candidateEvent) {
+  const event = cloneJson(candidateEvent);
+
+  if (!event || !event.event_type) {
+    throw new Error('missing_learning_event');
+  }
+
+  getLearningEventStageOrdinal(event.event_type);
+  assertPayloadAndProvenance(event);
+
+  const dedupeKey = dedupeRef(event.event_type, event.dedupe_key);
+  if (store.dedupeRefs.has(dedupeKey)) {
+    return {
+      inserted: false,
+      reason_code: 'duplicate_dedupe_key',
+      event: null,
+      pipeline_state: cloneJson(store.pipelineStateByAttempt.get(event.aggregate_id) ?? null),
+    };
+  }
+
+  assertOrderedAppend(store, event);
+
+  const streamKey = streamRef(event.aggregate_id, event.sequence_no);
+  if (store.streamRefs.has(streamKey)) {
+    throw new Error('duplicate_stream_sequence');
+  }
+
+  const revisionStageKey = revisionStageRef(event.aggregate_id, event.truth_revision, event.event_type);
+  if (store.revisionStageRefs.has(revisionStageKey)) {
+    throw new Error('duplicate_revision_stage');
+  }
+
+  store.events.push(event);
+  store.dedupeRefs.add(dedupeKey);
+  store.streamRefs.add(streamKey);
+  store.revisionStageRefs.add(revisionStageKey);
+
+  const previousState = store.pipelineStateByAttempt.get(event.aggregate_id) ?? null;
+  const nextState = buildNextPipelineState(previousState, event);
+  store.pipelineStateByAttempt.set(event.aggregate_id, nextState);
+
+  return {
+    inserted: true,
+    reason_code: null,
+    event: cloneJson(event),
+    pipeline_state: cloneJson(nextState),
+  };
+}
+
+export function tryStartLearningEventEffect(store, input) {
+  const normalizedInput = assertEffectInput(input);
+  const nowIso = getNowIso();
+  const ref = effectRef(normalizedInput.handler_name, normalizedInput.effect_key);
+  const existing = store.effectRefs.get(ref) ?? null;
+
+  if (existing) {
+    return {
+      inserted: false,
+      reason_code: 'duplicate_effect_key',
+      effect: cloneEffect(existing),
+    };
+  }
+
+  const effect = {
+    effect_id: randomUUID(),
+    ...normalizedInput,
+    status: 'started',
+    result_ref_type: null,
+    result_ref_id: null,
+    error_code: null,
+    error_message: null,
+    attempt_count: 1,
+    first_started_at: nowIso,
+    last_updated_at: nowIso,
+  };
+
+  store.effects.push(effect);
+  store.effectRefs.set(ref, effect);
+
+  return {
+    inserted: true,
+    reason_code: null,
+    effect: cloneEffect(effect),
+  };
+}
+
+export function markLearningEventEffectStatus(store, {
+  handlerName,
+  effectKey,
+  status,
+  resultRefType = null,
+  resultRefId = null,
+  errorCode = null,
+  errorMessage = null,
+} = {}) {
+  const normalizedHandlerName = normalizeString(handlerName);
+  const normalizedEffectKey = normalizeString(effectKey);
+  const normalizedStatus = normalizeString(status);
+
+  if (!normalizedHandlerName) {
+    throw new Error('missing_handler_name');
+  }
+  if (!normalizedEffectKey) {
+    throw new Error('missing_effect_key');
+  }
+  if (!LEARNING_EVENT_EFFECT_STATUSES.includes(normalizedStatus)) {
+    throw new Error('invalid_effect_status');
+  }
+
+  const ref = effectRef(normalizedHandlerName, normalizedEffectKey);
+  const effect = store.effectRefs.get(ref) ?? null;
+  if (!effect) {
+    throw new Error('effect_not_found');
+  }
+
+  effect.status = normalizedStatus;
+  effect.result_ref_type = resultRefType;
+  effect.result_ref_id = resultRefId;
+  effect.error_code = errorCode;
+  effect.error_message = errorMessage;
+  effect.last_updated_at = getNowIso();
+
+  return cloneEffect(effect);
+}
+
+export function acquireAttemptStreamLock(store, attemptId) {
+  const normalizedAttemptId = normalizeString(attemptId);
+  if (!normalizedAttemptId) {
+    throw new Error('missing_attempt_id');
+  }
+
+  if (store.attemptLockRefs.has(normalizedAttemptId)) {
+    return {
+      acquired: false,
+      reason_code: 'attempt_stream_locked',
+      attempt_id: normalizedAttemptId,
+    };
+  }
+
+  store.attemptLockRefs.add(normalizedAttemptId);
+  return {
+    acquired: true,
+    reason_code: null,
+    attempt_id: normalizedAttemptId,
+  };
+}
+
+export function releaseAttemptStreamLock(store, attemptId) {
+  const normalizedAttemptId = normalizeString(attemptId);
+  if (!normalizedAttemptId) {
+    throw new Error('missing_attempt_id');
+  }
+
+  return store.attemptLockRefs.delete(normalizedAttemptId);
+}
+
+export async function runWithAttemptStreamLock(store, attemptId, operation) {
+  const acquisition = acquireAttemptStreamLock(store, attemptId);
+  if (!acquisition.acquired) {
+    throw new Error(acquisition.reason_code);
+  }
+
+  try {
+    return await operation();
+  } finally {
+    releaseAttemptStreamLock(store, attemptId);
+  }
+}
+
+export function isAttemptPipelineStatus(value) {
+  return ATTEMPT_PIPELINE_STATUSES.includes(value);
+}

--- a/api/learning/lib/events/event-service.js
+++ b/api/learning/lib/events/event-service.js
@@ -286,6 +286,7 @@ function cloneEffect(effect) {
 export function createEmptyLearningEventStore() {
   return {
     events: [],
+    eventsById: new Map(),
     effects: [],
     dedupeRefs: new Set(),
     streamRefs: new Set(),
@@ -427,6 +428,7 @@ export function appendLearningEvent(store, candidateEvent) {
   }
 
   store.events.push(event);
+  store.eventsById.set(event.event_id, event);
   store.dedupeRefs.add(dedupeKey);
   store.streamRefs.add(streamKey);
   store.revisionStageRefs.add(revisionStageKey);
@@ -455,6 +457,10 @@ export function tryStartLearningEventEffect(store, input) {
       reason_code: 'duplicate_effect_key',
       effect: cloneEffect(existing),
     };
+  }
+
+  if (!store.eventsById.has(normalizedInput.event_id)) {
+    throw new Error('unknown_effect_event_id');
   }
 
   const effect = {

--- a/api/learning/lib/events/event-service.js
+++ b/api/learning/lib/events/event-service.js
@@ -24,8 +24,8 @@ function dedupeRef(eventType, dedupeKey) {
   return `${eventType}::${dedupeKey}`;
 }
 
-function streamRef(aggregateId, sequenceNo) {
-  return `${aggregateId}::${sequenceNo}`;
+function streamRef(aggregateId, truthRevision, sequenceNo) {
+  return `${aggregateId}::${truthRevision}::${sequenceNo}`;
 }
 
 function revisionStageRef(aggregateId, truthRevision, eventType) {
@@ -186,7 +186,15 @@ function assertOrderedAppend(store, event) {
   }
 
   if (event.truth_revision !== state.current_truth_revision) {
-    throw new Error('out_of_order_event');
+    const isNextTruthRevisionStart = event.truth_revision === state.current_truth_revision + 1
+      && event.event_type === 'AttemptSubmitted'
+      && event.sequence_no === 1;
+
+    if (!isNextTruthRevisionStart) {
+      throw new Error('out_of_order_event');
+    }
+
+    return;
   }
 
   const expectedStageOrdinal = getLearningEventStageOrdinal(state.current_stage) + 1;
@@ -197,9 +205,8 @@ function assertOrderedAppend(store, event) {
 }
 
 function buildNextPipelineState(previousState, event) {
-  const nextState = previousState
-    ? { ...previousState }
-    : {
+  const nextState = !previousState || previousState.current_truth_revision !== event.truth_revision
+    ? {
       attempt_id: event.aggregate_id,
       learner_id: event.learner_id,
       session_id: event.session_id ?? null,
@@ -218,7 +225,8 @@ function buildNextPipelineState(previousState, event) {
       last_error_code: null,
       last_error_message: null,
       updated_at: null,
-    };
+    }
+    : { ...previousState };
 
   nextState.learner_id = event.learner_id;
   nextState.session_id = event.session_id ?? null;
@@ -330,7 +338,7 @@ export function buildSyntheticAttemptEventFlow({
 export function buildReplayLearningEvent(sourceEvent, {
   eventId = randomUUID(),
   truthRevision = Number(sourceEvent?.truth_revision ?? 0) + 1,
-  sequenceNo = Number(sourceEvent?.sequence_no ?? 0) + 1,
+  sequenceNo,
   emittedBy = 'phase0-event-replay',
   replayOfEventId = sourceEvent?.event_id ?? null,
   supersedesEventId = sourceEvent?.event_id ?? null,
@@ -345,6 +353,12 @@ export function buildReplayLearningEvent(sourceEvent, {
   if (!sourceEvent || !sourceEvent.event_type) {
     throw new Error('missing_replay_source_event');
   }
+
+  const normalizedSequenceNo = Number.isInteger(sequenceNo)
+    ? sequenceNo
+    : (truthRevision === Number(sourceEvent.truth_revision)
+        ? Number(sourceEvent.sequence_no ?? 0) + 1
+        : Number(sourceEvent.sequence_no ?? 0));
 
   const replayPayload = cloneJson(payload ?? sourceEvent.payload);
   const replayProvenance = cloneJson(provenance ?? sourceEvent.provenance) ?? {};
@@ -365,7 +379,7 @@ export function buildReplayLearningEvent(sourceEvent, {
     session_id: sourceEvent.session_id ?? null,
     subject_code: sourceEvent.subject_code,
     truth_revision: truthRevision,
-    sequence_no: sequenceNo,
+    sequence_no: normalizedSequenceNo,
     correlation_id: sourceEvent.correlation_id,
     causation_event_id: causationEventId,
     replay_of_event_id: replayOfEventId,
@@ -402,7 +416,7 @@ export function appendLearningEvent(store, candidateEvent) {
 
   assertOrderedAppend(store, event);
 
-  const streamKey = streamRef(event.aggregate_id, event.sequence_no);
+  const streamKey = streamRef(event.aggregate_id, event.truth_revision, event.sequence_no);
   if (store.streamRefs.has(streamKey)) {
     throw new Error('duplicate_stream_sequence');
   }

--- a/data/learning_runtime/release_evidence/event-pipeline-gate-receipt.v1.json
+++ b/data/learning_runtime/release_evidence/event-pipeline-gate-receipt.v1.json
@@ -3,7 +3,7 @@
   "status": "pass",
   "phase0_ready": true,
   "migration_path": "supabase/migrations/20260412090000_phase0_learning_events_core.sql",
-  "generated_at": "2026-04-14T07:35:23.117Z",
+  "generated_at": "2026-04-14T07:41:46.913Z",
   "gates": {
     "migration_contract": {
       "status": "pass",

--- a/data/learning_runtime/release_evidence/event-pipeline-gate-receipt.v1.json
+++ b/data/learning_runtime/release_evidence/event-pipeline-gate-receipt.v1.json
@@ -3,7 +3,7 @@
   "status": "pass",
   "phase0_ready": true,
   "migration_path": "supabase/migrations/20260412090000_phase0_learning_events_core.sql",
-  "generated_at": "2026-04-14T07:25:59.769Z",
+  "generated_at": "2026-04-14T07:35:23.117Z",
   "gates": {
     "migration_contract": {
       "status": "pass",

--- a/data/learning_runtime/release_evidence/event-pipeline-gate-receipt.v1.json
+++ b/data/learning_runtime/release_evidence/event-pipeline-gate-receipt.v1.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "learning_runtime_event_pipeline_gate_receipt_v1",
+  "status": "pass",
+  "phase0_ready": true,
+  "migration_path": "supabase/migrations/20260412090000_phase0_learning_events_core.sql",
+  "generated_at": "2026-04-14T05:49:53.626Z",
+  "gates": {
+    "migration_contract": {
+      "status": "pass",
+      "checked_path": "supabase/migrations/20260412090000_phase0_learning_events_core.sql",
+      "blocked_reasons": [],
+      "required_tokens": [
+        "create table if not exists public.learning_events",
+        "create table if not exists public.learning_event_effects",
+        "create table if not exists public.attempt_pipeline_state",
+        "unique (aggregate_id, sequence_no)",
+        "unique (aggregate_id, truth_revision, event_type)",
+        "unique (event_type, dedupe_key)",
+        "unique (handler_name, effect_key)",
+        "attemptsubmitted",
+        "artifactsuggestionscreated"
+      ],
+      "missing_tokens": []
+    },
+    "ordered_pipeline": {
+      "status": "pass",
+      "blocked_reasons": [],
+      "inserted_count": 7,
+      "final_stage": "ArtifactSuggestionsCreated",
+      "final_status": "completed",
+      "last_sequence_no": 7
+    },
+    "dedupe_guard": {
+      "status": "pass",
+      "blocked_reasons": [],
+      "first_inserted": true,
+      "duplicate_inserted": false,
+      "duplicate_reason_code": "duplicate_dedupe_key"
+    },
+    "effect_idempotency": {
+      "status": "pass",
+      "blocked_reasons": [],
+      "first_inserted": true,
+      "completed_status": "succeeded",
+      "replay_inserted": false,
+      "replay_reason_code": "duplicate_effect_key",
+      "effect_count": 1
+    },
+    "attempt_stream_lock": {
+      "status": "pass",
+      "blocked_reasons": [],
+      "first_acquired": true,
+      "second_acquired": false,
+      "second_reason_code": "attempt_stream_locked",
+      "released": true,
+      "third_acquired": true
+    },
+    "out_of_order_guard": {
+      "status": "pass",
+      "blocked_reasons": [],
+      "error_code": "out_of_order_event"
+    }
+  },
+  "failing_gate_names": []
+}

--- a/data/learning_runtime/release_evidence/event-pipeline-gate-receipt.v1.json
+++ b/data/learning_runtime/release_evidence/event-pipeline-gate-receipt.v1.json
@@ -3,7 +3,7 @@
   "status": "pass",
   "phase0_ready": true,
   "migration_path": "supabase/migrations/20260412090000_phase0_learning_events_core.sql",
-  "generated_at": "2026-04-14T05:49:53.626Z",
+  "generated_at": "2026-04-14T07:25:59.769Z",
   "gates": {
     "migration_contract": {
       "status": "pass",
@@ -13,7 +13,7 @@
         "create table if not exists public.learning_events",
         "create table if not exists public.learning_event_effects",
         "create table if not exists public.attempt_pipeline_state",
-        "unique (aggregate_id, sequence_no)",
+        "unique (aggregate_id, truth_revision, sequence_no)",
         "unique (aggregate_id, truth_revision, event_type)",
         "unique (event_type, dedupe_key)",
         "unique (handler_name, effect_key)",
@@ -29,6 +29,16 @@
       "final_stage": "ArtifactSuggestionsCreated",
       "final_status": "completed",
       "last_sequence_no": 7
+    },
+    "replay_revision": {
+      "status": "pass",
+      "blocked_reasons": [],
+      "inserted_count": 7,
+      "current_truth_revision": 2,
+      "final_stage": "ArtifactSuggestionsCreated",
+      "final_status": "completed",
+      "last_sequence_no": 7,
+      "event_count": 14
     },
     "dedupe_guard": {
       "status": "pass",

--- a/docs/reports/learning_runtime_event_pipeline_gate_2026-04-12.md
+++ b/docs/reports/learning_runtime_event_pipeline_gate_2026-04-12.md
@@ -2,7 +2,7 @@
 
 - status: `pass`
 - phase0_ready: `true`
-- generated_at: `2026-04-14T07:25:59.769Z`
+- generated_at: `2026-04-14T07:35:23.117Z`
 - migration_path: `supabase/migrations/20260412090000_phase0_learning_events_core.sql`
 
 ## Gates

--- a/docs/reports/learning_runtime_event_pipeline_gate_2026-04-12.md
+++ b/docs/reports/learning_runtime_event_pipeline_gate_2026-04-12.md
@@ -2,7 +2,7 @@
 
 - status: `pass`
 - phase0_ready: `true`
-- generated_at: `2026-04-14T05:49:53.626Z`
+- generated_at: `2026-04-14T07:25:59.769Z`
 - migration_path: `supabase/migrations/20260412090000_phase0_learning_events_core.sql`
 
 ## Gates
@@ -10,7 +10,7 @@
 ### migration_contract
 - status: `pass`
 - checked_path: `"supabase/migrations/20260412090000_phase0_learning_events_core.sql"`
-- required_tokens: `["create table if not exists public.learning_events","create table if not exists public.learning_event_effects","create table if not exists public.attempt_pipeline_state","unique (aggregate_id, sequence_no)","unique (aggregate_id, truth_revision, event_type)","unique (event_type, dedupe_key)","unique (handler_name, effect_key)","attemptsubmitted","artifactsuggestionscreated"]`
+- required_tokens: `["create table if not exists public.learning_events","create table if not exists public.learning_event_effects","create table if not exists public.attempt_pipeline_state","unique (aggregate_id, truth_revision, sequence_no)","unique (aggregate_id, truth_revision, event_type)","unique (event_type, dedupe_key)","unique (handler_name, effect_key)","attemptsubmitted","artifactsuggestionscreated"]`
 - missing_tokens: `[]`
 
 ### ordered_pipeline
@@ -19,6 +19,15 @@
 - final_stage: `"ArtifactSuggestionsCreated"`
 - final_status: `"completed"`
 - last_sequence_no: `7`
+
+### replay_revision
+- status: `pass`
+- inserted_count: `7`
+- current_truth_revision: `2`
+- final_stage: `"ArtifactSuggestionsCreated"`
+- final_status: `"completed"`
+- last_sequence_no: `7`
+- event_count: `14`
 
 ### dedupe_guard
 - status: `pass`

--- a/docs/reports/learning_runtime_event_pipeline_gate_2026-04-12.md
+++ b/docs/reports/learning_runtime_event_pipeline_gate_2026-04-12.md
@@ -1,0 +1,47 @@
+# Learning Event Pipeline Gate
+
+- status: `pass`
+- phase0_ready: `true`
+- generated_at: `2026-04-14T05:49:53.626Z`
+- migration_path: `supabase/migrations/20260412090000_phase0_learning_events_core.sql`
+
+## Gates
+
+### migration_contract
+- status: `pass`
+- checked_path: `"supabase/migrations/20260412090000_phase0_learning_events_core.sql"`
+- required_tokens: `["create table if not exists public.learning_events","create table if not exists public.learning_event_effects","create table if not exists public.attempt_pipeline_state","unique (aggregate_id, sequence_no)","unique (aggregate_id, truth_revision, event_type)","unique (event_type, dedupe_key)","unique (handler_name, effect_key)","attemptsubmitted","artifactsuggestionscreated"]`
+- missing_tokens: `[]`
+
+### ordered_pipeline
+- status: `pass`
+- inserted_count: `7`
+- final_stage: `"ArtifactSuggestionsCreated"`
+- final_status: `"completed"`
+- last_sequence_no: `7`
+
+### dedupe_guard
+- status: `pass`
+- first_inserted: `true`
+- duplicate_inserted: `false`
+- duplicate_reason_code: `"duplicate_dedupe_key"`
+
+### effect_idempotency
+- status: `pass`
+- first_inserted: `true`
+- completed_status: `"succeeded"`
+- replay_inserted: `false`
+- replay_reason_code: `"duplicate_effect_key"`
+- effect_count: `1`
+
+### attempt_stream_lock
+- status: `pass`
+- first_acquired: `true`
+- second_acquired: `false`
+- second_reason_code: `"attempt_stream_locked"`
+- released: `true`
+- third_acquired: `true`
+
+### out_of_order_guard
+- status: `pass`
+- error_code: `"out_of_order_event"`

--- a/docs/reports/learning_runtime_event_pipeline_gate_2026-04-12.md
+++ b/docs/reports/learning_runtime_event_pipeline_gate_2026-04-12.md
@@ -2,7 +2,7 @@
 
 - status: `pass`
 - phase0_ready: `true`
-- generated_at: `2026-04-14T07:35:23.117Z`
+- generated_at: `2026-04-14T07:41:46.913Z`
 - migration_path: `supabase/migrations/20260412090000_phase0_learning_events_core.sql`
 
 ## Gates

--- a/scripts/learning/__tests__/event-pipeline-gate.test.js
+++ b/scripts/learning/__tests__/event-pipeline-gate.test.js
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('event pipeline gate', () => {
+  test('phase 0 gate passes when migration and in-memory pipeline invariants hold', async () => {
+    const { buildEventPipelineGateReceipt } = await import('../lib/event-pipeline-gate.js');
+
+    const result = buildEventPipelineGateReceipt({ rootDir: process.cwd() });
+
+    expect(result).toMatchObject({
+      status: 'pass',
+      phase0_ready: true,
+      gates: {
+        migration_contract: { status: 'pass' },
+        ordered_pipeline: { status: 'pass' },
+        dedupe_guard: { status: 'pass' },
+        effect_idempotency: { status: 'pass' },
+        attempt_stream_lock: { status: 'pass' },
+      },
+    });
+    expect(result.schema_version).toBe('learning_runtime_event_pipeline_gate_receipt_v1');
+  });
+
+  test('cli writes auditable json and markdown outputs', async () => {
+    const { main } = await import('../run_event_pipeline_gate.js');
+    const outJson = 'tmp/event-pipeline-gate-test.json';
+    const outMd = 'tmp/event-pipeline-gate-test.md';
+
+    try {
+      main([
+        '--out-json',
+        outJson,
+        '--out-md',
+        outMd,
+      ]);
+
+      expect(fs.existsSync(path.join(process.cwd(), outJson))).toBe(true);
+      expect(fs.existsSync(path.join(process.cwd(), outMd))).toBe(true);
+
+      const payload = JSON.parse(fs.readFileSync(path.join(process.cwd(), outJson), 'utf8'));
+      const markdown = fs.readFileSync(path.join(process.cwd(), outMd), 'utf8');
+
+      expect(payload).toMatchObject({
+        schema_version: 'learning_runtime_event_pipeline_gate_receipt_v1',
+        status: 'pass',
+        phase0_ready: true,
+      });
+      expect(markdown).toContain('# Learning Event Pipeline Gate');
+      expect(markdown).toContain('learning_events');
+      expect(markdown).toContain('ordered_pipeline');
+      expect(markdown).toContain('effect_idempotency');
+      expect(markdown).toContain('attempt_stream_lock');
+    } finally {
+      fs.rmSync(path.join(process.cwd(), outJson), { force: true });
+      fs.rmSync(path.join(process.cwd(), outMd), { force: true });
+    }
+  });
+});

--- a/scripts/learning/__tests__/event-pipeline-gate.test.js
+++ b/scripts/learning/__tests__/event-pipeline-gate.test.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 describe('event pipeline gate', () => {
   test('phase 0 gate passes when migration and in-memory pipeline invariants hold', async () => {
@@ -58,6 +59,39 @@ describe('event pipeline gate', () => {
     } finally {
       fs.rmSync(path.join(process.cwd(), outJson), { force: true });
       fs.rmSync(path.join(process.cwd(), outMd), { force: true });
+    }
+  });
+
+  test('cli resolves gate paths from the repo root even when launched from a subdirectory', async () => {
+    const repoRoot = process.cwd();
+    const subdir = path.join(repoRoot, 'scripts');
+    const outJson = 'tmp/event-pipeline-gate-subdir.json';
+    const outMd = 'tmp/event-pipeline-gate-subdir.md';
+
+    try {
+      execFileSync('node', [
+        'learning/run_event_pipeline_gate.js',
+        '--out-json',
+        outJson,
+        '--out-md',
+        outMd,
+      ], {
+        cwd: subdir,
+      });
+
+      expect(fs.existsSync(path.join(repoRoot, outJson))).toBe(true);
+      expect(fs.existsSync(path.join(repoRoot, outMd))).toBe(true);
+
+      const payload = JSON.parse(fs.readFileSync(path.join(repoRoot, outJson), 'utf8'));
+      expect(payload).toMatchObject({
+        status: 'pass',
+        phase0_ready: true,
+      });
+    } finally {
+      fs.rmSync(path.join(repoRoot, outJson), { force: true });
+      fs.rmSync(path.join(repoRoot, outMd), { force: true });
+      fs.rmSync(path.join(subdir, outJson), { force: true });
+      fs.rmSync(path.join(subdir, outMd), { force: true });
     }
   });
 });

--- a/scripts/learning/__tests__/event-pipeline-gate.test.js
+++ b/scripts/learning/__tests__/event-pipeline-gate.test.js
@@ -13,12 +13,16 @@ describe('event pipeline gate', () => {
       gates: {
         migration_contract: { status: 'pass' },
         ordered_pipeline: { status: 'pass' },
+        replay_revision: { status: 'pass' },
         dedupe_guard: { status: 'pass' },
         effect_idempotency: { status: 'pass' },
         attempt_stream_lock: { status: 'pass' },
       },
     });
     expect(result.schema_version).toBe('learning_runtime_event_pipeline_gate_receipt_v1');
+    expect(result.gates.migration_contract.required_tokens).toContain(
+      'unique (aggregate_id, truth_revision, sequence_no)',
+    );
   });
 
   test('cli writes auditable json and markdown outputs', async () => {
@@ -48,6 +52,7 @@ describe('event pipeline gate', () => {
       expect(markdown).toContain('# Learning Event Pipeline Gate');
       expect(markdown).toContain('learning_events');
       expect(markdown).toContain('ordered_pipeline');
+      expect(markdown).toContain('replay_revision');
       expect(markdown).toContain('effect_idempotency');
       expect(markdown).toContain('attempt_stream_lock');
     } finally {

--- a/scripts/learning/lib/event-pipeline-gate.js
+++ b/scripts/learning/lib/event-pipeline-gate.js
@@ -206,6 +206,7 @@ function evaluateEffectIdempotency() {
     subjectCode: '9709',
     emittedBy: 'event-pipeline-gate',
   });
+  flow.forEach((event) => appendLearningEvent(store, event));
   const originalEvent = flow.at(-1);
   const replayEvent = buildReplayLearningEvent(originalEvent, {
     truthRevision: 2,

--- a/scripts/learning/lib/event-pipeline-gate.js
+++ b/scripts/learning/lib/event-pipeline-gate.js
@@ -1,0 +1,324 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  acquireAttemptStreamLock,
+  appendLearningEvent,
+  buildReplayLearningEvent,
+  buildSyntheticAttemptEventFlow,
+  createEmptyLearningEventStore,
+  markLearningEventEffectStatus,
+  releaseAttemptStreamLock,
+  tryStartLearningEventEffect,
+} from '../../../api/learning/lib/events/event-service.js';
+
+const PROJECT_ROOT = path.resolve(fileURLToPath(new URL('../../', import.meta.url)), '..');
+
+export const EVENT_PIPELINE_GATE_SCHEMA_VERSION = 'learning_runtime_event_pipeline_gate_receipt_v1';
+export const DEFAULT_EVENT_PIPELINE_MIGRATION_PATH = 'supabase/migrations/20260412090000_phase0_learning_events_core.sql';
+export const DEFAULT_EVENT_PIPELINE_GATE_RECEIPT_PATH = 'data/learning_runtime/release_evidence/event-pipeline-gate-receipt.v1.json';
+export const DEFAULT_EVENT_PIPELINE_GATE_REPORT_PATH = 'docs/reports/learning_runtime_event_pipeline_gate_2026-04-12.md';
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeRootDir(rootDir) {
+  return normalizeString(rootDir) || PROJECT_ROOT;
+}
+
+function resolveFromRoot(rootDir, relPath) {
+  return path.join(normalizeRootDir(rootDir), relPath);
+}
+
+function ensureParentDir(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function readTextArtifact(rootDir, relPath) {
+  return fs.readFileSync(resolveFromRoot(rootDir, relPath), 'utf8');
+}
+
+function toGateStatus(passed) {
+  return passed ? 'pass' : 'fail';
+}
+
+function evaluateMigrationContract(rootDir, migrationPath) {
+  const absolutePath = resolveFromRoot(rootDir, migrationPath);
+  if (!fs.existsSync(absolutePath)) {
+    return {
+      status: 'fail',
+      checked_path: migrationPath,
+      blocked_reasons: ['migration_missing'],
+      required_tokens: [],
+      missing_tokens: ['migration_missing'],
+    };
+  }
+
+  const sql = readTextArtifact(rootDir, migrationPath).toLowerCase();
+  const requiredTokens = [
+    'create table if not exists public.learning_events',
+    'create table if not exists public.learning_event_effects',
+    'create table if not exists public.attempt_pipeline_state',
+    'unique (aggregate_id, sequence_no)',
+    'unique (aggregate_id, truth_revision, event_type)',
+    'unique (event_type, dedupe_key)',
+    'unique (handler_name, effect_key)',
+    'attemptsubmitted',
+    'artifactsuggestionscreated',
+  ];
+  const missingTokens = requiredTokens.filter((token) => !sql.includes(token));
+
+  return {
+    status: toGateStatus(missingTokens.length === 0),
+    checked_path: migrationPath,
+    blocked_reasons: missingTokens.length === 0 ? [] : ['migration_contract_missing_token'],
+    required_tokens: requiredTokens,
+    missing_tokens: missingTokens,
+  };
+}
+
+function evaluateOrderedPipeline() {
+  const store = createEmptyLearningEventStore();
+  const flow = buildSyntheticAttemptEventFlow({
+    attemptId: 'phase0-attempt',
+    learnerId: 'phase0-learner',
+    sessionId: 'phase0-session',
+    subjectCode: '9709',
+    emittedBy: 'event-pipeline-gate',
+  });
+
+  const results = flow.map((event) => appendLearningEvent(store, event));
+  const finalState = store.pipelineStateByAttempt.get('phase0-attempt') ?? null;
+  const passed = results.every((result) => result.inserted)
+    && finalState?.current_stage === 'ArtifactSuggestionsCreated'
+    && finalState?.last_sequence_no === 7
+    && finalState?.current_status === 'completed';
+
+  return {
+    status: toGateStatus(passed),
+    blocked_reasons: passed ? [] : ['ordered_pipeline_failed'],
+    inserted_count: results.filter((result) => result.inserted).length,
+    final_stage: finalState?.current_stage ?? null,
+    final_status: finalState?.current_status ?? null,
+    last_sequence_no: finalState?.last_sequence_no ?? null,
+  };
+}
+
+function evaluateDedupeGuard() {
+  const store = createEmptyLearningEventStore();
+  const [attemptSubmitted] = buildSyntheticAttemptEventFlow({
+    attemptId: 'phase0-dedupe',
+    learnerId: 'phase0-learner',
+    sessionId: 'phase0-session',
+    subjectCode: '9709',
+    emittedBy: 'event-pipeline-gate',
+  });
+
+  const first = appendLearningEvent(store, attemptSubmitted);
+  const second = appendLearningEvent(store, attemptSubmitted);
+  const passed = first.inserted === true && second.inserted === false && second.reason_code === 'duplicate_dedupe_key';
+
+  return {
+    status: toGateStatus(passed),
+    blocked_reasons: passed ? [] : ['dedupe_guard_failed'],
+    first_inserted: first.inserted,
+    duplicate_inserted: second.inserted,
+    duplicate_reason_code: second.reason_code,
+  };
+}
+
+function evaluateOutOfOrderGuard() {
+  const store = createEmptyLearningEventStore();
+  const [attemptSubmitted, , markingCompleted] = buildSyntheticAttemptEventFlow({
+    attemptId: 'phase0-order',
+    learnerId: 'phase0-learner',
+    sessionId: 'phase0-session',
+    subjectCode: '9709',
+    emittedBy: 'event-pipeline-gate',
+  });
+
+  appendLearningEvent(store, attemptSubmitted);
+
+  let errorCode = null;
+  try {
+    appendLearningEvent(store, markingCompleted);
+  } catch (error) {
+    errorCode = error instanceof Error ? error.message : String(error);
+  }
+
+  const passed = errorCode === 'out_of_order_event';
+  return {
+    status: toGateStatus(passed),
+    blocked_reasons: passed ? [] : ['out_of_order_guard_failed'],
+    error_code: errorCode,
+  };
+}
+
+function evaluateEffectIdempotency() {
+  const store = createEmptyLearningEventStore();
+  const flow = buildSyntheticAttemptEventFlow({
+    attemptId: 'phase0-effect',
+    learnerId: 'phase0-learner',
+    sessionId: 'phase0-session',
+    subjectCode: '9709',
+    emittedBy: 'event-pipeline-gate',
+  });
+  const originalEvent = flow.at(-1);
+  const replayEvent = buildReplayLearningEvent(originalEvent, {
+    truthRevision: 2,
+    sequenceNo: 8,
+    emittedBy: 'event-pipeline-gate-replay',
+  });
+
+  const first = tryStartLearningEventEffect(store, {
+    eventId: originalEvent.event_id,
+    handlerName: 'project:artifact-suggestions',
+    effectKey: 'artifact-slot:review_queue:stable-output',
+    aggregateId: originalEvent.aggregate_id,
+    truthRevision: originalEvent.truth_revision,
+  });
+  const completed = markLearningEventEffectStatus(store, {
+    handlerName: 'project:artifact-suggestions',
+    effectKey: 'artifact-slot:review_queue:stable-output',
+    status: 'succeeded',
+    resultRefType: 'artifact_suggestion_version',
+    resultRefId: 'artifact-suggestion-1',
+  });
+  const replay = tryStartLearningEventEffect(store, {
+    eventId: replayEvent.event_id,
+    handlerName: 'project:artifact-suggestions',
+    effectKey: 'artifact-slot:review_queue:stable-output',
+    aggregateId: replayEvent.aggregate_id,
+    truthRevision: replayEvent.truth_revision,
+  });
+
+  const passed = first.inserted === true
+    && completed.status === 'succeeded'
+    && replay.inserted === false
+    && replay.reason_code === 'duplicate_effect_key'
+    && store.effects.length === 1;
+
+  return {
+    status: toGateStatus(passed),
+    blocked_reasons: passed ? [] : ['effect_idempotency_failed'],
+    first_inserted: first.inserted,
+    completed_status: completed.status,
+    replay_inserted: replay.inserted,
+    replay_reason_code: replay.reason_code,
+    effect_count: store.effects.length,
+  };
+}
+
+function evaluateAttemptStreamLock() {
+  const store = createEmptyLearningEventStore();
+  const first = acquireAttemptStreamLock(store, 'phase0-lock');
+  const second = acquireAttemptStreamLock(store, 'phase0-lock');
+  const released = releaseAttemptStreamLock(store, 'phase0-lock');
+  const third = acquireAttemptStreamLock(store, 'phase0-lock');
+  const cleanup = releaseAttemptStreamLock(store, 'phase0-lock');
+  const passed = first.acquired === true
+    && second.acquired === false
+    && second.reason_code === 'attempt_stream_locked'
+    && released === true
+    && third.acquired === true
+    && cleanup === true;
+
+  return {
+    status: toGateStatus(passed),
+    blocked_reasons: passed ? [] : ['attempt_stream_lock_failed'],
+    first_acquired: first.acquired,
+    second_acquired: second.acquired,
+    second_reason_code: second.reason_code,
+    released,
+    third_acquired: third.acquired,
+  };
+}
+
+export function buildEventPipelineGateReceipt({
+  rootDir = PROJECT_ROOT,
+  migrationPath = DEFAULT_EVENT_PIPELINE_MIGRATION_PATH,
+} = {}) {
+  const migrationContract = evaluateMigrationContract(rootDir, migrationPath);
+  const orderedPipeline = evaluateOrderedPipeline();
+  const dedupeGuard = evaluateDedupeGuard();
+  const effectIdempotency = evaluateEffectIdempotency();
+  const attemptStreamLock = evaluateAttemptStreamLock();
+  const outOfOrderGuard = evaluateOutOfOrderGuard();
+  const gates = {
+    migration_contract: migrationContract,
+    ordered_pipeline: orderedPipeline,
+    dedupe_guard: dedupeGuard,
+    effect_idempotency: effectIdempotency,
+    attempt_stream_lock: attemptStreamLock,
+    out_of_order_guard: outOfOrderGuard,
+  };
+  const failingGateNames = Object.entries(gates)
+    .filter(([, gate]) => gate.status !== 'pass')
+    .map(([gateName]) => gateName);
+
+  return {
+    schema_version: EVENT_PIPELINE_GATE_SCHEMA_VERSION,
+    status: failingGateNames.length === 0 ? 'pass' : 'fail',
+    phase0_ready: failingGateNames.length === 0,
+    migration_path: migrationPath,
+    generated_at: new Date().toISOString(),
+    gates,
+    failing_gate_names: failingGateNames,
+  };
+}
+
+export function renderEventPipelineGateReport(receipt) {
+  const lines = [
+    '# Learning Event Pipeline Gate',
+    '',
+    `- status: \`${receipt.status}\``,
+    `- phase0_ready: \`${receipt.phase0_ready}\``,
+    `- generated_at: \`${receipt.generated_at}\``,
+    `- migration_path: \`${receipt.migration_path}\``,
+    '',
+    '## Gates',
+    '',
+  ];
+
+  for (const [gateName, gate] of Object.entries(receipt.gates)) {
+    lines.push(`### ${gateName}`);
+    lines.push(`- status: \`${gate.status}\``);
+    if (Array.isArray(gate.blocked_reasons) && gate.blocked_reasons.length > 0) {
+      lines.push(`- blocked_reasons: \`${JSON.stringify(gate.blocked_reasons)}\``);
+    }
+    for (const [key, value] of Object.entries(gate)) {
+      if (key === 'status' || key === 'blocked_reasons') {
+        continue;
+      }
+      lines.push(`- ${key}: \`${JSON.stringify(value)}\``);
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trim()}\n`;
+}
+
+export function writeEventPipelineGateOutputs({
+  rootDir = PROJECT_ROOT,
+  migrationPath = DEFAULT_EVENT_PIPELINE_MIGRATION_PATH,
+  outJsonPath = DEFAULT_EVENT_PIPELINE_GATE_RECEIPT_PATH,
+  outMdPath = DEFAULT_EVENT_PIPELINE_GATE_REPORT_PATH,
+} = {}) {
+  const receipt = buildEventPipelineGateReceipt({ rootDir, migrationPath });
+  const markdown = renderEventPipelineGateReport(receipt);
+
+  const absoluteJsonPath = resolveFromRoot(rootDir, outJsonPath);
+  const absoluteMdPath = resolveFromRoot(rootDir, outMdPath);
+  ensureParentDir(absoluteJsonPath);
+  ensureParentDir(absoluteMdPath);
+  fs.writeFileSync(absoluteJsonPath, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(absoluteMdPath, markdown, 'utf8');
+
+  return {
+    receipt,
+    markdown,
+    outJsonPath,
+    outMdPath,
+  };
+}

--- a/scripts/learning/lib/event-pipeline-gate.js
+++ b/scripts/learning/lib/event-pipeline-gate.js
@@ -60,7 +60,7 @@ function evaluateMigrationContract(rootDir, migrationPath) {
     'create table if not exists public.learning_events',
     'create table if not exists public.learning_event_effects',
     'create table if not exists public.attempt_pipeline_state',
-    'unique (aggregate_id, sequence_no)',
+    'unique (aggregate_id, truth_revision, sequence_no)',
     'unique (aggregate_id, truth_revision, event_type)',
     'unique (event_type, dedupe_key)',
     'unique (handler_name, effect_key)',
@@ -125,6 +125,48 @@ function evaluateDedupeGuard() {
     first_inserted: first.inserted,
     duplicate_inserted: second.inserted,
     duplicate_reason_code: second.reason_code,
+  };
+}
+
+function evaluateReplayRevision() {
+  const store = createEmptyLearningEventStore();
+  const flow = buildSyntheticAttemptEventFlow({
+    attemptId: 'phase0-replay',
+    learnerId: 'phase0-learner',
+    sessionId: 'phase0-session',
+    subjectCode: '9709',
+    emittedBy: 'event-pipeline-gate',
+  });
+  flow.forEach((event) => appendLearningEvent(store, event));
+
+  const replayFlow = flow.map((sourceEvent) => buildReplayLearningEvent(sourceEvent, {
+    truthRevision: 2,
+    sequenceNo: sourceEvent.sequence_no,
+    emittedBy: 'event-pipeline-gate-replay',
+    replayOfEventId: sourceEvent.event_id,
+    supersedesEventId: sourceEvent.event_id,
+    causationEventId: sourceEvent.event_id,
+    reconciliationId: 'phase0-reconciliation-1',
+    dedupeKey: `${sourceEvent.aggregate_id}:2:${sourceEvent.event_type}:replay`,
+  }));
+  const replayResults = replayFlow.map((event) => appendLearningEvent(store, event));
+  const finalState = store.pipelineStateByAttempt.get('phase0-replay') ?? null;
+  const passed = replayResults.every((result) => result.inserted)
+    && finalState?.current_truth_revision === 2
+    && finalState?.current_stage === 'ArtifactSuggestionsCreated'
+    && finalState?.current_status === 'completed'
+    && finalState?.last_sequence_no === 7
+    && store.events.length === 14;
+
+  return {
+    status: toGateStatus(passed),
+    blocked_reasons: passed ? [] : ['replay_revision_failed'],
+    inserted_count: replayResults.filter((result) => result.inserted).length,
+    current_truth_revision: finalState?.current_truth_revision ?? null,
+    final_stage: finalState?.current_stage ?? null,
+    final_status: finalState?.current_status ?? null,
+    last_sequence_no: finalState?.last_sequence_no ?? null,
+    event_count: store.events.length,
   };
 }
 
@@ -241,6 +283,7 @@ export function buildEventPipelineGateReceipt({
 } = {}) {
   const migrationContract = evaluateMigrationContract(rootDir, migrationPath);
   const orderedPipeline = evaluateOrderedPipeline();
+  const replayRevision = evaluateReplayRevision();
   const dedupeGuard = evaluateDedupeGuard();
   const effectIdempotency = evaluateEffectIdempotency();
   const attemptStreamLock = evaluateAttemptStreamLock();
@@ -248,6 +291,7 @@ export function buildEventPipelineGateReceipt({
   const gates = {
     migration_contract: migrationContract,
     ordered_pipeline: orderedPipeline,
+    replay_revision: replayRevision,
     dedupe_guard: dedupeGuard,
     effect_idempotency: effectIdempotency,
     attempt_stream_lock: attemptStreamLock,

--- a/scripts/learning/run_event_pipeline_gate.js
+++ b/scripts/learning/run_event_pipeline_gate.js
@@ -9,8 +9,8 @@ import {
   writeEventPipelineGateOutputs,
 } from './lib/event-pipeline-gate.js';
 
-const ROOT = process.cwd();
 const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(fileURLToPath(new URL('../../', import.meta.url)));
 
 function parseCliArgs(args) {
   const output = {};

--- a/scripts/learning/run_event_pipeline_gate.js
+++ b/scripts/learning/run_event_pipeline_gate.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_EVENT_PIPELINE_GATE_RECEIPT_PATH,
+  DEFAULT_EVENT_PIPELINE_GATE_REPORT_PATH,
+  DEFAULT_EVENT_PIPELINE_MIGRATION_PATH,
+  writeEventPipelineGateOutputs,
+} from './lib/event-pipeline-gate.js';
+
+const ROOT = process.cwd();
+const __filename = fileURLToPath(import.meta.url);
+
+function parseCliArgs(args) {
+  const output = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (!token.startsWith('-')) {
+      continue;
+    }
+
+    const equalIndex = token.indexOf('=');
+    if (equalIndex !== -1) {
+      output[token.slice(token.startsWith('--') ? 2 : 1, equalIndex)] = token.slice(equalIndex + 1);
+      continue;
+    }
+
+    const key = token.slice(token.startsWith('--') ? 2 : 1);
+    const next = args[index + 1];
+    if (next && !next.startsWith('-')) {
+      output[key] = next;
+      index += 1;
+    } else {
+      output[key] = true;
+    }
+  }
+
+  return output;
+}
+
+function toRelative(filePath) {
+  return filePath.replace(/\\/g, '/');
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const cli = parseCliArgs(argv);
+  const migrationPath = cli.migration || DEFAULT_EVENT_PIPELINE_MIGRATION_PATH;
+  const outJsonPath = cli['out-json'] || DEFAULT_EVENT_PIPELINE_GATE_RECEIPT_PATH;
+  const outMdPath = cli['out-md'] || DEFAULT_EVENT_PIPELINE_GATE_REPORT_PATH;
+  const { receipt } = writeEventPipelineGateOutputs({
+    rootDir: ROOT,
+    migrationPath,
+    outJsonPath,
+    outMdPath,
+  });
+
+  process.stdout.write(`${toRelative(outJsonPath)}\n`);
+  process.stdout.write(`${toRelative(outMdPath)}\n`);
+  if (receipt.status !== 'pass') {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main();
+}

--- a/supabase/migrations/20260412090000_phase0_learning_events_core.sql
+++ b/supabase/migrations/20260412090000_phase0_learning_events_core.sql
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS public.learning_events (
   provenance JSONB NOT NULL,
   emitted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   CONSTRAINT uq_learning_events_stream_seq
-    UNIQUE (aggregate_id, sequence_no),
+    UNIQUE (aggregate_id, truth_revision, sequence_no),
   CONSTRAINT uq_learning_events_revision_stage
     UNIQUE (aggregate_id, truth_revision, event_type),
   CONSTRAINT uq_learning_events_dedupe

--- a/supabase/migrations/20260412090000_phase0_learning_events_core.sql
+++ b/supabase/migrations/20260412090000_phase0_learning_events_core.sql
@@ -1,0 +1,239 @@
+-- Phase 0: P6 event infrastructure core tables
+-- Scope: append-only event store, handler idempotency ledger, per-attempt observable pipeline state
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.learning_events (
+  event_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type TEXT NOT NULL CHECK (
+    event_type IN (
+      'AttemptSubmitted',
+      'QuestionClassified',
+      'MarkingCompleted',
+      'LearningUpdateProposed',
+      'MasteryUpdated',
+      'ReviewTasksCreated',
+      'ArtifactSuggestionsCreated'
+    )
+  ),
+  aggregate_type TEXT NOT NULL DEFAULT 'attempt' CHECK (aggregate_type = 'attempt'),
+  aggregate_id UUID NOT NULL REFERENCES public.attempts(attempt_id) ON DELETE RESTRICT,
+  learner_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
+  session_id UUID REFERENCES public.learning_sessions(session_id) ON DELETE SET NULL,
+  subject_code TEXT NOT NULL,
+  truth_revision INTEGER NOT NULL DEFAULT 1 CHECK (truth_revision >= 1),
+  sequence_no INTEGER NOT NULL CHECK (sequence_no >= 1),
+  stage_ordinal SMALLINT GENERATED ALWAYS AS (
+    CASE event_type
+      WHEN 'AttemptSubmitted' THEN 1
+      WHEN 'QuestionClassified' THEN 2
+      WHEN 'MarkingCompleted' THEN 3
+      WHEN 'LearningUpdateProposed' THEN 4
+      WHEN 'MasteryUpdated' THEN 5
+      WHEN 'ReviewTasksCreated' THEN 6
+      WHEN 'ArtifactSuggestionsCreated' THEN 7
+    END
+  ) STORED,
+  correlation_id UUID NOT NULL,
+  causation_event_id UUID REFERENCES public.learning_events(event_id),
+  replay_of_event_id UUID REFERENCES public.learning_events(event_id),
+  supersedes_event_id UUID REFERENCES public.learning_events(event_id),
+  reconciliation_id UUID,
+  dedupe_key TEXT NOT NULL,
+  basis_hash TEXT NOT NULL,
+  emitted_by TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  provenance JSONB NOT NULL,
+  emitted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT uq_learning_events_stream_seq
+    UNIQUE (aggregate_id, sequence_no),
+  CONSTRAINT uq_learning_events_revision_stage
+    UNIQUE (aggregate_id, truth_revision, event_type),
+  CONSTRAINT uq_learning_events_dedupe
+    UNIQUE (event_type, dedupe_key),
+  CONSTRAINT ck_learning_events_payload_object
+    CHECK (jsonb_typeof(payload) = 'object'),
+  CONSTRAINT ck_learning_events_provenance_object
+    CHECK (jsonb_typeof(provenance) = 'object'),
+  CONSTRAINT ck_learning_events_payload_attempt_id
+    CHECK ((payload->>'attempt_id') = aggregate_id::TEXT),
+  CONSTRAINT ck_learning_events_provenance_shape
+    CHECK (
+      provenance ?& ARRAY['subject_code', 'subject_adapter', 'evidence_refs', 'lineage', 'trust']
+      AND COALESCE(provenance->>'subject_code', '') = subject_code
+      AND jsonb_typeof(provenance->'subject_adapter') = 'object'
+      AND jsonb_typeof(provenance->'evidence_refs') = 'array'
+      AND jsonb_typeof(provenance->'lineage') = 'object'
+      AND jsonb_typeof(provenance->'trust') = 'object'
+    ),
+  CONSTRAINT ck_attemptsubmitted_payload
+    CHECK (
+      event_type <> 'AttemptSubmitted'
+      OR (
+        payload ?& ARRAY['attempt_id', 'attempt_mode', 'submission', 'submitted_at']
+        AND jsonb_typeof(payload->'submission') = 'object'
+      )
+    ),
+  CONSTRAINT ck_questionclassified_payload
+    CHECK (
+      event_type <> 'QuestionClassified'
+      OR (
+        payload ?& ARRAY[
+          'attempt_id',
+          'classification',
+          'classification_confidence',
+          'subject_adapter',
+          'classification_version'
+        ]
+        AND jsonb_typeof(payload->'classification') = 'object'
+        AND COALESCE(jsonb_typeof(payload->'uncertain_flags'), 'array') = 'array'
+      )
+    ),
+  CONSTRAINT ck_markingcompleted_payload
+    CHECK (
+      event_type <> 'MarkingCompleted'
+      OR (
+        payload ?& ARRAY[
+          'attempt_id',
+          'marking_mode',
+          'released_scope',
+          'rubric_ref',
+          'diagnostics'
+        ]
+        AND jsonb_typeof(payload->'rubric_ref') = 'object'
+        AND jsonb_typeof(payload->'diagnostics') = 'object'
+        AND COALESCE(jsonb_typeof(payload->'uncertain_flags'), 'array') = 'array'
+      )
+    ),
+  CONSTRAINT ck_learningupdateproposed_payload
+    CHECK (
+      event_type <> 'LearningUpdateProposed'
+      OR (
+        payload ?& ARRAY[
+          'attempt_id',
+          'proposal_key',
+          'guardrail_decisions',
+          'proposed_mastery_effects',
+          'proposed_review_tasks',
+          'proposed_artifact_suggestions'
+        ]
+        AND jsonb_typeof(payload->'guardrail_decisions') = 'object'
+        AND jsonb_typeof(payload->'proposed_mastery_effects') = 'array'
+        AND jsonb_typeof(payload->'proposed_review_tasks') = 'array'
+        AND jsonb_typeof(payload->'proposed_artifact_suggestions') = 'array'
+      )
+    ),
+  CONSTRAINT ck_masteryupdated_payload
+    CHECK (
+      event_type <> 'MasteryUpdated'
+      OR (
+        payload ?& ARRAY['attempt_id', 'proposal_key', 'applied_effects']
+        AND jsonb_typeof(payload->'applied_effects') = 'array'
+      )
+    ),
+  CONSTRAINT ck_reviewtaskscreated_payload
+    CHECK (
+      event_type <> 'ReviewTasksCreated'
+      OR (
+        payload ?& ARRAY['attempt_id', 'proposal_key', 'tasks']
+        AND jsonb_typeof(payload->'tasks') = 'array'
+      )
+    ),
+  CONSTRAINT ck_artifactsuggestionscreated_payload
+    CHECK (
+      event_type <> 'ArtifactSuggestionsCreated'
+      OR (
+        payload ?& ARRAY['attempt_id', 'proposal_key', 'suggestions']
+        AND jsonb_typeof(payload->'suggestions') = 'array'
+      )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_learning_events_aggregate_revision_seq
+  ON public.learning_events (aggregate_id, truth_revision DESC, sequence_no DESC);
+
+CREATE INDEX IF NOT EXISTS idx_learning_events_subject_stage_time
+  ON public.learning_events (subject_code, stage_ordinal, emitted_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_learning_events_correlation_time
+  ON public.learning_events (correlation_id, emitted_at);
+
+CREATE INDEX IF NOT EXISTS idx_learning_events_causation
+  ON public.learning_events (causation_event_id)
+  WHERE causation_event_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_learning_events_reconciliation
+  ON public.learning_events (reconciliation_id, sequence_no)
+  WHERE reconciliation_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_learning_events_payload_gin
+  ON public.learning_events USING GIN (payload jsonb_path_ops);
+
+CREATE INDEX IF NOT EXISTS idx_learning_events_provenance_gin
+  ON public.learning_events USING GIN (provenance jsonb_path_ops);
+
+CREATE TABLE IF NOT EXISTS public.learning_event_effects (
+  effect_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id UUID NOT NULL REFERENCES public.learning_events(event_id) ON DELETE CASCADE,
+  handler_name TEXT NOT NULL,
+  effect_key TEXT NOT NULL,
+  aggregate_id UUID NOT NULL REFERENCES public.attempts(attempt_id) ON DELETE CASCADE,
+  truth_revision INTEGER NOT NULL,
+  reconciliation_id UUID,
+  status TEXT NOT NULL CHECK (
+    status IN ('started', 'succeeded', 'failed', 'noop', 'superseded')
+  ),
+  result_ref_type TEXT,
+  result_ref_id TEXT,
+  error_code TEXT,
+  error_message TEXT,
+  attempt_count INTEGER NOT NULL DEFAULT 1,
+  first_started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (handler_name, effect_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_learning_event_effects_event
+  ON public.learning_event_effects (event_id);
+
+CREATE INDEX IF NOT EXISTS idx_learning_event_effects_aggregate_handler_status
+  ON public.learning_event_effects (aggregate_id, handler_name, status);
+
+CREATE TABLE IF NOT EXISTS public.attempt_pipeline_state (
+  attempt_id UUID PRIMARY KEY REFERENCES public.attempts(attempt_id) ON DELETE CASCADE,
+  learner_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
+  session_id UUID REFERENCES public.learning_sessions(session_id) ON DELETE SET NULL,
+  subject_code TEXT NOT NULL,
+  current_truth_revision INTEGER NOT NULL DEFAULT 1,
+  last_sequence_no INTEGER NOT NULL DEFAULT 0,
+  current_stage TEXT NOT NULL CHECK (
+    current_stage IN (
+      'AttemptSubmitted',
+      'QuestionClassified',
+      'MarkingCompleted',
+      'LearningUpdateProposed',
+      'MasteryUpdated',
+      'ReviewTasksCreated',
+      'ArtifactSuggestionsCreated'
+    )
+  ),
+  current_status TEXT NOT NULL DEFAULT 'running' CHECK (
+    current_status IN ('running', 'completed', 'failed', 'blocked', 'reconciling')
+  ),
+  last_event_id UUID REFERENCES public.learning_events(event_id),
+  active_classification_event_id UUID REFERENCES public.learning_events(event_id),
+  active_marking_event_id UUID REFERENCES public.learning_events(event_id),
+  active_learning_update_event_id UUID REFERENCES public.learning_events(event_id),
+  active_mastery_event_id UUID REFERENCES public.learning_events(event_id),
+  active_review_tasks_event_id UUID REFERENCES public.learning_events(event_id),
+  active_artifact_suggestions_event_id UUID REFERENCES public.learning_events(event_id),
+  last_error_code TEXT,
+  last_error_message TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_attempt_pipeline_state_subject_stage
+  ON public.attempt_pipeline_state (subject_code, current_stage);
+
+CREATE INDEX IF NOT EXISTS idx_attempt_pipeline_state_status_updated
+  ON public.attempt_pipeline_state (current_status, updated_at DESC);


### PR DESCRIPTION
## Summary
This PR lands the missing Phase 0 learning event infrastructure on top of `main` as a standalone change set. It adds the append-only event contract and in-memory event service, introduces the Phase 0 migration for `learning_events`, `learning_event_effects`, and `attempt_pipeline_state`, and adds the event-pipeline gate runner with its auditable receipt and report outputs.

## Problem
`main` already had Phase A work that assumed an event-oriented learning pipeline, but the underlying Phase 0 gate and supporting event primitives were never landed on their own. That left the branch without the foundational migration, dedupe/idempotency logic, or a focused gate to prove the seven-step attempt pipeline can execute safely and observably.

## Root Cause
The Phase 0 implementation existed only in dirty root-repo files and had not been intentionally ported onto a clean `origin/main` worktree. As a result, the project had later-phase code without the baseline event infrastructure and release evidence that Phase 0 was supposed to provide.

## Fix
This PR ports the missing Phase 0 files into the clean branch without editing unrelated Phase A code. The new event contract defines the canonical stage ordering and status enums. The in-memory event service enforces strict ordering, dedupe by event type plus key, replay-safe effect idempotency, and per-attempt stream locking. The migration creates the core event tables and integrity constraints. The gate script validates the migration contract plus ordered pipeline progression, dedupe, out-of-order rejection, effect idempotency, and stream-lock behavior, and writes both JSON and markdown evidence artifacts.

## Validation
I verified the port with the focused checks requested in the handoff:

- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/event-service.test.js`
- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand scripts/learning/__tests__/event-pipeline-gate.test.js`
- `node scripts/learning/run_event_pipeline_gate.js`

The gate run generated a passing receipt at `data/learning_runtime/release_evidence/event-pipeline-gate-receipt.v1.json` and a matching markdown report at `docs/reports/learning_runtime_event_pipeline_gate_2026-04-12.md`.
