### PR TITLE
feat: bridge evaluate-v1 attempt events

### DIFF
--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -1,0 +1,209 @@
+function createMockClient({
+  learningEventsError = null,
+  pipelineStateError = null,
+  warningError = null,
+} = {}) {
+  const records = {
+    learningEvents: null,
+    pipelineState: null,
+    bridgeWarning: null,
+  };
+
+  return {
+    client: {
+      from(table) {
+        if (table === 'learning_events') {
+          return {
+            insert: async (rows) => {
+              records.learningEvents = rows;
+              return { error: learningEventsError };
+            },
+          };
+        }
+
+        if (table === 'attempt_pipeline_state') {
+          return {
+            upsert: async (row) => {
+              records.pipelineState = row;
+              return { error: pipelineStateError };
+            },
+          };
+        }
+
+        if (table === 'error_events') {
+          return {
+            insert: async (rows) => {
+              records.bridgeWarning = rows;
+              return { error: warningError };
+            },
+          };
+        }
+
+        throw new Error(`unexpected_table:${table}`);
+      },
+    },
+    records,
+  };
+}
+
+function buildBridgeInput(overrides = {}) {
+  return {
+    attemptId: 'att-bridge-1',
+    learnerId: 'user-bridge-1',
+    subjectCode: '9709',
+    markRunId: 'mr-bridge-1',
+    questionId: 'question-bridge-1',
+    storageKey: '9709/s22/qp11/q01.png',
+    qNumber: 1,
+    subpart: 'a_i',
+    studentSteps: [{ step_id: 's1', text: 'x = 2' }],
+    decisions: [
+      {
+        rubric_id: 'rubric-1',
+        awarded: false,
+        awarded_marks: 0,
+        reason: 'algebra_error',
+        alignment_confidence: 0.91,
+      },
+    ],
+    questionContext: {
+      family_id: '9709.trigonometry_manipulation_equations',
+      question_type_id: '9709.trigonometry.equations',
+      question_type_release_state: 'released',
+      primary_topic_id: 'topic-trig-equations',
+      primary_topic_path: '9709/trigonometry/equations',
+      classification_confidence: 0.93,
+      candidate_rubric_refs: [
+        {
+          kind: 'rubric_release',
+          rubric_version_id: 'trig-v1',
+          release_state: 'released',
+        },
+      ],
+      release_scope_status: 'released_scoring',
+    },
+    attemptContext: {
+      topic_id: 'topic-trig-equations',
+      topic_path: '9709/trigonometry/equations',
+    },
+    authorityPosture: {
+      release_scope_status: 'released_scoring',
+      authoritative_scoring_allowed: true,
+      fallback_mode: null,
+      fallback_reason_code: null,
+      classification_confidence: 0.93,
+      learning_signal_posture: 'authoritative_scoring',
+    },
+    markingResult: {
+      attempt_id: 'att-bridge-1',
+      mark_run_id: 'mr-bridge-1',
+      marking_summary: {
+        coverage_scope: 'subpart',
+      },
+    },
+    sourceAttemptRef: {
+      kind: 'attempt',
+      attempt_id: 'att-bridge-1',
+    },
+    sourceMarkRunRef: {
+      kind: 'mark_run',
+      mark_run_id: 'mr-bridge-1',
+    },
+    correlationId: '11111111-1111-1111-1111-111111111111',
+    submittedAt: '2026-04-16T15:00:00.000Z',
+    emittedAt: '2026-04-16T15:00:05.000Z',
+    emittedBy: 'evaluate-v1',
+    ...overrides,
+  };
+}
+
+describe('attempt-event-service', () => {
+  test('persists ordered attempt events through LearningUpdateProposed and upserts pipeline state', async () => {
+    const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
+    const { client, records } = createMockClient();
+
+    const result = await persistAttemptEventBridge(client, buildBridgeInput());
+
+    expect(result).toMatchObject({
+      ok: true,
+      warningRecorded: false,
+      persisted_event_types: [
+        'AttemptSubmitted',
+        'QuestionClassified',
+        'MarkingCompleted',
+        'LearningUpdateProposed',
+      ],
+      pipeline_state: {
+        attempt_id: 'att-bridge-1',
+        current_stage: 'LearningUpdateProposed',
+        current_status: 'running',
+        last_sequence_no: 4,
+      },
+    });
+
+    expect(records.learningEvents).toHaveLength(4);
+    expect(records.learningEvents.map((event) => event.event_type)).toEqual([
+      'AttemptSubmitted',
+      'QuestionClassified',
+      'MarkingCompleted',
+      'LearningUpdateProposed',
+    ]);
+
+    records.learningEvents.forEach((event, index) => {
+      expect(event.aggregate_id).toBe('att-bridge-1');
+      expect(event.payload.attempt_id).toBe('att-bridge-1');
+      expect(event.sequence_no).toBe(index + 1);
+      expect(event.payload.authority_posture).toMatchObject({
+        authoritative_scoring_allowed: true,
+        learning_signal_posture: 'authoritative_scoring',
+      });
+      expect(event.provenance.trust.authority_posture).toMatchObject({
+        authoritative_scoring_allowed: true,
+        learning_signal_posture: 'authoritative_scoring',
+      });
+    });
+
+    expect(records.pipelineState).toMatchObject({
+      attempt_id: 'att-bridge-1',
+      learner_id: 'user-bridge-1',
+      subject_code: '9709',
+      current_stage: 'LearningUpdateProposed',
+      current_status: 'running',
+      last_sequence_no: 4,
+    });
+    expect(records.bridgeWarning).toBeNull();
+  });
+
+  test('records a durable bridge warning/debt row when persistence fails', async () => {
+    const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
+    const { client, records } = createMockClient({
+      learningEventsError: { message: 'learning_events insert failed' },
+    });
+
+    const result = await persistAttemptEventBridge(client, buildBridgeInput());
+
+    expect(result).toMatchObject({
+      ok: false,
+      warningRecorded: true,
+      reason_code: 'attempt_event_bridge_failed',
+      failed_stage: 'learning_events_insert',
+    });
+    expect(records.pipelineState).toBeNull();
+    expect(records.bridgeWarning).toHaveLength(1);
+    expect(records.bridgeWarning[0]).toMatchObject({
+      attempt_id: 'att-bridge-1',
+      mark_decision_id: null,
+      severity: 'minor',
+      misconception_tag: 'unclassified',
+      metadata: {
+        kind: 'attempt_event_bridge_warning',
+        failed_stage: 'learning_events_insert',
+        mark_run_id: 'mr-bridge-1',
+        authority_posture: {
+          authoritative_scoring_allowed: true,
+          learning_signal_posture: 'authoritative_scoring',
+        },
+      },
+    });
+  });
+});

