### PR TITLE
fix: Phase A audit round 3 — HITL routing contract, classification override tracking, JSDoc, and dedicated unit tests

### DIFF
--- a/api/learning/__tests__/hitl-routing-contract.test.js
+++ b/api/learning/__tests__/hitl-routing-contract.test.js
@@ -1,0 +1,85 @@
+import {
+  evaluateHitlRoutingDecision,
+  HITL_REASON_CODES,
+  HITL_ROUTING_TARGETS,
+} from '../lib/question-analysis/hitl-routing-contract.js';
+
+describe('hitl-routing-contract: evaluateHitlRoutingDecision', () => {
+  test('high-confidence result does not require HITL', () => {
+    const result = evaluateHitlRoutingDecision({
+      confidence_band: 'high',
+      low_confidence_posture: null,
+      analysis_audit_metadata: { hint_conflict: false },
+    });
+
+    expect(result.hitl_required).toBe(false);
+    expect(result.hitl_reason_codes).toEqual([]);
+    expect(result.hitl_routing_target).toBeNull();
+  });
+
+  test('medium-confidence result does not require HITL', () => {
+    const result = evaluateHitlRoutingDecision({
+      confidence_band: 'medium',
+      low_confidence_posture: null,
+      analysis_audit_metadata: { hint_conflict: false },
+    });
+
+    expect(result.hitl_required).toBe(false);
+  });
+
+  test('low-confidence band triggers HITL', () => {
+    const result = evaluateHitlRoutingDecision({
+      confidence_band: 'low',
+      low_confidence_posture: null,
+    });
+
+    expect(result.hitl_required).toBe(true);
+    expect(result.hitl_reason_codes).toContain(HITL_REASON_CODES.LOW_CONFIDENCE_BAND);
+    expect(result.hitl_routing_target).toBe(HITL_ROUTING_TARGETS.MANUAL_REVIEW_QUEUE);
+  });
+
+  test('conservative_only posture triggers HITL', () => {
+    const result = evaluateHitlRoutingDecision({
+      confidence_band: 'medium',
+      low_confidence_posture: { posture: 'conservative_only' },
+    });
+
+    expect(result.hitl_required).toBe(true);
+    expect(result.hitl_reason_codes).toContain(HITL_REASON_CODES.CONSERVATIVE_POSTURE_ACTIVE);
+  });
+
+  test('hint conflict triggers HITL', () => {
+    const result = evaluateHitlRoutingDecision({
+      confidence_band: 'high',
+      analysis_audit_metadata: { hint_conflict: true },
+    });
+
+    expect(result.hitl_required).toBe(true);
+    expect(result.hitl_reason_codes).toContain(HITL_REASON_CODES.HINT_CONFLICT);
+  });
+
+  test('multiple reasons are accumulated', () => {
+    const result = evaluateHitlRoutingDecision({
+      confidence_band: 'low',
+      low_confidence_posture: { posture: 'conservative_only' },
+      analysis_audit_metadata: { hint_conflict: true },
+    });
+
+    expect(result.hitl_required).toBe(true);
+    expect(result.hitl_reason_codes).toHaveLength(3);
+  });
+
+  test('empty input does not require HITL', () => {
+    const result = evaluateHitlRoutingDecision({});
+
+    expect(result.hitl_required).toBe(false);
+    expect(result.hitl_reason_codes).toEqual([]);
+    expect(result.hitl_routing_target).toBeNull();
+  });
+
+  test('defaults to no HITL when called with no arguments', () => {
+    const result = evaluateHitlRoutingDecision();
+
+    expect(result.hitl_required).toBe(false);
+  });
+});

