### PR TITLE
feat: add AO evidence bundles for question-analysis backfill

### DIFF
--- a/scripts/learning/__tests__/question-analysis-backfill.test.js
+++ b/scripts/learning/__tests__/question-analysis-backfill.test.js
@@ -348,6 +348,155 @@ describe('question-analysis backfill', () => {
     });
   });
 
+  test('classifies from non-OCR bundle evidence when formula_latex_list carries the signal', async () => {
+    const { client, state } = createBackfillClient();
+
+    const summary = await runQuestionAnalysisBackfill(client, {
+      questions: [
+        {
+          question_id: 'question-formula-only',
+          source_kind: 'imported_question',
+          subject_code: '9709',
+          prompt_representation: {
+            type: 'text',
+            value: 'Unreadable raw image placeholder.',
+          },
+          questionEvidenceBundle: {
+            schema_version: 'question_evidence_bundle_v1',
+            storage_key: '9709/s19_qp_11/questions/q06.png',
+            analysis_hints: {
+              topic_path_hint: '9709.p3.differential_equations',
+            },
+            evidence: {
+              ocr_text: '',
+              formula_latex_list: ['dy/dx = 2xy'],
+              subquestion_blocks: [],
+              layout_hints: ['single_column_prompt'],
+              diagram_present: false,
+              diagram_elements: [],
+              spatial_evidence: [],
+            },
+            route: {
+              route: 'review_lane',
+              model: 'qwen3.6-plus',
+              region: 'dashscope-cn',
+              prompt_template_version: 'v1',
+              response_schema_version: 'v1',
+            },
+            model_provenance: [
+              {
+                route: 'review_lane',
+                model: 'qwen3.6-plus',
+                region: 'dashscope-cn',
+                prompt_template_version: 'v1',
+                response_schema_version: 'v1',
+              },
+            ],
+            lazy_attach_original_image: true,
+            lazy_attach_reasons: ['requires_review'],
+            original_image_asset: {
+              input_asset_id: '9709/s19_qp_11/questions/q06.png',
+              input_asset_hash: 'hash-review-1',
+            },
+            review_posture: {
+              requires_review: true,
+              gate_critical: false,
+            },
+          },
+          provenance_summary: {
+            import_source: 'manual_paste',
+            storage_key: '9709/s19_qp_11/questions/q06.png',
+          },
+          classification_snapshot_ref: null,
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      processed: 1,
+      backfilled: 1,
+      skipped: 0,
+    });
+    expect(state.snapshots.get('snapshot-1')).toMatchObject({
+      primary_question_type_id: '9709.differential_equations.separable',
+      analysis_audit_metadata: expect.objectContaining({
+        ao_input_source: 'question_evidence_bundle_v1',
+      }),
+    });
+  });
+
+  test('records which structured bundle sections were serialized into the AO classification input', async () => {
+    const { client, state } = createBackfillClient();
+
+    await runQuestionAnalysisBackfill(client, {
+      questions: [
+        {
+          question_id: 'question-structured-sections',
+          source_kind: 'imported_question',
+          subject_code: '9709',
+          prompt_representation: {
+            type: 'text',
+            value: 'Unreadable raw image placeholder.',
+          },
+          questionEvidenceBundle: {
+            schema_version: 'question_evidence_bundle_v1',
+            storage_key: '9709/s20_qp_33/questions/q02.png',
+            analysis_hints: {
+              topic_path_hint: '9709.p3.integration',
+            },
+            evidence: {
+              ocr_text: '',
+              formula_latex_list: ['\\int (2x+1)(x^2+x)^4 \\, dx'],
+              subquestion_blocks: ['(a) Evaluate the integral.'],
+              layout_hints: ['single_column_prompt'],
+              diagram_present: true,
+              diagram_elements: ['curve C labelled y=f(x)'],
+              spatial_evidence: ['bounded by the x-axis'],
+            },
+            route: {
+              route: 'review_lane',
+              model: 'qwen3.6-plus',
+              region: 'dashscope-cn',
+              prompt_template_version: 'v1',
+              response_schema_version: 'v1',
+            },
+            model_provenance: [],
+            lazy_attach_original_image: true,
+            lazy_attach_reasons: ['requires_review'],
+            original_image_asset: {
+              input_asset_id: '9709/s20_qp_33/questions/q02.png',
+              input_asset_hash: 'hash-review-2',
+            },
+            review_posture: {
+              requires_review: true,
+              gate_critical: false,
+            },
+          },
+          provenance_summary: {
+            import_source: 'manual_paste',
+            storage_key: '9709/s20_qp_33/questions/q02.png',
+          },
+          classification_snapshot_ref: null,
+        },
+      ],
+    });
+
+    expect(state.snapshots.get('snapshot-1')).toMatchObject({
+      analysis_audit_metadata: expect.objectContaining({
+        question_evidence_bundle_v1: expect.objectContaining({
+          classification_input_sections: expect.arrayContaining([
+            'formula_latex_list',
+            'subquestion_blocks',
+            'layout_hints',
+            'diagram_present',
+            'diagram_elements',
+            'spatial_evidence',
+          ]),
+        }),
+      }),
+    });
+  });
+
   test('skips questions that already have an active snapshot unless force is enabled', async () => {
     const { client } = createBackfillClient();
 

--- a/scripts/learning/__tests__/question-analysis-backfill.test.js
+++ b/scripts/learning/__tests__/question-analysis-backfill.test.js
@@ -211,6 +211,143 @@ describe('question-analysis backfill', () => {
     });
   });
 
+  test('passes per-question analysisHints through the batch runner when no evidence bundle is present', async () => {
+    const { client, state } = createBackfillClient();
+
+    const summary = await runQuestionAnalysisBackfill(client, {
+      questions: [
+        {
+          question_id: 'question-hints',
+          source_kind: 'imported_question',
+          subject_code: '9709',
+          prompt_representation: {
+            type: 'text',
+            value: 'What is the capital of France?',
+          },
+          analysisHints: {
+            runtime_context_id: '9709.integration.application',
+            question_type_hint_id: '9709.integration.application',
+            topic_path_hint: '9709.p3.integration',
+          },
+          provenance_summary: {
+            import_source: 'manual_paste',
+          },
+          classification_snapshot_ref: null,
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      processed: 1,
+      backfilled: 1,
+      skipped: 0,
+    });
+    expect(state.snapshots.get('snapshot-1')).toMatchObject({
+      primary_question_type_id: '9709.integration.application',
+      analysis_audit_metadata: expect.objectContaining({
+        analysis_hints: expect.objectContaining({
+          question_type_hint_id: '9709.integration.application',
+          topic_path_hint: '9709.p3.integration',
+        }),
+      }),
+    });
+  });
+
+  test('prefers question evidence bundle OCR text and persists replay provenance for gate-critical rows', async () => {
+    const { client, state } = createBackfillClient();
+
+    const summary = await runQuestionAnalysisBackfill(client, {
+      questions: [
+        {
+          question_id: 'question-bundle',
+          source_kind: 'imported_question',
+          subject_code: '9709',
+          prompt_representation: {
+            type: 'text',
+            value: 'Unreadable raw image placeholder.',
+          },
+          questionEvidenceBundle: {
+            schema_version: 'question_evidence_bundle_v1',
+            storage_key: '9709/s19_qp_11/questions/q06.png',
+            analysis_hints: {
+              topic_path_hint: '9709.p3.differential_equations',
+            },
+            evidence: {
+              ocr_text: 'Solve the differential equation dy/dx = 2xy given that y = 1 when x = 0.',
+              formula_latex_list: ['\\frac{dy}{dx} = 2xy'],
+              subquestion_blocks: ['(a) Solve the differential equation.'],
+              layout_hints: ['single_column_prompt'],
+              diagram_present: false,
+              diagram_elements: [],
+              spatial_evidence: [],
+            },
+            route: {
+              route: 'review_lane',
+              model: 'qwen3.6-plus',
+              region: 'dashscope-cn',
+              prompt_template_version: 'v1',
+              response_schema_version: 'v1',
+            },
+            model_provenance: [
+              {
+                route: 'review_lane',
+                model: 'qwen3.6-plus',
+                region: 'dashscope-cn',
+                prompt_template_version: 'v1',
+                response_schema_version: 'v1',
+              },
+            ],
+            lazy_attach_original_image: true,
+            lazy_attach_reasons: ['gate_critical', 'requires_review'],
+            original_image_asset: {
+              input_asset_id: '9709/s19_qp_11/questions/q06.png',
+              input_asset_hash: 'hash-review-1',
+            },
+            review_posture: {
+              requires_review: true,
+              gate_critical: true,
+            },
+          },
+          provenance_summary: {
+            import_source: 'manual_paste',
+            storage_key: '9709/s19_qp_11/questions/q06.png',
+          },
+          classification_snapshot_ref: null,
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      processed: 1,
+      backfilled: 1,
+      skipped: 0,
+    });
+    expect(state.snapshots.get('snapshot-1')).toMatchObject({
+      primary_question_type_id: '9709.differential_equations.separable',
+      analysis_audit_metadata: expect.objectContaining({
+        ao_input_source: 'question_evidence_bundle_v1',
+        question_evidence_bundle_v1: expect.objectContaining({
+          storage_key: '9709/s19_qp_11/questions/q06.png',
+          lazy_attach_original_image: true,
+          route: expect.objectContaining({
+            route: 'review_lane',
+            model: 'qwen3.6-plus',
+            region: 'dashscope-cn',
+            prompt_template_version: 'v1',
+            response_schema_version: 'v1',
+          }),
+        }),
+      }),
+    });
+    expect(state.events.get('question-event-1')).toMatchObject({
+      provenance: expect.objectContaining({
+        audit_metadata: expect.objectContaining({
+          ao_input_source: 'question_evidence_bundle_v1',
+        }),
+      }),
+    });
+  });
+
   test('skips questions that already have an active snapshot unless force is enabled', async () => {
     const { client } = createBackfillClient();
 

--- a/scripts/learning/__tests__/question-evidence-bundle-v1.test.js
+++ b/scripts/learning/__tests__/question-evidence-bundle-v1.test.js
@@ -1,0 +1,234 @@
+import {
+  buildQuestionEvidenceBundlesV1,
+  summarizeQuestionEvidenceBundlesV1,
+} from '../lib/question-evidence-bundle-v1.js';
+
+function buildManifest(items) {
+  return {
+    schema_version: 'v1',
+    manifest_id: 'test_manifest',
+    items,
+  };
+}
+
+function buildLaneOutput({
+  inputAssetId,
+  route,
+  model,
+  confidence = 0.9,
+  failureReason = null,
+  inputAssetHash = 'hash-1',
+  warnings = [],
+  evidence = {},
+} = {}) {
+  return {
+    model,
+    route,
+    prompt_template_version: 'v1',
+    region: 'dashscope-cn',
+    base_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    api_key_scope: 'DASHSCOPE_API_KEY',
+    input_asset_id: inputAssetId,
+    input_asset_hash: inputAssetHash,
+    response_schema_version: 'v1',
+    confidence,
+    failure_reason: failureReason,
+    output: {
+      summary: null,
+      evidence: Object.entries(evidence).map(([field, value]) => ({ field, value })),
+      warnings,
+    },
+  };
+}
+
+describe('question evidence bundle v1', () => {
+  test('builds a structured AO bundle without attaching the original image for non-conflict OCR rows', () => {
+    const manifest = buildManifest([
+      {
+        storage_key: '9709/s24_qp_31/questions/q08.png',
+        syllabus_code: '9709',
+        year: 2024,
+        session: 's',
+        paper: 3,
+        variant: 1,
+        q_number: 8,
+        primary_topic_path: '9709.p3.integration',
+        route_hint: 'ocr_lane',
+        diagram_present: false,
+        formula_dense: true,
+        table_heavy: false,
+        surface_evidence_status: 'verified_primary_asset',
+        gate_critical: false,
+        requires_review: false,
+      },
+    ]);
+
+    const bundles = buildQuestionEvidenceBundlesV1({
+      manifest,
+      laneOutputs: [
+        buildLaneOutput({
+          inputAssetId: '9709/s24_qp_31/questions/q08.png',
+          route: 'ocr_lane',
+          model: 'qwen-vl-ocr',
+          evidence: {
+            ocr_text: 'Find the value of the integral of (2x + 1)(x^2 + x)^4 dx.',
+            formula_latex_list: ['\\int (2x + 1)(x^2 + x)^4 \\, dx'],
+            subquestion_blocks: ['(a) Find the value of the integral.'],
+            layout_hints: ['single_column_prompt'],
+          },
+        }),
+      ],
+    });
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]).toMatchObject({
+      schema_version: 'question_evidence_bundle_v1',
+      manifest_id: 'test_manifest',
+      storage_key: '9709/s24_qp_31/questions/q08.png',
+      analysis_hints: {
+        topic_path_hint: '9709.p3.integration',
+      },
+      evidence: {
+        ocr_text: 'Find the value of the integral of (2x + 1)(x^2 + x)^4 dx.',
+        formula_latex_list: ['\\int (2x + 1)(x^2 + x)^4 \\, dx'],
+        subquestion_blocks: ['(a) Find the value of the integral.'],
+        layout_hints: ['single_column_prompt'],
+        diagram_present: false,
+        diagram_elements: [],
+        spatial_evidence: [],
+      },
+      route: {
+        route: 'ocr_lane',
+        model: 'qwen-vl-ocr',
+        region: 'dashscope-cn',
+        prompt_template_version: 'v1',
+        response_schema_version: 'v1',
+      },
+      lazy_attach_original_image: false,
+      original_image_asset: null,
+      review_posture: {
+        requires_review: false,
+        gate_critical: false,
+      },
+    });
+    expect(bundles[0].model_provenance).toEqual([
+      expect.objectContaining({
+        route: 'ocr_lane',
+        model: 'qwen-vl-ocr',
+        input_asset_id: '9709/s24_qp_31/questions/q08.png',
+      }),
+    ]);
+  });
+
+  test('marks lazy image attachment explicitly for gate-critical or low-confidence rows', () => {
+    const manifest = buildManifest([
+      {
+        storage_key: '9709/s19_qp_11/questions/q06.png',
+        syllabus_code: '9709',
+        year: 2019,
+        session: 's',
+        paper: 1,
+        variant: 1,
+        q_number: 6,
+        primary_topic_path: '9709.p1.trigonometry',
+        route_hint: 'review_lane',
+        diagram_present: null,
+        formula_dense: null,
+        table_heavy: null,
+        surface_evidence_status: 'unknown_requires_primary_asset_replay',
+        gate_critical: true,
+        requires_review: true,
+      },
+    ]);
+
+    const bundles = buildQuestionEvidenceBundlesV1({
+      manifest,
+      laneOutputs: [
+        buildLaneOutput({
+          inputAssetId: '9709/s19_qp_11/questions/q06.png',
+          route: 'review_lane',
+          model: 'qwen3.6-plus',
+          confidence: 0.41,
+          warnings: ['requires_review', 'lazy_attach_original_image'],
+          evidence: {
+            requires_review: true,
+            review_reasons: ['unknown_surface_flags'],
+            ambiguity_flags: ['low_legibility'],
+            review_summary: 'Needs AO review with the original image attached.',
+          },
+        }),
+      ],
+    });
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]).toMatchObject({
+      lazy_attach_original_image: true,
+      original_image_asset: {
+        input_asset_id: '9709/s19_qp_11/questions/q06.png',
+        input_asset_hash: 'hash-1',
+      },
+      review_posture: {
+        requires_review: true,
+        gate_critical: true,
+        review_reasons: ['unknown_surface_flags'],
+        ambiguity_flags: ['low_legibility'],
+      },
+    });
+    expect(bundles[0].lazy_attach_reasons).toEqual(expect.arrayContaining([
+      'route_requires_original_image',
+      'gate_critical',
+      'requires_review',
+      'low_confidence',
+    ]));
+  });
+
+  test('summarizes route and lazy-attach counts for a bundle set', () => {
+    const bundles = buildQuestionEvidenceBundlesV1({
+      manifest: buildManifest([
+        {
+          storage_key: '9709/s24_qp_31/questions/q08.png',
+          syllabus_code: '9709',
+          year: 2024,
+          session: 's',
+          paper: 3,
+          variant: 1,
+          q_number: 8,
+          primary_topic_path: '9709.p3.integration',
+          route_hint: 'ocr_lane',
+          diagram_present: false,
+          formula_dense: true,
+          table_heavy: false,
+          surface_evidence_status: 'verified_primary_asset',
+          gate_critical: false,
+          requires_review: false,
+        },
+        {
+          storage_key: '9709/s19_qp_11/questions/q06.png',
+          syllabus_code: '9709',
+          year: 2019,
+          session: 's',
+          paper: 1,
+          variant: 1,
+          q_number: 6,
+          primary_topic_path: '9709.p1.trigonometry',
+          route_hint: 'review_lane',
+          diagram_present: null,
+          formula_dense: null,
+          table_heavy: null,
+          surface_evidence_status: 'unknown_requires_primary_asset_replay',
+          gate_critical: true,
+          requires_review: true,
+        },
+      ]),
+    });
+
+    expect(summarizeQuestionEvidenceBundlesV1(bundles)).toMatchObject({
+      bundles_planned: 2,
+      lazy_attach_original_image: 1,
+      route_counts: {
+        ocr_lane: 1,
+        review_lane: 1,
+      },
+    });
+  });
+});

--- a/scripts/learning/__tests__/question-evidence-bundle-v1.test.js
+++ b/scripts/learning/__tests__/question-evidence-bundle-v1.test.js
@@ -182,6 +182,131 @@ describe('question evidence bundle v1', () => {
     ]));
   });
 
+  test('uses review-lane structured evidence when review-routed rows have no OCR or diagram lane outputs', () => {
+    const manifest = buildManifest([
+      {
+        storage_key: '9709/s19_qp_11/questions/q06.png',
+        syllabus_code: '9709',
+        year: 2019,
+        session: 's',
+        paper: 1,
+        variant: 1,
+        q_number: 6,
+        primary_topic_path: '9709.p1.trigonometry',
+        route_hint: 'review_lane',
+        diagram_present: null,
+        formula_dense: null,
+        table_heavy: null,
+        surface_evidence_status: 'unknown_requires_primary_asset_replay',
+        gate_critical: true,
+        requires_review: true,
+      },
+    ]);
+
+    const bundles = buildQuestionEvidenceBundlesV1({
+      manifest,
+      laneOutputs: [
+        buildLaneOutput({
+          inputAssetId: '9709/s19_qp_11/questions/q06.png',
+          route: 'review_lane',
+          model: 'qwen3.6-plus',
+          confidence: 0.86,
+          warnings: ['requires_review', 'lazy_attach_original_image'],
+          evidence: {
+            ocr_text: 'Solve the differential equation dy/dx = 2xy given that y = 1 when x = 0.',
+            formula_latex_list: ['\\frac{dy}{dx} = 2xy'],
+            subquestion_blocks: ['(a) Solve the differential equation.'],
+            layout_hints: ['single_column_prompt'],
+            diagram_present: false,
+            diagram_elements: [],
+            spatial_evidence: [],
+            requires_review: true,
+            review_reasons: ['unknown_surface_flags'],
+            ambiguity_flags: ['low_legibility'],
+            review_summary: 'Review lane recovered structured evidence but still requires AO review.',
+          },
+        }),
+      ],
+    });
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]).toMatchObject({
+      evidence: {
+        ocr_text: 'Solve the differential equation dy/dx = 2xy given that y = 1 when x = 0.',
+        formula_latex_list: ['\\frac{dy}{dx} = 2xy'],
+        subquestion_blocks: ['(a) Solve the differential equation.'],
+        layout_hints: ['single_column_prompt'],
+        diagram_present: false,
+        diagram_elements: [],
+        spatial_evidence: [],
+      },
+      route: {
+        route: 'review_lane',
+        model: 'qwen3.6-plus',
+        confidence: 0.86,
+      },
+      model_provenance: [
+        expect.objectContaining({
+          route: 'review_lane',
+          model: 'qwen3.6-plus',
+          confidence: 0.86,
+        }),
+      ],
+    });
+  });
+
+  test('does not copy model or confidence from an unrelated fallback lane when the decided lane output is missing', () => {
+    const manifest = buildManifest([
+      {
+        storage_key: '9709/s19_qp_11/questions/q06.png',
+        syllabus_code: '9709',
+        year: 2019,
+        session: 's',
+        paper: 1,
+        variant: 1,
+        q_number: 6,
+        primary_topic_path: '9709.p1.trigonometry',
+        route_hint: 'review_lane',
+        diagram_present: null,
+        formula_dense: null,
+        table_heavy: null,
+        surface_evidence_status: 'unknown_requires_primary_asset_replay',
+        gate_critical: true,
+        requires_review: true,
+      },
+    ]);
+
+    const bundles = buildQuestionEvidenceBundlesV1({
+      manifest,
+      laneOutputs: [
+        buildLaneOutput({
+          inputAssetId: '9709/s19_qp_11/questions/q06.png',
+          route: 'ocr_lane',
+          model: 'qwen-vl-ocr',
+          confidence: 0.99,
+          evidence: {
+            ocr_text: 'Unrelated OCR output that should not override review-lane provenance.',
+          },
+        }),
+      ],
+    });
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0].route).toMatchObject({
+      route: 'review_lane',
+      model: 'qwen3.6-plus',
+      region: 'dashscope-cn',
+      base_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      api_key_scope: 'DASHSCOPE_API_KEY',
+      prompt_template_version: 'v1',
+      response_schema_version: 'v1',
+      input_asset_id: '9709/s19_qp_11/questions/q06.png',
+      input_asset_hash: null,
+      confidence: null,
+      failure_reason: null,
+    });
+  });
+
   test('summarizes route and lazy-attach counts for a bundle set', () => {
     const bundles = buildQuestionEvidenceBundlesV1({
       manifest: buildManifest([

--- a/scripts/learning/__tests__/run-question-analysis-backfill.test.js
+++ b/scripts/learning/__tests__/run-question-analysis-backfill.test.js
@@ -25,7 +25,46 @@ describe('run_question_analysis_backfill cli', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain(
-      `Usage: node ${path.join('scripts', 'learning', 'run_question_analysis_backfill.js')} [--force]`,
+      `Usage: node ${path.join('scripts', 'learning', 'run_question_analysis_backfill.js')} [--force] [--evidence-bundles <path>]`,
     );
+  });
+
+  test('attaches evidence bundles to matching questions by storage key or question id', async () => {
+    const module = await import('../run_question_analysis_backfill.js');
+
+    expect(module.attachEvidenceBundlesToQuestions([
+      {
+        question_id: 'question-1',
+        provenance_summary: {
+          storage_key: '9709/s19_qp_11/questions/q06.png',
+        },
+      },
+      {
+        question_id: 'question-2',
+        provenance_summary: {},
+      },
+    ], [
+      {
+        schema_version: 'question_evidence_bundle_v1',
+        storage_key: '9709/s19_qp_11/questions/q06.png',
+      },
+      {
+        schema_version: 'question_evidence_bundle_v1',
+        question_id: 'question-2',
+      },
+    ])).toEqual([
+      expect.objectContaining({
+        question_id: 'question-1',
+        questionEvidenceBundle: expect.objectContaining({
+          storage_key: '9709/s19_qp_11/questions/q06.png',
+        }),
+      }),
+      expect.objectContaining({
+        question_id: 'question-2',
+        questionEvidenceBundle: expect.objectContaining({
+          question_id: 'question-2',
+        }),
+      }),
+    ]);
   });
 });

--- a/scripts/learning/__tests__/run-question-analysis-backfill.test.js
+++ b/scripts/learning/__tests__/run-question-analysis-backfill.test.js
@@ -67,4 +67,18 @@ describe('run_question_analysis_backfill cli', () => {
       }),
     ]);
   });