--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -2,6 +2,7 @@ function createMockClient({
   learningEventsError = null,
   pipelineStateError = null,
   warningError = null,
+  existingStreamHead = null,
 } = {}) {
   const records = {
     learningEvents: null,
@@ -13,7 +14,19 @@ function createMockClient({
     client: {
       from(table) {
         if (table === 'learning_events') {
+          const query = {
+            select: () => query,
+            eq: () => query,
+            order: () => query,
+            limit: () => query,
+            maybeSingle: async () => ({
+              data: existingStreamHead,
+              error: null,
+            }),
+          };
+
           return {
+            ...query,
             insert: async (rows) => {
               records.learningEvents = rows;
               return { error: learningEventsError };
@@ -204,6 +217,47 @@ describe('attempt-event-service', () => {
           learning_signal_posture: 'authoritative_scoring',
         },
       },
+    });
+  });
+
+  test('increments truth revision when the attempt already has persisted bridge events', async () => {
+    const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
+    const { client, records } = createMockClient({
+      existingStreamHead: {
+        truth_revision: 1,
+        sequence_no: 4,
+      },
+    });
+
+    const result = await persistAttemptEventBridge(client, buildBridgeInput({
+      markRunId: 'mr-bridge-2',
+      sourceMarkRunRef: {
+        kind: 'mark_run',
+        mark_run_id: 'mr-bridge-2',
+      },
+      markingResult: {
+        attempt_id: 'att-bridge-1',
+        mark_run_id: 'mr-bridge-2',
+        marking_summary: {
+          coverage_scope: 'subpart',
+        },
+      },
+    }));
+
+    expect(result).toMatchObject({
+      ok: true,
+      warningRecorded: false,
+      pipeline_state: {
+        attempt_id: 'att-bridge-1',
+        current_truth_revision: 2,
+        last_sequence_no: 4,
+      },
+    });
+
+    expect(records.learningEvents).toHaveLength(4);
+    records.learningEvents.forEach((event, index) => {
+      expect(event.truth_revision).toBe(2);
+      expect(event.sequence_no).toBe(index + 1);
     });
   });
 });

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -301,6 +301,47 @@ function assertImmutableAttemptId({
   return normalizedAttemptId;
 }
 
+async function loadExistingStreamHead(client, attemptId) {
+  const { data, error } = await client
+    .from('learning_events')
+    .select('truth_revision, sequence_no')
+    .eq('aggregate_id', attemptId)
+    .order('truth_revision', { ascending: false })
+    .order('sequence_no', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message || 'Failed to load learning_events stream head.');
+  }
+
+  return data ?? null;
+}
+
+function resolveNextTruthRevision(streamHead) {
+  const currentTruthRevision = Number(streamHead?.truth_revision);
+  return Number.isInteger(currentTruthRevision) && currentTruthRevision >= 1
+    ? currentTruthRevision + 1
+    : 1;
+}
+
+function buildProjectionSeedState(attemptId, streamHead) {
+  const currentTruthRevision = Number(streamHead?.truth_revision);
+  const lastSequenceNo = Number(streamHead?.sequence_no);
+
+  if (!Number.isInteger(currentTruthRevision) || currentTruthRevision < 1) {
+    return null;
+  }
+
+  return {
+    attempt_id: attemptId,
+    current_truth_revision: currentTruthRevision,
+    last_sequence_no: Number.isInteger(lastSequenceNo) && lastSequenceNo >= 0 ? lastSequenceNo : 0,
+    current_stage: 'LearningUpdateProposed',
+    current_status: 'running',
+  };
+}
+
 function buildBridgeEvents(input = {}) {
   const attemptId = assertImmutableAttemptId(input);
   const learnerId = normalizeString(input.learnerId);
@@ -317,6 +358,7 @@ function buildBridgeEvents(input = {}) {
   const attemptContext = cloneJson(input.attemptContext ?? {}) ?? {};
   const sourceAttemptRef = cloneJson(input.sourceAttemptRef ?? null);
   const sourceMarkRunRef = cloneJson(input.sourceMarkRunRef ?? null);
+  const truthRevision = resolveNextTruthRevision(input.streamHead);
 
   if (!learnerId) {
     throw new Error('missing_learner_id');
@@ -380,7 +422,7 @@ function buildBridgeEvents(input = {}) {
     learner_id: learnerId,
     session_id: sessionId,
     subject_code: subjectCode,
-    truth_revision: 1,
+    truth_revision: truthRevision,
     sequence_no: index + 1,
     correlation_id: correlationId,
     causation_event_id: null,
@@ -457,8 +499,15 @@ export async function persistAttemptEventBridge(client, input = {}) {
   const markRunId = normalizeString(input.markRunId) || null;
 
   try {
-    const events = buildBridgeEvents(input);
-    const pipelineState = projectAttemptPipelineState(events);
+    const streamHead = await loadExistingStreamHead(client, attemptId);
+    const events = buildBridgeEvents({
+      ...input,
+      streamHead,
+    });
+    const pipelineState = projectAttemptPipelineState(
+      events,
+      buildProjectionSeedState(attemptId, streamHead),
+    );
 
     await insertLearningEvents(client, events);
     await upsertAttemptPipelineState(client, pipelineState);

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -1,0 +1,496 @@
+import { randomUUID } from 'node:crypto';
+import { projectAttemptPipelineState } from './event-service.js';
+
+const BRIDGE_EVENT_TYPES = Object.freeze([
+  'AttemptSubmitted',
+  'QuestionClassified',
+  'MarkingCompleted',
+  'LearningUpdateProposed',
+]);
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function normalizeQuestionNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeAuthorityPosture(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? cloneJson(value)
+    : {};
+}
+
+function normalizePrimaryTopicRef(questionContext = {}, attemptContext = {}) {
+  const topicId = normalizeString(attemptContext.topic_id ?? questionContext.primary_topic_id) || null;
+  const topicPath = normalizeString(
+    attemptContext.topic_path
+    ?? questionContext.primary_topic_path
+    ?? questionContext.topic_path,
+  ) || null;
+
+  if (!topicId && !topicPath) {
+    return null;
+  }
+
+  return {
+    kind: 'topic',
+    topic_id: topicId,
+    topic_path: topicPath,
+  };
+}
+
+function buildSubjectAdapterRef(subjectCode) {
+  return {
+    key: `subject-adapter:${subjectCode}`,
+    version: 'evaluate-v1.runtime-bridge.v1',
+  };
+}
+
+function buildTrustEnvelope(authorityPosture) {
+  const fallbackReason = normalizeString(authorityPosture.fallback_reason_code) || null;
+  const learningSignalPosture = normalizeString(authorityPosture.learning_signal_posture) || null;
+
+  return {
+    level: authorityPosture.authoritative_scoring_allowed ? 'authoritative' : 'conservative',
+    reasons: fallbackReason ? [fallbackReason] : [learningSignalPosture || 'runtime_bridge'],
+    authority_posture: cloneJson(authorityPosture),
+  };
+}
+
+function buildEvidenceRefs({
+  sourceAttemptRef,
+  sourceMarkRunRef,
+  questionId,
+  questionContext,
+  attemptContext,
+} = {}) {
+  const refs = [];
+
+  if (sourceAttemptRef) {
+    refs.push(cloneJson(sourceAttemptRef));
+  }
+
+  if (sourceMarkRunRef) {
+    refs.push(cloneJson(sourceMarkRunRef));
+  }
+
+  if (normalizeString(questionId)) {
+    refs.push({
+      kind: 'question',
+      question_id: normalizeString(questionId),
+    });
+  }
+
+  const primaryTopicRef = normalizePrimaryTopicRef(questionContext, attemptContext);
+  if (primaryTopicRef) {
+    refs.push(primaryTopicRef);
+  }
+
+  return refs;
+}
+
+function buildBaseProvenance({
+  subjectCode,
+  authorityPosture,
+  correlationId,
+  sourceAttemptRef,
+  sourceMarkRunRef,
+  questionId,
+  questionContext,
+  attemptContext,
+} = {}) {
+  return {
+    subject_code: subjectCode,
+    subject_adapter: buildSubjectAdapterRef(subjectCode),
+    evidence_refs: buildEvidenceRefs({
+      sourceAttemptRef,
+      sourceMarkRunRef,
+      questionId,
+      questionContext,
+      attemptContext,
+    }),
+    lineage: {
+      correlation_id: correlationId,
+      source_attempt_id: sourceAttemptRef?.attempt_id ?? null,
+      source_mark_run_id: sourceMarkRunRef?.mark_run_id ?? null,
+    },
+    trust: buildTrustEnvelope(authorityPosture),
+    source: {
+      kind: 'marking_runtime',
+      route: 'evaluate-v1',
+    },
+  };
+}
+
+function buildAttemptSubmittedPayload({
+  attemptId,
+  authorityPosture,
+  submittedAt,
+  questionId,
+  markRunId,
+  storageKey,
+  qNumber,
+  subpart,
+  studentSteps,
+} = {}) {
+  return {
+    attempt_id: attemptId,
+    authority_posture: cloneJson(authorityPosture),
+    attempt_mode: 'guided_solve',
+    submitted_at: submittedAt,
+    source_question_ref: questionId
+      ? {
+        kind: 'question',
+        question_id: questionId,
+      }
+      : null,
+    source_mark_run_ref: markRunId
+      ? {
+        kind: 'mark_run',
+        mark_run_id: markRunId,
+      }
+      : null,
+    submission: {
+      storage_key: normalizeString(storageKey) || null,
+      q_number: normalizeQuestionNumber(qNumber),
+      subpart: normalizeString(subpart) || null,
+      answer_parts: normalizeArray(studentSteps).map((step, index) => ({
+        part_ref: normalizeString(subpart) || `part-${index + 1}`,
+        step_id: normalizeString(step?.step_id) || `step-${index + 1}`,
+        raw_text: normalizeString(step?.text) || '',
+      })),
+    },
+  };
+}
+
+function buildQuestionClassifiedPayload({
+  attemptId,
+  authorityPosture,
+  questionId,
+  questionContext,
+  attemptContext,
+  subjectCode,
+} = {}) {
+  return {
+    attempt_id: attemptId,
+    authority_posture: cloneJson(authorityPosture),
+    classification_version: 'evaluate-v1.runtime-bridge.v1',
+    classification_confidence:
+      questionContext.classification_confidence
+      ?? authorityPosture.classification_confidence
+      ?? null,
+    subject_adapter: buildSubjectAdapterRef(subjectCode),
+    classification: {
+      question_id: normalizeString(questionId) || null,
+      family_key: normalizeString(questionContext.family_id) || null,
+      type_key: normalizeString(questionContext.question_type_id) || null,
+      variant_tags: normalizeArray(questionContext.variant_tags),
+      primary_topic_ref: normalizePrimaryTopicRef(questionContext, attemptContext),
+      release_scope_status: normalizeString(questionContext.release_scope_status) || null,
+    },
+    uncertain_flags: authorityPosture.authoritative_scoring_allowed
+      ? []
+      : [normalizeString(authorityPosture.fallback_reason_code) || 'non_authoritative_bridge'],
+  };
+}
+
+function buildRubricRef(questionContext = {}) {
+  const releasedRef = normalizeArray(questionContext.candidate_rubric_refs)[0];
+  if (releasedRef && typeof releasedRef === 'object') {
+    return cloneJson(releasedRef);
+  }
+
+  return {
+    kind: 'rubric_release',
+    rubric_version_id: null,
+    release_state: null,
+  };
+}
+
+function buildMarkingCompletedPayload({
+  attemptId,
+  authorityPosture,
+  questionContext,
+  markRunId,
+  decisions,
+  markingResult,
+} = {}) {
+  return {
+    attempt_id: attemptId,
+    authority_posture: cloneJson(authorityPosture),
+    marking_mode: authorityPosture.authoritative_scoring_allowed ? 'authoritative' : 'fallback',
+    released_scope: authorityPosture.release_scope_status === 'released_scoring',
+    rubric_ref: buildRubricRef(questionContext),
+    diagnostics: {
+      decision_count: normalizeArray(decisions).length,
+      awarded_decision_count: normalizeArray(decisions).filter((decision) => decision?.awarded === true).length,
+      misconception_tags: [],
+      missing_steps: [],
+      strengths: [],
+      source_mark_run_ref: markRunId
+        ? {
+          kind: 'mark_run',
+          mark_run_id: markRunId,
+        }
+        : null,
+      marking_result: cloneJson(markingResult ?? null),
+    },
+    uncertain_flags: authorityPosture.authoritative_scoring_allowed
+      ? []
+      : [normalizeString(authorityPosture.fallback_reason_code) || 'non_authoritative_bridge'],
+  };
+}
+
+function buildLearningUpdateProposedPayload({
+  attemptId,
+  authorityPosture,
+  markRunId,
+} = {}) {
+  const fallbackReason = normalizeString(authorityPosture.fallback_reason_code) || null;
+
+  return {
+    attempt_id: attemptId,
+    authority_posture: cloneJson(authorityPosture),
+    proposal_key: normalizeString(markRunId) ? `mark-run:${markRunId}` : `attempt:${attemptId}`,
+    guardrail_decisions: {
+      authoritative_scoring_allowed: Boolean(authorityPosture.authoritative_scoring_allowed),
+      release_scope_status: normalizeString(authorityPosture.release_scope_status) || null,
+      learning_signal_posture: normalizeString(authorityPosture.learning_signal_posture) || null,
+      fallback_mode: normalizeString(authorityPosture.fallback_mode) || null,
+      fallback_reason_code: fallbackReason,
+      reasons: fallbackReason ? [fallbackReason] : ['released_scoring'],
+    },
+    proposed_mastery_effects: [],
+    proposed_review_tasks: [],
+    proposed_artifact_suggestions: [],
+  };
+}
+
+function assertImmutableAttemptId({
+  attemptId,
+  sourceAttemptRef,
+  markingResult,
+} = {}) {
+  const normalizedAttemptId = normalizeString(attemptId);
+  const sourceAttemptId = normalizeString(sourceAttemptRef?.attempt_id);
+  const markingResultAttemptId = normalizeString(markingResult?.attempt_id);
+
+  if (!normalizedAttemptId) {
+    throw new Error('missing_attempt_id');
+  }
+
+  if (sourceAttemptId && sourceAttemptId !== normalizedAttemptId) {
+    throw new Error('immutable_attempt_id_mismatch');
+  }
+
+  if (markingResultAttemptId && markingResultAttemptId !== normalizedAttemptId) {
+    throw new Error('immutable_attempt_id_mismatch');
+  }
+
+  return normalizedAttemptId;
+}
+
+function buildBridgeEvents(input = {}) {
+  const attemptId = assertImmutableAttemptId(input);
+  const learnerId = normalizeString(input.learnerId);
+  const subjectCode = normalizeString(input.subjectCode);
+  const correlationId = normalizeString(input.correlationId) || randomUUID();
+  const emittedBy = normalizeString(input.emittedBy) || 'evaluate-v1';
+  const submittedAt = normalizeString(input.submittedAt) || new Date().toISOString();
+  const emittedAt = normalizeString(input.emittedAt) || submittedAt;
+  const authorityPosture = normalizeAuthorityPosture(input.authorityPosture);
+  const markRunId = normalizeString(input.markRunId) || null;
+  const questionId = normalizeString(input.questionId) || null;
+  const sessionId = normalizeString(input.sessionId) || null;
+  const questionContext = cloneJson(input.questionContext ?? {}) ?? {};
+  const attemptContext = cloneJson(input.attemptContext ?? {}) ?? {};
+  const sourceAttemptRef = cloneJson(input.sourceAttemptRef ?? null);
+  const sourceMarkRunRef = cloneJson(input.sourceMarkRunRef ?? null);
+
+  if (!learnerId) {
+    throw new Error('missing_learner_id');
+  }
+
+  if (!subjectCode) {
+    throw new Error('missing_subject_code');
+  }
+
+  const baseProvenance = buildBaseProvenance({
+    subjectCode,
+    authorityPosture,
+    correlationId,
+    sourceAttemptRef,
+    sourceMarkRunRef,
+    questionId,
+    questionContext,
+    attemptContext,
+  });
+
+  const payloads = [
+    buildAttemptSubmittedPayload({
+      attemptId,
+      authorityPosture,
+      submittedAt,
+      questionId,
+      markRunId,
+      storageKey: input.storageKey,
+      qNumber: input.qNumber,
+      subpart: input.subpart,
+      studentSteps: input.studentSteps,
+    }),
+    buildQuestionClassifiedPayload({
+      attemptId,
+      authorityPosture,
+      questionId,
+      questionContext,
+      attemptContext,
+      subjectCode,
+    }),
+    buildMarkingCompletedPayload({
+      attemptId,
+      authorityPosture,
+      questionContext,
+      markRunId,
+      decisions: input.decisions,
+      markingResult: input.markingResult,
+    }),
+    buildLearningUpdateProposedPayload({
+      attemptId,
+      authorityPosture,
+      markRunId,
+    }),
+  ];
+
+  return BRIDGE_EVENT_TYPES.map((eventType, index) => ({
+    event_id: randomUUID(),
+    event_type: eventType,
+    aggregate_type: 'attempt',
+    aggregate_id: attemptId,
+    learner_id: learnerId,
+    session_id: sessionId,
+    subject_code: subjectCode,
+    truth_revision: 1,
+    sequence_no: index + 1,
+    correlation_id: correlationId,
+    causation_event_id: null,
+    replay_of_event_id: null,
+    supersedes_event_id: null,
+    reconciliation_id: null,
+    dedupe_key: `${markRunId || attemptId}:runtime-bridge:${eventType}`,
+    basis_hash: `${markRunId || attemptId}:runtime-bridge:${eventType}:v1`,
+    emitted_by: emittedBy,
+    payload: payloads[index],
+    provenance: cloneJson(baseProvenance),
+    emitted_at: emittedAt,
+  })).map((event, index, events) => ({
+    ...event,
+    causation_event_id: index === 0 ? null : events[index - 1].event_id,
+  }));
+}
+
+async function insertLearningEvents(client, events) {
+  const { error } = await client
+    .from('learning_events')
+    .insert(events);
+
+  if (error) {
+    throw new Error(error.message || 'Failed to insert learning_events.');
+  }
+}
+
+async function upsertAttemptPipelineState(client, pipelineState) {
+  const { error } = await client
+    .from('attempt_pipeline_state')
+    .upsert(pipelineState);
+
+  if (error) {
+    throw new Error(error.message || 'Failed to upsert attempt_pipeline_state.');
+  }
+}
+
+async function writeBridgeWarning(client, {
+  attemptId,
+  attemptContext,
+  markRunId,
+  authorityPosture,
+  failedStage,
+  errorMessage,
+} = {}) {
+  const warningRow = {
+    attempt_id: attemptId,
+    mark_decision_id: null,
+    topic_path: attemptContext?.topic_path ?? null,
+    node_id: attemptContext?.topic_id ?? null,
+    misconception_tag: 'unclassified',
+    severity: 'minor',
+    metadata: {
+      kind: 'attempt_event_bridge_warning',
+      failed_stage: failedStage,
+      mark_run_id: markRunId,
+      error_message: errorMessage,
+      authority_posture: cloneJson(authorityPosture),
+    },
+  };
+
+  const { error } = await client
+    .from('error_events')
+    .insert([warningRow]);
+
+  return !error;
+}
+
+export async function persistAttemptEventBridge(client, input = {}) {
+  const attemptId = assertImmutableAttemptId(input);
+  const authorityPosture = normalizeAuthorityPosture(input.authorityPosture);
+  const attemptContext = cloneJson(input.attemptContext ?? {}) ?? {};
+  const markRunId = normalizeString(input.markRunId) || null;
+
+  try {
+    const events = buildBridgeEvents(input);
+    const pipelineState = projectAttemptPipelineState(events);
+
+    await insertLearningEvents(client, events);
+    await upsertAttemptPipelineState(client, pipelineState);
+
+    return {
+      ok: true,
+      warningRecorded: false,
+      persisted_event_types: events.map((event) => event.event_type),
+      pipeline_state: pipelineState,
+    };
+  } catch (error) {
+    const errorMessage = error?.message || String(error);
+    const failedStage = /learning_events/i.test(errorMessage)
+      ? 'learning_events_insert'
+      : /attempt_pipeline_state/i.test(errorMessage)
+        ? 'attempt_pipeline_state_upsert'
+        : 'bridge_validation';
+    const warningRecorded = await writeBridgeWarning(client, {
+      attemptId,
+      attemptContext,
+      markRunId,
+      authorityPosture,
+      failedStage,
+      errorMessage,
+    });
+
+    return {
+      ok: false,
+      warningRecorded,
+      reason_code: 'attempt_event_bridge_failed',
+      failed_stage: failedStage,
+      error_message: errorMessage,
+    };
+  }
+}

--- a/api/learning/lib/events/event-service.js
+++ b/api/learning/lib/events/event-service.js
@@ -445,6 +445,21 @@ export function appendLearningEvent(store, candidateEvent) {
   };
 }
 
+export function projectAttemptPipelineState(events = []) {
+  const store = createEmptyLearningEventStore();
+  let pipelineState = null;
+
+  for (const event of events) {
+    const result = appendLearningEvent(store, event);
+    if (!result.inserted) {
+      throw new Error(result.reason_code || 'learning_event_not_inserted');
+    }
+    pipelineState = result.pipeline_state;
+  }
+
+  return pipelineState;
+}
+
 export function tryStartLearningEventEffect(store, input) {
   const normalizedInput = assertEffectInput(input);
   const nowIso = getNowIso();

--- a/api/learning/lib/events/event-service.js
+++ b/api/learning/lib/events/event-service.js
@@ -445,9 +445,13 @@ export function appendLearningEvent(store, candidateEvent) {
   };
 }
 
-export function projectAttemptPipelineState(events = []) {
+export function projectAttemptPipelineState(events = [], seedState = null) {
   const store = createEmptyLearningEventStore();
   let pipelineState = null;
+
+  if (seedState && events[0]?.aggregate_id) {
+    store.pipelineStateByAttempt.set(events[0].aggregate_id, cloneJson(seedState));
+  }
 
   for (const event of events) {
     const result = appendLearningEvent(store, event);

--- a/api/marking/__tests__/evaluate-v1.test.js
+++ b/api/marking/__tests__/evaluate-v1.test.js
@@ -110,6 +110,22 @@ const mockApplyLearningEffects = jest.fn(async () => ({
   artifact_candidates: [],
   reconciliation: null,
 }));
+const mockPersistAttemptEventBridge = jest.fn(async () => ({
+  ok: true,
+  warningRecorded: false,
+  persisted_event_types: [
+    'AttemptSubmitted',
+    'QuestionClassified',
+    'MarkingCompleted',
+    'LearningUpdateProposed',
+  ],
+  pipeline_state: {
+    attempt_id: 'att-001',
+    current_stage: 'LearningUpdateProposed',
+    current_status: 'running',
+    last_sequence_no: 4,
+  },
+}));
 
 jest.unstable_mockModule('../lib/auth-helper.js', () => ({
   resolveUserId: mockResolveUserId,
@@ -127,6 +143,10 @@ jest.unstable_mockModule('../lib/ledger-orchestrator.js', () => ({
 
 jest.unstable_mockModule('../../learning/lib/mastery/mastery-orchestrator.js', () => ({
   applyLearningEffects: mockApplyLearningEffects,
+}));
+
+jest.unstable_mockModule('../../learning/lib/events/attempt-event-service.js', () => ({
+  persistAttemptEventBridge: mockPersistAttemptEventBridge,
 }));
 
 // Dynamic import after mocks are set up
@@ -161,6 +181,7 @@ beforeEach(() => {
   process.env.SUPABASE_URL = 'https://test.supabase.co';
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
   process.env.EVIDENCE_LEDGER_ENABLED = 'false';
+  process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'false';
   jest.clearAllMocks();
   mockApplyLearningEffects.mockResolvedValue({
     release_scope_status: 'released_scoring',
@@ -511,5 +532,49 @@ describe('learning-runtime orchestration', () => {
     const body = res.json.mock.calls[0][0];
     expect(body.learning_effects).toBeUndefined();
     expect(mockApplyLearningEffects).not.toHaveBeenCalled();
+  });
+
+  it('calls the attempt-event bridge behind the dedicated runtime flag', async () => {
+    process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'true';
+
+    const req = mockReq();
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockPersistAttemptEventBridge).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        attemptId: 'att-001',
+        markRunId: 'mr-001',
+        authorityPosture: expect.objectContaining({
+          authoritative_scoring_allowed: true,
+          learning_signal_posture: 'authoritative_scoring',
+        }),
+      }),
+    );
+  });
+
+  it('returns 200 when the attempt-event bridge fails after scoring + ledger succeed', async () => {
+    process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'true';
+    mockPersistAttemptEventBridge.mockResolvedValueOnce({
+      ok: false,
+      warningRecorded: true,
+      reason_code: 'attempt_event_bridge_failed',
+      failed_stage: 'learning_events_insert',
+    });
+
+    const req = mockReq();
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0]).toMatchObject({
+      ledger_write_status: 'success',
+    });
+    expect(mockPersistAttemptEventBridge).toHaveBeenCalled();
+    expect(mockApplyLearningEffects).toHaveBeenCalled();
   });
 });

--- a/api/marking/evaluate-v1.js
+++ b/api/marking/evaluate-v1.js
@@ -11,11 +11,17 @@ import { resolveUserId, AuthError } from './lib/auth-helper.js';
 import { resolveQuestionId, ValidationError } from './lib/attempt-repository.js';
 import { writeLedger } from './lib/ledger-orchestrator.js';
 import { buildMarkingResult } from './lib/marking-result-contract.js';
+import { resolveReleasedScoringPosture } from '../learning/lib/contracts/released-scope.js';
+import { persistAttemptEventBridge } from '../learning/lib/events/attempt-event-service.js';
 import { applyLearningEffects } from '../learning/lib/mastery/mastery-orchestrator.js';
 
 // ── Feature flag (evaluated per-request so env changes take effect) ──────────
 function isV1Enabled() {
   return process.env.MARKING_V1_ENABLED === 'true';
+}
+
+function isRuntimeBridgeEnabled() {
+  return process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED === 'true';
 }
 
 // ── Unified error codes ─────────────────────────────────────────────────────
@@ -211,6 +217,7 @@ export default async function handler(req, res) {
       compat_mode = null,
       include_uncertain_reason = false,
     } = body;
+    const subjectCode = storage_key.split('/')[0] || null;
 
     // ── Resolve trusted user_id (JWT required) ─────────────────────────────
     let user_id;
@@ -382,11 +389,75 @@ export default async function handler(req, res) {
       }));
 
       if (ledgerResult.decision_write_status === 'success') {
+        const releaseScopePosture = resolveReleasedScoringPosture({
+          questionTypeId: questionContext.question_type_id,
+          questionTypeReleaseState: questionContext.question_type_release_state,
+          candidateRubricRefs: questionContext.candidate_rubric_refs,
+          classificationConfidence: questionContext.classification_confidence,
+          uncertaintyValidated: true,
+        });
+
+        if (isRuntimeBridgeEnabled()) {
+          try {
+            const bridgeResult = await persistAttemptEventBridge(supabase, {
+              attemptId: ledgerResult.attempt_id,
+              learnerId: user_id,
+              subjectCode,
+              markRunId: ledgerResult.mark_run_id,
+              questionId: question_id,
+              storageKey: storage_key,
+              qNumber: q_number,
+              subpart: requestScopedSubpartId,
+              studentSteps: student_steps,
+              decisions,
+              questionContext: {
+                ...questionContext,
+                primary_topic_path: ledgerResult.attempt_context?.topic_path ?? null,
+              },
+              attemptContext: ledgerResult.attempt_context ?? null,
+              authorityPosture: releaseScopePosture,
+              markingResult: markingResult,
+              sourceAttemptRef: {
+                kind: 'attempt',
+                attempt_id: ledgerResult.attempt_id,
+              },
+              sourceMarkRunRef: {
+                kind: 'mark_run',
+                mark_run_id: ledgerResult.mark_run_id,
+              },
+              correlationId: run_id,
+              emittedBy: 'evaluate-v1',
+            });
+
+            if (!bridgeResult.ok) {
+              console.warn(JSON.stringify({
+                event: 'evaluate_v1_attempt_event_bridge_warning',
+                run_id,
+                attempt_id: ledgerResult.attempt_id,
+                mark_run_id: ledgerResult.mark_run_id,
+                failed_stage: bridgeResult.failed_stage,
+                warning_recorded: bridgeResult.warningRecorded,
+                error: bridgeResult.error_message,
+                ts: new Date().toISOString(),
+              }));
+            }
+          } catch (attemptBridgeError) {
+            console.warn(JSON.stringify({
+              event: 'evaluate_v1_attempt_event_bridge_error',
+              run_id,
+              attempt_id: ledgerResult.attempt_id,
+              mark_run_id: ledgerResult.mark_run_id,
+              error: attemptBridgeError?.message || String(attemptBridgeError),
+              ts: new Date().toISOString(),
+            }));
+          }
+        }
+
         try {
           learningEffects = await applyLearningEffects({
             supabase,
             user_id,
-            subject_code: storage_key.split('/')[0] || null,
+            subject_code: subjectCode,
             question_id,
             question_context: {
               family_id: questionContext.family_id,
@@ -413,6 +484,7 @@ export default async function handler(req, res) {
             decisions,
             marking_result: markingResult,
             uncertainty_validated: true,
+            release_scope_posture: releaseScopePosture,
           }, {
             supabase,
           });

--- a/docs/reports/2026-04-16-issue-211-closeout.md
+++ b/docs/reports/2026-04-16-issue-211-closeout.md
@@ -1,0 +1,102 @@
+# Issue 211 Closeout
+
+## Scope Shipped
+
+- wired `evaluate-v1` into a dedicated attempt-event bridge behind `MARKING_V1_RUNTIME_BRIDGE_ENABLED`
+- persisted ordered attempt-scoped learning events through `LearningUpdateProposed`
+- projected and upserted `attempt_pipeline_state` from the same ordered event flow
+- froze `attempt_id` as the aggregate identity for the bridge write path
+- carried explicit authority posture on persisted bridge events and on durable bridge warning metadata
+- kept bridge failures non-blocking for the student request path and recorded them durably
+
+## Files Changed
+
+- `api/marking/evaluate-v1.js`
+- `api/learning/lib/events/attempt-event-service.js`
+- `api/learning/lib/events/event-service.js`
+- `api/learning/__tests__/attempt-event-service.test.js`
+- `api/marking/__tests__/evaluate-v1.test.js`
+
+## Verification
+
+### Required baseline sync
+
+Command:
+
+```bash
+npm run workflow:baseline:sync
+```
+
+Outcome:
+
+- Passed.
+- `git -C /home/samsen/code/ciecopilot-home fetch origin --prune`
+- `git -C /home/samsen/code/ciecopilot-home pull --ff-only`
+- root baseline reported `Already up to date.`
+
+### Required focused test command
+
+Command:
+
+```bash
+npm test -- --runInBand api/learning/__tests__/attempt-event-service.test.js api/marking/__tests__/evaluate-v1.test.js
+```
+
+Outcome:
+
+- Failed in this worktree because `node_modules/jest/bin/jest.js` does not exist locally.
+- Failure was environmental, not code-level.
+
+Fallback command actually used:
+
+```bash
+NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules \
+node --experimental-vm-modules \
+  /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js \
+  --runInBand \
+  api/learning/__tests__/attempt-event-service.test.js \
+  api/marking/__tests__/evaluate-v1.test.js
+```
+
+Fallback outcome:
+
+- Passed.
+- Test suites: `2 passed, 2 total`
+- Tests: `25 passed, 25 total`
+
+### Extra focused test for indirect touch
+
+Command:
+
+```bash
+NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules \
+node --experimental-vm-modules \
+  /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js \
+  --runInBand \
+  api/learning/__tests__/event-service.test.js
+```
+
+Outcome:
+
+- Passed.
+- Test suites: `1 passed, 1 total`
+- Tests: `7 passed, 7 total`
+
+### Diff hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Outcome:
+
+- Passed with no diff hygiene errors.
+
+## Residual Risks / Debt
+
+- The AO-referenced docs `docs/reports/2026-04-16-ao-execution-decision-alignment.md` and `docs/reports/2026-04-16-ao-issue-slice-round1.md` were not present on this branch, so implementation aligned to the live issue body plus AO continuation notes instead.
+- The durable bridge warning surface uses an attempt-scoped `error_events` row with structured metadata. That is durable and auditable, but it is not yet a dedicated runtime-bridge debt table or reconciliation queue.
+- `attempt_pipeline_state` remains a stage/status projection. The explicit authority posture is persisted on the ordered bridge events and warning metadata, not on a separate projection column.
+- When the bridge records a warning, the existing `applyLearningEffects` path still proceeds so the student request remains non-blocking. That preserves current request-path behavior, but it means downstream materialized effects can temporarily diverge from the canonical attempt-event bridge until later reconciliation work lands.

--- a/docs/reports/2026-04-16-issue-211-closeout.md
+++ b/docs/reports/2026-04-16-issue-211-closeout.md
@@ -62,7 +62,7 @@ Fallback outcome:
 
 - Passed.
 - Test suites: `2 passed, 2 total`
-- Tests: `25 passed, 25 total`
+- Tests: `26 passed, 26 total`
 
 ### Extra focused test for indirect touch
 
@@ -81,6 +81,26 @@ Outcome:
 - Passed.
 - Test suites: `1 passed, 1 total`
 - Tests: `7 passed, 7 total`
+
+### Review follow-up regression
+
+Command:
+
+```bash
+NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules \
+node --experimental-vm-modules \
+  /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js \
+  --runInBand \
+  api/learning/__tests__/attempt-event-service.test.js \
+  api/marking/__tests__/evaluate-v1.test.js \
+  api/learning/__tests__/event-service.test.js
+```
+
+Outcome:
+
+- Passed after fixing repeated-write revision handling on the bridge path.
+- Test suites: `3 passed, 3 total`
+- Tests: `33 passed, 33 total`
 
 ### Diff hygiene
 


### PR DESCRIPTION
## Summary
- wire successful evaluate-v1 ledger writes into ordered attempt events through LearningUpdateProposed behind MARKING_V1_RUNTIME_BRIDGE_ENABLED
- upsert attempt_pipeline_state from the same ordered bridge flow while freezing attempt_id and persisting explicit authority posture on the bridge events
- record durable attempt-scoped bridge warnings in error_events when bridge persistence fails and keep the student request path non-blocking

## Verification
- npm run workflow:baseline:sync
- npm test -- --runInBand api/learning/__tests__/attempt-event-service.test.js api/marking/__tests__/evaluate-v1.test.js (fails in this worktree because local node_modules is absent)
- NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/attempt-event-service.test.js api/marking/__tests__/evaluate-v1.test.js api/learning/__tests__/event-service.test.js
- git diff --check

## Notes
- closeout report: docs/reports/2026-04-16-issue-211-closeout.md
- residual risk: when the bridge records a warning, applyLearningEffects still proceeds so downstream materialized effects can temporarily diverge until later reconciliation work lands

Closes #211