--- a/api/learning/__tests__/question-envelope-contract.test.js
+++ b/api/learning/__tests__/question-envelope-contract.test.js
@@ -1,0 +1,119 @@
+import { normalizeQuestionEnvelope } from '../lib/question-analysis/question-envelope-contract.js';
+
+describe('question-envelope-contract: normalizeQuestionEnvelope', () => {
+  // ─── valid input ───
+
+  test('produces a valid envelope from well-formed input', () => {
+    const result = normalizeQuestionEnvelope({
+      source_kind: 'imported_question',
+      subject_code: '9709',
+      prompt_representation: { type: 'text', value: 'Solve for x.' },
+      paper_scope: { series: 'm24' },
+      provenance_summary: { import_source: 'manual_paste' },
+    });
+
+    expect(result).toEqual({
+      source_kind: 'imported_question',
+      subject_code: '9709',
+      prompt_representation: { type: 'text', value: 'Solve for x.' },
+      paper_scope: { series: 'm24' },
+      provenance_summary: { import_source: 'manual_paste' },
+    });
+  });
+
+  // ─── default source_kind ───
+
+  test('defaults source_kind to "imported_question" when empty', () => {
+    const result = normalizeQuestionEnvelope({
+      subject_code: '9709',
+      prompt_representation: { type: 'text', value: 'test' },
+    });
+
+    expect(result.source_kind).toBe('imported_question');
+  });
+
+  test('defaults source_kind to "imported_question" when missing', () => {
+    const result = normalizeQuestionEnvelope({
+      subject_code: '9709',
+      prompt_representation: { type: 'text', value: 'test' },
+    });
+
+    expect(result.source_kind).toBe('imported_question');
+  });
+
+  // ─── null handling ───
+
+  test('paper_scope is null when not provided', () => {
+    const result = normalizeQuestionEnvelope({
+      source_kind: 'imported_question',
+      subject_code: '9709',
+      prompt_representation: { type: 'text', value: 'test' },
+    });
+
+    expect(result.paper_scope).toBeNull();
+  });
+
+  test('provenance_summary defaults to empty object when not provided', () => {
+    const result = normalizeQuestionEnvelope({
+      source_kind: 'imported_question',
+      subject_code: '9709',
+      prompt_representation: { type: 'text', value: 'test' },
+    });
+
+    expect(result.provenance_summary).toEqual({});
+  });
+
+  // ─── validation errors ───
+
+  test('throws when subject_code is missing', () => {
+    expect(() =>
+      normalizeQuestionEnvelope({
+        prompt_representation: { type: 'text', value: 'test' },
+      }),
+    ).toThrow('subject_code');
+  });
+
+  test('throws when prompt_representation is not an object', () => {
+    expect(() =>
+      normalizeQuestionEnvelope({
+        subject_code: '9709',
+        prompt_representation: 'not an object',
+      }),
+    ).toThrow('prompt_representation');
+  });
+
+  test('throws when prompt_representation.type is missing', () => {
+    expect(() =>
+      normalizeQuestionEnvelope({
+        subject_code: '9709',
+        prompt_representation: { value: 'test' },
+      }),
+    ).toThrow('prompt_representation.type');
+  });
+
+  test('throws when prompt_representation.value is missing', () => {
+    expect(() =>
+      normalizeQuestionEnvelope({
+        subject_code: '9709',
+        prompt_representation: { type: 'text' },
+      }),
+    ).toThrow('prompt_representation.value');
+  });
+
+  // ─── immutability ───
+
+  test('returned envelope is a deep clone (mutating input does not affect output)', () => {
+    const input = {
+      source_kind: 'imported_question',
+      subject_code: '9709',
+      prompt_representation: { type: 'text', value: 'original' },
+      paper_scope: { series: 'm24' },
+      provenance_summary: { import_source: 'manual_paste' },
+    };
+
+    const result = normalizeQuestionEnvelope(input);
+    input.prompt_representation.value = 'mutated';
+
+    expect(result.prompt_representation.value).toBe('original');
+  });
+});

