### PR TITLE
feat(vlm): add qwen wave-1 router runtime

### DIFF
--- a/scripts/vlm/contracts.py
+++ b/scripts/vlm/contracts.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 import hashlib
 import json
+from functools import lru_cache
+from pathlib import Path
 import re
 from dataclasses import dataclass, field, asdict
 from typing import Literal
@@ -144,3 +146,82 @@ def compute_response_sha256(data: dict) -> str:
 
 def validate_sha256(h: str) -> bool:
     return bool(re.fullmatch(r"[a-f0-9]{64}", h))
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+QWEN_WAVE1_OUTPUT_CONTRACT_PATH = PROJECT_ROOT / "data/contracts/9709_qwen_wave1_output_contract_v1.json"
+
+
+@lru_cache(maxsize=1)
+def _load_qwen_wave1_output_contract() -> dict:
+    return json.loads(QWEN_WAVE1_OUTPUT_CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def _type_matches(value, expected_type) -> bool:
+    mapping = {
+        "string": lambda v: isinstance(v, str),
+        "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+        "object": lambda v: isinstance(v, dict),
+        "array": lambda v: isinstance(v, list),
+        "boolean": lambda v: isinstance(v, bool),
+        "null": lambda v: v is None,
+    }
+    validator = mapping.get(expected_type)
+    return bool(validator and validator(value))
+
+
+def _validate_field(field_name: str, value, rules: dict) -> None:
+    expected_type = rules.get("type")
+    if expected_type is not None:
+        allowed_types = expected_type if isinstance(expected_type, list) else [expected_type]
+        if not any(_type_matches(value, type_name) for type_name in allowed_types):
+            raise ValueError(f"{field_name} has invalid type")
+
+    if "enum" in rules and value not in rules["enum"]:
+        raise ValueError(f"{field_name} has invalid value: {value}")
+
+    if "const" in rules and value != rules["const"]:
+        raise ValueError(f"{field_name} must equal {rules['const']}")
+
+    if "pattern" in rules and value is not None:
+        if not isinstance(value, str) or re.fullmatch(rules["pattern"], value) is None:
+            raise ValueError(f"{field_name} does not match pattern {rules['pattern']}")
+
+    if "minimum" in rules and value is not None and value < rules["minimum"]:
+        raise ValueError(f"{field_name} is below minimum {rules['minimum']}")
+
+    if "maximum" in rules and value is not None and value > rules["maximum"]:
+        raise ValueError(f"{field_name} is above maximum {rules['maximum']}")
+
+
+def validate_qwen_wave1_output(payload: dict) -> dict:
+    """Validate the additive Qwen wave-1 output envelope."""
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be a dict")
+
+    contract = _load_qwen_wave1_output_contract()
+    missing = [field for field in contract["required_top_level_fields"] if field not in payload]
+    if missing:
+        raise ValueError(f"Missing required output fields: {', '.join(missing)}")
+
+    for field_name, rules in contract["field_contract"].items():
+        if field_name not in payload:
+            continue
+        _validate_field(field_name, payload[field_name], rules)
+
+    output = payload["output"]
+    if not isinstance(output, dict):
+        raise ValueError("output must be an object")
+
+    for key in ("summary", "evidence", "warnings"):
+        if key not in output:
+            raise ValueError(f"output missing required field: {key}")
+
+    if output["summary"] is not None and not isinstance(output["summary"], str):
+        raise ValueError("output.summary must be a string or null")
+    if not isinstance(output["evidence"], list) or not all(isinstance(item, dict) for item in output["evidence"]):
+        raise ValueError("output.evidence must be a list of objects")
+    if not isinstance(output["warnings"], list) or not all(isinstance(item, str) for item in output["warnings"]):
+        raise ValueError("output.warnings must be a list of strings")
+
+    return payload

--- a/scripts/vlm/create_jobs_from_manifest.py
+++ b/scripts/vlm/create_jobs_from_manifest.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Materialize additive Qwen wave-1 job plans from a frozen manifest."""
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.vlm.qwen_router_v1 import route_manifest_item
+
+DEFAULT_EXTRACTOR_VERSION = "qwen_wave1_v1"
+
+
+def load_manifest(manifest_path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+
+
+def build_manifest_job(
+    item: dict[str, Any],
+    *,
+    manifest_id: str,
+    position: int,
+) -> dict[str, Any]:
+    decision = route_manifest_item(item)
+    return {
+        "manifest_id": manifest_id,
+        "manifest_position": position,
+        "storage_key": item["storage_key"],
+        "syllabus_code": item["syllabus_code"],
+        "year": item["year"],
+        "session": item["session"],
+        "paper": item["paper"],
+        "variant": item["variant"],
+        "q_number": item["q_number"],
+        "primary_topic_path": item["primary_topic_path"],
+        "descriptor_required": item.get("descriptor_required", False),
+        "gate_critical": item["gate_critical"],
+        "requires_review": item["requires_review"],
+        "diagram_present": item.get("diagram_present"),
+        "formula_dense": item.get("formula_dense"),
+        "table_heavy": item.get("table_heavy"),
+        "route_hint": item.get("route_hint"),
+        "surface_evidence_status": item.get("surface_evidence_status"),
+        "extractor_version": DEFAULT_EXTRACTOR_VERSION,
+        **decision.to_dict(),
+    }
+
+
+def build_manifest_jobs(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    manifest_id = manifest.get("manifest_id", "unknown_manifest")
+    items = manifest.get("items", [])
+    return [
+        build_manifest_job(item, manifest_id=manifest_id, position=index)
+        for index, item in enumerate(items)
+    ]
+
+
+def summarize_jobs(jobs: list[dict[str, Any]]) -> dict[str, Any]:
+    route_counts = Counter(job["route"] for job in jobs)
+    model_counts = Counter(job["model"] for job in jobs)
+    provider_counts = Counter(job["provider"] for job in jobs)
+    prompt_counts = Counter(
+        f"{job['prompt_template_id']}@{job['prompt_template_version']}" for job in jobs
+    )
+    return {
+        "jobs_planned": len(jobs),
+        "route_counts": dict(sorted(route_counts.items())),
+        "model_counts": dict(sorted(model_counts.items())),
+        "provider_counts": dict(sorted(provider_counts.items())),
+        "prompt_counts": dict(sorted(prompt_counts.items())),
+    }
+
+
+def _write_output(output_path: Path, manifest: dict[str, Any], jobs: list[dict[str, Any]]) -> None:
+    payload = {
+        "manifest_id": manifest.get("manifest_id"),
+        "jobs": jobs,
+        "summary": summarize_jobs(jobs),
+    }
+    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create additive Qwen wave-1 jobs from a frozen manifest.",
+    )
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--output", type=Path, help="Optional path to write the materialized job plan JSON.")
+    parser.add_argument("--dry-run", action="store_true", help="Print counts without materializing a job plan file.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    manifest = load_manifest(args.manifest)
+    jobs = build_manifest_jobs(manifest)
+    summary = summarize_jobs(jobs)
+
+    print(f"manifest_id: {manifest.get('manifest_id', 'unknown')}")
+    print(f"jobs_planned: {summary['jobs_planned']}")
+    for route, count in summary["route_counts"].items():
+        print(f"{route}: {count}")
+
+    if args.dry_run:
+        return 0
+
+    if args.output:
+        _write_output(args.output, manifest, jobs)
+        print(f"wrote_job_plan: {args.output}")
+        return 0
+
+    print(json.dumps({"manifest_id": manifest.get("manifest_id"), "jobs": jobs}, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vlm/providers.py
+++ b/scripts/vlm/providers.py
@@ -3,8 +3,12 @@ VLM provider abstraction for run_extraction_v0.py
 """
 from __future__ import annotations
 from abc import ABC, abstractmethod
+import json
 from pathlib import Path
 import re
+from typing import Any
+
+from scripts.vlm.qwen_openai_client_v1 import call_qwen_openai_v1
 
 class RetryableError(Exception):
     """Error that should trigger retry with backoff."""
@@ -46,8 +50,210 @@ class MockProvider(VLMProvider):
             "summary": f"Mock extraction for {stem}",
         }
 
