### PR TITLE
Question search foundation: freeze fallback and add search projection

### DIFF
--- a/api/learning/__tests__/schema-contract.test.js
+++ b/api/learning/__tests__/schema-contract.test.js
@@ -1,6 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 
+const LEARNING_QUESTION_SEARCH_MIGRATION =
+  'supabase/migrations/20260415152950_create_learning_question_search_projection.sql';
+
 const LEARNING_RUNTIME_MIGRATIONS = [
   'supabase/migrations/20260320110000_expand_question_bank_for_learning_runtime.sql',
   'supabase/migrations/20260320111000_create_learning_runtime_core.sql',
@@ -8,7 +11,8 @@ const LEARNING_RUNTIME_MIGRATIONS = [
   'supabase/migrations/20260320112000_create_learning_runtime_read_models.sql',
   'supabase/migrations/20260324110000_promote_learning_runtime_integration_application.sql',
   'supabase/migrations/20260412103000_expand_learning_question_analysis_snapshots_phase_a.sql',
-  'supabase/migrations/20260413110000_phase_a_question_classified_events.sql'
+  'supabase/migrations/20260413110000_phase_a_question_classified_events.sql',
+  LEARNING_QUESTION_SEARCH_MIGRATION
 ];
 
 function readMigration(relPath) {
@@ -248,5 +252,42 @@ describe('learning runtime schema contract', () => {
     expect(sql).toContain(
       'create unique index if not exists uq_question_bank_storage_q_present on public.question_bank (storage_key, q_number) where storage_key is not null and q_number is not null'
     );
+  });
+
+  test('learning_question_search_projection is migration-owned and freezes descriptor fallback semantics', () => {
+    const sql = normalizeSql(readMigration(LEARNING_QUESTION_SEARCH_MIGRATION));
+
+    expect(sql).toContain('create or replace view public.learning_question_search_projection as');
+
+    [
+      'qb.question_id',
+      'qb.source_kind',
+      'qb.subject_code',
+      'qb.release_scope_status',
+      'qb.primary_topic_id',
+      'cn.topic_path::text as primary_topic_path',
+      'cn.title as primary_topic_title',
+      'qb.family_id',
+      'qb.primary_question_type_id',
+      'qb.variant_tags',
+      'qb.storage_key',
+      'qb.q_number',
+      'descriptor_rows.summary',
+      'descriptor_rows.question_type',
+      'descriptor_rows.answer_form',
+      'descriptor_rows.year',
+      'descriptor_rows.session',
+      'descriptor_rows.paper_number',
+      'descriptor_rows.variant',
+      'as search_text'
+    ].forEach((token) => expect(sql).toContain(token));
+
+    expect(sql).toContain("to_regclass('public.question_descriptions_prod_v1') is not null");
+    expect(sql).toContain("public.question_descriptions_prod_v1");
+    expect(sql).toContain("public.question_descriptions_v0 where status = 'ok'");
+    expect(sql).toContain('left join descriptor_rows');
+    expect(sql).toContain('descriptor_rows.storage_key = qb.storage_key');
+    expect(sql).toContain('descriptor_rows.q_number = qb.q_number');
+    expect(sql).toContain("qb.prompt_representation ->> 'value'");
   });
 });