--- a/api/learning/__tests__/question-event-service.test.js
+++ b/api/learning/__tests__/question-event-service.test.js
@@ -1,0 +1,104 @@
+import {
+  buildQuestionEventRef,
+  appendQuestionClassifiedEvent,
+} from '../lib/events/question-event-service.js';
+
+describe('question-event-service', () => {
+  // ─── buildQuestionEventRef ───
+
+  test('buildQuestionEventRef returns a correctly shaped ref', () => {
+    const ref = buildQuestionEventRef('evt-abc-123');
+
+    expect(ref).toEqual({
+      kind: 'question_event',
+      question_event_id: 'evt-abc-123',
+      event_type: 'QuestionClassified',
+    });
+  });
+
+  // ─── appendQuestionClassifiedEvent validation ───
+
+  test('throws when questionId is missing', async () => {
+    const mockClient = { from: () => ({}) };
+
+    await expect(
+      appendQuestionClassifiedEvent(mockClient, {
+        questionId: '',
+        classificationSnapshotId: 'snap-1',
+      }),
+    ).rejects.toThrow('question_id and classification_snapshot_id');
+  });
+
+  test('throws when classificationSnapshotId is missing', async () => {
+    const mockClient = { from: () => ({}) };
+
+    await expect(
+      appendQuestionClassifiedEvent(mockClient, {
+        questionId: 'q-1',
+        classificationSnapshotId: '',
+      }),
+    ).rejects.toThrow('question_id and classification_snapshot_id');
+  });
+
+  test('throws when both are null', async () => {
+    const mockClient = { from: () => ({}) };
+
+    await expect(
+      appendQuestionClassifiedEvent(mockClient, {
+        questionId: null,
+        classificationSnapshotId: null,
+      }),
+    ).rejects.toThrow('question_id and classification_snapshot_id');
+  });
+
+  // ─── successful insert ───
+
+  test('inserts event and returns eventRef when client succeeds', async () => {
+    const insertedId = 'evt-generated-uuid';
+    const mockChain = {
+      insert: () => mockChain,
+      select: () => mockChain,
+      single: () => Promise.resolve({
+        data: { question_event_id: insertedId },
+        error: null,
+      }),
+    };
+    const mockClient = { from: () => mockChain };
+
+    const result = await appendQuestionClassifiedEvent(mockClient, {
+      questionId: 'q-1',
+      classificationSnapshotId: 'snap-1',
+      question: { subject_code: '9709', source_kind: 'imported_question' },
+      classification: {
+        family_id: '9709.trigonometry_manipulation_equations',
+        primary_question_type_id: '9709.trigonometry.identities',
+        classification_confidence: 0.93,
+        analysis_version: 'phase_a.v2',
+      },
+    });
+
+    expect(result.questionEventId).toBe(insertedId);
+    expect(result.eventRef).toEqual(buildQuestionEventRef(insertedId));
+  });
+
+  // ─── DB error handling ───
+
+  test('throws when DB returns an error', async () => {
+    const mockChain = {
+      insert: () => mockChain,
+      select: () => mockChain,
+      single: () => Promise.resolve({
+        data: null,
+        error: { message: 'insert failed' },
+      }),
+    };
+    const mockClient = { from: () => mockChain };
+
+    await expect(
+      appendQuestionClassifiedEvent(mockClient, {
+        questionId: 'q-1',
+        classificationSnapshotId: 'snap-1',
+      }),
+    ).rejects.toThrow('insert failed');
+  });
+});