-def get_provider(name: str, model: str = None) -> VLMProvider:
+
+class WindowsHostQwenProvider(VLMProvider):
+    """Qwen provider that sends requests through the Windows host wrapper."""
+
+    name = "windows-qwen"
+
+    def __init__(
+        self,
+        model: str = "qwen-vl-ocr",
+        lane: str | None = None,
+        prompt_template_id: str | None = None,
+        prompt_template_version: str = "v1",
+    ):
+        self.model = model
+        self.lane = lane
+        self.prompt_template_id = prompt_template_id
+        self.prompt_template_version = prompt_template_version
+
+    def generate(self, image_path: Path) -> dict:
+        response = call_qwen_openai_v1({
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": self._build_prompt_text(),
+                        },
+                        {
+                            "type": "image_path",
+                            "image_path": str(image_path),
+                        },
+                    ],
+                }
+            ],
+            "max_tokens": 512,
+            "temperature": 0,
+            "enable_thinking": False,
+            "response_format": {"type": "json_object"},
+        })
+        raw_content = response["choices"][0]["message"]["content"]
+        try:
+            parsed = json.loads(raw_content)
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                "Windows-host Qwen provider did not return a valid JSON object"
+            ) from error
+        if not isinstance(parsed, dict):
+            raise ValueError("Windows-host Qwen provider did not return a valid JSON object")
+        return self._normalize_result(parsed)
+
+    def _build_prompt_text(self) -> str:
+        if self.lane == "ocr":
+            return (
+                "Return a single JSON object only. "
+                "This is an OCR and document-surface extraction task. "
+                "Do not infer topic, syllabus, or solution steps. "
+                "Include keys ocr_text, formula_latex_list, subquestion_blocks, layout_hints, "
+                "symbol_inventory, table_blocks, line_boxes, ocr_confidence. "
+                "Use the exact visible text for ocr_text. "
+                "Use arrays for list-like fields, objects for detected blocks/boxes, and numbers for confidence. "
+                "If a field is not visible, return an empty string only for ocr_text and otherwise return [] or 0. "
+                "Do not include markdown fences or explanation."
+            )
+        if self.lane == "diagram":
+            return (
+                "Return a single JSON object only. "
+                "This is a diagram and spatial extraction task. "
+                "Do not infer topic, syllabus, or solution steps. "
+                "Include keys diagram_present, diagram_type, diagram_elements, axes_labels, "
+                "curve_point_annotations, shape_relations, object_grounding, spatial_evidence, diagram_confidence. "
+                "Use false for diagram_present when no meaningful diagram is visible. "
+                "Use [] for list fields, an empty string for diagram_type when unknown, and 0 for diagram_confidence. "
+                "Do not include markdown fences or explanation."
+            )
+        if self.lane == "review":
+            return (
+                "Return a single JSON object only. "
+                "This is a multimodal review triage task. "
+                "Do not assign final topic, syllabus, or answer. "
+                "Include keys requires_review, review_reasons, ambiguity_flags, review_summary, review_confidence. "
+                "Set requires_review true only when the image has visual ambiguity, legibility risk, diagram complexity, "
+                "or layout issues that likely need downstream review. "
+                "Use [] for list fields, an empty string for review_summary when nothing useful can be said, and 0 for review_confidence. "
+                "Do not include markdown fences or explanation."
+            )
+        return (
+            "Return a single JSON object only. "
+            "Include keys question_type, math_expressions_latex, variables, "
+            "units, diagram_elements, answer_form, confidence, summary. "
+            "Do not include any markdown fences or explanation."
+        )
+
+    def _normalize_result(self, parsed: dict[str, Any]) -> dict[str, Any]:
+        if self.lane == "ocr":
+            return {
+                "ocr_text": _normalize_text(parsed.get("ocr_text")),
+                "formula_latex_list": _normalize_string_list(parsed.get("formula_latex_list")),
+                "subquestion_blocks": _normalize_string_list(parsed.get("subquestion_blocks")),
+                "layout_hints": _normalize_string_list(parsed.get("layout_hints")),
+                "symbol_inventory": _normalize_string_list(parsed.get("symbol_inventory")),
+                "table_blocks": _normalize_object_list(parsed.get("table_blocks")),
+                "line_boxes": _normalize_object_list(parsed.get("line_boxes")),
+                "ocr_confidence": _normalize_float(parsed.get("ocr_confidence")),
+            }
+        if self.lane == "diagram":
+            return {
+                "diagram_present": _normalize_bool(parsed.get("diagram_present")),
+                "diagram_type": _normalize_text(parsed.get("diagram_type")),
+                "diagram_elements": _normalize_string_list(parsed.get("diagram_elements")),
+                "axes_labels": _normalize_string_list(parsed.get("axes_labels")),
+                "curve_point_annotations": _normalize_string_list(parsed.get("curve_point_annotations")),
+                "shape_relations": _normalize_string_list(parsed.get("shape_relations")),
+                "object_grounding": _normalize_object_list(parsed.get("object_grounding")),
+                "spatial_evidence": _normalize_string_list(parsed.get("spatial_evidence")),
+                "diagram_confidence": _normalize_float(parsed.get("diagram_confidence")),
+            }
+        if self.lane == "review":
+            return {
+                "requires_review": _normalize_bool(parsed.get("requires_review")),
+                "review_reasons": _normalize_string_list(parsed.get("review_reasons")),
+                "ambiguity_flags": _normalize_string_list(parsed.get("ambiguity_flags")),
+                "review_summary": _normalize_text(parsed.get("review_summary")),
+                "review_confidence": _normalize_float(parsed.get("review_confidence")),
+            }
+        return parsed
+
+
+def _normalize_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        parts = [str(item).strip() for item in value if str(item).strip()]
+        return "\n".join(parts)
+    return str(value).strip()
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        return [stripped] if stripped else []
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value:
+        if item is None:
+            continue
+        stripped = str(item).strip()
+        if stripped:
+            out.append(stripped)
+    return out
+
+
+def _normalize_object_list(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        return [value]
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _normalize_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "y"}:
+            return True
+        if lowered in {"false", "0", "no", "n", ""}:
+            return False
+    return False
+
+
+def _normalize_float(value: Any) -> float:
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def get_provider(
+    name: str,
+    model: str = None,
+    lane: str | None = None,
+    prompt_template_id: str | None = None,
+    prompt_template_version: str = "v1",
+) -> VLMProvider:
     """Get provider by name. Use 'mock' for testing, 'auto' falls back to mock."""
     if name in ("mock", "auto"):
         return MockProvider()
-    raise ValueError(f"Unknown provider: {name}. Available: mock, auto")
+    if name == "windows-qwen":
+        return WindowsHostQwenProvider(
+            model=model or "qwen-vl-ocr",
+            lane=lane,
+            prompt_template_id=prompt_template_id,
+            prompt_template_version=prompt_template_version,
+        )
+    raise ValueError(f"Unknown provider: {name}. Available: mock, auto, windows-qwen")