--- a/docs/reports/2026-04-15-question-search-slice-v1-report.md
+++ b/docs/reports/2026-04-15-question-search-slice-v1-report.md
@@ -1,0 +1,120 @@
+# 2026-04-15 Question Search Slice V1 Report
+
+## Scope
+
+This report closes issue `#188` for the question-search foundation slice.
+
+The scope is intentionally narrow:
+
+- verify descriptor-source reality in the target environment
+- freeze the retrieval fallback contract for descriptor reads
+- record the imported-question caveat before projection work starts
+
+No schema migration, API route, or search endpoint is added in this issue.
+
+## Repo Evidence For Descriptor Source Posture
+
+The current repository does not treat `question_descriptions_v1` or
+`question_descriptions_prod_v1` as migration-owned runtime surfaces.
+
+- `scripts/vlm/build_production_table_v1.py` builds `question_descriptions_v1`
+  from `question_descriptions_v0`
+- `scripts/vlm/publish_production_view_v1.py` publishes
+  `question_descriptions_prod_v1` as a filtered view over
+  `question_descriptions_v1`
+
+That means later retrieval SQL cannot safely assume either relation exists in
+every environment just because the repo contains the Python publishing flow.
+
+## Repo Evidence For Imported-Question Join Risk
+
+Imported questions are allowed to exist without paper-backed descriptor keys.
+
+- `supabase/migrations/20260320110000_expand_question_bank_for_learning_runtime.sql`
+  drops `NOT NULL` from `question_bank.storage_key` and
+  `question_bank.q_number`
+- `api/learning/__tests__/question-registry-repository.test.js` asserts that
+  imported-question inserts do not persist `storage_key` or `q_number`
+
+This matters because any descriptor join keyed on `(storage_key, q_number)` can
+legitimately miss for imported questions.
+
+## Target Environment Preflight
+
+Commands run from this worker worktree against `"$DATABASE_URL"`:
+
+```bash
+psql "$DATABASE_URL" \
+  -c "\dt+ public.question_descriptions_v0" \
+  -c "\dt+ public.question_descriptions_v1" \
+  -c "\dv+ public.question_descriptions_prod_v1" \
+  -c "select count(*) as question_descriptions_v0_count from public.question_descriptions_v0;" \
+  -c "select count(*) as question_descriptions_v1_count from public.question_descriptions_v1;" \
+  -c "select count(*) as question_descriptions_prod_v1_count from public.question_descriptions_prod_v1;"
+```
+
+Observed result:
+
+| Relation | Expected kind | Exists in target env | Row count |
+| --- | --- | --- | --- |
+| `public.question_descriptions_v0` | table | yes | `0` |
+| `public.question_descriptions_v1` | table | no | not present |
+| `public.question_descriptions_prod_v1` | view | no | not present |
+
+The count queries for `question_descriptions_v1` and
+`question_descriptions_prod_v1` failed with relation-not-found errors, which is
+consistent with the existence check above.
+
+## Frozen Fallback Contract
+
+The retrieval slice must treat descriptor source selection as an explicit
+runtime branch:
+
+1. Prefer `public.question_descriptions_prod_v1` when that relation exists.
+2. Otherwise fall back to `public.question_descriptions_v0` with
+   `status = 'ok'`.
+3. Do not create or publish `question_descriptions_v1` /
+   `question_descriptions_prod_v1` as part of this issue.
+
+This contract is now frozen for the next projection issue. Later SQL must own
+the branch explicitly instead of assuming `question_descriptions_prod_v1`
+exists.
+
+## Imported-Question Caveat For Retrieval
+
+Because `question_bank` supports imported questions that may not have
+`storage_key` or `q_number`, paper-backed descriptor joins are partial by
+design.
+
+The next retrieval projection must therefore:
+
+- use `LEFT JOIN` semantics for descriptor lookups keyed on
+  `(storage_key, q_number)`
+- preserve imported-question rows when no paper-backed descriptor matches
+- fall back to runtime-owned text such as `prompt_representation` when a
+  descriptor-backed summary is unavailable
+
+This issue records that constraint only. It does not implement the projection.
+
+## Preflight Notes
+
+`npm run workflow:baseline:sync` was run before implementation because the
+current repo workflow requires it. In this environment the script failed during
+its root-worktree `git pull --ff-only` step because the preserved branch
+`task/post-cleanup-baseline` has no upstream tracking branch. This was treated
+as an environment preflight note only and did not change the descriptor-source
+evidence above.
+
+## Readiness For Issue #189
+
+Issue `#188` does not expose a hard blocker for issue `#189`.
+
+The required assumption for `#189` is now explicit:
+
+- the projection must not assume `question_descriptions_prod_v1` exists
+- the projection must implement the fallback branch defined in this report
+
+The target local environment currently has `0` rows in
+`question_descriptions_v0`, so later end-to-end retrieval verification will
+need seeded or populated descriptor data. That is a data-posture note, not a
+contract blocker.

--- a/docs/reports/INDEX.md
+++ b/docs/reports/INDEX.md
@@ -9,6 +9,7 @@
 - `2026-04-03-ao-phase6-soak-and-incident-report.md` - fresh phase-6 smoke and incident drill evidence for blocked-path, green-path, stale-leader, stale-worker, ambiguity, and dirty-worktree coverage.
 - `2026-04-03-ao-reviewer-gate-rehearsal.md` - repo-local independent reviewer gate rehearsal showing request, claim, verdict, and durable freeze/release posture.
 - `2026-04-12-phase-a-question-intelligence-slice-1-report.md` - takeover closeout report for the first Phase A question-intelligence slice, including scope, touched modules, focused verification, and residual risks.
