### PR TITLE
Add question search backend and learning questions API

### DIFF
--- a/api/_runtime/__tests__/route-registry-learning.test.js
+++ b/api/_runtime/__tests__/route-registry-learning.test.js
@@ -119,4 +119,12 @@ describe('learning route registry', () => {
       params: {},
     });
   });
+
+  test('does not let the learning questions search route match deeper subtree paths', () => {
+    expect(findRoute('/api/learning/questions/foo', 'GET')).toEqual({
+      route: null,
+      allowed: false,
+      params: {},
+    });
+  });
 });

--- a/api/_runtime/__tests__/route-registry-learning.test.js
+++ b/api/_runtime/__tests__/route-registry-learning.test.js
@@ -36,6 +36,14 @@ describe('learning route registry', () => {
       allowed: true,
     });
 
+    expect(findRoute('/api/learning/questions', 'GET')).toMatchObject({
+      route: expect.objectContaining({
+        module: 'learning-questions',
+        importPath: '../learning/questions/index.js',
+      }),
+      allowed: true,
+    });
+
     expect(findRoute('/api/learning/workspaces/topic-1', 'GET')).toMatchObject({
       route: expect.objectContaining({
         module: 'learning-workspace-topic',
@@ -82,6 +90,7 @@ describe('learning route registry', () => {
       'learning-sessions-id',
       'learning-sessions',
       'learning-questions-import',
+      'learning-questions',
       'learning-workspace-topic',
       'learning-review-task-id',
       'learning-review-tasks',

--- a/api/_runtime/route-registry.js
+++ b/api/_runtime/route-registry.js
@@ -60,6 +60,14 @@ const ROUTES = [
     methods: ['POST', 'OPTIONS'],
   },
   {
+    module: 'learning-questions',
+    pathPrefix: '/api/learning/questions',
+    importPath: '../learning/questions/index.js',
+    auth: 'jwt_required',
+    authMode: 'authenticated',
+    methods: ['GET', 'OPTIONS'],
+  },
+  {
     module: 'learning-workspace-topic',
     pathPrefix: '/api/learning/workspaces/:topicId',
     pattern: /^\/api\/learning\/workspaces\/[^/]+$/,

--- a/api/_runtime/route-registry.js
+++ b/api/_runtime/route-registry.js
@@ -62,6 +62,7 @@ const ROUTES = [
   {
     module: 'learning-questions',
     pathPrefix: '/api/learning/questions',
+    pattern: /^\/api\/learning\/questions$/,
     importPath: '../learning/questions/index.js',
     auth: 'jwt_required',
     authMode: 'authenticated',

--- a/api/learning/__tests__/question-search-api.test.js
+++ b/api/learning/__tests__/question-search-api.test.js
@@ -1,0 +1,173 @@
+import { jest } from '@jest/globals';
+
+const mockSearchQuestions = jest.fn();
+const mockServiceClient = { kind: 'service-client' };
+const mockGetServiceClient = jest.fn(() => mockServiceClient);
+const mockRequireAuth = jest.fn();
+
+jest.unstable_mockModule('../../lib/supabase/client.js', () => ({
+  getServiceClient: mockGetServiceClient,
+}));
+
+jest.unstable_mockModule('../../lib/security/auth-guard.js', () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+jest.unstable_mockModule('../lib/questions/question-search-service.js', () => ({
+  searchQuestions: mockSearchQuestions,
+}));
+
+const { default: handler } = await import('../questions/index.js');
+
+function createReq({
+  method = 'GET',
+  query = { subject_code: '9709' },
+  authUserId = 'student-1',
+  requestId = 'req-question-search-api',
+} = {}) {
+  return {
+    method,
+    query,
+    auth_user_id: authUserId,
+    request_id: requestId,
+    path: '/api/learning/questions',
+  };
+}
+
+function createRes() {
+  const headers = {};
+
+  return {
+    statusCode: 200,
+    headers,
+    body: null,
+    writableEnded: false,
+    setHeader(name, value) {
+      headers[String(name).toLowerCase()] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      this.writableEnded = true;
+      return this;
+    },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRequireAuth.mockResolvedValue({
+    ok: true,
+    user: {
+      id: 'student-1',
+    },
+  });
+});
+
+describe('question-search-api', () => {
+  test('GET /api/learning/questions returns the paginated service payload without inventing a second response shape', async () => {
+    mockSearchQuestions.mockResolvedValueOnce({
+      items: [
+        {
+          question_id: 'question-1',
+          subject_code: '9709',
+          search_text: 'Use a trigonometric identity.',
+          match_context: {
+            filters_applied: ['subject_code'],
+            text_query_used: false,
+          },
+        },
+      ],
+      total: 1,
+      page: 1,
+      page_size: 10,
+    });
+
+    const req = createReq({
+      query: {
+        subject_code: '9709',
+        family_id: 'family-1',
+        page: '1',
+        page_size: '10',
+      },
+    });
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(mockGetServiceClient).toHaveBeenCalledTimes(1);
+    expect(mockSearchQuestions).toHaveBeenCalledWith(mockServiceClient, req.query);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      request_id: 'req-question-search-api',
+      items: [
+        {
+          question_id: 'question-1',
+          subject_code: '9709',
+          search_text: 'Use a trigonometric identity.',
+          match_context: {
+            filters_applied: ['subject_code'],
+            text_query_used: false,
+          },
+        },
+      ],
+      total: 1,
+      page: 1,
+      page_size: 10,
+    });
+  });
+
+  test('GET /api/learning/questions rejects non-GET methods', async () => {
+    const req = createReq({ method: 'POST' });
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(mockSearchQuestions).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(405);
+    expect(res.body).toEqual({
+      request_id: 'req-question-search-api',
+      error: {
+        code: 'invalid_payload',
+        message: 'Method not allowed.',
+        retryable: false,
+        details: {},
+      },
+    });
+  });
+
+  test('GET /api/learning/questions surfaces deterministic validation failures from the search service', async () => {
+    const error = new Error('invalid_payload');
+    error.code = 'invalid_payload';
+    error.status = 400;
+    error.publicMessage = 'subject_code is required.';
+    error.details = { field: 'subject_code' };
+    mockSearchQuestions.mockRejectedValueOnce(error);
+
+    const req = createReq({
+      query: {
+        page: '1',
+        page_size: '10',
+      },
+    });
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(mockSearchQuestions).toHaveBeenCalledWith(mockServiceClient, req.query);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      request_id: 'req-question-search-api',
+      error: {
+        code: 'invalid_payload',
+        message: 'subject_code is required.',
+        retryable: false,
+        details: { field: 'subject_code' },
+      },
+    });
+  });
+});

--- a/api/learning/__tests__/question-search-repository.test.js
+++ b/api/learning/__tests__/question-search-repository.test.js
@@ -1,0 +1,191 @@
+import { searchQuestionProjection } from '../lib/repositories/question-search-repository.js';
+
+class QueryBuilder {
+  constructor(table, state) {
+    this.table = table;
+    this.state = state;
+    this.operation = 'select';
+    this.columns = '*';
+    this.selectOptions = {};
+    this.filters = [];
+    this.orders = [];
+    this.rangeArgs = null;
+  }
+
+  select(columns, options = {}) {
+    this.columns = columns;
+    this.selectOptions = options;
+    return this;
+  }
+
+  eq(field, value) {
+    this.filters.push({ type: 'eq', field, value });
+    return this;
+  }
+
+  ilike(field, pattern) {
+    this.filters.push({ type: 'ilike', field, pattern });
+    return this;
+  }
+
+  order(field, options = {}) {
+    this.orders.push({ field, options });
+    return this;
+  }
+
+  range(from, to) {
+    this.rangeArgs = { from, to };
+    return this;
+  }
+
+  then(resolve, reject) {
+    this.state.queries.push({
+      table: this.table,
+      operation: this.operation,
+      columns: this.columns,
+      selectOptions: this.selectOptions,
+      filters: [...this.filters],
+      orders: [...this.orders],
+      range: this.rangeArgs,
+    });
+
+    return Promise.resolve(this.state.response()).then(resolve, reject);
+  }
+}
+
+function createQuestionSearchDb(response = { data: [], count: 0, error: null }) {
+  const state = {
+    queries: [],
+    response: typeof response === 'function' ? response : () => response,
+  };
+
+  return {
+    state,
+    from(table) {
+      return new QueryBuilder(table, state);
+    },
+  };
+}
+
+describe('question-search-repository', () => {
+  test('searchQuestionProjection applies structured filters and returns total with rows', async () => {
+    const row = {
+      question_id: 'question-1',
+      source_kind: 'paper_question',
+      subject_code: '9709',
+      year: 2024,
+      paper_number: 1,
+      variant: 2,
+      search_text: 'Prove the trigonometric identity.',
+    };
+    const db = createQuestionSearchDb({
+      data: [row],
+      count: 7,
+      error: null,
+    });
+
+    const result = await searchQuestionProjection(db, {
+      subject_code: '9709',
+      year: 2024,
+      paper_number: 1,
+      variant: 2,
+      page: 2,
+      page_size: 3,
+    });
+
+    expect(db.state.queries).toEqual([
+      {
+        table: 'learning_question_search_projection',
+        operation: 'select',
+        columns: '*',
+        selectOptions: { count: 'exact' },
+        filters: [
+          { type: 'eq', field: 'subject_code', value: '9709' },
+          { type: 'eq', field: 'year', value: 2024 },
+          { type: 'eq', field: 'paper_number', value: 1 },
+          { type: 'eq', field: 'variant', value: 2 },
+        ],
+        orders: [{ field: 'question_id', options: { ascending: true } }],
+        range: { from: 3, to: 5 },
+      },
+    ]);
+    expect(result).toEqual({
+      total: 7,
+      rows: [row],
+    });
+  });
+
+  test('searchQuestionProjection applies text search only to search_text with ilike', async () => {
+    const db = createQuestionSearchDb({
+      data: [],
+      count: 0,
+      error: null,
+    });
+
+    await searchQuestionProjection(db, {
+      subject_code: '9709',
+      query: 'identity',
+      page: 1,
+      page_size: 10,
+    });
+
+    expect(
+      db.state.queries[0].filters.filter((filter) => filter.type === 'ilike'),
+    ).toEqual([
+      { type: 'ilike', field: 'search_text', pattern: '%identity%' },
+    ]);
+  });
+
+  test('searchQuestionProjection translates page and page_size into a stable range window', async () => {
+    const db = createQuestionSearchDb({
+      data: [],
+      count: 0,
+      error: null,
+    });
+
+    await searchQuestionProjection(db, {
+      subject_code: '9709',
+      page: 3,
+      page_size: 4,
+    });
+
+    expect(db.state.queries[0].range).toEqual({ from: 8, to: 11 });
+  });
+
+  test('searchQuestionProjection preserves imported-question fallback rows when descriptor fields are null', async () => {
+    const importedRow = {
+      question_id: 'question-imported-1',
+      source_kind: 'imported_question',
+      subject_code: '9709',
+      summary: null,
+      question_type: null,
+      answer_form: null,
+      year: null,
+      session: null,
+      paper_number: null,
+      variant: null,
+      search_text: 'Solve 2sin(x)=1 for 0<=x<=360.',
+    };
+    const db = createQuestionSearchDb({
+      data: [importedRow],
+      count: 1,
+      error: null,
+    });
+
+    const result = await searchQuestionProjection(db, {
+      subject_code: '9709',
+      query: '2sin',
+      page: 1,
+      page_size: 10,
+    });
+
+    expect(db.state.queries[0].filters).toEqual([
+      { type: 'eq', field: 'subject_code', value: '9709' },
+      { type: 'ilike', field: 'search_text', pattern: '%2sin%' },
+    ]);
+    expect(result).toEqual({
+      total: 1,
+      rows: [importedRow],
+    });
+  });
+});

--- a/api/learning/__tests__/question-search-service.test.js
+++ b/api/learning/__tests__/question-search-service.test.js
@@ -1,0 +1,150 @@
+import { jest } from '@jest/globals';
+
+const mockSearchQuestionProjection = jest.fn();
+
+jest.unstable_mockModule('../lib/repositories/question-search-repository.js', () => ({
+  searchQuestionProjection: mockSearchQuestionProjection,
+}));
+
+const { MAX_QUESTION_SEARCH_PAGE_SIZE, searchQuestions } = await import(
+  '../lib/questions/question-search-service.js'
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('question-search-service', () => {
+  test('searchQuestions rejects requests without subject_code', async () => {
+    await expect(
+      searchQuestions({}, {
+        page: 1,
+        page_size: 10,
+      }),
+    ).rejects.toMatchObject({
+      code: 'invalid_payload',
+      status: 400,
+      publicMessage: 'subject_code is required.',
+      details: { field: 'subject_code' },
+    });
+
+    expect(mockSearchQuestionProjection).not.toHaveBeenCalled();
+  });
+
+  test('searchQuestions normalizes numeric filters and caps page_size before hitting the repository', async () => {
+    mockSearchQuestionProjection.mockResolvedValueOnce({
+      total: 1,
+      rows: [
+        {
+          question_id: 'question-1',
+          subject_code: '9709',
+          search_text: 'Find tan(x).',
+        },
+      ],
+    });
+
+    const result = await searchQuestions({}, {
+      subject_code: ' 9709 ',
+      primary_topic_id: ' topic-1 ',
+      family_id: ' family-1 ',
+      primary_question_type_id: ' 9709.trigonometry.equations ',
+      year: ' 2024 ',
+      session: ' mj ',
+      paper_number: ' 3 ',
+      variant: ' 2 ',
+      q_number: ' 5 ',
+      query: ' tan ',
+      page: ' 2 ',
+      page_size: ' 500 ',
+    });
+
+    expect(mockSearchQuestionProjection).toHaveBeenCalledWith({}, {
+      subject_code: '9709',
+      primary_topic_id: 'topic-1',
+      family_id: 'family-1',
+      primary_question_type_id: '9709.trigonometry.equations',
+      year: 2024,
+      session: 'mj',
+      paper_number: 3,
+      variant: 2,
+      q_number: 5,
+      query: 'tan',
+      page: 2,
+      page_size: MAX_QUESTION_SEARCH_PAGE_SIZE,
+    });
+    expect(result.page).toBe(2);
+    expect(result.page_size).toBe(MAX_QUESTION_SEARCH_PAGE_SIZE);
+  });
+
+  test('searchQuestions rejects invalid numeric filters deterministically', async () => {
+    await expect(
+      searchQuestions({}, {
+        subject_code: '9709',
+        year: 'twenty-twenty-four',
+      }),
+    ).rejects.toMatchObject({
+      code: 'invalid_payload',
+      status: 400,
+      publicMessage: 'year must be a positive integer.',
+      details: { field: 'year', value: 'twenty-twenty-four' },
+    });
+
+    expect(mockSearchQuestionProjection).not.toHaveBeenCalled();
+  });
+
+  test('searchQuestions rejects malformed numeric strings instead of truncating them', async () => {
+    await expect(
+      searchQuestions({}, {
+        subject_code: '9709',
+        q_number: '12a',
+      }),
+    ).rejects.toMatchObject({
+      code: 'invalid_payload',
+      status: 400,
+      publicMessage: 'q_number must be a positive integer.',
+      details: { field: 'q_number', value: '12a' },
+    });
+
+    expect(mockSearchQuestionProjection).not.toHaveBeenCalled();
+  });
+
+  test('searchQuestions attaches the fixed match_context shape to every returned row', async () => {
+    mockSearchQuestionProjection.mockResolvedValueOnce({
+      total: 1,
+      rows: [
+        {
+          question_id: 'question-1',
+          subject_code: '9709',
+          family_id: 'family-1',
+          search_text: 'Use a trigonometric identity.',
+        },
+      ],
+    });
+
+    const result = await searchQuestions({}, {
+      subject_code: '9709',
+      family_id: 'family-1',
+      query: ' identity ',
+      page: ' 1 ',
+      page_size: ' 10 ',
+    });
+
+    expect(result).toEqual({
+      items: [
+        {
+          question_id: 'question-1',
+          subject_code: '9709',
+          family_id: 'family-1',
+          search_text: 'Use a trigonometric identity.',
+          match_context: {
+            filters_applied: ['subject_code', 'family_id'],
+            text_query_used: true,
+          },
+        },
+      ],
+      total: 1,
+      page: 1,
+      page_size: 10,
+    });
+  });
+});

--- a/api/learning/lib/questions/question-search-service.js
+++ b/api/learning/lib/questions/question-search-service.js
@@ -1,0 +1,122 @@
+import { LEARNING_ERROR_CODES } from '../contracts/error-contract.js';
+import { LearningHttpError } from '../http/learning-http.js';
+import { searchQuestionProjection } from '../repositories/question-search-repository.js';
+
+const DEFAULT_QUESTION_SEARCH_PAGE = 1;
+const DEFAULT_QUESTION_SEARCH_PAGE_SIZE = 20;
+export const MAX_QUESTION_SEARCH_PAGE_SIZE = 50;
+
+const STRUCTURED_FILTER_FIELDS = Object.freeze([
+  'subject_code',
+  'primary_topic_id',
+  'family_id',
+  'primary_question_type_id',
+  'year',
+  'session',
+  'paper_number',
+  'variant',
+  'q_number',
+]);
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeNullableString(value) {
+  const normalized = normalizeString(value);
+  return normalized || null;
+}
+
+function createInvalidPayloadError(message, details = {}) {
+  return new LearningHttpError(
+    LEARNING_ERROR_CODES.INVALID_PAYLOAD,
+    message,
+    { details },
+  );
+}
+
+function normalizeRequiredString(value, fieldName) {
+  const normalized = normalizeNullableString(value);
+  if (!normalized) {
+    throw createInvalidPayloadError(`${fieldName} is required.`, {
+      field: fieldName,
+    });
+  }
+  return normalized;
+}
+
+function normalizePositiveInteger(value, fieldName, { defaultValue = null, max = null } = {}) {
+  if (value === null || typeof value === 'undefined') {
+    return defaultValue;
+  }
+
+  if (typeof value === 'string' && normalizeString(value) === '') {
+    return defaultValue;
+  }
+
+  const parsed = typeof value === 'number'
+    ? value
+    : (/^\d+$/.test(String(value).trim())
+      ? Number.parseInt(String(value).trim(), 10)
+      : Number.NaN);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw createInvalidPayloadError(`${fieldName} must be a positive integer.`, {
+      field: fieldName,
+      value,
+    });
+  }
+
+  if (typeof max === 'number') {
+    return Math.min(parsed, max);
+  }
+
+  return parsed;
+}
+
+export function normalizeQuestionSearchInput(input = {}) {
+  return {
+    subject_code: normalizeRequiredString(input.subject_code, 'subject_code'),
+    primary_topic_id: normalizeNullableString(input.primary_topic_id),
+    family_id: normalizeNullableString(input.family_id),
+    primary_question_type_id: normalizeNullableString(input.primary_question_type_id),
+    year: normalizePositiveInteger(input.year, 'year'),
+    session: normalizeNullableString(input.session),
+    paper_number: normalizePositiveInteger(input.paper_number, 'paper_number'),
+    variant: normalizePositiveInteger(input.variant, 'variant'),
+    q_number: normalizePositiveInteger(input.q_number, 'q_number'),
+    query: normalizeNullableString(input.query),
+    page: normalizePositiveInteger(input.page, 'page', {
+      defaultValue: DEFAULT_QUESTION_SEARCH_PAGE,
+    }),
+    page_size: normalizePositiveInteger(input.page_size, 'page_size', {
+      defaultValue: DEFAULT_QUESTION_SEARCH_PAGE_SIZE,
+      max: MAX_QUESTION_SEARCH_PAGE_SIZE,
+    }),
+  };
+}
+
+function buildMatchContext(filters) {
+  return {
+    filters_applied: STRUCTURED_FILTER_FIELDS.filter((field) => filters[field] !== null),
+    text_query_used: Boolean(filters.query),
+  };
+}
+
+export async function searchQuestions(client, input = {}) {
+  const normalizedFilters = normalizeQuestionSearchInput(input);
+  const { rows, total } = await searchQuestionProjection(client, normalizedFilters);
+  const matchContext = buildMatchContext(normalizedFilters);
+
+  return {
+    items: rows.map((row) => ({
+      ...row,
+      match_context: {
+        filters_applied: [...matchContext.filters_applied],
+        text_query_used: matchContext.text_query_used,
+      },
+    })),
+    total,
+    page: normalizedFilters.page,
+    page_size: normalizedFilters.page_size,
+  };
+}

--- a/api/learning/lib/repositories/question-search-repository.js
+++ b/api/learning/lib/repositories/question-search-repository.js
@@ -1,0 +1,60 @@
+const QUESTION_SEARCH_PROJECTION = 'learning_question_search_projection';
+
+function normalizeNullableString(value) {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  return normalized || null;
+}
+
+function escapeLikePattern(value) {
+  return String(value).replace(/[\\%_]/g, '\\$&');
+}
+
+export async function searchQuestionProjection(client, filters = {}) {
+  const page = Number.isInteger(filters.page) && filters.page > 0 ? filters.page : 1;
+  const pageSize = Number.isInteger(filters.page_size) && filters.page_size > 0
+    ? filters.page_size
+    : 20;
+  const rangeStart = (page - 1) * pageSize;
+  const rangeEnd = rangeStart + pageSize - 1;
+
+  let query = client
+    .from(QUESTION_SEARCH_PROJECTION)
+    .select('*', { count: 'exact' });
+
+  const structuredFilters = [
+    ['subject_code', filters.subject_code],
+    ['primary_topic_id', filters.primary_topic_id],
+    ['family_id', filters.family_id],
+    ['primary_question_type_id', filters.primary_question_type_id],
+    ['year', filters.year],
+    ['session', filters.session],
+    ['paper_number', filters.paper_number],
+    ['variant', filters.variant],
+    ['q_number', filters.q_number],
+  ];
+
+  for (const [field, value] of structuredFilters) {
+    if (value !== null && typeof value !== 'undefined') {
+      query = query.eq(field, value);
+    }
+  }
+
+  const textQuery = normalizeNullableString(filters.query);
+  if (textQuery) {
+    // V1 tradeoff: pilot-scale retrieval uses ILIKE on search_text only.
+    query = query.ilike('search_text', `%${escapeLikePattern(textQuery)}%`);
+  }
+
+  const { data, count, error } = await query
+    .order('question_id', { ascending: true })
+    .range(rangeStart, rangeEnd);
+
+  if (error) {
+    throw new Error(`Failed to search question projection: ${error.message}`);
+  }
+
+  return {
+    total: Number.isInteger(count) ? count : 0,
+    rows: Array.isArray(data) ? data : [],
+  };
+}

--- a/api/learning/questions/index.js
+++ b/api/learning/questions/index.js
@@ -1,0 +1,70 @@
+import { requireAuth } from '../../lib/security/auth-guard.js';
+import { getServiceClient } from '../../lib/supabase/client.js';
+import { LEARNING_ERROR_CODES } from '../lib/contracts/error-contract.js';
+import {
+  LearningHttpError,
+  sendLearningError,
+  sendLearningHttpError,
+  sendLearningJson,
+} from '../lib/http/learning-http.js';
+import { searchQuestions } from '../lib/questions/question-search-service.js';
+
+async function ensureLearningAuth(req) {
+  if (req?.auth_user_id) {
+    return {
+      ok: true,
+      userId: req.auth_user_id,
+    };
+  }
+
+  const auth = await requireAuth(req);
+  if (!auth.ok) {
+    return auth;
+  }
+
+  return {
+    ok: true,
+    userId: auth.user?.id || req?.auth_user_id || null,
+  };
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return sendLearningError(
+      res,
+      req?.request_id || null,
+      LEARNING_ERROR_CODES.INVALID_PAYLOAD,
+      {
+        status: 405,
+        message: 'Method not allowed.',
+      },
+    );
+  }
+
+  const auth = await ensureLearningAuth(req);
+  if (!auth.ok || !auth.userId) {
+    return sendLearningError(
+      res,
+      req?.request_id || null,
+      auth.code || LEARNING_ERROR_CODES.AUTH_REQUIRED,
+      {
+        status: auth.status || 401,
+        message: auth.message || 'Authentication required.',
+      },
+    );
+  }
+
+  try {
+    const payload = await searchQuestions(getServiceClient(), req.query || {});
+    return sendLearningJson(res, req?.request_id || null, payload);
+  } catch (error) {
+    if (error instanceof LearningHttpError) {
+      return sendLearningHttpError(res, req?.request_id || null, error);
+    }
+
+    return sendLearningError(res, req?.request_id || null, 'internal_error', {
+      status: 500,
+      message: 'Internal server error.',
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `question-search` repository and service on top of `learning_question_search_projection`
- normalize structured search filters, cap page size, and attach the fixed `match_context` shape while keeping `ILIKE` scoped to `search_text` as the V1 pilot-scale tradeoff
- add `GET /api/learning/questions` plus route-registry coverage so the new handler is reachable through the API gateway

## Verification
- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/_runtime/__tests__/route-registry-learning.test.js api/learning/__tests__/question-search-repository.test.js api/learning/__tests__/question-search-service.test.js api/learning/__tests__/question-search-api.test.js`
- `git diff --check`

Closes #190
Closes #191
Tracker: #186