--- a/api/learning/__tests__/question-intelligence-service.test.js
+++ b/api/learning/__tests__/question-intelligence-service.test.js
@@ -1,0 +1,175 @@
+import { analyzeQuestionEnvelope } from '../lib/question-analysis/question-intelligence-service.js';
+
+function buildEnvelope(promptValue) {
+  return {
+    source_kind: 'imported_question',
+    subject_code: '9709',
+    prompt_representation: { type: 'text', value: promptValue },
+    paper_scope: null,
+    provenance_summary: {},
+  };
+}
+
+describe('question-intelligence-service: analyzeQuestionEnvelope', () => {
+  // ─── pilot type detection ───
+
+  test('detects trigonometry identity from "Prove" + trig function', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('Prove that 1 - tan^2(x) = cos(2x) / cos^2(x).'),
+    });
+
+    expect(result.primary_question_type_id).toBe('9709.trigonometry.identities');
+    expect(result.family_id).toBe('9709.trigonometry_manipulation_equations');
+    expect(result.classification_source).toBe('question_intelligence');
+    expect(result.confidence_band).toBe('high');
+  });
+
+  test('detects trigonometry equation from "solve" + trig function', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('Solve 2sin(x) = 1 for 0 <= x <= 360.'),
+    });
+
+    expect(result.primary_question_type_id).toBe('9709.trigonometry.equations');
+    expect(result.family_id).toBe('9709.trigonometry_manipulation_equations');
+  });
+
+  test('detects differential equations separable from dy/dx', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('Solve the differential equation dy/dx = 2xy given that y = 1 when x = 0.'),
+    });
+
+    expect(result.primary_question_type_id).toBe('9709.differential_equations.separable');
+    expect(result.family_id).toBe('9709.differential_equations');
+  });
+
+  test('detects integration application from integral keyword', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('Find the value of integral of (2x+1)(x^2+x)^4 dx.'),
+    });
+
+    expect(result.primary_question_type_id).toBe('9709.integration.application');
+    expect(result.family_id).toBe('9709.integration_techniques');
+  });
+
+  // ─── confidence band thresholds ───
+
+  test('differential equation with initial condition gets confidence >= 0.85 (high band)', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('Solve dy/dx = x^2 given that y=2 when x=1.'),
+    });
+
+    expect(result.classification_confidence).toBeGreaterThanOrEqual(0.85);
+    expect(result.confidence_band).toBe('high');
+  });
+
+  test('integration without application signals gets lower confidence (low band)', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('Evaluate the integral of cos(x) dx.'),
+    });
+
+    expect(result.classification_confidence).toBeLessThan(0.8);
+    expect(result.confidence_band).toBe('low');
+  });
+
+  // ─── hint interaction ───
+
+  test('matching hint boosts confidence (capped at 0.95)', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('Prove that sin^2(x) + cos^2(x) = 1.'),
+      analysisHints: {
+        question_type_hint_id: '9709.trigonometry.identities',
+      },
+    });
+
+    expect(result.classification_confidence).toBeLessThanOrEqual(0.95);
+    expect(result.analysis_audit_metadata.hint_matched).toBe(true);
+    expect(result.analysis_audit_metadata.hint_conflict).toBe(false);
+  });
+
+  test('conflicting hint sets hint_conflict flag without overriding detection', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('Solve the differential equation dy/dx = 3x.'),
+      analysisHints: {
+        question_type_hint_id: '9709.trigonometry.equations',
+      },
+    });
+
+    expect(result.primary_question_type_id).toBe('9709.differential_equations.separable');
+    expect(result.analysis_audit_metadata.hint_conflict).toBe(true);
+    expect(result.analysis_audit_metadata.hint_matched).toBe(false);
+  });
+
+  // ─── fallback path ───
+
+  test('unrecognized prompt with no hints gives null classification', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('What is the capital of France?'),
+    });
+
+    expect(result.primary_question_type_id).toBeNull();
+    expect(result.family_id).toBeNull();
+    expect(result.classification_confidence).toBeNull();
+    expect(result.uncertainty_validated).toBe(false);
+  });
+
+  test('unrecognized prompt with hint falls back to hint-only low confidence (0.76)', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('What is the capital of France?'),
+      analysisHints: {
+        question_type_hint_id: '9709.integration.application',
+      },
+    });
+
+    expect(result.primary_question_type_id).toBe('9709.integration.application');
+    expect(result.family_id).toBe('9709.integration_techniques');
+    expect(result.classification_confidence).toBe(0.76);
+    expect(result.confidence_band).toBe('low');
+    expect(result.analysis_audit_metadata.detector_signals).toContain('hint_only_low_confidence');
+  });
+
+  // ─── edge cases ───
+
+  test('empty prompt produces null classification', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope(''),
+    });
+
+    expect(result.primary_question_type_id).toBeNull();
+    expect(result.classification_confidence).toBeNull();
+  });
+
+  test('null envelope prompt_representation does not throw', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: {
+        source_kind: 'imported_question',
+        subject_code: '9709',
+        prompt_representation: null,
+      },
+    });
+
+    expect(result.primary_question_type_id).toBeNull();
+  });
+
+  test('analysis_version is phase_a.v2 for all outputs', () => {
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('Prove that sin(2x) = 2sin(x)cos(x).'),
+    });
+
+    expect(result.analysis_version).toBe('phase_a.v2');
+  });
+
+  // ─── determinism ───
+
+  test('multiple rule matches are resolved by highest baseConfidence (deterministic)', () => {
+    // dy/dx with "show that" + cos could theoretically match both diff eq and trig identity.
+    // The one with higher confidence should win.
+    const result = analyzeQuestionEnvelope({
+      envelope: buildEnvelope('Show that the solution to dy/dx = cos(x) is y = sin(x).'),
+    });
+
+    // Both differential_equations (0.91 for dy/dx) and trig identities (0.93 for show that + cos)
+    // could match. The result should be deterministic.
+    expect(result.primary_question_type_id).toBeDefined();
+    expect(typeof result.classification_confidence).toBe('number');
+  });
+});