--- a/scripts/vlm/qwen_lane_runner_v1.py
+++ b/scripts/vlm/qwen_lane_runner_v1.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Additive manifest-driven Qwen lane runner for the wave-1 runtime."""
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.common.env import resolve_assets_root
+from scripts.vlm.contracts import validate_qwen_wave1_output
+from scripts.vlm.create_jobs_from_manifest import build_manifest_jobs, load_manifest
+from scripts.vlm.providers import get_provider
+
+
+def build_provider_for_job(job: dict[str, Any]):
+    return get_provider(
+        job["provider"],
+        job["model"],
+        lane=job["lane"],
+        prompt_template_id=job.get("prompt_template_id"),
+        prompt_template_version=job.get("prompt_template_version", "v1"),
+    )
+
+
+def _compute_file_sha256(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _confidence_from_output(lane_output: dict[str, Any]) -> float:
+    for key in ("ocr_confidence", "diagram_confidence", "review_confidence", "confidence"):
+        value = lane_output.get(key)
+        if isinstance(value, (int, float)):
+            return max(0.0, min(1.0, float(value)))
+    return 0.0
+
+
+def _summary_from_output(job: dict[str, Any], lane_output: dict[str, Any]) -> str | None:
+    if job["route"] == "ocr_lane":
+        return lane_output.get("ocr_text") or None
+    if job["route"] == "diagram_lane":
+        return lane_output.get("diagram_type") or None
+    if job["route"] == "review_lane":
+        return lane_output.get("review_summary") or None
+    return None
+
+
+def _warnings_for_job(
+    job: dict[str, Any],
+    *,
+    failure_reason: str | None = None,
+) -> list[str]:
+    warnings: list[str] = []
+    if job.get("requires_review"):
+        warnings.append("requires_review")
+    if job.get("lazy_attach_original_image"):
+        warnings.append("lazy_attach_original_image")
+    if any(job.get(flag) is None for flag in ("diagram_present", "formula_dense", "table_heavy")):
+        warnings.append("unknown_surface_flags")
+    if failure_reason:
+        warnings.append("provider_failure")
+    return list(dict.fromkeys(warnings))
+
+
+def build_lane_output(
+    job: dict[str, Any],
+    lane_output: dict[str, Any],
+    *,
+    input_asset_hash: str | None,
+    failure_reason: str | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "provider": job["provider"],
+        "model": job["model"],
+        "route": job["route"],
+        "lane": job["lane"],
+        "prompt_template_id": job["prompt_template_id"],
+        "prompt_template_version": job["prompt_template_version"],
+        "region": job["region"],
+        "base_url": job["base_url"],
+        "input_asset_id": job["storage_key"],
+        "input_asset_hash": input_asset_hash,
+        "response_schema_version": job["response_schema_version"],
+        "confidence": _confidence_from_output(lane_output),
+        "failure_reason": failure_reason,
+        "lazy_attach_original_image": bool(job.get("lazy_attach_original_image")),
+        "output": {
+            "summary": None if failure_reason else _summary_from_output(job, lane_output),
+            "evidence": [] if failure_reason else [
+                {"field": key, "value": value}
+                for key, value in lane_output.items()
+            ],
+            "warnings": _warnings_for_job(job, failure_reason=failure_reason),
+        },
+    }
+    return validate_qwen_wave1_output(payload)
+
+
+def run_lane_job(
+    job: dict[str, Any],
+    *,
+    image_path: str | Path,
+    provider=None,
+) -> dict[str, Any]:
+    resolved_image_path = Path(image_path)
+    input_asset_hash = _compute_file_sha256(resolved_image_path)
+    runtime_provider = provider or build_provider_for_job(job)
+
+    try:
+        lane_output = runtime_provider.generate(resolved_image_path)
+    except Exception as error:  # pragma: no cover - tested through public envelope
+        return build_lane_output(
+            job,
+            {},
+            input_asset_hash=input_asset_hash,
+            failure_reason=str(error),
+        )
+
+    return build_lane_output(
+        job,
+        lane_output,
+        input_asset_hash=input_asset_hash,
+    )
+
+
+def _build_jobs_from_args(args: argparse.Namespace) -> list[dict[str, Any]]:
+    manifest = load_manifest(args.manifest)
+    jobs = build_manifest_jobs(manifest)
+    if args.max_jobs is not None:
+        jobs = jobs[:args.max_jobs]
+    return jobs
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run additive Qwen wave-1 jobs from a frozen manifest.",
+    )
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--assets-root", type=Path, default=resolve_assets_root())
+    parser.add_argument("--max-jobs", type=int)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    jobs = _build_jobs_from_args(args)
+
+    if args.dry_run:
+        route_counts = Counter(job["route"] for job in jobs)
+        print(f"jobs_planned: {len(jobs)}")
+        for route, count in sorted(route_counts.items()):
+            print(f"{route}: {count}")
+        return 0
+
+    payloads = []
+    for job in jobs:
+        image_path = args.assets_root / job["storage_key"]
+        payloads.append(run_lane_job(job, image_path=image_path))
+
+    rendered = json.dumps(payloads, ensure_ascii=False, indent=2)
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+        print(f"wrote_results: {args.output}")
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vlm/qwen_lane_runner_v1.py
+++ b/scripts/vlm/qwen_lane_runner_v1.py
@@ -12,7 +12,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from scripts.common.env import resolve_assets_root
+from scripts.common.env import load_project_env, resolve_assets_root
 from scripts.vlm.contracts import validate_qwen_wave1_output
 from scripts.vlm.create_jobs_from_manifest import build_manifest_jobs, load_manifest
 from scripts.vlm.providers import get_provider
@@ -151,6 +151,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
+    load_project_env()
     args = parse_args(argv)
     jobs = _build_jobs_from_args(args)
 

--- a/scripts/vlm/qwen_openai_client_v1.py
+++ b/scripts/vlm/qwen_openai_client_v1.py
@@ -12,6 +12,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable
 
+from scripts.common.env import load_project_env
+
 DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 
 
@@ -189,6 +191,8 @@ def call_qwen_openai_v1(
     timeout: int = 90,
     temp_dir: str | Path | None = None,
 ) -> dict[str, Any]:
+    if env is None:
+        load_project_env()
     base_env = dict(env if env is not None else os.environ)
     api_key = get_dashscope_api_key(base_env)
     effective_path_converter = bind_path_converter(runner, path_converter)

--- a/scripts/vlm/qwen_openai_client_v1.py
+++ b/scripts/vlm/qwen_openai_client_v1.py
@@ -65,6 +65,19 @@ def normalize_request_for_windows_host(
     return normalized
 
 
+def bind_path_converter(
+    runner: Callable[..., Any],
+    path_converter: Callable[[str | Path], str] | None = None,
+) -> Callable[[str | Path], str]:
+    if path_converter is not None:
+        return path_converter
+
+    def _convert(path: str | Path) -> str:
+        return to_windows_path(path, runner=runner)
+
+    return _convert
+
+
 def build_powershell_command(
     *,
     script_path: str,
@@ -171,17 +184,18 @@ def call_qwen_openai_v1(
     *,
     env: dict[str, str] | None = None,
     runner: Callable[..., Any] = subprocess.run,
-    path_converter: Callable[[str | Path], str] = to_windows_path,
+    path_converter: Callable[[str | Path], str] | None = None,
     base_url: str = DEFAULT_BASE_URL,
     timeout: int = 90,
     temp_dir: str | Path | None = None,
 ) -> dict[str, Any]:
     base_env = dict(env if env is not None else os.environ)
     api_key = get_dashscope_api_key(base_env)
+    effective_path_converter = bind_path_converter(runner, path_converter)
 
     normalized_request = normalize_request_for_windows_host(
         request,
-        path_converter=path_converter,
+        path_converter=effective_path_converter,
     )
 
     with tempfile.NamedTemporaryFile(
@@ -207,8 +221,8 @@ def call_qwen_openai_v1(
         script_path = Path(handle.name)
 
     try:
-        windows_request_path = path_converter(request_path)
-        windows_script_path = path_converter(script_path)
+        windows_request_path = effective_path_converter(request_path)
+        windows_script_path = effective_path_converter(script_path)
         command = build_powershell_command(
             script_path=windows_script_path,
             request_path=windows_request_path,

--- a/scripts/vlm/qwen_openai_client_v1.py
+++ b/scripts/vlm/qwen_openai_client_v1.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""DashScope OpenAI-compatible client routed through the Windows host."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Callable
+
+DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+
+class QwenOpenAIClientError(RuntimeError):
+    """Raised when the Windows-host Qwen wrapper cannot complete a request."""
+
+
+def get_dashscope_api_key(env: dict[str, str] | None = None) -> str:
+    scope = env if env is not None else os.environ
+    key = scope.get("DASHSCOPE_API_KEY")
+    if not key:
+        raise QwenOpenAIClientError("DASHSCOPE_API_KEY is required")
+    return key
+
+
+def to_windows_path(
+    path: str | Path,
+    runner: Callable[..., Any] = subprocess.run,
+) -> str:
+    result = runner(
+        ["wslpath", "-w", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise QwenOpenAIClientError(
+            f"Failed to convert WSL path to Windows path: {result.stderr.strip() or result.stdout.strip()}",
+        )
+    return result.stdout.strip()
+
+
+def normalize_request_for_windows_host(
+    request: dict[str, Any],
+    path_converter: Callable[[str | Path], str] = to_windows_path,
+) -> dict[str, Any]:
+    normalized = deepcopy(request)
+
+    for message in normalized.get("messages", []):
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if (
+                isinstance(part, dict)
+                and part.get("type") == "image_path"
+                and part.get("image_path")
+            ):
+                part["image_path"] = path_converter(part["image_path"])
+
+    return normalized
+
+
+def build_powershell_command(
+    *,
+    script_path: str,
+    request_path: str,
+    base_url: str = DEFAULT_BASE_URL,
+) -> list[str]:
+    return [
+        "powershell.exe",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        script_path,
+        request_path,
+        base_url,
+    ]
+
+
+def build_powershell_script() -> str:
+    return r"""
+param(
+  [string]$RequestPath,
+  [string]$BaseUrl
+)
+
+$ErrorActionPreference = 'Stop'
+$request = Get-Content -Raw -Path $RequestPath | ConvertFrom-Json
+
+function Convert-ImagePathToPart($part) {
+  if ($null -eq $part) { return $null }
+  if ($part.type -ne 'image_path') { return $part }
+
+  $imagePath = [string]$part.image_path
+  $bytes = [System.IO.File]::ReadAllBytes($imagePath)
+  $extension = [System.IO.Path]::GetExtension($imagePath).ToLowerInvariant()
+  $mediaType = switch ($extension) {
+    '.jpg' { 'image/jpeg' }
+    '.jpeg' { 'image/jpeg' }
+    '.webp' { 'image/webp' }
+    default { 'image/png' }
+  }
+
+  return @{
+    type = 'image_url'
+    image_url = @{
+      url = ('data:' + $mediaType + ';base64,' + [Convert]::ToBase64String($bytes))
+    }
+  }
+}
+
+$normalizedMessages = @()
+foreach ($message in $request.messages) {
+  $content = $message.content
+  if ($content -is [System.Array]) {
+    $normalizedContent = @()
+    foreach ($part in $content) {
+      $normalizedContent += @(Convert-ImagePathToPart $part)
+    }
+    $content = $normalizedContent
+  }
+
+  $normalizedMessages += @(@{
+    role = [string]$message.role
+    content = $content
+  })
+}
+
+$body = @{
+  model = [string]$request.model
+  messages = $normalizedMessages
+}
+
+if ($request.PSObject.Properties.Name -contains 'max_tokens') {
+  $body.max_tokens = $request.max_tokens
+}
+if ($request.PSObject.Properties.Name -contains 'temperature') {
+  $body.temperature = $request.temperature
+}
+if ($request.PSObject.Properties.Name -contains 'enable_thinking') {
+  $body.enable_thinking = $request.enable_thinking
+}
+if ($request.PSObject.Properties.Name -contains 'response_format') {
+  $body.response_format = $request.response_format
+}
+
+$headers = @{
+  Authorization = ('Bearer ' + $env:DASHSCOPE_API_KEY)
+  'Content-Type' = 'application/json'
+}
+
+$response = Invoke-RestMethod `
+  -Uri ($BaseUrl.TrimEnd('/') + '/chat/completions') `
+  -Method Post `
+  -Headers $headers `
+  -Body ($body | ConvertTo-Json -Depth 100 -Compress) `
+  -TimeoutSec 90
+
+$response | ConvertTo-Json -Depth 100 -Compress
+""".strip()
+
+
+def call_qwen_openai_v1(
+    request: dict[str, Any],
+    *,
+    env: dict[str, str] | None = None,
+    runner: Callable[..., Any] = subprocess.run,
+    path_converter: Callable[[str | Path], str] = to_windows_path,
+    base_url: str = DEFAULT_BASE_URL,
+    timeout: int = 90,
+    temp_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    base_env = dict(env if env is not None else os.environ)
+    api_key = get_dashscope_api_key(base_env)
+
+    normalized_request = normalize_request_for_windows_host(
+        request,
+        path_converter=path_converter,
+    )
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".json",
+        prefix="qwen-openai-request-",
+        dir=temp_dir,
+        delete=False,
+        encoding="utf-8",
+    ) as handle:
+        json.dump(normalized_request, handle, ensure_ascii=False)
+        request_path = Path(handle.name)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".ps1",
+        prefix="qwen-openai-runner-",
+        dir=temp_dir,
+        delete=False,
+        encoding="utf-8",
+    ) as handle:
+        handle.write(build_powershell_script())
+        script_path = Path(handle.name)
+
+    try:
+        windows_request_path = path_converter(request_path)
+        windows_script_path = path_converter(script_path)
+        command = build_powershell_command(
+            script_path=windows_script_path,
+            request_path=windows_request_path,
+            base_url=base_url,
+        )
+        command_env = {**base_env, "DASHSCOPE_API_KEY": api_key}
+        result = runner(
+            command,
+            capture_output=True,
+            text=True,
+            env=command_env,
+            timeout=timeout,
+            check=False,
+        )
+    finally:
+        request_path.unlink(missing_ok=True)
+        script_path.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        raise QwenOpenAIClientError(
+            result.stderr.strip()
+            or result.stdout.strip()
+            or "Windows-host Qwen request failed",
+        )
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise QwenOpenAIClientError(
+            f"Windows-host Qwen request returned non-JSON stdout: {result.stdout[:200]}",
+        ) from error
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Call DashScope OpenAI-compatible Qwen API through Windows PowerShell.",
+    )
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--text")
+    parser.add_argument("--image-path")
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--enable-thinking", action="store_true")
+    parser.add_argument("--json-object", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.text and not args.image_path:
+        print("Provide --text or --image-path", file=sys.stderr)
+        return 4
+
+    if args.image_path:
+        content: Any = []
+        if args.text:
+            content.append({"type": "text", "text": args.text})
+        content.append({"type": "image_path", "image_path": args.image_path})
+    else:
+        content = args.text
+
+    request: dict[str, Any] = {
+        "model": args.model,
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": args.max_tokens,
+        "temperature": args.temperature,
+        "enable_thinking": args.enable_thinking,
+    }
+    if args.json_object:
+        request["response_format"] = {"type": "json_object"}
+
+    response = call_qwen_openai_v1(request, base_url=args.base_url)
+    print(json.dumps(response, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vlm/qwen_router_v1.py
+++ b/scripts/vlm/qwen_router_v1.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Deterministic manifest router for the additive Qwen wave-1 runtime."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+ROUTER_CONTRACT_PATH = PROJECT_ROOT / "data/contracts/9709_qwen_wave1_router_contract_v1.json"
+
+ROUTE_TO_LANE = {
+    "ocr_lane": "ocr",
+    "diagram_lane": "diagram",
+    "review_lane": "review",
+}
+PROMPT_TEMPLATE_IDS = {
+    "ocr_lane": "ocr_specialist",
+    "diagram_lane": "diagram_specialist",
+    "review_lane": "review_specialist",
+}
+PROMPT_TEMPLATE_VERSION = "v1"
+RESPONSE_SCHEMA_VERSION = "v1"
+DEFAULT_PROVIDER_NAME = "windows-qwen"
+SURFACE_FLAGS = ("diagram_present", "formula_dense", "table_heavy")
+
+
+class QwenRouterError(ValueError):
+    """Raised when the manifest row cannot be routed deterministically."""
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    route: str
+    lane: str
+    provider: str
+    model: str
+    prompt_template_id: str
+    prompt_template_version: str
+    response_schema_version: str
+    lazy_attach_original_image: bool
+    region: str
+    base_url: str
+    api_key_scope: str
+    stateless: bool
+    response_format: dict[str, str]
+    enable_thinking: bool
+    decision_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["decision_reasons"] = list(self.decision_reasons)
+        payload["response_format"] = dict(self.response_format)
+        return payload
+
+
+@lru_cache(maxsize=1)
+def load_router_contract() -> dict[str, Any]:
+    return json.loads(ROUTER_CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def _missing_required_fields(item: dict[str, Any], contract: dict[str, Any]) -> list[str]:
+    required_fields = contract.get("router_input_required_fields", [])
+    return [field for field in required_fields if field not in item]
+
+
+def _surface_flags_unknown(item: dict[str, Any]) -> bool:
+    return any(item.get(field) is None for field in SURFACE_FLAGS)
+
+
+def build_route_decision(
+    route: str,
+    decision_reasons: list[str],
+    contract: dict[str, Any] | None = None,
+) -> RouteDecision:
+    scope = contract or load_router_contract()
+    try:
+        route_contract = scope["routes"][route]
+    except KeyError as error:
+        raise QwenRouterError(f"Unknown route: {route}") from error
+
+    runtime = scope["runtime_freeze"]
+    return RouteDecision(
+        route=route,
+        lane=ROUTE_TO_LANE[route],
+        provider=DEFAULT_PROVIDER_NAME,
+        model=route_contract["model"],
+        prompt_template_id=PROMPT_TEMPLATE_IDS[route],
+        prompt_template_version=PROMPT_TEMPLATE_VERSION,
+        response_schema_version=RESPONSE_SCHEMA_VERSION,
+        lazy_attach_original_image=bool(route_contract["lazy_attach_original_image"]),
+        region=runtime["region"],
+        base_url=runtime["base_url"],
+        api_key_scope=runtime["api_key_scope"],
+        stateless=bool(runtime["stateless"]),
+        response_format=dict(runtime["response_format"]),
+        enable_thinking=bool(runtime["enable_thinking"]),
+        decision_reasons=tuple(dict.fromkeys(decision_reasons)),
+    )
+
+
+def route_manifest_item(
+    item: dict[str, Any],
+    contract: dict[str, Any] | None = None,
+) -> RouteDecision:
+    scope = contract or load_router_contract()
+    missing = _missing_required_fields(item, scope)
+    if missing:
+        raise QwenRouterError(
+            f"Manifest row missing required router fields: {', '.join(missing)}"
+        )
+
+    reasons: list[str] = []
+    if item.get("gate_critical"):
+        reasons.append("gate_critical")
+    if item.get("requires_review"):
+        reasons.append("requires_review")
+    if _surface_flags_unknown(item):
+        reasons.append("unknown_surface_flags")
+
+    if reasons:
+        return build_route_decision("review_lane", reasons, scope)
+
+    if item.get("diagram_present") is True:
+        return build_route_decision("diagram_lane", ["diagram_present"], scope)
+
+    if item.get("table_heavy") is True:
+        return build_route_decision("ocr_lane", ["table_heavy"], scope)
+
+    if item.get("formula_dense") is True:
+        return build_route_decision("ocr_lane", ["formula_dense"], scope)
+
+    route_hint = item.get("route_hint")
+    if route_hint == "diagram_lane":
+        return build_route_decision("diagram_lane", ["route_hint"], scope)
+    if route_hint == "ocr_lane":
+        return build_route_decision("ocr_lane", ["text_dominant"], scope)
+
+    if item.get("diagram_present") is False:
+        return build_route_decision("ocr_lane", ["text_dominant"], scope)
+
+    return build_route_decision("review_lane", ["router_fallback"], scope)
+
+
+def route_manifest_items(items: list[dict[str, Any]]) -> list[RouteDecision]:
+    return [route_manifest_item(item) for item in items]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Route a frozen Qwen wave-1 manifest into OCR/diagram/review lanes.",
+    )
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--json", action="store_true", help="Emit full routed rows as JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    routed = [
+        {
+            "storage_key": item["storage_key"],
+            **route_manifest_item(item).to_dict(),
+        }
+        for item in manifest.get("items", [])
+    ]
+
+    if args.json:
+        print(json.dumps(routed, ensure_ascii=False, indent=2))
+        return 0
+
+    counts: dict[str, int] = {}
+    for row in routed:
+        counts[row["route"]] = counts.get(row["route"], 0) + 1
+
+    print(f"manifest_id: {manifest.get('manifest_id', 'unknown')}")
+    print(f"jobs_planned: {len(routed)}")
+    for route in sorted(counts):
+        print(f"{route}: {counts[route]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_qwen_lane_runner_v1.py
+++ b/tests/test_qwen_lane_runner_v1.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.vlm.contracts import validate_qwen_wave1_output  # noqa: E402
+from scripts.vlm.qwen_lane_runner_v1 import (  # noqa: E402
+    build_provider_for_job,
+    run_lane_job,
+)
+
+
+def _job(**overrides):
+    job = {
+        "storage_key": "9709/s20_qp_12/questions/q02.png",
+        "route": "ocr_lane",
+        "lane": "ocr",
+        "provider": "windows-qwen",
+        "model": "qwen-vl-ocr",
+        "prompt_template_id": "ocr_specialist",
+        "prompt_template_version": "v1",
+        "response_schema_version": "v1",
+        "region": "dashscope-cn",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "requires_review": False,
+        "lazy_attach_original_image": False,
+    }
+    job.update(overrides)
+    return job
+
+
+def test_build_provider_for_job_uses_job_lane_metadata():
+    provider = build_provider_for_job(_job(route="diagram_lane", lane="diagram", model="qwen3-vl-plus"))
+
+    assert provider.name == "windows-qwen"
+    assert provider.lane == "diagram"
+    assert provider.model == "qwen3-vl-plus"
+
+
+def test_run_lane_job_wraps_provider_output_in_wave1_contract(tmp_path):
+    image_path = tmp_path / "q02.png"
+    image_path.write_bytes(b"fake-image")
+
+    class FakeProvider:
+        name = "windows-qwen"
+        model = "qwen-vl-ocr"
+
+        def generate(self, _image_path):
+            return {
+                "ocr_text": "Find the value of x.",
+                "formula_latex_list": ["x^2=9"],
+                "subquestion_blocks": ["(a)"],
+                "layout_hints": ["single column"],
+                "symbol_inventory": ["x"],
+                "table_blocks": [],
+                "line_boxes": [],
+                "ocr_confidence": 0.82,
+            }
+
+    payload = run_lane_job(_job(), image_path=image_path, provider=FakeProvider())
+
+    validate_qwen_wave1_output(payload)
+    assert payload["route"] == "ocr_lane"
+    assert payload["provider"] == "windows-qwen"
+    assert payload["input_asset_hash"] is not None
+    assert payload["failure_reason"] is None
+    assert payload["output"]["summary"] == "Find the value of x."
+    assert any(entry["field"] == "ocr_text" for entry in payload["output"]["evidence"])
+
+
+def test_run_lane_job_surfaces_provider_failures_in_contract_envelope(tmp_path):
+    image_path = tmp_path / "q07.png"
+    image_path.write_bytes(b"fake-image")
+
+    class FailingProvider:
+        name = "windows-qwen"
+        model = "qwen3.6-plus"
+
+        def generate(self, _image_path):
+            raise RuntimeError("network timeout")
+
+    payload = run_lane_job(
+        _job(
+            route="review_lane",
+            lane="review",
+            model="qwen3.6-plus",
+            prompt_template_id="review_specialist",
+            lazy_attach_original_image=True,
+            requires_review=True,
+        ),
+        image_path=image_path,
+        provider=FailingProvider(),
+    )
+
+    validate_qwen_wave1_output(payload)
+    assert payload["route"] == "review_lane"
+    assert payload["failure_reason"] == "network timeout"
+    assert payload["confidence"] == 0.0
+    assert payload["output"]["summary"] is None
+    assert "lazy_attach_original_image" in payload["output"]["warnings"]

--- a/tests/test_qwen_lane_runner_v1.py
+++ b/tests/test_qwen_lane_runner_v1.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.vlm.contracts import validate_qwen_wave1_output  # noqa: E402
 from scripts.vlm.qwen_lane_runner_v1 import (  # noqa: E402
     build_provider_for_job,
+    main,
     run_lane_job,
 )
 
@@ -100,3 +102,20 @@ def test_run_lane_job_surfaces_provider_failures_in_contract_envelope(tmp_path):
     assert payload["confidence"] == 0.0
     assert payload["output"]["summary"] is None
     assert "lazy_attach_original_image" in payload["output"]["warnings"]
+
+
+def test_main_loads_project_env_before_running_manifest(capsys):
+    with patch("scripts.vlm.qwen_lane_runner_v1.load_project_env") as mock_load_env:
+        with patch(
+            "scripts.vlm.qwen_lane_runner_v1._build_jobs_from_args",
+            return_value=[],
+        ):
+            exit_code = main([
+                "--manifest",
+                "data/manifests/9709_question_search_recovery_v1.json",
+                "--dry-run",
+            ])
+
+    assert exit_code == 0
+    mock_load_env.assert_called_once()
+    assert "jobs_planned: 0" in capsys.readouterr().out

--- a/tests/test_qwen_openai_client_v1.py
+++ b/tests/test_qwen_openai_client_v1.py
@@ -68,7 +68,13 @@ def test_build_powershell_script_supports_machine_consumable_fields():
 def test_call_qwen_openai_v1_invokes_powershell_and_parses_json_response(tmp_path):
     captured = {}
 
-    def fake_runner(cmd, *, capture_output, text, env, timeout, check):
+    def fake_runner(cmd, *, capture_output, text, env=None, timeout=None, check=False):
+        if cmd[0] == "wslpath":
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f"WIN::{cmd[-1]}",
+                stderr="",
+            )
         captured["cmd"] = cmd
         captured["env"] = env
         captured["timeout"] = timeout
@@ -97,6 +103,41 @@ def test_call_qwen_openai_v1_invokes_powershell_and_parses_json_response(tmp_pat
     assert captured["env"]["DASHSCOPE_API_KEY"] == "secret-key"
     assert captured["cmd"][0] == "powershell.exe"
     assert captured["timeout"] == 90
+
+
+def test_call_qwen_openai_v1_routes_path_conversion_through_injected_runner(tmp_path):
+    commands = []
+
+    def fake_runner(cmd, *, capture_output, text, env=None, timeout=None, check=False):
+        commands.append(cmd)
+        if cmd[0] == "wslpath":
+            source = cmd[-1]
+            return SimpleNamespace(returncode=0, stdout=f"WIN::{source}", stderr="")
+        return SimpleNamespace(
+            returncode=0,
+            stdout='{"model":"qwen-vl-ocr","choices":[{"message":{"content":"ok"}}]}',
+            stderr="",
+        )
+
+    with patch(
+        "scripts.vlm.qwen_openai_client_v1.get_dashscope_api_key",
+        return_value="secret-key",
+    ):
+        call_qwen_openai_v1(
+            {
+                "model": "qwen-vl-ocr",
+                "messages": [{"role": "user", "content": "Reply with exactly: ok"}],
+                "enable_thinking": False,
+                "response_format": {"type": "json_object"},
+            },
+            runner=fake_runner,
+            temp_dir=tmp_path,
+        )
+
+    assert [cmd[0] for cmd in commands[:2]] == ["wslpath", "wslpath"]
+    assert commands[2][0] == "powershell.exe"
+    assert commands[2][5].startswith("WIN::")
+    assert commands[2][6].startswith("WIN::")
 
 
 def test_main_builds_image_request_and_json_object_flag(capsys):

--- a/tests/test_qwen_openai_client_v1.py
+++ b/tests/test_qwen_openai_client_v1.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.vlm.qwen_openai_client_v1 import (  # noqa: E402
+    DEFAULT_BASE_URL,
+    build_powershell_command,
+    build_powershell_script,
+    call_qwen_openai_v1,
+    main,
+    normalize_request_for_windows_host,
+)
+
+
+def test_normalize_request_converts_image_paths_for_windows_host():
+    request = {
+        "model": "qwen-vl-ocr",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "read the image"},
+                    {"type": "image_path", "image_path": "/home/samsen/code/cie-assets/test.png"},
+                ],
+            }
+        ],
+    }
+
+    normalized = normalize_request_for_windows_host(
+        request,
+        path_converter=lambda value: f"WIN::{value}",
+    )
+
+    assert normalized["messages"][0]["content"][1] == {
+        "type": "image_path",
+        "image_path": "WIN::/home/samsen/code/cie-assets/test.png",
+    }
+
+
+def test_build_powershell_command_targets_dashscope_chat_completions():
+    command = build_powershell_command(
+        script_path="C:\\temp\\invoke-qwen.ps1",
+        request_path="C:\\temp\\request.json",
+        base_url=DEFAULT_BASE_URL,
+    )
+
+    assert command[0] == "powershell.exe"
+    assert "-NoProfile" in command
+    assert "-ExecutionPolicy" in command
+    assert "Bypass" in command
+    assert "-File" in command
+    assert command[-2:] == ["C:\\temp\\request.json", DEFAULT_BASE_URL]
+
+
+def test_build_powershell_script_supports_machine_consumable_fields():
+    script = build_powershell_script()
+
+    assert "enable_thinking" in script
+    assert "response_format" in script
+    assert "ConvertTo-Json -Depth 100 -Compress" in script
+
+
+def test_call_qwen_openai_v1_invokes_powershell_and_parses_json_response(tmp_path):
+    captured = {}
+
+    def fake_runner(cmd, *, capture_output, text, env, timeout, check):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        captured["timeout"] = timeout
+        return SimpleNamespace(
+            returncode=0,
+            stdout='{"model":"qwen3.6-plus","choices":[{"message":{"content":"ok"}}]}',
+            stderr="",
+        )
+
+    with patch(
+        "scripts.vlm.qwen_openai_client_v1.get_dashscope_api_key",
+        return_value="secret-key",
+    ):
+        response = call_qwen_openai_v1(
+            {
+                "model": "qwen3.6-plus",
+                "messages": [{"role": "user", "content": "Reply with exactly: ok"}],
+                "enable_thinking": False,
+                "response_format": {"type": "json_object"},
+            },
+            runner=fake_runner,
+            temp_dir=tmp_path,
+        )
+
+    assert response["choices"][0]["message"]["content"] == "ok"
+    assert captured["env"]["DASHSCOPE_API_KEY"] == "secret-key"
+    assert captured["cmd"][0] == "powershell.exe"
+    assert captured["timeout"] == 90
+
+
+def test_main_builds_image_request_and_json_object_flag(capsys):
+    with patch(
+        "scripts.vlm.qwen_openai_client_v1.call_qwen_openai_v1",
+        return_value={"model": "qwen-vl-ocr", "choices": [{"message": {"content": "{\"ok\":true}"}}]},
+    ) as mock_call:
+        exit_code = main([
+            "--model",
+            "qwen-vl-ocr",
+            "--text",
+            "Read the page",
+            "--image-path",
+            "/tmp/q01.png",
+            "--json-object",
+        ])
+
+    assert exit_code == 0
+    request = mock_call.call_args.args[0]
+    assert request["model"] == "qwen-vl-ocr"
+    assert request["enable_thinking"] is False
+    assert request["response_format"] == {"type": "json_object"}
+    assert request["messages"][0]["content"][1] == {
+        "type": "image_path",
+        "image_path": "/tmp/q01.png",
+    }
+    assert '\\"ok\\":true' in capsys.readouterr().out
+
+
+def test_main_rejects_missing_user_content(capsys):
+    exit_code = main(["--model", "qwen3.6-plus"])
+
+    assert exit_code == 4
+    assert "Provide --text or --image-path" in capsys.readouterr().err

--- a/tests/test_qwen_openai_client_v1.py
+++ b/tests/test_qwen_openai_client_v1.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -138,6 +139,46 @@ def test_call_qwen_openai_v1_routes_path_conversion_through_injected_runner(tmp_
     assert commands[2][0] == "powershell.exe"
     assert commands[2][5].startswith("WIN::")
     assert commands[2][6].startswith("WIN::")
+
+
+def test_call_qwen_openai_v1_honors_dashscope_api_key_loaded_from_dotenv(tmp_path, monkeypatch):
+    captured = {"load_calls": 0}
+
+    def fake_runner(cmd, *, capture_output, text, env=None, timeout=None, check=False):
+        if cmd[0] == "wslpath":
+            return SimpleNamespace(returncode=0, stdout=f"WIN::{cmd[-1]}", stderr="")
+        captured["env"] = env
+        return SimpleNamespace(
+            returncode=0,
+            stdout='{"model":"qwen-vl-ocr","choices":[{"message":{"content":"ok"}}]}',
+            stderr="",
+        )
+
+    def fake_load_project_env():
+        captured["load_calls"] += 1
+        os.environ["DASHSCOPE_API_KEY"] = "dotenv-secret"
+
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "scripts.vlm.qwen_openai_client_v1.load_project_env",
+        fake_load_project_env,
+        raising=False,
+    )
+
+    response = call_qwen_openai_v1(
+        {
+            "model": "qwen-vl-ocr",
+            "messages": [{"role": "user", "content": "Reply with exactly: ok"}],
+            "enable_thinking": False,
+            "response_format": {"type": "json_object"},
+        },
+        runner=fake_runner,
+        temp_dir=tmp_path,
+    )
+
+    assert response["choices"][0]["message"]["content"] == "ok"
+    assert captured["load_calls"] == 1
+    assert captured["env"]["DASHSCOPE_API_KEY"] == "dotenv-secret"
 
 
 def test_main_builds_image_request_and_json_object_flag(capsys):

--- a/tests/test_qwen_router_v1.py
+++ b/tests/test_qwen_router_v1.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.vlm.create_jobs_from_manifest import build_manifest_jobs  # noqa: E402
+from scripts.vlm.qwen_router_v1 import route_manifest_item  # noqa: E402
+
+
+def _item(**overrides):
+    item = {
+        "storage_key": "9709/s20_qp_12/questions/q02.png",
+        "syllabus_code": "9709",
+        "year": 2020,
+        "session": "s",
+        "paper": 1,
+        "variant": 2,
+        "q_number": 2,
+        "primary_topic_path": "9709.p1.trigonometry",
+        "route_hint": "ocr_lane",
+        "diagram_present": False,
+        "formula_dense": True,
+        "table_heavy": False,
+        "surface_evidence_status": "asset_audited",
+        "gate_critical": False,
+        "requires_review": False,
+        "descriptor_required": True,
+    }
+    item.update(overrides)
+    return item
+
+
+def test_route_manifest_item_prefers_review_lane_for_gate_critical_unknown_surface():
+    decision = route_manifest_item(
+        _item(
+            route_hint="review_lane",
+            diagram_present=None,
+            formula_dense=None,
+            table_heavy=None,
+            gate_critical=True,
+            requires_review=True,
+            surface_evidence_status="unknown_requires_primary_asset_replay",
+        )
+    )
+
+    assert decision.route == "review_lane"
+    assert decision.lane == "review"
+    assert decision.model == "qwen3.6-plus"
+    assert decision.lazy_attach_original_image is True
+    assert decision.enable_thinking is False
+    assert decision.response_format == {"type": "json_object"}
+    assert "gate_critical" in decision.decision_reasons
+    assert "unknown_surface_flags" in decision.decision_reasons
+
+
+def test_route_manifest_item_selects_diagram_lane_for_evidence_backed_diagram_rows():
+    decision = route_manifest_item(
+        _item(
+            route_hint="diagram_lane",
+            paper=3,
+            variant=1,
+            q_number=8,
+            primary_topic_path="9709.p3.trigonometry",
+            diagram_present=True,
+            formula_dense=False,
+            table_heavy=False,
+        )
+    )
+
+    assert decision.route == "diagram_lane"
+    assert decision.lane == "diagram"
+    assert decision.model == "qwen3-vl-plus"
+    assert decision.lazy_attach_original_image is True
+    assert "diagram_present" in decision.decision_reasons
+
+
+def test_route_manifest_item_selects_ocr_lane_for_formula_dense_text_dominant_rows():
+    decision = route_manifest_item(
+        _item(
+            route_hint="ocr_lane",
+            diagram_present=False,
+            formula_dense=True,
+            table_heavy=False,
+        )
+    )
+
+    assert decision.route == "ocr_lane"
+    assert decision.lane == "ocr"
+    assert decision.model == "qwen-vl-ocr"
+    assert decision.lazy_attach_original_image is False
+    assert "formula_dense" in decision.decision_reasons
+
+
+def test_build_manifest_jobs_carries_lane_provider_model_and_prompt_metadata():
+    jobs = build_manifest_jobs({"manifest_id": "unit-test", "items": [_item(route_hint="diagram_lane", diagram_present=True, formula_dense=False)]})
+
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job["route"] == "diagram_lane"
+    assert job["lane"] == "diagram"
+    assert job["provider"] == "windows-qwen"
+    assert job["model"] == "qwen3-vl-plus"
+    assert job["prompt_template_id"] == "diagram_specialist"
+    assert job["prompt_template_version"] == "v1"
+    assert job["response_schema_version"] == "v1"
+    assert job["enable_thinking"] is False
+    assert job["response_format"] == {"type": "json_object"}

--- a/tests/test_qwen_windows_host_provider.py
+++ b/tests/test_qwen_windows_host_provider.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.vlm.providers import WindowsHostQwenProvider, get_provider  # noqa: E402
+
+
+def test_get_provider_returns_windows_host_qwen_provider():
+    provider = get_provider("windows-qwen", "qwen-vl-ocr", lane="ocr")
+
+    assert isinstance(provider, WindowsHostQwenProvider)
+    assert provider.name == "windows-qwen"
+    assert provider.model == "qwen-vl-ocr"
+    assert provider.lane == "ocr"
+
+
+def test_windows_host_qwen_provider_calls_wrapper_with_ocr_lane_contract_and_normalizes_empty_fields(tmp_path):
+    image_path = tmp_path / "q02.png"
+    image_path.write_bytes(b"fake-image")
+
+    captured = {}
+
+    def fake_call(request, **kwargs):
+        captured["request"] = request
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": '{"ocr_text":"","formula_latex_list":"","subquestion_blocks":"","layout_hints":"","symbol_inventory":[],"table_blocks":"","line_boxes":"","ocr_confidence":""}'
+                    }
+                }
+            ]
+        }
+
+    provider = WindowsHostQwenProvider(model="qwen-vl-ocr", lane="ocr")
+
+    with patch("scripts.vlm.providers.call_qwen_openai_v1", side_effect=fake_call):
+        result = provider.generate(image_path)
+
+    assert captured["request"]["model"] == "qwen-vl-ocr"
+    assert captured["request"]["enable_thinking"] is False
+    assert captured["request"]["response_format"] == {"type": "json_object"}
+    prompt_text = captured["request"]["messages"][0]["content"][0]["text"]
+    assert "ocr_text" in prompt_text
+    assert "question_type" not in prompt_text
+    assert captured["request"]["messages"][0]["content"][1] == {
+        "type": "image_path",
+        "image_path": str(image_path),
+    }
+    assert result == {
+        "ocr_text": "",
+        "formula_latex_list": [],
+        "subquestion_blocks": [],
+        "layout_hints": [],
+        "symbol_inventory": [],
+        "table_blocks": [],
+        "line_boxes": [],
+        "ocr_confidence": 0.0,
+    }
+
+
+def test_windows_host_qwen_provider_builds_diagram_lane_contract(tmp_path):
+    image_path = tmp_path / "q02.png"
+    image_path.write_bytes(b"fake-image")
+
+    captured = {}
+
+    def fake_call(request, **kwargs):
+        captured["request"] = request
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": '{"diagram_present":true,"diagram_type":"graph","diagram_elements":["curve"],"axes_labels":["x","y"],"curve_point_annotations":[],"shape_relations":[],"object_grounding":[],"spatial_evidence":[],"diagram_confidence":0.9}'
+                    }
+                }
+            ]
+        }
+
+    provider = WindowsHostQwenProvider(model="qwen3-vl-plus", lane="diagram")
+
+    with patch("scripts.vlm.providers.call_qwen_openai_v1", side_effect=fake_call):
+        result = provider.generate(image_path)
+
+    prompt_text = captured["request"]["messages"][0]["content"][0]["text"]
+    assert "diagram_present" in prompt_text
+    assert "ocr_text" not in prompt_text
+    assert result["diagram_present"] is True
+    assert result["diagram_type"] == "graph"
+
+
+def test_windows_host_qwen_provider_builds_review_lane_contract(tmp_path):
+    image_path = tmp_path / "q06.png"
+    image_path.write_bytes(b"fake-image")
+
+    captured = {}
+
+    def fake_call(request, **kwargs):
+        captured["request"] = request
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": '{"requires_review":true,"review_reasons":["gate_critical"],"ambiguity_flags":["unknown_surface"],"review_summary":"Needs specialist review","review_confidence":0.65}'
+                    }
+                }
+            ]
+        }
+
+    provider = WindowsHostQwenProvider(model="qwen3.6-plus", lane="review")
+
+    with patch("scripts.vlm.providers.call_qwen_openai_v1", side_effect=fake_call):
+        result = provider.generate(image_path)
+
+    prompt_text = captured["request"]["messages"][0]["content"][0]["text"]
+    assert "requires_review" in prompt_text
+    assert "question_type" not in prompt_text
+    assert result["requires_review"] is True
+    assert result["review_summary"] == "Needs specialist review"
+
+
+def test_windows_host_qwen_provider_rejects_non_json_wrapper_output(tmp_path):
+    image_path = tmp_path / "q02.png"
+    image_path.write_bytes(b"fake-image")
+
+    provider = WindowsHostQwenProvider(model="qwen-vl-ocr", lane="ocr")
+
+    with patch(
+        "scripts.vlm.providers.call_qwen_openai_v1",
+        return_value={"choices": [{"message": {"content": "not-json"}}]},
+    ):
+        try:
+            provider.generate(image_path)
+        except ValueError as exc:
+            assert "valid JSON object" in str(exc)
+        else:
+            raise AssertionError("Expected ValueError for non-JSON wrapper output")


### PR DESCRIPTION
Closes #199.

This PR lands the additive Qwen wave-1 router and official lane runtime for the `9709` recovery slice without replacing the existing `v0` extraction path.

The root issue was that the repository had frozen contracts and a deterministic manifest from #198, but it still lacked repo-owned runtime code that could turn manifest metadata into lane decisions, carry lane/provider/model/prompt provenance forward into job creation, and execute the official DashScope-compatible Qwen path in a machine-consumable way. That left the architecture as a documented intention rather than a runnable additive path.

The fix adds a deterministic `qwen_router_v1.py` that reads the frozen router contract and selects `ocr_lane`, `diagram_lane`, or `review_lane` from manifest metadata with explicit reasons and frozen runtime provenance. It also adds `create_jobs_from_manifest.py`, which materializes manifest-backed Qwen job plans carrying lane, provider, model, prompt template, response schema, and machine-consumable request metadata. Because the current frozen manifest rows still have unresolved surface flags, the current dry-run correctly stays on `review_lane` for all 17 rows instead of coercing unknowns to false.

The PR also formalizes the Windows-host DashScope transport path that existed only as a local prototype. `qwen_openai_client_v1.py` now wraps the OpenAI-compatible DashScope call through Windows PowerShell with image-path normalization for WSL, and `providers.py` gains a lane-aware `windows-qwen` provider with specialist OCR, diagram, and review prompts instead of one generic descriptor prompt. `qwen_lane_runner_v1.py` consumes the manifest-backed jobs, resolves providers from the routed metadata, and emits the frozen machine-consumable output envelope with route/model/region/prompt provenance plus failure envelopes when a provider call fails.

Validation used the focused wave-1 test and CLI commands below:

- `.venv/bin/python -m pytest tests/test_qwen_router_v1.py tests/test_qwen_openai_client_v1.py tests/test_qwen_lane_runner_v1.py tests/test_qwen_windows_host_provider.py -q`
- `.venv/bin/python -m pytest tests/test_call_vlm.py -q`
- `python3 scripts/vlm/create_jobs_from_manifest.py --manifest data/manifests/9709_question_search_recovery_v1.json --dry-run`
- `python3 scripts/vlm/qwen_lane_runner_v1.py --manifest data/manifests/9709_question_search_recovery_v1.json --max-jobs 5 --dry-run`

Residual risk remains on live transport execution rather than contracts: this session did not perform a real DashScope call, so the Windows-host path is covered by unit tests and dry-runs but not by a live API invocation. Also, the frozen manifest still carries unknown surface flags, so production routing will remain review-heavy until a later primary-asset replay resolves diagram/formula/table evidence with real asset-backed metadata.
