### PR TITLE
feat: add product-ranked question search contract

### DIFF
--- a/api/learning/__tests__/question-search-api.test.js
+++ b/api/learning/__tests__/question-search-api.test.js
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../../lib/security/auth-guard.js', () => ({
 }));
 
 jest.unstable_mockModule('../lib/questions/question-search-service.js', () => ({
+  getQuestionSearchProductFlagStatus: () => ({ enabled: true }),
   searchQuestions: mockSearchQuestions,
 }));
 
@@ -76,6 +77,15 @@ describe('question-search-api', () => {
           question_id: 'question-1',
           subject_code: '9709',
           search_text: 'Use a trigonometric identity.',
+          product_posture: {
+            code: 'paper_backed',
+            label: 'Paper-backed',
+            is_provisional: false,
+          },
+          product_card: {
+            title: 'S19 P1 Q6',
+            summary_line: 'Use a trigonometric identity.',
+          },
           match_context: {
             filters_applied: ['subject_code'],
             text_query_used: false,
@@ -85,6 +95,9 @@ describe('question-search-api', () => {
       total: 1,
       page: 1,
       page_size: 10,
+      feature_flags: {
+        question_search_product_enabled: true,
+      },
     });
 
     const req = createReq({
@@ -100,7 +113,9 @@ describe('question-search-api', () => {
     await handler(req, res);
 
     expect(mockGetServiceClient).toHaveBeenCalledTimes(1);
-    expect(mockSearchQuestions).toHaveBeenCalledWith(mockServiceClient, req.query);
+    expect(mockSearchQuestions).toHaveBeenCalledWith(mockServiceClient, req.query, {
+      productMode: true,
+    });
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({
       request_id: 'req-question-search-api',
@@ -109,6 +124,15 @@ describe('question-search-api', () => {
           question_id: 'question-1',
           subject_code: '9709',
           search_text: 'Use a trigonometric identity.',
+          product_posture: {
+            code: 'paper_backed',
+            label: 'Paper-backed',
+            is_provisional: false,
+          },
+          product_card: {
+            title: 'S19 P1 Q6',
+            summary_line: 'Use a trigonometric identity.',
+          },
           match_context: {
             filters_applied: ['subject_code'],
             text_query_used: false,
@@ -118,6 +142,9 @@ describe('question-search-api', () => {
       total: 1,
       page: 1,
       page_size: 10,
+      feature_flags: {
+        question_search_product_enabled: true,
+      },
     });
   });
 
@@ -158,7 +185,9 @@ describe('question-search-api', () => {
 
     await handler(req, res);
 
-    expect(mockSearchQuestions).toHaveBeenCalledWith(mockServiceClient, req.query);
+    expect(mockSearchQuestions).toHaveBeenCalledWith(mockServiceClient, req.query, {
+      productMode: true,
+    });
     expect(res.statusCode).toBe(400);
     expect(res.body).toEqual({
       request_id: 'req-question-search-api',

--- a/api/learning/__tests__/question-search-repository.test.js
+++ b/api/learning/__tests__/question-search-repository.test.js
@@ -188,4 +188,28 @@ describe('question-search-repository', () => {
       rows: [importedRow],
     });
   });
+
+  test('searchQuestionProjection can skip the range window when product ranking needs the full candidate set', async () => {
+    const db = createQuestionSearchDb({
+      data: [],
+      count: 3,
+      error: null,
+    });
+
+    await searchQuestionProjection(db, {
+      subject_code: '9709',
+      query: 'identity',
+      unpaged: true,
+      page: 2,
+      page_size: 2,
+    });
+
+    expect(db.state.queries[0]).toEqual(expect.objectContaining({
+      filters: [
+        { type: 'eq', field: 'subject_code', value: '9709' },
+        { type: 'ilike', field: 'search_text', pattern: '%identity%' },
+      ],
+      range: null,
+    }));
+  });
 });

--- a/api/learning/__tests__/question-search-service.test.js
+++ b/api/learning/__tests__/question-search-service.test.js
@@ -145,6 +145,166 @@ describe('question-search-service', () => {
       total: 1,
       page: 1,
       page_size: 10,
+      feature_flags: {
+        question_search_product_enabled: false,
+      },
     });
+  });
+
+  test('searchQuestions ranks paper-backed results ahead of imported rows in product mode and shapes grounded result cards', async () => {
+    mockSearchQuestionProjection.mockResolvedValueOnce({
+      total: 3,
+      rows: [
+        {
+          question_id: 'question-imported-1',
+          source_kind: 'imported_question',
+          subject_code: '9709',
+          release_scope_status: 'released_scoring',
+          primary_topic_title: 'Trigonometric equations',
+          primary_question_type_id: '9709.trigonometry.equations',
+          family_id: '9709.trigonometry_manipulation_equations',
+          q_number: 91,
+          summary: null,
+          question_type: null,
+          answer_form: null,
+          search_text: 'Prove a trigonometric identity and solve the equation in the given interval.',
+        },
+        {
+          question_id: 'question-paper-1',
+          source_kind: 'paper_question',
+          subject_code: '9709',
+          release_scope_status: 'non_released_fallback',
+          primary_topic_title: 'Trigonometric equations',
+          primary_question_type_id: '9709.trigonometry.equations',
+          family_id: '9709.trigonometry_manipulation_equations',
+          year: 2019,
+          session: 's',
+          paper_number: 1,
+          q_number: 6,
+          summary: '  Prove a trigonometric identity and solve the resulting equation.  ',
+          question_type: 'proof_and_solve',
+          answer_form: 'free_response',
+          search_text: 'Prove a trigonometric identity and solve the resulting equation.',
+        },
+        {
+          question_id: 'question-imported-2',
+          source_kind: 'imported_question',
+          subject_code: '9709',
+          release_scope_status: 'non_released_fallback',
+          primary_topic_title: 'Trigonometric equations',
+          primary_question_type_id: '9709.trigonometry.equations',
+          family_id: '9709.trigonometry_manipulation_equations',
+          q_number: 4,
+          summary: '',
+          question_type: null,
+          answer_form: null,
+          search_text: 'Solve tan x = 1.',
+        },
+      ],
+    });
+
+    const result = await searchQuestions({}, {
+      subject_code: '9709',
+      primary_question_type_id: '9709.trigonometry.equations',
+      query: 'identity solve equation',
+      page: 1,
+      page_size: 2,
+    }, {
+      productMode: true,
+    });
+
+    expect(mockSearchQuestionProjection).toHaveBeenCalledWith({}, {
+      subject_code: '9709',
+      primary_topic_id: null,
+      family_id: null,
+      primary_question_type_id: '9709.trigonometry.equations',
+      year: null,
+      session: null,
+      paper_number: null,
+      variant: null,
+      q_number: null,
+      query: 'identity solve equation',
+      page: 1,
+      page_size: 2,
+      unpaged: true,
+    });
+    expect(result.feature_flags).toEqual({
+      question_search_product_enabled: true,
+    });
+    expect(result.items.map((item) => item.question_id)).toEqual([
+      'question-paper-1',
+      'question-imported-1',
+    ]);
+    expect(result.items[0].product_posture).toEqual({
+      code: 'paper_backed',
+      label: 'Paper-backed',
+      is_provisional: false,
+    });
+    expect(result.items[0].product_card).toEqual(expect.objectContaining({
+      title: 'S19 P1 Q6',
+      summary_line: 'Prove a trigonometric identity and solve the resulting equation.',
+    }));
+    expect(result.items[1].product_posture).toEqual({
+      code: 'imported_provisional',
+      label: 'Imported / provisional',
+      is_provisional: true,
+    });
+    expect(result.items[1].product_card).toEqual(expect.objectContaining({
+      summary_line: null,
+    }));
+    expect(result.total).toBe(3);
+    expect(result.page).toBe(1);
+    expect(result.page_size).toBe(2);
+  });
+
+  test('searchQuestions keeps the legacy contract when product mode is explicitly disabled', async () => {
+    mockSearchQuestionProjection.mockResolvedValueOnce({
+      total: 2,
+      rows: [
+        {
+          question_id: 'question-imported-1',
+          source_kind: 'imported_question',
+          subject_code: '9709',
+          search_text: 'Imported row first.',
+        },
+        {
+          question_id: 'question-paper-1',
+          source_kind: 'paper_question',
+          subject_code: '9709',
+          search_text: 'Paper row second.',
+        },
+      ],
+    });
+
+    const result = await searchQuestions({}, {
+      subject_code: '9709',
+      page: 1,
+      page_size: 10,
+    }, {
+      productMode: false,
+    });
+
+    expect(mockSearchQuestionProjection).toHaveBeenCalledWith({}, {
+      subject_code: '9709',
+      primary_topic_id: null,
+      family_id: null,
+      primary_question_type_id: null,
+      year: null,
+      session: null,
+      paper_number: null,
+      variant: null,
+      q_number: null,
+      query: null,
+      page: 1,
+      page_size: 10,
+    });
+    expect(result.feature_flags).toEqual({
+      question_search_product_enabled: false,
+    });
+    expect(result.items.map((item) => item.question_id)).toEqual([
+      'question-imported-1',
+      'question-paper-1',
+    ]);
+    expect(result.items[0].product_card).toBeUndefined();
   });
 });

--- a/api/learning/lib/questions/question-search-service.js
+++ b/api/learning/lib/questions/question-search-service.js
@@ -5,6 +5,7 @@ import { searchQuestionProjection } from '../repositories/question-search-reposi
 const DEFAULT_QUESTION_SEARCH_PAGE = 1;
 const DEFAULT_QUESTION_SEARCH_PAGE_SIZE = 20;
 export const MAX_QUESTION_SEARCH_PAGE_SIZE = 50;
+export const QUESTION_SEARCH_PRODUCT_FLAG = 'QUESTION_SEARCH_PRODUCT_ENABLED';
 
 const STRUCTURED_FILTER_FIELDS = Object.freeze([
   'subject_code',
@@ -17,6 +18,18 @@ const STRUCTURED_FILTER_FIELDS = Object.freeze([
   'variant',
   'q_number',
 ]);
+
+const STRUCTURED_FILTER_WEIGHTS = Object.freeze({
+  subject_code: 1,
+  primary_topic_id: 8,
+  family_id: 4,
+  primary_question_type_id: 6,
+  year: 5,
+  session: 3,
+  paper_number: 5,
+  variant: 2,
+  q_number: 7,
+});
 
 function normalizeString(value) {
   return typeof value === 'string' ? value.trim() : '';
@@ -102,21 +115,318 @@ function buildMatchContext(filters) {
   };
 }
 
-export async function searchQuestions(client, input = {}) {
-  const normalizedFilters = normalizeQuestionSearchInput(input);
-  const { rows, total } = await searchQuestionProjection(client, normalizedFilters);
-  const matchContext = buildMatchContext(normalizedFilters);
+function isStrictProductionRuntime() {
+  return process.env.NODE_ENV === 'production' || process.env.VERCEL_ENV === 'production';
+}
+
+export function getQuestionSearchProductFlagStatus() {
+  const strict = isStrictProductionRuntime();
+  const enabled = strict
+    ? process.env[QUESTION_SEARCH_PRODUCT_FLAG] === 'true'
+    : true;
 
   return {
-    items: rows.map((row) => ({
-      ...row,
-      match_context: {
-        filters_applied: [...matchContext.filters_applied],
-        text_query_used: matchContext.text_query_used,
-      },
-    })),
+    enabled,
+    strict,
+    flag_name: QUESTION_SEARCH_PRODUCT_FLAG,
+    reason: strict
+      ? (enabled ? 'feature_flag_enabled' : 'feature_flag_disabled')
+      : 'non_production_runtime',
+  };
+}
+
+function normalizeCompactLine(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized || null;
+}
+
+function tokenizeQuery(value) {
+  return [...new Set(
+    normalizeString(value)
+      .toLowerCase()
+      .split(/[^a-z0-9]+/i)
+      .filter(Boolean),
+  )];
+}
+
+function compareNullableString(left, right) {
+  const normalizedLeft = normalizeNullableString(left);
+  const normalizedRight = normalizeNullableString(right);
+
+  if (normalizedLeft === normalizedRight) {
+    return 0;
+  }
+  if (normalizedLeft === null) {
+    return 1;
+  }
+  if (normalizedRight === null) {
+    return -1;
+  }
+
+  return normalizedLeft.localeCompare(normalizedRight);
+}
+
+function compareNullableNumber(left, right) {
+  const normalizedLeft = Number.isInteger(left) ? left : null;
+  const normalizedRight = Number.isInteger(right) ? right : null;
+
+  if (normalizedLeft === normalizedRight) {
+    return 0;
+  }
+  if (normalizedLeft === null) {
+    return 1;
+  }
+  if (normalizedRight === null) {
+    return -1;
+  }
+
+  return normalizedLeft - normalizedRight;
+}
+
+function buildStructuredExactnessWeight(row, filters) {
+  return STRUCTURED_FILTER_FIELDS.reduce((acc, field) => {
+    if (filters[field] !== null && row?.[field] === filters[field]) {
+      return acc + (STRUCTURED_FILTER_WEIGHTS[field] || 1);
+    }
+    return acc;
+  }, 0);
+}
+
+function buildTypeFamilyMatchStrength(row, filters) {
+  let rank = 0;
+
+  if (filters.primary_question_type_id && row?.primary_question_type_id === filters.primary_question_type_id) {
+    rank += 2;
+  }
+
+  if (filters.family_id && row?.family_id === filters.family_id) {
+    rank += 1;
+  }
+
+  if (!filters.primary_question_type_id && normalizeNullableString(row?.primary_question_type_id)) {
+    rank += 1;
+  }
+
+  if (!filters.family_id && normalizeNullableString(row?.family_id)) {
+    rank += 1;
+  }
+
+  return rank;
+}
+
+function buildTextualSimilarity(row, query) {
+  const normalizedQuery = normalizeString(query).toLowerCase();
+  const queryTokens = tokenizeQuery(query);
+  const haystack = [
+    row?.summary,
+    row?.search_text,
+    row?.primary_topic_title,
+    row?.question_type,
+  ]
+    .map((value) => normalizeString(value).toLowerCase())
+    .filter(Boolean)
+    .join(' ');
+
+  if (!queryTokens.length || !haystack) {
+    return {
+      exact_phrase_match: false,
+      matched_query_token_count: 0,
+      normalized_score: 0,
+    };
+  }
+
+  const matchedTokenCount = queryTokens.filter((token) => haystack.includes(token)).length;
+  return {
+    exact_phrase_match: normalizedQuery.length > 0 && haystack.includes(normalizedQuery),
+    matched_query_token_count: matchedTokenCount,
+    normalized_score: queryTokens.length > 0
+      ? Number((matchedTokenCount / queryTokens.length).toFixed(4))
+      : 0,
+  };
+}
+
+function buildResultSortKey(row, filters) {
+  const textualSimilarity = buildTextualSimilarity(row, filters.query);
+
+  return {
+    authority_tier: row?.source_kind === 'paper_question' ? 2 : 1,
+    structured_exactness_weight: buildStructuredExactnessWeight(row, filters),
+    release_posture_rank: row?.release_scope_status === 'released_scoring' ? 1 : 0,
+    type_family_match_strength: buildTypeFamilyMatchStrength(row, filters),
+    textual_similarity: textualSimilarity,
+    tiebreakers: {
+      storage_key: normalizeNullableString(row?.storage_key),
+      year: Number.isInteger(row?.year) ? row.year : null,
+      session: normalizeNullableString(row?.session),
+      paper_number: Number.isInteger(row?.paper_number) ? row.paper_number : null,
+      variant: Number.isInteger(row?.variant) ? row.variant : null,
+      q_number: Number.isInteger(row?.q_number) ? row.q_number : null,
+      question_id: normalizeNullableString(row?.question_id),
+    },
+  };
+}
+
+function compareTextualSimilarity(left, right) {
+  if (left.exact_phrase_match !== right.exact_phrase_match) {
+    return left.exact_phrase_match ? -1 : 1;
+  }
+
+  if (left.matched_query_token_count !== right.matched_query_token_count) {
+    return right.matched_query_token_count - left.matched_query_token_count;
+  }
+
+  if (left.normalized_score !== right.normalized_score) {
+    return right.normalized_score - left.normalized_score;
+  }
+
+  return 0;
+}
+
+function compareResultSortKeys(left, right) {
+  if (left.authority_tier !== right.authority_tier) {
+    return right.authority_tier - left.authority_tier;
+  }
+
+  if (left.structured_exactness_weight !== right.structured_exactness_weight) {
+    return right.structured_exactness_weight - left.structured_exactness_weight;
+  }
+
+  if (left.release_posture_rank !== right.release_posture_rank) {
+    return right.release_posture_rank - left.release_posture_rank;
+  }
+
+  if (left.type_family_match_strength !== right.type_family_match_strength) {
+    return right.type_family_match_strength - left.type_family_match_strength;
+  }
+
+  const textualSimilarityComparison = compareTextualSimilarity(
+    left.textual_similarity,
+    right.textual_similarity,
+  );
+  if (textualSimilarityComparison !== 0) {
+    return textualSimilarityComparison;
+  }
+
+  for (const field of ['storage_key', 'session', 'question_id']) {
+    const stringComparison = compareNullableString(
+      left.tiebreakers[field],
+      right.tiebreakers[field],
+    );
+    if (stringComparison !== 0) {
+      return stringComparison;
+    }
+  }
+
+  for (const field of ['year', 'paper_number', 'variant', 'q_number']) {
+    const numberComparison = compareNullableNumber(
+      left.tiebreakers[field],
+      right.tiebreakers[field],
+    );
+    if (numberComparison !== 0) {
+      return numberComparison;
+    }
+  }
+
+  return 0;
+}
+
+function formatPaperQuestionTitle(row) {
+  if (!Number.isInteger(row?.year)
+    || !normalizeNullableString(row?.session)
+    || !Number.isInteger(row?.paper_number)
+    || !Number.isInteger(row?.q_number)) {
+    return null;
+  }
+
+  const shortYear = String(row.year).slice(-2);
+  return `${normalizeString(row.session).toUpperCase()}${shortYear} P${row.paper_number} Q${row.q_number}`;
+}
+
+function buildProductPosture(row) {
+  if (row?.source_kind === 'paper_question') {
+    return {
+      code: 'paper_backed',
+      label: 'Paper-backed',
+      is_provisional: false,
+    };
+  }
+
+  return {
+    code: 'imported_provisional',
+    label: 'Imported / provisional',
+    is_provisional: true,
+  };
+}
+
+function buildProductCard(row) {
+  const title = formatPaperQuestionTitle(row)
+    || normalizeNullableString(row?.primary_topic_title)
+    || normalizeNullableString(row?.question_type)
+    || (row?.source_kind === 'imported_question' ? 'Imported question' : 'Question');
+
+  const metaParts = [
+    normalizeNullableString(row?.primary_topic_title),
+    normalizeNullableString(row?.question_type),
+    normalizeNullableString(row?.answer_form),
+  ].filter(Boolean).filter((value, index, values) => values.indexOf(value) === index && value !== title);
+
+  return {
+    title,
+    meta_line: metaParts.length > 0 ? metaParts.join(' · ') : null,
+    summary_line: normalizeCompactLine(row?.summary),
+  };
+}
+
+function attachMatchContext(row, matchContext) {
+  return {
+    ...row,
+    match_context: {
+      filters_applied: [...matchContext.filters_applied],
+      text_query_used: matchContext.text_query_used,
+    },
+  };
+}
+
+function paginateRows(rows, page, pageSize) {
+  const start = (page - 1) * pageSize;
+  return rows.slice(start, start + pageSize);
+}
+
+export async function searchQuestions(client, input = {}, options = {}) {
+  const normalizedFilters = normalizeQuestionSearchInput(input);
+  const productMode = options.productMode === true;
+  const repositoryFilters = productMode
+    ? { ...normalizedFilters, unpaged: true }
+    : normalizedFilters;
+  const { rows, total } = await searchQuestionProjection(client, repositoryFilters);
+  const matchContext = buildMatchContext(normalizedFilters);
+  const items = productMode
+    ? paginateRows(
+      rows
+        .map((row) => ({
+          ...attachMatchContext(row, matchContext),
+          product_posture: buildProductPosture(row),
+          product_card: buildProductCard(row),
+          __sort_key: buildResultSortKey(row, normalizedFilters),
+        }))
+        .sort((left, right) => compareResultSortKeys(left.__sort_key, right.__sort_key))
+        .map(({ __sort_key, ...row }) => row),
+      normalizedFilters.page,
+      normalizedFilters.page_size,
+    )
+    : rows.map((row) => attachMatchContext(row, matchContext));
+
+  return {
+    items,
     total,
     page: normalizedFilters.page,
     page_size: normalizedFilters.page_size,
+    feature_flags: {
+      question_search_product_enabled: productMode,
+    },
   };
 }

--- a/api/learning/lib/repositories/question-search-repository.js
+++ b/api/learning/lib/repositories/question-search-repository.js
@@ -14,6 +14,7 @@ export async function searchQuestionProjection(client, filters = {}) {
   const pageSize = Number.isInteger(filters.page_size) && filters.page_size > 0
     ? filters.page_size
     : 20;
+  const unpaged = filters.unpaged === true;
   const rangeStart = (page - 1) * pageSize;
   const rangeEnd = rangeStart + pageSize - 1;
 
@@ -45,9 +46,12 @@ export async function searchQuestionProjection(client, filters = {}) {
     query = query.ilike('search_text', `%${escapeLikePattern(textQuery)}%`);
   }
 
-  const { data, count, error } = await query
-    .order('question_id', { ascending: true })
-    .range(rangeStart, rangeEnd);
+  let orderedQuery = query.order('question_id', { ascending: true });
+  if (!unpaged) {
+    orderedQuery = orderedQuery.range(rangeStart, rangeEnd);
+  }
+
+  const { data, count, error } = await orderedQuery;
 
   if (error) {
     throw new Error(`Failed to search question projection: ${error.message}`);

--- a/api/learning/questions/index.js
+++ b/api/learning/questions/index.js
@@ -7,7 +7,10 @@ import {
   sendLearningHttpError,
   sendLearningJson,
 } from '../lib/http/learning-http.js';
-import { searchQuestions } from '../lib/questions/question-search-service.js';
+import {
+  getQuestionSearchProductFlagStatus,
+  searchQuestions,
+} from '../lib/questions/question-search-service.js';
 
 async function ensureLearningAuth(req) {
   if (req?.auth_user_id) {
@@ -55,7 +58,9 @@ export default async function handler(req, res) {
   }
 
   try {
-    const payload = await searchQuestions(getServiceClient(), req.query || {});
+    const payload = await searchQuestions(getServiceClient(), req.query || {}, {
+      productMode: getQuestionSearchProductFlagStatus().enabled,
+    });
     return sendLearningJson(res, req?.request_id || null, payload);
   } catch (error) {
     if (error instanceof LearningHttpError) {

--- a/data/eval/question_search_gold_9709_v1.json
+++ b/data/eval/question_search_gold_9709_v1.json
@@ -156,6 +156,37 @@
         "kind": "manual_audit_review_sheet",
         "storage_key": "9709/s16_qp_33/questions/q07.png"
       }
+    },
+    {
+      "id": "mixed-ranking-paper-authority",
+      "description": "When paper-backed and imported rows both match the same trig prompt, the paper-backed result must rank first.",
+      "query": {
+        "topic_path": "9709.p1.trigonometry",
+        "primary_question_type_id": "9709.trigonometry.equations",
+        "query": "identity solve equation"
+      },
+      "expected": {
+        "match": {
+          "source_kind": "paper_question",
+          "subject_code": "9709",
+          "primary_topic_path": "9709.p1.trigonometry",
+          "primary_question_type_id": "9709.trigonometry.equations",
+          "q_number": 6
+        },
+        "required_metadata": [
+          "source_kind",
+          "subject_code",
+          "primary_topic_path",
+          "primary_question_type_id",
+          "q_number",
+          "summary"
+        ],
+        "summary_policy": "require_non_null"
+      },
+      "source_reference": {
+        "kind": "manual_audit_review_sheet",
+        "storage_key": "9709/s19_qp_11/questions/q06.png"
+      }
     }
   ]
 }

--- a/docs/reports/2026-04-16-issue-218-closeout.md
+++ b/docs/reports/2026-04-16-issue-218-closeout.md
@@ -24,7 +24,7 @@ Shipped behavior:
 - compact result-card payloads expose grounded title, meta line, and one-line summary data
 - one-line result summaries come only from structured `summary` fields; unsupported summaries remain absent
 - feature-flagged integration into the canonical `/api/learning/questions` flow and the learning runtime API client normalization
-- shared question-search gate coverage extended with mixed-source ranking fixtures so the checked-in evidence exercises the same product-mode service
+- shared question-search gate coverage extended with mixed-source ranking fixtures, using the shared product-mode service when service-role Supabase env is available and preserving the prior SQL fallback for `DATABASE_URL`-only and `SUPABASE_PG_COMPAT=true` environments
 
 ## Boundary Kept
 
@@ -60,14 +60,14 @@ Actual outcome:
 
 - pass
 - `5` suites passed
-- `36` tests passed
+- `40` tests passed
 
 Focused surfaces covered by the passing run:
 
 - repository slice
 - service ranking and grounded-card behavior
 - `/api/learning/questions` API surface
-- shared gate runner unit coverage
+- shared gate runner unit coverage, including `DATABASE_URL`-only and `SUPABASE_PG_COMPAT=true` compatibility
 - learning runtime API client normalization
 
 ## Actual Outcome
@@ -83,4 +83,5 @@ Acceptance-critical outcome on this branch:
 
 - production rollout still depends on explicitly enabling `QUESTION_SEARCH_PRODUCT_ENABLED`
 - retrieval quality remains bounded by the completeness of existing paper metadata and structured descriptor fields; `#218` intentionally did not backfill or repair those data surfaces
+- the gate runner now has an explicit compatibility split between service-backed and SQL-backed search execution, so future retrieval changes need to keep both execution modes aligned
 - the issue does not change release readiness for unrelated search, browse, or answer-generation flows because those were explicitly out of scope

--- a/docs/reports/2026-04-16-issue-218-closeout.md
+++ b/docs/reports/2026-04-16-issue-218-closeout.md
@@ -1,0 +1,86 @@
+# 2026-04-16 Issue 218 Closeout
+
+Date: 2026-04-16
+Issue: `#218`
+PR: `#219`
+Branch: `feat/218`
+Status: implementation shipped on branch and PR; issue-level closeout evidence recorded
+
+## Shipped Scope
+
+This issue hardened the existing structured question-search slice with the product-facing ranking and result-card contract for mixed paper-backed and imported results.
+
+Shipped behavior:
+
+- deterministic ordered ranking keys in product mode:
+  - authority tier
+  - structured exactness
+  - release posture
+  - type/family match strength
+  - textual similarity
+  - deterministic tiebreakers
+- `paper_question` rows always outrank `imported_question` rows
+- imported rows remain visible and always surface the `Imported / provisional` posture
+- compact result-card payloads expose grounded title, meta line, and one-line summary data
+- one-line result summaries come only from structured `summary` fields; unsupported summaries remain absent
+- feature-flagged integration into the canonical `/api/learning/questions` flow and the learning runtime API client normalization
+- shared question-search gate coverage extended with mixed-source ranking fixtures so the checked-in evidence exercises the same product-mode service
+
+## Boundary Kept
+
+This issue reused the earlier `#185`, `#186`, and `#187` infrastructure. It did not reopen:
+
+- projection creation
+- backend endpoint creation
+- retrieval gate infrastructure
+- descriptor backfill or data repair
+- search-index redesign
+- homepage or browse IA redesign
+- open-ended RAG answer generation
+
+## Feature Flag
+
+Flag name: `QUESTION_SEARCH_PRODUCT_ENABLED`
+
+Behavior:
+
+- non-production runtime: enabled by default
+- production runtime: enabled only when `QUESTION_SEARCH_PRODUCT_ENABLED=true`
+- response payloads expose `feature_flags.question_search_product_enabled` so clients can tell whether the product contract is active
+
+## Verification
+
+Exact command run on this branch:
+
+```bash
+npm test -- --runInBand api/learning/__tests__/question-search-repository.test.js api/learning/__tests__/question-search-service.test.js api/learning/__tests__/question-search-api.test.js scripts/evaluation/__tests__/question-search-gate.test.js src/api/__tests__/learningRuntimeApi.test.js
+```
+
+Actual outcome:
+
+- pass
+- `5` suites passed
+- `36` tests passed
+
+Focused surfaces covered by the passing run:
+
+- repository slice
+- service ranking and grounded-card behavior
+- `/api/learning/questions` API surface
+- shared gate runner unit coverage
+- learning runtime API client normalization
+
+## Actual Outcome
+
+Acceptance-critical outcome on this branch:
+
+- mixed paper-backed and imported ranking is deterministic in product mode
+- imported results remain visible but are always downgraded and badged as provisional
+- result-card summaries do not synthesize unsupported claims; they are grounded or omitted
+- focused mixed-source ranking and no-summary fallback coverage is in place
+
+## Residual Risks And Follow-Up Debt
+
+- production rollout still depends on explicitly enabling `QUESTION_SEARCH_PRODUCT_ENABLED`
+- retrieval quality remains bounded by the completeness of existing paper metadata and structured descriptor fields; `#218` intentionally did not backfill or repair those data surfaces
+- the issue does not change release readiness for unrelated search, browse, or answer-generation flows because those were explicitly out of scope

--- a/scripts/evaluation/__tests__/question-search-gate.test.js
+++ b/scripts/evaluation/__tests__/question-search-gate.test.js
@@ -36,6 +36,9 @@ describe('question-search-gate', () => {
         && Number.isInteger(testCase.query.paper_number)
       )),
     ).toBe(true);
+    expect(
+      fixture.cases.some((testCase) => testCase.id === 'mixed-ranking-paper-authority'),
+    ).toBe(true);
   });
 
   test('runQuestionSearchGate computes release metrics and passes when thresholds are met', async () => {
@@ -385,6 +388,104 @@ describe('question-search-gate', () => {
     expect(result.report_markdown).toContain('Prefer `public.question_descriptions_prod_v1`');
     expect(result.report_markdown).toContain('paper_question: 0');
     expect(result.report_markdown).toContain('paper-backed pinned cases cannot pass');
+  });
+
+  test('runQuestionSearchGate keeps mixed-source authority fixtures green when paper-backed rows rank first', async () => {
+    const fixture = {
+      subject_code: '9709',
+      curriculum_version_tag: DEFAULT_CURRICULUM_VERSION_TAG,
+      thresholds: DEFAULT_QUESTION_SEARCH_GATE_THRESHOLDS,
+      cases: [
+        {
+          id: 'mixed-ranking-paper-authority',
+          description: 'Paper-backed rows outrank imported rows when both satisfy the same structured query.',
+          query: {
+            topic_path: '9709.p1.trigonometry',
+            primary_question_type_id: '9709.trigonometry.equations',
+            query: 'identity solve equation',
+          },
+          expected: {
+            match: {
+              question_id: 'question-paper-1',
+              source_kind: 'paper_question',
+              subject_code: '9709',
+              primary_topic_path: '9709.p1.trigonometry',
+              primary_question_type_id: '9709.trigonometry.equations',
+              q_number: 6,
+            },
+            required_metadata: [
+              'question_id',
+              'source_kind',
+              'subject_code',
+              'primary_topic_path',
+              'primary_question_type_id',
+              'q_number',
+              'summary',
+            ],
+            summary_policy: 'require_non_null',
+          },
+        },
+      ],
+    };
+
+    const searchQuestionsFn = jest.fn().mockResolvedValue({
+      items: [
+        {
+          question_id: 'question-paper-1',
+          source_kind: 'paper_question',
+          subject_code: '9709',
+          primary_topic_path: '9709.p1.trigonometry',
+          primary_question_type_id: '9709.trigonometry.equations',
+          q_number: 6,
+          summary: 'Prove a trigonometric identity and solve the resulting equation.',
+        },
+        {
+          question_id: 'question-imported-1',
+          source_kind: 'imported_question',
+          subject_code: '9709',
+          primary_topic_path: '9709.p1.trigonometry',
+          primary_question_type_id: '9709.trigonometry.equations',
+          q_number: 91,
+          summary: null,
+        },
+      ],
+      total: 2,
+      page: 1,
+      page_size: 20,
+    });
+
+    const resolveTopicPathFn = jest.fn().mockResolvedValue('topic-paper-trigonometry');
+    const inspectDescriptorSourceFn = jest.fn().mockResolvedValue({
+      selected_branch: 'question_descriptions_v0_status_ok',
+      surfaces: {
+        question_descriptions_prod_v1: { exists: false, count: null, count_9709: null },
+        question_descriptions_v1: { exists: false, count: null, count_9709: null },
+        question_descriptions_v0: { exists: true, count: 24, count_9709: 24 },
+        learning_question_search_projection: { count: 24, count_9709: 24 },
+        question_bank_9709: { total: 24, paper_question: 22, imported_question: 2 },
+      },
+    });
+
+    const result = await runQuestionSearchGate({
+      fixture,
+      searchQuestionsFn,
+      resolveTopicPathFn,
+      inspectDescriptorSourceFn,
+      nowIso: '2026-04-16T09:00:00Z',
+    });
+
+    expect(result.metrics).toEqual({
+      exact_structured_match_rate: 1,
+      subject_leakage_rate: 0,
+      metadata_completeness_rate: 1,
+      null_summary_rate: 0,
+    });
+    expect(result.gate.pass).toBe(true);
+    expect(result.case_results[0]).toEqual(expect.objectContaining({
+      id: 'mixed-ranking-paper-authority',
+      top_result_question_id: 'question-paper-1',
+      total_results: 2,
+    }));
   });
 
   test('curriculum node resolution SQL filters by syllabus, topic_path, and explicit version_tag', () => {

--- a/scripts/evaluation/__tests__/question-search-gate.test.js
+++ b/scripts/evaluation/__tests__/question-search-gate.test.js
@@ -5,8 +5,10 @@ import {
   buildCurriculumNodeResolutionSql,
   DEFAULT_CURRICULUM_VERSION_TAG,
   DEFAULT_QUESTION_SEARCH_GATE_THRESHOLDS,
+  getProjectionSearchMode,
   loadQuestionSearchGoldFixture,
   runQuestionSearchGate,
+  searchProjectionFromDatabase,
 } from '../run_question_search_gate.js';
 
 const FIXTURE_PATH = path.join(
@@ -501,5 +503,83 @@ describe('question-search-gate', () => {
     expect(sql).toContain("version_tag = '2025-2027_v1'");
     expect(sql).toContain('ORDER BY node_id ASC');
     expect(sql).toContain('LIMIT 1');
+  });
+
+  test('getProjectionSearchMode falls back to psql for DATABASE_URL-only environments', () => {
+    expect(getProjectionSearchMode({
+      DATABASE_URL: 'postgres://example.test/db',
+    })).toBe('psql');
+  });
+
+  test('getProjectionSearchMode falls back to psql when SUPABASE_PG_COMPAT is enabled', () => {
+    expect(getProjectionSearchMode({
+      DATABASE_URL: 'postgres://example.test/db',
+      SUPABASE_URL: 'https://supabase.example.test',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+      SUPABASE_PG_COMPAT: 'true',
+    })).toBe('psql');
+  });
+
+  test('searchProjectionFromDatabase uses SQL fallback when service env is unavailable', async () => {
+    const runPsqlJsonFn = jest.fn().mockResolvedValue({
+      total: 1,
+      items: [{ question_id: 'question-paper-1' }],
+    });
+    const searchQuestionsFn = jest.fn();
+    const getServiceClientFn = jest.fn();
+
+    const result = await searchProjectionFromDatabase({
+      subject_code: '9709',
+      primary_topic_id: 'topic-paper-trigonometry',
+      query: 'identity solve equation',
+    }, {
+      env: {
+        DATABASE_URL: 'postgres://example.test/db',
+      },
+      runPsqlJsonFn,
+      searchQuestionsFn,
+      getServiceClientFn,
+    });
+
+    expect(result).toEqual({
+      total: 1,
+      items: [{ question_id: 'question-paper-1' }],
+    });
+    expect(searchQuestionsFn).not.toHaveBeenCalled();
+    expect(getServiceClientFn).not.toHaveBeenCalled();
+    expect(runPsqlJsonFn).toHaveBeenCalledTimes(1);
+    expect(runPsqlJsonFn.mock.calls[0][0]).toContain('FROM public.learning_question_search_projection');
+    expect(runPsqlJsonFn.mock.calls[0][0]).toContain("subject_code = '9709'");
+    expect(runPsqlJsonFn.mock.calls[0][0]).toContain("primary_topic_id = 'topic-paper-trigonometry'");
+    expect(runPsqlJsonFn.mock.calls[0][0]).toContain("search_text ILIKE '%' || 'identity solve equation' || '%' ESCAPE '\\'");
+  });
+
+  test('searchProjectionFromDatabase uses SQL fallback when pg-compat is enabled', async () => {
+    const runPsqlJsonFn = jest.fn().mockResolvedValue({
+      total: 2,
+      items: [{ question_id: 'question-paper-1' }, { question_id: 'question-imported-1' }],
+    });
+    const searchQuestionsFn = jest.fn();
+    const getServiceClientFn = jest.fn();
+
+    const result = await searchProjectionFromDatabase({
+      subject_code: '9709',
+      query: 'tan^2',
+    }, {
+      env: {
+        DATABASE_URL: 'postgres://example.test/db',
+        SUPABASE_URL: 'https://supabase.example.test',
+        SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+        SUPABASE_PG_COMPAT: 'true',
+      },
+      runPsqlJsonFn,
+      searchQuestionsFn,
+      getServiceClientFn,
+    });
+
+    expect(result.total).toBe(2);
+    expect(runPsqlJsonFn).toHaveBeenCalledTimes(1);
+    expect(searchQuestionsFn).not.toHaveBeenCalled();
+    expect(getServiceClientFn).not.toHaveBeenCalled();
   });
 });

--- a/scripts/evaluation/run_question_search_gate.js
+++ b/scripts/evaluation/run_question_search_gate.js
@@ -82,6 +82,10 @@ function ratio(numerator, denominator) {
   return roundRate(numerator / denominator);
 }
 
+function escapeLikePattern(value) {
+  return String(value).replace(/[\\%_]/g, '\\$&');
+}
+
 function sqlLiteral(value) {
   if (value === null || typeof value === 'undefined') {
     return 'NULL';
@@ -703,6 +707,11 @@ async function runPsql(sql) {
   return stdout.trim();
 }
 
+async function runPsqlJson(sql) {
+  const raw = await runPsql(sql);
+  return JSON.parse(raw);
+}
+
 async function resolveTopicPathFromDatabase({
   subjectCode,
   topicPath,
@@ -716,8 +725,72 @@ async function resolveTopicPathFromDatabase({
   return JSON.parse(await runPsql(sql));
 }
 
-async function searchProjectionFromDatabase(searchInput) {
-  return searchQuestions(getServiceClient(), searchInput, {
+function hasServiceSearchEnv(env = process.env) {
+  return Boolean(
+    env.SUPABASE_URL
+      && (env.SUPABASE_SERVICE_ROLE_KEY || env.SUPABASE_SERVICE_ROLE),
+  );
+}
+
+export function getProjectionSearchMode(env = process.env) {
+  if (env.SUPABASE_PG_COMPAT === 'true') {
+    return 'psql';
+  }
+
+  if (!hasServiceSearchEnv(env)) {
+    return 'psql';
+  }
+
+  return 'service';
+}
+
+function buildProjectionSearchSql(searchInput) {
+  const conditions = [];
+
+  STRUCTURED_FILTER_FIELDS.forEach((field) => {
+    if (isPresent(searchInput[field])) {
+      conditions.push(`${field} = ${sqlLiteral(searchInput[field])}`);
+    }
+  });
+
+  if (isPresent(searchInput.query)) {
+    const escaped = escapeLikePattern(searchInput.query);
+    conditions.push(`search_text ILIKE '%' || ${sqlLiteral(escaped)} || '%' ESCAPE '\\'`);
+  }
+
+  const whereSql = conditions.length > 0
+    ? `WHERE ${conditions.join(' AND ')}`
+    : '';
+
+  return [
+    'WITH filtered AS (',
+    '  SELECT *',
+    '  FROM public.learning_question_search_projection',
+    `  ${whereSql}`,
+    '), paged AS (',
+    '  SELECT *',
+    '  FROM filtered',
+    '  ORDER BY question_id ASC',
+    '  LIMIT 20',
+    ')',
+    'SELECT json_build_object(',
+    "  'total', (SELECT COUNT(*) FROM filtered),",
+    "  'items', COALESCE((SELECT json_agg(row_to_json(paged)) FROM paged), '[]'::json)",
+    ')::text;',
+  ].join('\n');
+}
+
+export async function searchProjectionFromDatabase(searchInput, {
+  env = process.env,
+  runPsqlJsonFn = runPsqlJson,
+  searchQuestionsFn = searchQuestions,
+  getServiceClientFn = getServiceClient,
+} = {}) {
+  if (getProjectionSearchMode(env) === 'psql') {
+    return runPsqlJsonFn(buildProjectionSearchSql(searchInput));
+  }
+
+  return searchQuestionsFn(getServiceClientFn(), searchInput, {
     productMode: true,
   });
 }

--- a/scripts/evaluation/run_question_search_gate.js
+++ b/scripts/evaluation/run_question_search_gate.js
@@ -5,6 +5,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import { getServiceClient } from '../../api/lib/supabase/client.js';
+import { searchQuestions } from '../../api/learning/lib/questions/question-search-service.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -78,10 +80,6 @@ function ratio(numerator, denominator) {
     return 0;
   }
   return roundRate(numerator / denominator);
-}
-
-function escapeLikePattern(value) {
-  return String(value).replace(/[\\%_]/g, '\\$&');
 }
 
 function sqlLiteral(value) {
@@ -705,11 +703,6 @@ async function runPsql(sql) {
   return stdout.trim();
 }
 
-async function runPsqlJson(sql) {
-  const raw = await runPsql(sql);
-  return JSON.parse(raw);
-}
-
 async function resolveTopicPathFromDatabase({
   subjectCode,
   topicPath,
@@ -724,41 +717,9 @@ async function resolveTopicPathFromDatabase({
 }
 
 async function searchProjectionFromDatabase(searchInput) {
-  const conditions = [];
-
-  STRUCTURED_FILTER_FIELDS.forEach((field) => {
-    if (isPresent(searchInput[field])) {
-      conditions.push(`${field} = ${sqlLiteral(searchInput[field])}`);
-    }
+  return searchQuestions(getServiceClient(), searchInput, {
+    productMode: true,
   });
-
-  if (isPresent(searchInput.query)) {
-    const escaped = escapeLikePattern(searchInput.query);
-    conditions.push(`search_text ILIKE '%' || ${sqlLiteral(escaped)} || '%' ESCAPE '\\'`);
-  }
-
-  const whereSql = conditions.length > 0
-    ? `WHERE ${conditions.join(' AND ')}`
-    : '';
-
-  const sql = [
-    'WITH filtered AS (',
-    '  SELECT *',
-    '  FROM public.learning_question_search_projection',
-    `  ${whereSql}`,
-    '), paged AS (',
-    '  SELECT *',
-    '  FROM filtered',
-    '  ORDER BY question_id ASC',
-    '  LIMIT 20',
-    ')',
-    'SELECT json_build_object(',
-    "  'total', (SELECT COUNT(*) FROM filtered),",
-    "  'items', COALESCE((SELECT json_agg(row_to_json(paged)) FROM paged), '[]'::json)",
-    ')::text;',
-  ].join('\n');
-
-  return runPsqlJson(sql);
 }
 
 async function inspectDescriptorSourceFromDatabase(subjectCode) {

--- a/src/api/__tests__/learningRuntimeApi.test.js
+++ b/src/api/__tests__/learningRuntimeApi.test.js
@@ -21,9 +21,11 @@ const {
   normalizeAskResponse,
   normalizeArtifactResponse,
   normalizeImportQuestionResponse,
+  normalizeQuestionSearchResponse,
   normalizeReviewTaskResponse,
   normalizeSessionResponse,
   pinArtifact,
+  searchQuestions,
   supersedeArtifact,
   unpinArtifact,
 } = await import('../learningRuntimeApi.js');
@@ -253,6 +255,56 @@ function createReviewTaskEnvelope() {
   };
 }
 
+function createQuestionSearchEnvelope() {
+  return {
+    items: [
+      {
+        question_id: 'question-paper-1',
+        source_kind: 'paper_question',
+        subject_code: '9709',
+        primary_topic_title: 'Trigonometric equations',
+        primary_question_type_id: '9709.trigonometry.equations',
+        q_number: 6,
+        product_posture: {
+          code: 'paper_backed',
+          label: 'Paper-backed',
+          is_provisional: false,
+        },
+        product_card: {
+          title: 'S19 P1 Q6',
+          meta_line: 'Trigonometric equations',
+          summary_line: 'Prove a trigonometric identity and solve the resulting equation.',
+        },
+      },
+      {
+        question_id: 'question-imported-1',
+        source_kind: 'imported_question',
+        subject_code: '9709',
+        primary_topic_title: 'Trigonometric equations',
+        primary_question_type_id: '9709.trigonometry.equations',
+        q_number: 91,
+        product_posture: {
+          code: 'imported_provisional',
+          label: 'Imported / provisional',
+          is_provisional: true,
+        },
+        product_card: {
+          title: 'Imported question',
+          meta_line: 'Trigonometric equations',
+          summary_line: null,
+        },
+      },
+    ],
+    total: 2,
+    page: 1,
+    page_size: 20,
+    feature_flags: {
+      question_search_product_enabled: true,
+    },
+    request_id: 'req-question-search-1',
+  };
+}
+
 describe('learning runtime api', () => {
   beforeEach(() => {
     global.fetch = jest.fn();
@@ -275,6 +327,7 @@ describe('learning runtime api', () => {
       'listReviewTasks',
       'markArtifactContested',
       'pinArtifact',
+      'searchQuestions',
       'supersedeArtifact',
       'unpinArtifact',
       'updateReviewTask',
@@ -420,6 +473,34 @@ describe('learning runtime api', () => {
     });
   });
 
+  test('normalizes question-search envelopes and preserves product posture/card fields', () => {
+    const payload = normalizeQuestionSearchResponse(createQuestionSearchEnvelope());
+
+    expect(payload.items.map((item) => item.questionId)).toEqual([
+      'question-paper-1',
+      'question-imported-1',
+    ]);
+    expect(payload.items[0].productPosture).toEqual({
+      code: 'paper_backed',
+      label: 'Paper-backed',
+      isProvisional: false,
+    });
+    expect(payload.items[0].productCard).toEqual({
+      title: 'S19 P1 Q6',
+      metaLine: 'Trigonometric equations',
+      summaryLine: 'Prove a trigonometric identity and solve the resulting equation.',
+    });
+    expect(payload.items[1].productPosture).toEqual({
+      code: 'imported_provisional',
+      label: 'Imported / provisional',
+      isProvisional: true,
+    });
+    expect(payload.items[1].productCard.summaryLine).toBeNull();
+    expect(payload.featureFlags).toEqual({
+      questionSearchProductEnabled: true,
+    });
+  });
+
   test('normalizes review-task write envelopes for actionable queue feedback', () => {
     const payload = normalizeReviewTaskResponse(createReviewTaskEnvelope());
 
@@ -559,6 +640,35 @@ describe('learning runtime api', () => {
     });
     expect(response.question.questionId).toBe('question-import-1');
     expect(response.scoringScopePosture.fallbackMode).toBe('non_released_fallback');
+  });
+
+  test('searchQuestions encodes the shared query contract and normalizes product search results', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => createQuestionSearchEnvelope(),
+    });
+
+    const response = await searchQuestions({
+      subjectCode: '9709',
+      primaryQuestionTypeId: '9709.trigonometry.equations',
+      query: 'identity solve equation',
+      page: 1,
+      pageSize: 20,
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe(
+      '/api/learning/questions?subject_code=9709&primary_question_type_id=9709.trigonometry.equations&query=identity+solve+equation&page=1&page_size=20',
+    );
+    expect(global.fetch.mock.calls[0][1]).toMatchObject({
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer token-123',
+      },
+    });
+    expect(response.items[0].productCard.title).toBe('S19 P1 Q6');
+    expect(response.items[1].productPosture.label).toBe('Imported / provisional');
+    expect(response.featureFlags.questionSearchProductEnabled).toBe(true);
   });
 
   test('createSession throws structured learning runtime errors for actionable UI states', async () => {

--- a/src/api/learningRuntimeApi.js
+++ b/src/api/learningRuntimeApi.js
@@ -198,6 +198,15 @@ export function normalizeImportQuestionResponse(payload = {}) {
   };
 }
 
+export function normalizeQuestionSearchResponse(payload = {}) {
+  const camelized = camelizeKeys(payload);
+  return {
+    ...camelized,
+    items: Array.isArray(camelized.items) ? camelized.items : [],
+    featureFlags: camelized.featureFlags || {},
+  };
+}
+
 export function normalizeReviewTaskListResponse(payload = {}) {
   const camelized = camelizeKeys(payload);
   return {
@@ -258,6 +267,35 @@ export async function importQuestion(payload, options = {}) {
     body: payload,
     idempotencyKey: options.idempotencyKey ?? null,
   }));
+}
+
+export async function searchQuestions(params = {}) {
+  const query = buildQuery({
+    subjectCode: params.subjectCode ?? params.subject_code,
+    primaryTopicId: params.primaryTopicId ?? params.primary_topic_id,
+    familyId: params.familyId ?? params.family_id,
+    primaryQuestionTypeId: params.primaryQuestionTypeId ?? params.primary_question_type_id,
+    year: params.year,
+    session: params.session,
+    paperNumber: params.paperNumber ?? params.paper_number,
+    variant: params.variant,
+    qNumber: params.qNumber ?? params.q_number,
+    query: params.query,
+    page: params.page,
+    pageSize: params.pageSize ?? params.page_size,
+  }, {
+    subjectCode: 'subject_code',
+    primaryTopicId: 'primary_topic_id',
+    familyId: 'family_id',
+    primaryQuestionTypeId: 'primary_question_type_id',
+    paperNumber: 'paper_number',
+    qNumber: 'q_number',
+    pageSize: 'page_size',
+  });
+
+  return normalizeQuestionSearchResponse(
+    await learningRequest(`/questions${query}`),
+  );
 }
 
 export async function getWorkspace(topicId) {
@@ -341,6 +379,7 @@ export const learningRuntimeApi = {
   getSession,
   askInSession,
   importQuestion,
+  searchQuestions,
   getWorkspace,
   listReviewTasks,
   updateReviewTask,


### PR DESCRIPTION
Closes #218

## Summary

This PR hardens the existing structured question-search slice with the product-facing contract for mixed-source results. The earlier projection, backend query surface, and gate remain intact; this change adds deterministic product ranking, compact grounded card data, and a client entry surface that can consume the flagged response.

## What Changed

- ranked product-mode question search results by authority tier, structured exactness, release posture, type/family strength, textual similarity, and stable tiebreakers
- kept imported rows visible while always surfacing the `Imported / provisional` posture
- constrained one-line result summaries to grounded structured `summary` data and left them absent when unsupported
- threaded the `QUESTION_SEARCH_PRODUCT_ENABLED` flag through `/api/learning/questions` and the learning runtime API client surface
- extended the question-search gate coverage with mixed-source ranking fixtures while preserving runner compatibility: the gate uses the shared product-mode service when service-role Supabase env is available and falls back to the prior SQL projection query for `DATABASE_URL`-only or `SUPABASE_PG_COMPAT=true` environments

## Verification

- `npm test -- --runInBand api/learning/__tests__/question-search-repository.test.js api/learning/__tests__/question-search-service.test.js api/learning/__tests__/question-search-api.test.js scripts/evaluation/__tests__/question-search-gate.test.js src/api/__tests__/learningRuntimeApi.test.js`
- outcome: `5` suites passed, `40` tests passed

## Scope Notes

- no schema changes
- no `api/rag/search` or open-ended RAG answer generation changes
- no descriptor backfill or data repair