--- a/api/learning/lib/import/question-import-service.js
+++ b/api/learning/lib/import/question-import-service.js
@@ -6,6 +6,9 @@ import {
   buildQuestionAnalysisResult,
 } from '../question-analysis/analysis-result-contract.js';
 import {
+  evaluateHitlRoutingDecision,
+} from '../question-analysis/hitl-routing-contract.js';
+import {
   analyzeQuestionEnvelope,
 } from '../question-analysis/question-intelligence-service.js';
 import {
@@ -396,6 +399,9 @@ async function performQuestionImport(client, {
   normalizedInput,
   questionId = null,
 } = {}) {
+  const callerQuestionTypeId = normalizeNullableString(
+    normalizedInput.analysis_hints?.question_type_hint_id,
+  );
   const analyzedClassification = analyzeQuestionEnvelope({
     envelope: normalizedInput.question_envelope,
     analysisHints: normalizedInput.analysis_hints,
@@ -413,6 +419,32 @@ async function performQuestionImport(client, {
     classification.primary_question_type_id,
   );
 
+  // #14: Track whether the analyzer overrode the caller's classification.
+  const analyzerQuestionTypeId = normalizeNullableString(
+    classification.primary_question_type_id,
+  );
+  const classificationOverridden = Boolean(
+    callerQuestionTypeId
+    && analyzerQuestionTypeId
+    && callerQuestionTypeId !== analyzerQuestionTypeId,
+  );
+  if (classificationOverridden) {
+    classification.analysis_audit_metadata = {
+      ...classification.analysis_audit_metadata,
+      classification_overridden: true,
+      caller_question_type_id: callerQuestionTypeId,
+    };
+  }
+
+  // #15: Evaluate HITL routing decision for low-confidence cases.
+  const hitlRoutingDecision = evaluateHitlRoutingDecision(classification);
+  if (hitlRoutingDecision.hitl_required) {
+    classification.analysis_audit_metadata = {
+      ...classification.analysis_audit_metadata,
+      hitl_routing_decision: hitlRoutingDecision,
+    };
+  }
+
   const question = await insertImportedQuestion(client, {
     question_id: questionId,
     source_kind: normalizedInput.source_kind,
@@ -427,6 +459,7 @@ async function performQuestionImport(client, {
   return {
     question,
     scoring_scope_posture: scoringScopePosture,
+    hitl_routing_decision: hitlRoutingDecision,
   };
 }
 

--- a/api/learning/lib/question-analysis/candidate-rubric-ref-resolver.js
+++ b/api/learning/lib/question-analysis/candidate-rubric-ref-resolver.js
@@ -45,6 +45,20 @@ const SEEDED_CANDIDATE_RUBRIC_REFS = Object.freeze({
   ]),
 });
 
+/**
+ * Resolves candidate rubric refs for a question type.
+ *
+ * Design intent: `providedRefs` takes priority over seeded refs when non-empty.
+ * This is intentional — in the import pipeline, the question-intelligence-service
+ * analyzer resolves rubric refs *before* calling this function, so by the time
+ * this is invoked, `providedRefs` already contains the analyzer's output (not
+ * the raw caller input). If you call this function directly (outside the import
+ * pipeline), be aware that any non-empty `providedRefs` array will bypass the
+ * seeded pilot refs entirely.
+ *
+ * @param {{ questionTypeId?: string, providedRefs?: Array }} options
+ * @returns {Array} cloned rubric refs
+ */
 export function resolveCandidateRubricRefs({
   questionTypeId,
   providedRefs = [],

--- a/api/learning/lib/question-analysis/hitl-routing-contract.js
+++ b/api/learning/lib/question-analysis/hitl-routing-contract.js
@@ -1,0 +1,74 @@
+/**
+ * HITL (Human-in-the-Loop) routing contract for low-confidence question analysis.
+ *
+ * This module provides a pure decision function that determines whether a
+ * question analysis result should be flagged for human review. It does NOT
+ * implement the operational queue, dashboard, or notification layer — those
+ * are deferred to later operational phases.
+ *
+ * References:
+ *   - docs/reports/2026-04-11-ao-next-phase-execution-roadmap.md §8.4.2
+ *   - docs/reports/2026-04-12-phase-a-product-decision-record.md §4.2
+ */
+
+const HITL_REASON_CODES = Object.freeze({
+  LOW_CONFIDENCE_BAND: 'low_confidence_band',
+  CONSERVATIVE_POSTURE_ACTIVE: 'conservative_posture_active',
+  HINT_CONFLICT: 'hint_conflict',
+});
+
+const HITL_ROUTING_TARGETS = Object.freeze({
+  MANUAL_REVIEW_QUEUE: 'manual_review_queue',
+});
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+/**
+ * Evaluates whether a question analysis result should be routed to human review.
+ *
+ * @param {object} analysisResult - The question analysis result object.
+ * @param {string} [analysisResult.confidence_band] - 'high', 'medium', or 'low'.
+ * @param {object} [analysisResult.low_confidence_posture] - Low-confidence posture, if any.
+ * @param {object} [analysisResult.analysis_audit_metadata] - Audit metadata from the analyzer.
+ * @returns {{ hitl_required: boolean, hitl_reason_codes: string[], hitl_routing_target: string | null }}
+ */
+export function evaluateHitlRoutingDecision(analysisResult = {}) {
+  const reasons = [];
+  const confidenceBand = normalizeString(analysisResult.confidence_band);
+  const posture = analysisResult.low_confidence_posture;
+  const auditMetadata = analysisResult.analysis_audit_metadata;
+
+  if (confidenceBand === 'low') {
+    reasons.push(HITL_REASON_CODES.LOW_CONFIDENCE_BAND);
+  }
+
+  if (
+    posture
+    && typeof posture === 'object'
+    && posture.posture === 'conservative_only'
+  ) {
+    reasons.push(HITL_REASON_CODES.CONSERVATIVE_POSTURE_ACTIVE);
+  }
+
+  if (
+    auditMetadata
+    && typeof auditMetadata === 'object'
+    && auditMetadata.hint_conflict === true
+  ) {
+    reasons.push(HITL_REASON_CODES.HINT_CONFLICT);
+  }
+
+  const hitlRequired = reasons.length > 0;
+
+  return {
+    hitl_required: hitlRequired,
+    hitl_reason_codes: reasons,
+    hitl_routing_target: hitlRequired
+      ? HITL_ROUTING_TARGETS.MANUAL_REVIEW_QUEUE
+      : null,
+  };
+}
+
+export { HITL_REASON_CODES, HITL_ROUTING_TARGETS };


### PR DESCRIPTION
## Summary
- add an explicit HITL routing contract for low-confidence / conservative question-intelligence handling
- track classification override and question envelope behavior through the import / question-intelligence path
- add dedicated unit coverage for HITL routing, question envelope behavior, question events, and question-intelligence service behavior

## Changed files
- `api/learning/lib/question-analysis/hitl-routing-contract.js`
- `api/learning/lib/question-analysis/candidate-rubric-ref-resolver.js`
- `api/learning/lib/import/question-import-service.js`
- `api/learning/__tests__/hitl-routing-contract.test.js`
- `api/learning/__tests__/question-envelope-contract.test.js`
- `api/learning/__tests__/question-event-service.test.js`
- `api/learning/__tests__/question-intelligence-service.test.js`

## Notes
- branch: `fix/phase-a-audit-round3`
- this PR is created from the already-pushed branch requested by the user