+
+  test('fails loudly when --evidence-bundles is passed without a value', () => {
+    const result = runCli(['--evidence-bundles']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('--evidence-bundles requires a file path');
+  });
+
+  test('fails loudly when --evidence-bundles is followed by another flag instead of a value', () => {
+    const result = runCli(['--evidence-bundles', '--force']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('--evidence-bundles requires a file path');
+  });
 });

--- a/scripts/learning/__tests__/run-question-evidence-bundle-v1.test.js
+++ b/scripts/learning/__tests__/run-question-evidence-bundle-v1.test.js
@@ -1,0 +1,87 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const PROJECT_ROOT = process.cwd();
+const TMP_MANIFEST = path.join(PROJECT_ROOT, 'tmp', 'question-evidence-bundle-v1-manifest.json');
+
+function runCli(args = []) {
+  return spawnSync(process.execPath, ['scripts/learning/run_question_evidence_bundle_v1.js', ...args], {
+    cwd: PROJECT_ROOT,
+    encoding: 'utf8',
+  });
+}
+
+function writeManifest() {
+  fs.mkdirSync(path.dirname(TMP_MANIFEST), { recursive: true });
+  fs.writeFileSync(TMP_MANIFEST, JSON.stringify({
+    schema_version: 'v1',
+    manifest_id: 'test_manifest',
+    items: [
+      {
+        storage_key: '9709/s24_qp_31/questions/q08.png',
+        syllabus_code: '9709',
+        year: 2024,
+        session: 's',
+        paper: 3,
+        variant: 1,
+        q_number: 8,
+        primary_topic_path: '9709.p3.integration',
+        route_hint: 'ocr_lane',
+        diagram_present: false,
+        formula_dense: true,
+        table_heavy: false,
+        surface_evidence_status: 'verified_primary_asset',
+        gate_critical: false,
+        requires_review: false,
+      },
+      {
+        storage_key: '9709/s19_qp_11/questions/q06.png',
+        syllabus_code: '9709',
+        year: 2019,
+        session: 's',
+        paper: 1,
+        variant: 1,
+        q_number: 6,
+        primary_topic_path: '9709.p1.trigonometry',
+        route_hint: 'review_lane',
+        diagram_present: null,
+        formula_dense: null,
+        table_heavy: null,
+        surface_evidence_status: 'unknown_requires_primary_asset_replay',
+        gate_critical: true,
+        requires_review: true,
+      },
+    ],
+  }, null, 2));
+}
+
+describe('run_question_evidence_bundle_v1 cli', () => {
+  beforeEach(() => {
+    writeManifest();
+  });
+
+  afterEach(() => {
+    fs.rmSync(TMP_MANIFEST, { force: true });
+  });
+
+  test('treats a relative argv[1] as the active script when resolving the entrypoint guard', async () => {
+    const module = await import('../run_question_evidence_bundle_v1.js');
+    const scriptPath = path.join('scripts', 'learning', 'run_question_evidence_bundle_v1.js');
+    const scriptUrl = pathToFileURL(path.join(PROJECT_ROOT, scriptPath)).href;
+
+    expect(module.isQuestionEvidenceBundleEntrypoint(scriptPath, scriptUrl)).toBe(true);
+  });
+
+  test('prints dry-run bundle counts including lazy-attach totals', () => {
+    const result = runCli(['--manifest', TMP_MANIFEST, '--dry-run']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('manifest_id: test_manifest');
+    expect(result.stdout).toContain('bundles_planned: 2');
+    expect(result.stdout).toContain('ocr_lane: 1');
+    expect(result.stdout).toContain('review_lane: 1');
+    expect(result.stdout).toContain('lazy_attach_original_image: 1');
+  });
+});

--- a/scripts/learning/lib/question-analysis-backfill.js
+++ b/scripts/learning/lib/question-analysis-backfill.js
@@ -9,6 +9,14 @@ function normalizeString(value) {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map((entry) => normalizeString(entry)).filter(Boolean);
+}
+
 function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
 }