+- `2026-04-15-question-search-slice-v1-report.md` - descriptor-source preflight report for the question-search foundation slice, freezing the `question_descriptions_prod_v1` to `question_descriptions_v0 where status='ok'` fallback contract and recording imported-question join caveats.
 - `2026-04-14-phase-a-reassessment-report.md` - follow-up reassessment confirming current main still satisfies the approved Phase A question-intelligence + P3 contract landing boundary while recording the carry-forward runtime-wiring debt.
 - `ao_codex_work_dossier_2026-03-26.md` - issue-by-issue reconstruction of prior AO and Codex work, with branch-vs-mainline divergence notes.
 - `prd_progress_report_2026-03-16.md` - PRD-aligned project progress assessment after recovery, including current stage, recovery impact, and parallel workstreams.

--- a/supabase/migrations/20260415152950_create_learning_question_search_projection.sql
+++ b/supabase/migrations/20260415152950_create_learning_question_search_projection.sql
@@ -1,0 +1,70 @@
+-- Create a migration-owned question-search projection with explicit descriptor fallback.
+
+DO $migration$
+DECLARE
+  descriptor_source_sql TEXT;
+BEGIN
+  IF to_regclass('public.question_descriptions_prod_v1') IS NOT NULL THEN
+    descriptor_source_sql := 'public.question_descriptions_prod_v1';
+  ELSE
+    descriptor_source_sql := $fallback$
+      (
+        SELECT *
+        FROM public.question_descriptions_v0
+        WHERE status = 'ok'
+      )
+    $fallback$;
+  END IF;
+
+  EXECUTE format(
+    $view$
+    CREATE OR REPLACE VIEW public.learning_question_search_projection AS
+    WITH descriptor_rows AS (
+      SELECT
+        qd.storage_key,
+        qd.q_number,
+        qd.summary,
+        qd.question_type,
+        qd.answer_form,
+        qd.year,
+        qd.session,
+        qd.paper AS paper_number,
+        qd.variant
+      FROM %s qd
+    )
+    SELECT
+      qb.question_id,
+      qb.source_kind,
+      qb.subject_code,
+      qb.release_scope_status,
+      qb.primary_topic_id,
+      cn.topic_path::text AS primary_topic_path,
+      cn.title AS primary_topic_title,
+      qb.family_id,
+      qb.primary_question_type_id,
+      qb.variant_tags,
+      qb.storage_key,
+      qb.q_number,
+      descriptor_rows.summary,
+      descriptor_rows.question_type,
+      descriptor_rows.answer_form,
+      descriptor_rows.year,
+      descriptor_rows.session,
+      descriptor_rows.paper_number,
+      descriptor_rows.variant,
+      COALESCE(
+        NULLIF(BTRIM(descriptor_rows.summary), ''),
+        NULLIF(BTRIM(qb.prompt_representation ->> 'value'), ''),
+        NULLIF(BTRIM(qb.provenance_summary ->> 'title'), '')
+      ) AS search_text
+    FROM public.question_bank qb
+    LEFT JOIN public.curriculum_nodes cn
+      ON cn.node_id = qb.primary_topic_id
+    LEFT JOIN descriptor_rows
+      ON descriptor_rows.storage_key = qb.storage_key
+     AND descriptor_rows.q_number = qb.q_number
+    $view$,
+    descriptor_source_sql
+  );
+END
+$migration$;


### PR DESCRIPTION
## Summary
- add the checked-in `#188` report documenting descriptor-source reality, imported-question join risk, and the frozen fallback contract
- add a migration-owned `learning_question_search_projection` view for `#189`
- make the migration own the descriptor branch explicitly: prefer `question_descriptions_prod_v1`, otherwise fall back to `question_descriptions_v0 where status = ok`
- keep descriptor matching on an explicit `LEFT JOIN` by `storage_key + q_number` so imported questions are preserved when no paper-backed descriptor row exists
- make `search_text` fall back to runtime-owned text from `prompt_representation`
- extend schema-contract coverage so the projection shape and fallback logic are asserted from the migration itself

## Verification
- `npm run workflow:baseline:sync` *(fails in this environment because the preserved root-worktree branch `task/post-cleanup-baseline` has no upstream; recorded in the `#188` report as a preflight note only)*
- `psql "$DATABASE_URL" -c "\\dt+ public.question_descriptions_v0" -c "\\dt+ public.question_descriptions_v1" -c "\\dv+ public.question_descriptions_prod_v1" -c "select count(*) as question_descriptions_v0_count from public.question_descriptions_v0;"`
- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/schema-contract.test.js`
- `psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/migrations/20260415152950_create_learning_question_search_projection.sql`
- `psql "$DATABASE_URL" -c "\\dv+ public.learning_question_search_projection" -c "select count(*) as learning_question_search_projection_count from public.learning_question_search_projection;"`
- `git diff --check`

Closes #188
Closes #189