@@ -43,6 +51,81 @@ function normalizeQuestionEvidenceBundle(value) {
     : null;
 }
 
+function normalizeFormulaLatexForPrompt(value) {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return '';
+  }
+
+  return normalized
+    .replace(/\\frac\s*\{([^{}]+)\}\s*\{([^{}]+)\}/gu, '$1/$2')
+    .replace(/\\int\b/gu, 'integral')
+    .replace(/\\([a-zA-Z]+)/gu, '$1')
+    .replace(/[{}]/gu, '')
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+function buildQuestionEvidenceBundleClassificationInput(questionEvidenceBundle = null) {
+  const evidence = questionEvidenceBundle?.evidence ?? {};
+  const sections = [];
+  const classificationInputSections = [];
+
+  const ocrText = normalizeString(evidence.ocr_text);
+  if (ocrText) {
+    sections.push(ocrText);
+    classificationInputSections.push('ocr_text');
+  }
+
+  const normalizedFormulaLatex = normalizeStringArray(
+    normalizeArray(evidence.formula_latex_list).map(normalizeFormulaLatexForPrompt),
+  );
+  if (normalizedFormulaLatex.length > 0) {
+    sections.push(`Formula LaTeX:\n${normalizedFormulaLatex.join('\n')}`);
+    classificationInputSections.push('formula_latex_list');
+  }
+
+  const subquestionBlocks = normalizeStringArray(evidence.subquestion_blocks);
+  if (subquestionBlocks.length > 0) {
+    sections.push(`Subquestion Blocks:\n${subquestionBlocks.join('\n')}`);
+    classificationInputSections.push('subquestion_blocks');
+  }
+
+  const layoutHints = normalizeStringArray(evidence.layout_hints);
+  if (layoutHints.length > 0) {
+    sections.push(`Layout Hints:\n${layoutHints.join('\n')}`);
+    classificationInputSections.push('layout_hints');
+  }
+
+  if (typeof evidence.diagram_present === 'boolean') {
+    sections.push(`Diagram Present: ${evidence.diagram_present}`);
+    classificationInputSections.push('diagram_present');
+  }
+
+  const diagramElements = normalizeStringArray(evidence.diagram_elements);
+  if (diagramElements.length > 0) {
+    sections.push(`Diagram Elements:\n${diagramElements.join('\n')}`);
+    classificationInputSections.push('diagram_elements');
+  }
+
+  const spatialEvidence = normalizeStringArray(evidence.spatial_evidence);
+  if (spatialEvidence.length > 0) {
+    sections.push(`Spatial Evidence:\n${spatialEvidence.join('\n')}`);
+    classificationInputSections.push('spatial_evidence');
+  }
+
+  return {
+    mode: sections.length > 0 ? 'structured_bundle_prompt' : 'raw_question_prompt_fallback',
+    classification_input_sections: classificationInputSections,
+    prompt_representation: sections.length > 0
+      ? {
+        type: 'text',
+        value: sections.join('\n\n'),
+      }
+      : null,
+  };
+}
+
 function resolveQuestionAnalysisHints({
   analysisHints = null,
   question = {},
@@ -61,7 +144,10 @@ function resolveQuestionAnalysisHints({
   });
 }
 
-function buildQuestionEvidenceBundleAuditMetadata(questionEvidenceBundle) {
+function buildQuestionEvidenceBundleAuditMetadata(
+  questionEvidenceBundle,
+  questionEvidenceBundleClassificationInput = null,
+) {
   if (!questionEvidenceBundle) {
     return {};
   }
@@ -86,6 +172,11 @@ function buildQuestionEvidenceBundleAuditMetadata(questionEvidenceBundle) {
       lazy_attach_reasons: normalizeArray(questionEvidenceBundle.lazy_attach_reasons),
       original_image_asset: normalizeObject(questionEvidenceBundle.original_image_asset),
       review_posture: normalizeObject(questionEvidenceBundle.review_posture),
+      classification_input_mode:
+        questionEvidenceBundleClassificationInput?.mode ?? 'raw_question_prompt_fallback',
+      classification_input_sections: normalizeStringArray(
+        questionEvidenceBundleClassificationInput?.classification_input_sections,
+      ),
       evidence_presence: {
         ocr_text: Boolean(normalizeString(evidence.ocr_text)),
         formula_latex_count: normalizeArray(evidence.formula_latex_list).length,
@@ -100,7 +191,11 @@ function buildQuestionEvidenceBundleAuditMetadata(questionEvidenceBundle) {
   };
 }
 
-function applyQuestionEvidenceBundle(rawClassification, questionEvidenceBundle) {
+function applyQuestionEvidenceBundle(
+  rawClassification,
+  questionEvidenceBundle,
+  questionEvidenceBundleClassificationInput = null,
+) {
   if (!questionEvidenceBundle) {
     return rawClassification;
   }
@@ -109,7 +204,10 @@ function applyQuestionEvidenceBundle(rawClassification, questionEvidenceBundle) 
     ...rawClassification,
     analysis_audit_metadata: {
       ...(rawClassification.analysis_audit_metadata ?? {}),
-      ...buildQuestionEvidenceBundleAuditMetadata(questionEvidenceBundle),
+      ...buildQuestionEvidenceBundleAuditMetadata(
+        questionEvidenceBundle,
+        questionEvidenceBundleClassificationInput,
+      ),
     },
   };
 }
@@ -138,14 +236,9 @@ function buildSnapshotRow(questionId, classification) {
   };
 }
 
-function buildEnvelopeFromQuestion(question, questionEvidenceBundle = null) {
-  const evidencePrompt = normalizeString(questionEvidenceBundle?.evidence?.ocr_text);
-  const promptRepresentation = evidencePrompt
-    ? {
-      type: 'text',
-      value: evidencePrompt,
-    }
-    : question?.prompt_representation;
+function buildEnvelopeFromQuestion(question, questionEvidenceBundleClassificationInput = null) {
+  const promptRepresentation = questionEvidenceBundleClassificationInput?.prompt_representation
+    ?? question?.prompt_representation;
 
   return normalizeQuestionEnvelope({
     source_kind: question?.source_kind ?? 'imported_question',
@@ -208,7 +301,9 @@ export async function backfillQuestionAnalysisRecord(client, {
       ?? question?.questionEvidenceBundle
       ?? question?.question_evidence_bundle,
   );
-  const envelope = buildEnvelopeFromQuestion(question, normalizedQuestionEvidenceBundle);
+  const questionEvidenceBundleClassificationInput =
+    buildQuestionEvidenceBundleClassificationInput(normalizedQuestionEvidenceBundle);
+  const envelope = buildEnvelopeFromQuestion(question, questionEvidenceBundleClassificationInput);
   const resolvedAnalysisHints = resolveQuestionAnalysisHints({
     analysisHints,
     question,
@@ -217,7 +312,7 @@ export async function backfillQuestionAnalysisRecord(client, {
   const rawClassification = applyQuestionEvidenceBundle(analyzeQuestionEnvelope({
     envelope,
     analysisHints: resolvedAnalysisHints,
-  }), normalizedQuestionEvidenceBundle);
+  }), normalizedQuestionEvidenceBundle, questionEvidenceBundleClassificationInput);
   const {
     classification,
     scoringScopePosture,

--- a/scripts/learning/lib/question-analysis-backfill.js
+++ b/scripts/learning/lib/question-analysis-backfill.js
@@ -3,8 +3,11 @@ import { buildClassificationSnapshotRef } from '../../../api/learning/lib/contra
 import { appendQuestionClassifiedEvent } from '../../../api/learning/lib/events/question-event-service.js';
 import { resolveReleasedScoringPosture } from '../../../api/learning/lib/import/question-import-service.js';
 import { analyzeQuestionEnvelope } from '../../../api/learning/lib/question-analysis/question-intelligence-service.js';
-import { buildQuestionAnalysisResult } from '../../../api/learning/lib/question-analysis/analysis-result-contract.js';
 import { normalizeQuestionEnvelope } from '../../../api/learning/lib/question-analysis/question-envelope-contract.js';
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
 
 function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
@@ -14,6 +17,101 @@ function normalizeObject(value, fallback = null) {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? JSON.parse(JSON.stringify(value))
     : fallback;
+}
+
+function normalizeAnalysisHints(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const normalized = {
+    runtime_context_id: normalizeString(value.runtime_context_id),
+    question_type_hint_id: normalizeString(value.question_type_hint_id),
+    topic_path_hint: normalizeString(value.topic_path_hint),
+  };
+
+  return normalized.runtime_context_id
+    || normalized.question_type_hint_id
+    || normalized.topic_path_hint
+    ? normalized
+    : null;
+}
+
+function normalizeQuestionEvidenceBundle(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? JSON.parse(JSON.stringify(value))
+    : null;
+}
+
+function resolveQuestionAnalysisHints({
+  analysisHints = null,
+  question = {},
+  questionEvidenceBundle = null,
+} = {}) {
+  const bundleHints = normalizeAnalysisHints(
+    questionEvidenceBundle?.analysis_hints ?? questionEvidenceBundle?.analysisHints,
+  );
+  const questionHints = normalizeAnalysisHints(question?.analysisHints ?? question?.analysis_hints);
+  const explicitHints = normalizeAnalysisHints(analysisHints);
+
+  return normalizeAnalysisHints({
+    ...bundleHints,
+    ...questionHints,
+    ...explicitHints,
+  });
+}
+
+function buildQuestionEvidenceBundleAuditMetadata(questionEvidenceBundle) {
+  if (!questionEvidenceBundle) {
+    return {};
+  }
+
+  const evidence = questionEvidenceBundle.evidence ?? {};
+
+  return {
+    ao_input_source: 'question_evidence_bundle_v1',
+    question_evidence_bundle_v1: {
+      schema_version: questionEvidenceBundle.schema_version ?? 'question_evidence_bundle_v1',
+      question_id: questionEvidenceBundle.question_id ?? null,
+      storage_key:
+        questionEvidenceBundle.storage_key
+        ?? questionEvidenceBundle.route?.input_asset_id
+        ?? null,
+      analysis_hints: normalizeAnalysisHints(
+        questionEvidenceBundle.analysis_hints ?? questionEvidenceBundle.analysisHints,
+      ),
+      route: normalizeObject(questionEvidenceBundle.route, {}),
+      model_provenance: normalizeArray(questionEvidenceBundle.model_provenance),
+      lazy_attach_original_image: Boolean(questionEvidenceBundle.lazy_attach_original_image),
+      lazy_attach_reasons: normalizeArray(questionEvidenceBundle.lazy_attach_reasons),
+      original_image_asset: normalizeObject(questionEvidenceBundle.original_image_asset),
+      review_posture: normalizeObject(questionEvidenceBundle.review_posture),
+      evidence_presence: {
+        ocr_text: Boolean(normalizeString(evidence.ocr_text)),
+        formula_latex_count: normalizeArray(evidence.formula_latex_list).length,
+        subquestion_block_count: normalizeArray(evidence.subquestion_blocks).length,
+        layout_hint_count: normalizeArray(evidence.layout_hints).length,
+        diagram_present:
+          typeof evidence.diagram_present === 'boolean' ? evidence.diagram_present : null,
+        diagram_element_count: normalizeArray(evidence.diagram_elements).length,
+        spatial_evidence_count: normalizeArray(evidence.spatial_evidence).length,
+      },
+    },
+  };
+}
+
+function applyQuestionEvidenceBundle(rawClassification, questionEvidenceBundle) {
+  if (!questionEvidenceBundle) {
+    return rawClassification;
+  }
+
+  return {
+    ...rawClassification,
+    analysis_audit_metadata: {
+      ...(rawClassification.analysis_audit_metadata ?? {}),
+      ...buildQuestionEvidenceBundleAuditMetadata(questionEvidenceBundle),
+    },
+  };
 }
 
 function buildSnapshotRow(questionId, classification) {
@@ -40,11 +138,19 @@ function buildSnapshotRow(questionId, classification) {
   };
 }
 
-function buildEnvelopeFromQuestion(question) {
+function buildEnvelopeFromQuestion(question, questionEvidenceBundle = null) {
+  const evidencePrompt = normalizeString(questionEvidenceBundle?.evidence?.ocr_text);
+  const promptRepresentation = evidencePrompt
+    ? {
+      type: 'text',
+      value: evidencePrompt,
+    }
+    : question?.prompt_representation;
+
   return normalizeQuestionEnvelope({
     source_kind: question?.source_kind ?? 'imported_question',
     subject_code: question?.subject_code ?? null,
-    prompt_representation: question?.prompt_representation,
+    prompt_representation: promptRepresentation,
     paper_scope: question?.paper_scope ?? null,
     provenance_summary: question?.provenance_summary ?? {},
   });
@@ -94,13 +200,24 @@ async function supersedeActiveSnapshot(client, {
 export async function backfillQuestionAnalysisRecord(client, {
   question,
   analysisHints = null,
+  questionEvidenceBundle = null,
   force = false,
 } = {}) {
-  const envelope = buildEnvelopeFromQuestion(question);
-  const rawClassification = analyzeQuestionEnvelope({
-    envelope,
+  const normalizedQuestionEvidenceBundle = normalizeQuestionEvidenceBundle(
+    questionEvidenceBundle
+      ?? question?.questionEvidenceBundle
+      ?? question?.question_evidence_bundle,
+  );
+  const envelope = buildEnvelopeFromQuestion(question, normalizedQuestionEvidenceBundle);
+  const resolvedAnalysisHints = resolveQuestionAnalysisHints({
     analysisHints,
+    question,
+    questionEvidenceBundle: normalizedQuestionEvidenceBundle,
   });
+  const rawClassification = applyQuestionEvidenceBundle(analyzeQuestionEnvelope({
+    envelope,
+    analysisHints: resolvedAnalysisHints,
+  }), normalizedQuestionEvidenceBundle);
   const {
     classification,
     scoringScopePosture,
@@ -109,10 +226,7 @@ export async function backfillQuestionAnalysisRecord(client, {
     classification: rawClassification,
     questionEnvelope: envelope,
   });
-  const materializedClassification = buildQuestionAnalysisResult({
-    envelope,
-    classification,
-  });
+  const materializedClassification = classification;
   const activeSnapshotId = force
     ? await findActiveSnapshotId(client, { questionId: question?.question_id ?? null })
     : null;
@@ -214,6 +328,11 @@ export async function runQuestionAnalysisBackfill(client, {
 
     const result = await backfillQuestionAnalysisRecord(client, {
       question,
+      analysisHints: question?.analysisHints ?? question?.analysis_hints ?? null,
+      questionEvidenceBundle:
+        question?.questionEvidenceBundle
+        ?? question?.question_evidence_bundle
+        ?? null,
       force,
     });
     summary.backfilled += 1;

--- a/scripts/learning/lib/question-evidence-bundle-v1.js
+++ b/scripts/learning/lib/question-evidence-bundle-v1.js
@@ -1,0 +1,428 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const ROUTER_CONTRACT_PATH = path.join(
+  REPO_ROOT,
+  'data',
+  'contracts',
+  '9709_qwen_wave1_router_contract_v1.json',
+);
+
+const SURFACE_FLAGS = ['diagram_present', 'formula_dense', 'table_heavy'];
+const LOW_CONFIDENCE_THRESHOLD = 0.75;
+
+function cloneJson(value) {
+  return value === undefined ? null : JSON.parse(JSON.stringify(value));
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeNullableString(value) {
+  const normalized = normalizeString(value);
+  return normalized || null;
+}
+
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return [...new Set(value.map((entry) => normalizeString(entry)).filter(Boolean))];
+}
+
+function normalizeNullableBoolean(value) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  return value === null ? null : null;
+}
+
+function normalizeEvidenceValue(value) {
+  if (Array.isArray(value)) {
+    return cloneJson(value);
+  }
+
+  if (value && typeof value === 'object') {
+    return cloneJson(value);
+  }
+
+  return value ?? null;
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function loadRouterContract() {
+  return JSON.parse(fs.readFileSync(ROUTER_CONTRACT_PATH, 'utf8'));
+}
+
+function missingRequiredFields(item, contract) {
+  return (contract.router_input_required_fields ?? []).filter((field) => !(field in item));
+}
+
+function surfaceFlagsUnknown(item) {
+  return SURFACE_FLAGS.some((field) => item?.[field] === null || typeof item?.[field] === 'undefined');
+}
+
+function buildRouteDecision(route, decisionReasons, contract) {
+  const routeContract = contract.routes?.[route];
+  const runtime = contract.runtime_freeze ?? {};
+
+  if (!routeContract) {
+    throw new Error(`Unknown route "${route}" in router contract.`);
+  }
+
+  return {
+    route,
+    model: routeContract.model ?? null,
+    lazy_attach_original_image: Boolean(routeContract.lazy_attach_original_image),
+    region: runtime.region ?? null,
+    base_url: runtime.base_url ?? null,
+    api_key_scope: runtime.api_key_scope ?? null,
+    prompt_template_version: 'v1',
+    response_schema_version: 'v1',
+    decision_reasons: unique(decisionReasons),
+  };
+}
+
+export function resolveQuestionEvidenceRoute(manifestItem = {}, contract = loadRouterContract()) {
+  const missing = missingRequiredFields(manifestItem, contract);
+  if (missing.length > 0) {
+    throw new Error(`Manifest row missing required router fields: ${missing.join(', ')}`);
+  }
+
+  const reasons = [];
+  if (manifestItem.gate_critical) {
+    reasons.push('gate_critical');
+  }
+  if (manifestItem.requires_review) {
+    reasons.push('requires_review');
+  }
+  if (surfaceFlagsUnknown(manifestItem)) {
+    reasons.push('unknown_surface_flags');
+  }
+
+  if (reasons.length > 0) {
+    return buildRouteDecision('review_lane', reasons, contract);
+  }
+
+  if (manifestItem.diagram_present === true) {
+    return buildRouteDecision('diagram_lane', ['diagram_present'], contract);
+  }
+
+  if (manifestItem.table_heavy === true) {
+    return buildRouteDecision('ocr_lane', ['table_heavy'], contract);
+  }
+
+  if (manifestItem.formula_dense === true) {
+    return buildRouteDecision('ocr_lane', ['formula_dense'], contract);
+  }
+
+  if (manifestItem.route_hint === 'diagram_lane') {
+    return buildRouteDecision('diagram_lane', ['route_hint'], contract);
+  }
+
+  if (manifestItem.route_hint === 'ocr_lane') {
+    return buildRouteDecision('ocr_lane', ['text_dominant'], contract);
+  }
+
+  if (manifestItem.diagram_present === false) {
+    return buildRouteDecision('ocr_lane', ['text_dominant'], contract);
+  }
+
+  return buildRouteDecision('review_lane', ['router_fallback'], contract);
+}
+
+function laneEvidenceMap(laneOutput = {}) {
+  const entries = Array.isArray(laneOutput?.output?.evidence)
+    ? laneOutput.output.evidence
+    : [];
+
+  return entries.reduce((accumulator, entry) => {
+    if (!entry || typeof entry !== 'object') {
+      return accumulator;
+    }
+
+    const field = normalizeString(entry.field);
+    if (!field) {
+      return accumulator;
+    }
+
+    accumulator[field] = normalizeEvidenceValue(entry.value);
+    return accumulator;
+  }, {});
+}
+
+function pickFirstString(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return '';
+}
+
+function pickArray(...values) {
+  for (const value of values) {
+    if (Array.isArray(value) && value.length > 0) {
+      return cloneJson(value);
+    }
+  }
+
+  return [];
+}
+
+function firstNonNull(...values) {
+  for (const value of values) {
+    if (value !== null && typeof value !== 'undefined') {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function buildStructuredEvidence(manifestItem, laneOutputs) {
+  const ocrOutput = laneOutputs.find((entry) => entry.route === 'ocr_lane');
+  const diagramOutput = laneOutputs.find((entry) => entry.route === 'diagram_lane');
+
+  const ocrEvidence = laneEvidenceMap(ocrOutput);
+  const diagramEvidence = laneEvidenceMap(diagramOutput);
+
+  return {
+    ocr_text: pickFirstString(ocrEvidence.ocr_text),
+    formula_latex_list: pickArray(ocrEvidence.formula_latex_list),
+    subquestion_blocks: pickArray(ocrEvidence.subquestion_blocks),
+    layout_hints: pickArray(ocrEvidence.layout_hints),
+    diagram_present: firstNonNull(
+      normalizeNullableBoolean(diagramEvidence.diagram_present),
+      normalizeNullableBoolean(manifestItem.diagram_present),
+    ),
+    diagram_elements: pickArray(diagramEvidence.diagram_elements),
+    spatial_evidence: pickArray(diagramEvidence.spatial_evidence),
+  };
+}
+
+function buildReviewPosture(manifestItem, laneOutputs) {
+  const reviewOutput = laneOutputs.find((entry) => entry.route === 'review_lane');
+  const reviewEvidence = laneEvidenceMap(reviewOutput);
+
+  return {
+    requires_review: Boolean(
+      manifestItem.requires_review
+      || reviewEvidence.requires_review
+      || reviewOutput?.output?.warnings?.includes?.('requires_review'),
+    ),
+    gate_critical: Boolean(manifestItem.gate_critical),
+    review_reasons: normalizeStringArray(reviewEvidence.review_reasons),
+    ambiguity_flags: normalizeStringArray(reviewEvidence.ambiguity_flags),
+    review_summary: normalizeNullableString(reviewEvidence.review_summary),
+    review_confidence:
+      typeof reviewOutput?.confidence === 'number' ? reviewOutput.confidence : null,
+  };
+}
+
+function buildModelProvenance(laneOutputs) {
+  return laneOutputs.map((laneOutput) => ({
+    route: normalizeNullableString(laneOutput.route),
+    model: normalizeNullableString(laneOutput.model),
+    region: normalizeNullableString(laneOutput.region),
+    base_url: normalizeNullableString(laneOutput.base_url),
+    api_key_scope: normalizeNullableString(laneOutput.api_key_scope),
+    prompt_template_version: normalizeNullableString(laneOutput.prompt_template_version),
+    response_schema_version: normalizeNullableString(laneOutput.response_schema_version),
+    input_asset_id: normalizeNullableString(laneOutput.input_asset_id),
+    input_asset_hash: normalizeNullableString(laneOutput.input_asset_hash),
+    confidence: typeof laneOutput.confidence === 'number' ? laneOutput.confidence : null,
+    failure_reason: normalizeNullableString(laneOutput.failure_reason),
+  }));
+}
+
+function deriveLazyAttachReasons({
+  manifestItem,
+  routeDecision,
+  structuredEvidence,
+  reviewPosture,
+  modelProvenance,
+} = {}) {
+  const reasons = [];
+
+  if (routeDecision?.lazy_attach_original_image) {
+    reasons.push('route_requires_original_image');
+  }
+
+  if (manifestItem?.gate_critical) {
+    reasons.push('gate_critical');
+  }
+
+  if (reviewPosture?.requires_review) {
+    reasons.push('requires_review');
+  }
+
+  if (modelProvenance.some((entry) => typeof entry.confidence === 'number' && entry.confidence < LOW_CONFIDENCE_THRESHOLD)) {
+    reasons.push('low_confidence');
+  }
+
+  if (modelProvenance.some((entry) => normalizeString(entry.failure_reason))) {
+    reasons.push('provider_failure');
+  }
+
+  if (
+    typeof manifestItem?.diagram_present === 'boolean'
+    && typeof structuredEvidence?.diagram_present === 'boolean'
+    && manifestItem.diagram_present !== structuredEvidence.diagram_present
+  ) {
+    reasons.push('diagram_present_conflict');
+  }
+
+  return unique(reasons);
+}
+
+function buildSelectedRoute(routeDecision, manifestItem, laneOutputs) {
+  const selectedOutput = laneOutputs.find((entry) => entry.route === routeDecision.route) ?? laneOutputs[0] ?? {};
+
+  return {
+    route: routeDecision.route,
+    model: selectedOutput.model ?? routeDecision.model ?? null,
+    region: selectedOutput.region ?? routeDecision.region ?? null,
+    base_url: selectedOutput.base_url ?? routeDecision.base_url ?? null,
+    api_key_scope: selectedOutput.api_key_scope ?? routeDecision.api_key_scope ?? null,
+    prompt_template_version:
+      selectedOutput.prompt_template_version ?? routeDecision.prompt_template_version ?? null,
+    response_schema_version:
+      selectedOutput.response_schema_version ?? routeDecision.response_schema_version ?? null,
+    input_asset_id: selectedOutput.input_asset_id ?? manifestItem.storage_key ?? null,
+    input_asset_hash: selectedOutput.input_asset_hash ?? null,
+    confidence: typeof selectedOutput.confidence === 'number' ? selectedOutput.confidence : null,
+    failure_reason: normalizeNullableString(selectedOutput.failure_reason),
+    decision_reasons: cloneJson(routeDecision.decision_reasons ?? []),
+  };
+}
+
+function buildAnalysisHints(manifestItem = {}) {
+  const rawHints = manifestItem.analysis_hints ?? manifestItem.analysisHints ?? {};
+
+  return {
+    runtime_context_id: normalizeNullableString(rawHints.runtime_context_id),
+    question_type_hint_id: normalizeNullableString(rawHints.question_type_hint_id),
+    topic_path_hint: normalizeNullableString(
+      rawHints.topic_path_hint ?? manifestItem.primary_topic_path,
+    ),
+  };
+}
+
+export function buildQuestionEvidenceBundleV1({
+  manifestId = null,
+  manifestPosition = null,
+  manifestItem,
+  laneOutputs = [],
+} = {}) {
+  if (!manifestItem || typeof manifestItem !== 'object') {
+    throw new Error('question evidence bundle requires a manifest item.');
+  }
+
+  const routeDecision = resolveQuestionEvidenceRoute(manifestItem);
+  const structuredEvidence = buildStructuredEvidence(manifestItem, laneOutputs);
+  const reviewPosture = buildReviewPosture(manifestItem, laneOutputs);
+  const modelProvenance = buildModelProvenance(laneOutputs);
+  const lazyAttachReasons = deriveLazyAttachReasons({
+    manifestItem,
+    routeDecision,
+    structuredEvidence,
+    reviewPosture,
+    modelProvenance,
+  });
+  const lazyAttachOriginalImage = lazyAttachReasons.length > 0;
+  const selectedRoute = buildSelectedRoute(routeDecision, manifestItem, laneOutputs);
+
+  return {
+    schema_version: 'question_evidence_bundle_v1',
+    manifest_id: normalizeNullableString(manifestId),
+    manifest_position: Number.isInteger(manifestPosition) ? manifestPosition : null,
+    storage_key: normalizeNullableString(manifestItem.storage_key),
+    question_identity: {
+      subject_code: normalizeNullableString(manifestItem.syllabus_code),
+      year: manifestItem.year ?? null,
+      session: normalizeNullableString(manifestItem.session),
+      paper: manifestItem.paper ?? null,
+      variant: manifestItem.variant ?? null,
+      q_number: manifestItem.q_number ?? null,
+      primary_topic_path: normalizeNullableString(manifestItem.primary_topic_path),
+    },
+    analysis_hints: buildAnalysisHints(manifestItem),
+    evidence: structuredEvidence,
+    surface_posture: {
+      descriptor_required: Boolean(manifestItem.descriptor_required),
+      route_hint: normalizeNullableString(manifestItem.route_hint),
+      diagram_present: normalizeNullableBoolean(manifestItem.diagram_present),
+      formula_dense: normalizeNullableBoolean(manifestItem.formula_dense),
+      table_heavy: normalizeNullableBoolean(manifestItem.table_heavy),
+      surface_evidence_status: normalizeNullableString(manifestItem.surface_evidence_status),
+      gate_critical: Boolean(manifestItem.gate_critical),
+      requires_review: Boolean(manifestItem.requires_review),
+    },
+    review_posture: reviewPosture,
+    route: selectedRoute,
+    model_provenance: modelProvenance,
+    lazy_attach_original_image: lazyAttachOriginalImage,
+    lazy_attach_reasons: cloneJson(lazyAttachReasons),
+    original_image_asset: lazyAttachOriginalImage
+      ? {
+        input_asset_id: selectedRoute.input_asset_id,
+        input_asset_hash: selectedRoute.input_asset_hash,
+      }
+      : null,
+  };
+}
+
+export function buildQuestionEvidenceBundlesV1({
+  manifest = {},
+  laneOutputs = [],
+} = {}) {
+  const items = Array.isArray(manifest.items) ? manifest.items : [];
+  const outputsByAssetId = laneOutputs.reduce((accumulator, laneOutput) => {
+    const key = normalizeString(laneOutput?.input_asset_id);
+    if (!key) {
+      return accumulator;
+    }
+
+    if (!accumulator.has(key)) {
+      accumulator.set(key, []);
+    }
+    accumulator.get(key).push(cloneJson(laneOutput));
+    return accumulator;
+  }, new Map());
+
+  return items.map((manifestItem, index) => buildQuestionEvidenceBundleV1({
+    manifestId: manifest.manifest_id ?? null,
+    manifestPosition: index,
+    manifestItem,
+    laneOutputs: outputsByAssetId.get(manifestItem.storage_key) ?? [],
+  }));
+}
+
+export function summarizeQuestionEvidenceBundlesV1(bundles = []) {
+  const routeCounts = {};
+  let lazyAttachCount = 0;
+
+  for (const bundle of bundles) {
+    const route = bundle?.route?.route ?? 'unknown';
+    routeCounts[route] = (routeCounts[route] ?? 0) + 1;
+    if (bundle?.lazy_attach_original_image) {
+      lazyAttachCount += 1;
+    }
+  }
+
+  return {
+    bundles_planned: bundles.length,
+    route_counts: routeCounts,
+    lazy_attach_original_image: lazyAttachCount,
+  };
+}

--- a/scripts/learning/lib/question-evidence-bundle-v1.js
+++ b/scripts/learning/lib/question-evidence-bundle-v1.js
@@ -192,21 +192,39 @@ function firstNonNull(...values) {
 function buildStructuredEvidence(manifestItem, laneOutputs) {
   const ocrOutput = laneOutputs.find((entry) => entry.route === 'ocr_lane');
   const diagramOutput = laneOutputs.find((entry) => entry.route === 'diagram_lane');
+  const reviewOutput = laneOutputs.find((entry) => entry.route === 'review_lane');
 
   const ocrEvidence = laneEvidenceMap(ocrOutput);
   const diagramEvidence = laneEvidenceMap(diagramOutput);
+  const reviewEvidence = laneEvidenceMap(reviewOutput);
 
   return {
-    ocr_text: pickFirstString(ocrEvidence.ocr_text),
-    formula_latex_list: pickArray(ocrEvidence.formula_latex_list),
-    subquestion_blocks: pickArray(ocrEvidence.subquestion_blocks),
-    layout_hints: pickArray(ocrEvidence.layout_hints),
+    ocr_text: pickFirstString(ocrEvidence.ocr_text, reviewEvidence.ocr_text),
+    formula_latex_list: pickArray(
+      ocrEvidence.formula_latex_list,
+      reviewEvidence.formula_latex_list,
+    ),
+    subquestion_blocks: pickArray(
+      ocrEvidence.subquestion_blocks,
+      reviewEvidence.subquestion_blocks,
+    ),
+    layout_hints: pickArray(
+      ocrEvidence.layout_hints,
+      reviewEvidence.layout_hints,
+    ),
     diagram_present: firstNonNull(
       normalizeNullableBoolean(diagramEvidence.diagram_present),
+      normalizeNullableBoolean(reviewEvidence.diagram_present),
       normalizeNullableBoolean(manifestItem.diagram_present),
     ),
-    diagram_elements: pickArray(diagramEvidence.diagram_elements),
-    spatial_evidence: pickArray(diagramEvidence.spatial_evidence),
+    diagram_elements: pickArray(
+      diagramEvidence.diagram_elements,
+      reviewEvidence.diagram_elements,
+    ),
+    spatial_evidence: pickArray(
+      diagramEvidence.spatial_evidence,
+      reviewEvidence.spatial_evidence,
+    ),
   };
 }
 
@@ -286,22 +304,22 @@ function deriveLazyAttachReasons({
 }
 
 function buildSelectedRoute(routeDecision, manifestItem, laneOutputs) {
-  const selectedOutput = laneOutputs.find((entry) => entry.route === routeDecision.route) ?? laneOutputs[0] ?? {};
+  const selectedOutput = laneOutputs.find((entry) => entry.route === routeDecision.route) ?? null;
 
   return {
     route: routeDecision.route,
-    model: selectedOutput.model ?? routeDecision.model ?? null,
-    region: selectedOutput.region ?? routeDecision.region ?? null,
-    base_url: selectedOutput.base_url ?? routeDecision.base_url ?? null,
-    api_key_scope: selectedOutput.api_key_scope ?? routeDecision.api_key_scope ?? null,
+    model: routeDecision.model ?? null,
+    region: routeDecision.region ?? null,
+    base_url: routeDecision.base_url ?? null,
+    api_key_scope: routeDecision.api_key_scope ?? null,
     prompt_template_version:
-      selectedOutput.prompt_template_version ?? routeDecision.prompt_template_version ?? null,
+      routeDecision.prompt_template_version ?? null,
     response_schema_version:
-      selectedOutput.response_schema_version ?? routeDecision.response_schema_version ?? null,
-    input_asset_id: selectedOutput.input_asset_id ?? manifestItem.storage_key ?? null,
-    input_asset_hash: selectedOutput.input_asset_hash ?? null,
-    confidence: typeof selectedOutput.confidence === 'number' ? selectedOutput.confidence : null,
-    failure_reason: normalizeNullableString(selectedOutput.failure_reason),
+      routeDecision.response_schema_version ?? null,
+    input_asset_id: selectedOutput?.input_asset_id ?? manifestItem.storage_key ?? null,
+    input_asset_hash: selectedOutput?.input_asset_hash ?? null,
+    confidence: typeof selectedOutput?.confidence === 'number' ? selectedOutput.confidence : null,
+    failure_reason: normalizeNullableString(selectedOutput?.failure_reason),
     decision_reasons: cloneJson(routeDecision.decision_reasons ?? []),
   };
 }

--- a/scripts/learning/run_question_analysis_backfill.js
+++ b/scripts/learning/run_question_analysis_backfill.js
@@ -96,6 +96,12 @@ export async function main(argv = process.argv.slice(2)) {
   const evidenceBundlePath = evidenceBundlesIndex >= 0
     ? argv[evidenceBundlesIndex + 1] ?? null
     : null;
+  if (
+    evidenceBundlesIndex >= 0
+    && (!evidenceBundlePath || evidenceBundlePath.startsWith('--'))
+  ) {
+    throw new Error('--evidence-bundles requires a file path.');
+  }
   const client = getServiceClient();
   let questions = await loadCandidateQuestions(client);
   if (evidenceBundlePath) {

--- a/scripts/learning/run_question_analysis_backfill.js
+++ b/scripts/learning/run_question_analysis_backfill.js
@@ -1,10 +1,13 @@
 import path from 'node:path';
+import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { getServiceClient } from '../../api/lib/supabase/client.js';
 import { runQuestionAnalysisBackfill } from './lib/question-analysis-backfill.js';
 
 function printUsage() {
-  console.log('Usage: node scripts/learning/run_question_analysis_backfill.js [--force]');
+  console.log(
+    'Usage: node scripts/learning/run_question_analysis_backfill.js [--force] [--evidence-bundles <path>]',
+  );
 }
 
 async function loadCandidateQuestions(client) {
@@ -22,6 +25,66 @@ async function loadCandidateQuestions(client) {
   return Array.isArray(data) ? data : [];
 }
 
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function normalizeEvidenceBundlePayload(payload) {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (Array.isArray(payload?.bundles)) {
+    return payload.bundles;
+  }
+
+  throw new Error('Evidence bundle file must contain an array or a { bundles } payload.');
+}
+
+function buildQuestionEvidenceKey(question = {}) {
+  const storageKey = question?.provenance_summary?.storage_key ?? question?.storage_key ?? null;
+  return {
+    questionId: question?.question_id ?? null,
+    storageKey: typeof storageKey === 'string' ? storageKey.trim() : null,
+  };
+}
+
+export function attachEvidenceBundlesToQuestions(questions = [], bundles = []) {
+  const bundlesByQuestionId = new Map();
+  const bundlesByStorageKey = new Map();
+
+  for (const bundle of bundles) {
+    if (!bundle || typeof bundle !== 'object' || Array.isArray(bundle)) {
+      continue;
+    }
+
+    if (typeof bundle.question_id === 'string' && bundle.question_id.trim()) {
+      bundlesByQuestionId.set(bundle.question_id.trim(), bundle);
+    }
+
+    const storageKey = typeof bundle.storage_key === 'string'
+      ? bundle.storage_key.trim()
+      : '';
+    if (storageKey) {
+      bundlesByStorageKey.set(storageKey, bundle);
+    }
+  }
+
+  return questions.map((question) => {
+    const { questionId, storageKey } = buildQuestionEvidenceKey(question);
+    const questionEvidenceBundle = bundlesByQuestionId.get(questionId)
+      ?? bundlesByStorageKey.get(storageKey)
+      ?? null;
+
+    return questionEvidenceBundle
+      ? {
+        ...question,
+        questionEvidenceBundle,
+      }
+      : question;
+  });
+}
+
 export async function main(argv = process.argv.slice(2)) {
   if (argv.includes('--help')) {
     printUsage();
@@ -29,8 +92,18 @@ export async function main(argv = process.argv.slice(2)) {
   }
 
   const force = argv.includes('--force');
+  const evidenceBundlesIndex = argv.findIndex((token) => token === '--evidence-bundles');
+  const evidenceBundlePath = evidenceBundlesIndex >= 0
+    ? argv[evidenceBundlesIndex + 1] ?? null
+    : null;
   const client = getServiceClient();
-  const questions = await loadCandidateQuestions(client);
+  let questions = await loadCandidateQuestions(client);
+  if (evidenceBundlePath) {
+    questions = attachEvidenceBundlesToQuestions(
+      questions,
+      normalizeEvidenceBundlePayload(readJson(evidenceBundlePath)),
+    );
+  }
   const summary = await runQuestionAnalysisBackfill(client, {
     questions,
     force,

--- a/scripts/learning/run_question_evidence_bundle_v1.js
+++ b/scripts/learning/run_question_evidence_bundle_v1.js
@@ -1,0 +1,144 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  buildQuestionEvidenceBundlesV1,
+  summarizeQuestionEvidenceBundlesV1,
+} from './lib/question-evidence-bundle-v1.js';
+
+function printUsage() {
+  console.log(
+    'Usage: node scripts/learning/run_question_evidence_bundle_v1.js --manifest <path> [--lane-results <path>] [--output <path>] [--dry-run]',
+  );
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function normalizeLaneOutputPayload(payload) {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (Array.isArray(payload?.results)) {
+    return payload.results;
+  }
+
+  if (Array.isArray(payload?.outputs)) {
+    return payload.outputs;
+  }
+
+  if (Array.isArray(payload?.items)) {
+    return payload.items;
+  }
+
+  throw new Error('Lane results file must contain an array of outputs or a { results } payload.');
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    manifest: null,
+    laneResults: [],
+    output: null,
+    dryRun: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (token === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    if (token === '--dry-run') {
+      options.dryRun = true;
+      continue;
+    }
+
+    if (token === '--manifest') {
+      options.manifest = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    if (token === '--lane-results') {
+      options.laneResults.push(argv[index + 1] ?? null);
+      index += 1;
+      continue;
+    }
+
+    if (token === '--output') {
+      options.output = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return options;
+}
+
+function loadLaneOutputs(paths = []) {
+  return paths.flatMap((filePath) => normalizeLaneOutputPayload(readJson(filePath)));
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+
+  if (options.help || !options.manifest) {
+    printUsage();
+    return;
+  }
+
+  const manifest = readJson(options.manifest);
+  const laneOutputs = loadLaneOutputs(options.laneResults.filter(Boolean));
+  const bundles = buildQuestionEvidenceBundlesV1({
+    manifest,
+    laneOutputs,
+  });
+  const summary = summarizeQuestionEvidenceBundlesV1(bundles);
+
+  console.log(`manifest_id: ${manifest.manifest_id ?? 'unknown'}`);
+  console.log(`bundles_planned: ${summary.bundles_planned}`);
+  for (const [route, count] of Object.entries(summary.route_counts).sort(([left], [right]) => left.localeCompare(right))) {
+    console.log(`${route}: ${count}`);
+  }
+  console.log(`lazy_attach_original_image: ${summary.lazy_attach_original_image}`);
+
+  if (options.dryRun) {
+    return;
+  }
+
+  const payload = {
+    manifest_id: manifest.manifest_id ?? null,
+    bundles,
+    summary,
+  };
+
+  if (options.output) {
+    fs.writeFileSync(options.output, JSON.stringify(payload, null, 2));
+    console.log(`wrote_evidence_bundles: ${options.output}`);
+    return;
+  }
+
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+export function isQuestionEvidenceBundleEntrypoint(entryScriptPath, metaUrl = import.meta.url) {
+  if (!entryScriptPath) {
+    return false;
+  }
+
+  return path.resolve(entryScriptPath) === fileURLToPath(metaUrl);
+}
+
+if (isQuestionEvidenceBundleEntrypoint(process.argv[1], import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add a wave-1 AO evidence bundle builder and CLI for structured question evidence
- make question-analysis-backfill accept per-question analysis hints or evidence bundles while preserving replay provenance
- add focused Jest coverage for bundle assembly, CLI wiring, and evidence-aware backfill behavior

Closes #200

## Verification
- npm test -- --runInBand scripts/learning/__tests__/question-evidence-bundle-v1.test.js scripts/learning/__tests__/run-question-evidence-bundle-v1.test.js scripts/learning/__tests__/question-analysis-backfill.test.js scripts/learning/__tests__/run-question-analysis-backfill.test.js
- node scripts/learning/run_question_evidence_bundle_v1.js --manifest data/manifests/9709_question_search_recovery_v1.json --dry-run