### PR TITLE
feat: add grounded scheduler explanation contract

### DIFF
--- a/api/learning/__tests__/review-scheduler-policy.test.js
+++ b/api/learning/__tests__/review-scheduler-policy.test.js
@@ -4,6 +4,14 @@ import {
   REVIEW_SCHEDULER_POLICY,
 } from '../lib/review/review-scheduler-policy.js';
 
+const FROZEN_STUDENT_LABELS = new Set([
+  '最近出错',
+  '间隔已到',
+  '临近考试',
+  '同题型回补',
+  '回归风险',
+]);
+
 function buildTask(overrides = {}) {
   return {
     review_task_id: 'review-task-1',
@@ -175,5 +183,158 @@ describe('review scheduler policy', () => {
           value: 'escalated',
         }),
       }));
+  });
+
+  test('deriveReviewQueueProjection shapes compact student explanations from structured factors only', () => {
+    const fixtures = [
+      {
+        name: 'recent error repair',
+        now: '2026-03-25T10:00:00.000Z',
+        task: buildTask({
+          review_task_id: 'review-task-repair',
+          trigger_type: 'immediate_repair',
+          due_at: '2026-03-25T09:00:00.000Z',
+          source_question_id: 'question-1',
+          source_attempt_ref: {
+            kind: 'attempt',
+            attempt_id: 'attempt-1',
+          },
+          target_misconception_tags: ['domain:interval'],
+          success_criteria: {
+            scheduler_policy: {
+              route: 'immediate_repair',
+              freshness_bucket: 'fresh',
+            },
+          },
+        }),
+        expected: {
+          summary: '你最近在这个题型上出错过，所以先安排一次同题型回补。',
+          labels: ['最近出错', '同题型回补'],
+          summaryFactorCodes: ['recent_error', 'same_question_type_repair'],
+        },
+      },
+      {
+        name: 'due exam polish',
+        now: '2026-03-25T10:00:00.000Z',
+        task: buildTask({
+          review_task_id: 'review-task-exam',
+          trigger_type: 'exam_polish',
+          mode: 'timed_check',
+          priority: 'high',
+          due_at: '2026-03-25T09:30:00.000Z',
+          success_criteria: {
+            scheduler_policy: {
+              route: 'exam_polish',
+              freshness_bucket: 'cooling',
+            },
+          },
+        }),
+        expected: {
+          summary: '临近考试，而且现在到了这类内容的复习时间，所以安排一次回顾。',
+          labels: ['间隔已到', '临近考试'],
+          summaryFactorCodes: ['exam_near', 'interval_due'],
+        },
+      },
+      {
+        name: 'regression recovery',
+        now: '2026-03-25T10:00:00.000Z',
+        task: buildTask({
+          review_task_id: 'review-task-regression',
+          trigger_type: 'regression_recovery',
+          priority: 'urgent',
+          due_at: '2026-03-25T09:45:00.000Z',
+          source_question_id: 'question-2',
+          source_attempt_ref: {
+            kind: 'attempt',
+            attempt_id: 'attempt-2',
+          },
+          success_criteria: {
+            scheduler_policy: {
+              route: 'regression_recovery',
+              freshness_bucket: 'stale',
+            },
+          },
+        }),
+        expected: {
+          summary: '这类内容有回归风险，而且你最近在这个题型上出错过，所以安排一次同题型回补。',
+          labels: ['最近出错', '同题型回补', '回归风险'],
+          summaryFactorCodes: [
+            'regression_risk',
+            'recent_error',
+            'same_question_type_repair',
+          ],
+        },
+      },
+    ];
+
+    fixtures.forEach(({ name, now, task, expected }) => {
+      const item = deriveReviewQueueProjection([task], { now }).items[0];
+
+      expect(item.student_explanation).toEqual(expect.objectContaining({
+        summary: expected.summary,
+        labels: expected.labels,
+        provenance: expect.objectContaining({
+          summary_factor_codes: expected.summaryFactorCodes,
+          label_mappings: expected.labels.map((label) => expect.objectContaining({
+            label,
+          })),
+        }),
+      }));
+
+      expect(item.student_explanation.labels).toHaveLength(expected.labels.length);
+      expect(item.student_explanation.labels.every((label) => FROZEN_STUDENT_LABELS.has(label)))
+        .toBe(true);
+
+      const studentCopy = `${item.student_explanation.summary} ${item.student_explanation.labels.join(' ')}`;
+      ['immediate_repair', 'spaced_review', 'regression_recovery', 'exam_polish', 'band']
+        .forEach((token) => {
+          expect(studentCopy).not.toContain(token);
+        });
+
+      expect(item.explanation?.factors?.length).toBeGreaterThanOrEqual(2);
+      expect(item.student_explanation.provenance.label_mappings).toHaveLength(expected.labels.length);
+      expect(item.student_explanation.provenance.summary_factor_codes.length).toBeGreaterThanOrEqual(2);
+      expect(item.student_explanation.provenance.summary_factor_codes.length).toBeLessThanOrEqual(4);
+      expect(name).toBeTruthy();
+    });
+  });
+
+  test('deriveReviewQueueProjection omits compact student explanations when structured grounding is missing', () => {
+    const item = deriveReviewQueueProjection([
+      buildTask({
+        review_task_id: 'review-task-ungrounded',
+        target_question_type_id: null,
+        due_at: '2026-03-26T08:00:00.000Z',
+        source_question_id: null,
+        source_attempt_ref: null,
+        target_misconception_tags: [],
+        success_criteria: {
+          scheduler_policy: {
+            route: 'short_delay',
+            freshness_bucket: 'cooling',
+          },
+          explainability: {
+            attempt_history: {
+              attempt_count: 0,
+              source_attempt_refs: [],
+              source_question_ids: [],
+            },
+            evidence: {
+              source_question_id: null,
+              source_attempt_ref: null,
+              misconception_tags: [],
+            },
+            freshness: {
+              route: 'short_delay',
+              bucket: 'cooling',
+            },
+          },
+        },
+      }),
+    ], {
+      now: '2026-03-25T10:00:00.000Z',
+    }).items[0];
+
+    expect(item.student_explanation).toBeNull();
   });
 });

--- a/api/learning/lib/review/review-scheduler-policy.js
+++ b/api/learning/lib/review/review-scheduler-policy.js
@@ -23,6 +23,22 @@ const ROUTE_WEIGHT = Object.freeze({
   regression_recovery: 5,
 });
 
+const STUDENT_EXPLANATION_LABEL_BY_FACTOR = Object.freeze({
+  recent_error: '最近出错',
+  interval_due: '间隔已到',
+  exam_near: '临近考试',
+  same_question_type_repair: '同题型回补',
+  regression_risk: '回归风险',
+});
+
+const STUDENT_EXPLANATION_LABEL_ORDER = Object.freeze([
+  'recent_error',
+  'interval_due',
+  'exam_near',
+  'same_question_type_repair',
+  'regression_risk',
+]);
+
 export const REVIEW_SCHEDULER_POLICY = Object.freeze({
   DAILY_RECOMMENDATION_CAP: 3,
   MAX_HIGH_PRIORITY_OPEN_PER_TYPE: 1,
@@ -92,6 +108,15 @@ function normalizeRoute(task = {}) {
 
 function buildReason(code, summary) {
   return { code, summary };
+}
+
+function buildExplanationFactor(code, summary, value = null) {
+  return {
+    code,
+    status: 'grounded',
+    summary,
+    value,
+  };
 }
 
 function typeGroupingKey(task = {}) {
@@ -198,6 +223,25 @@ function uniqueTypedRefs(refs = []) {
   });
 }
 
+function uniqueExplanationFactors(factors = []) {
+  const seen = new Set();
+  return normalizeArray(factors).flatMap((factor) => {
+    const normalized = normalizeObject(factor);
+    const code = normalizeString(normalized.code);
+    if (!code || seen.has(code)) {
+      return [];
+    }
+
+    seen.add(code);
+    return [{
+      code,
+      status: normalizeString(normalized.status, 'grounded'),
+      summary: normalizeString(normalized.summary),
+      value: normalized.value ?? null,
+    }];
+  });
+}
+
 function labelFromMisconceptionTag(tag) {
   const normalized = normalizeString(tag);
   if (!normalized) {
@@ -224,6 +268,148 @@ function summarizeExplainability(task = {}, explainability = {}) {
   }
 
   return `Queued from ${evidenceLabel} evidence while authoritative mastery stays conservative.`;
+}
+
+function buildStructuredExplainabilityFactors(task = {}, explainability = {}, storedFactors = []) {
+  const attemptHistory = normalizeObject(explainability.attempt_history);
+  const evidence = normalizeObject(explainability.evidence);
+  const freshness = normalizeObject(explainability.freshness);
+  const schedulerState = normalizeObject(task?.scheduler_state);
+  const factors = [];
+
+  const hasRecentError = Boolean(
+    evidence.source_attempt_ref
+    || normalizeString(evidence.source_question_id)
+    || normalizeArray(evidence.misconception_tags).length > 0
+    || Number(attemptHistory.attempt_count ?? 0) > 0,
+  );
+  if (hasRecentError) {
+    factors.push(buildExplanationFactor(
+      'recent_error',
+      'Recent repair evidence exists for this task.',
+      {
+        attempt_count: Number(attemptHistory.attempt_count ?? 0),
+        misconception_tag_count: normalizeArray(evidence.misconception_tags).length,
+      },
+    ));
+  }
+
+  const sameQuestionTypeRepair = Boolean(
+    normalizeString(task?.target_question_type_id)
+    && (
+      evidence.source_attempt_ref
+      || normalizeString(evidence.source_question_id)
+    ),
+  );
+  if (sameQuestionTypeRepair) {
+    factors.push(buildExplanationFactor(
+      'same_question_type_repair',
+      'Repair stays on the same grounded question type.',
+      normalizeString(task?.target_question_type_id),
+    ));
+  }
+
+  const intervalDue = schedulerState?.reason_code === 'due_window_open'
+    || schedulerState?.value === 'due';
+  if (intervalDue) {
+    factors.push(buildExplanationFactor(
+      'interval_due',
+      'The scheduled review interval has opened.',
+      normalizeString(task?.due_at),
+    ));
+  }
+
+  if (freshness.route === 'exam_polish') {
+    factors.push(buildExplanationFactor(
+      'exam_near',
+      'This review was scheduled for exam-near preparation.',
+      normalizeString(task?.due_at),
+    ));
+  }
+
+  if (
+    freshness.route === 'regression_recovery'
+    || schedulerState?.reason_code === 'regression_recovery_due'
+  ) {
+    factors.push(buildExplanationFactor(
+      'regression_risk',
+      'Regression recovery evidence is active for this task.',
+      normalizeString(task?.due_at),
+    ));
+  }
+
+  return uniqueExplanationFactors([
+    ...normalizeArray(storedFactors),
+    ...factors,
+  ]);
+}
+
+function buildStudentExplanationSummary(factorCodes = []) {
+  const factorSet = new Set(normalizeArray(factorCodes));
+
+  if (
+    factorSet.has('regression_risk')
+    && factorSet.has('recent_error')
+    && factorSet.has('same_question_type_repair')
+  ) {
+    return {
+      summary: '这类内容有回归风险，而且你最近在这个题型上出错过，所以安排一次同题型回补。',
+      factor_codes: ['regression_risk', 'recent_error', 'same_question_type_repair'],
+    };
+  }
+
+  if (factorSet.has('exam_near') && factorSet.has('interval_due')) {
+    return {
+      summary: '临近考试，而且现在到了这类内容的复习时间，所以安排一次回顾。',
+      factor_codes: ['exam_near', 'interval_due'],
+    };
+  }
+
+  if (factorSet.has('recent_error') && factorSet.has('same_question_type_repair')) {
+    return {
+      summary: '你最近在这个题型上出错过，所以先安排一次同题型回补。',
+      factor_codes: ['recent_error', 'same_question_type_repair'],
+    };
+  }
+
+  if (factorSet.has('interval_due') && factorSet.has('same_question_type_repair')) {
+    return {
+      summary: '现在到了这类内容的复习时间，所以安排一次回顾。',
+      factor_codes: ['interval_due', 'same_question_type_repair'],
+    };
+  }
+
+  return {
+    summary: null,
+    factor_codes: [],
+  };
+}
+
+function buildStudentExplanation(task = {}, explanation = {}) {
+  const factors = uniqueExplanationFactors(explanation?.factors);
+  const factorCodes = new Set(factors.map((factor) => factor.code));
+  const labelMappings = STUDENT_EXPLANATION_LABEL_ORDER
+    .filter((code) => factorCodes.has(code))
+    .map((code) => ({
+      label: STUDENT_EXPLANATION_LABEL_BY_FACTOR[code],
+      factor_code: code,
+    }))
+    .slice(0, 4);
+  const labels = labelMappings.map((mapping) => mapping.label);
+  const summaryShape = buildStudentExplanationSummary(labelMappings.map((mapping) => mapping.factor_code));
+
+  if (labels.length < 2 || !summaryShape.summary) {
+    return null;
+  }
+
+  return {
+    summary: summaryShape.summary,
+    labels,
+    provenance: {
+      summary_factor_codes: summaryShape.factor_codes,
+      label_mappings: labelMappings,
+    },
+  };
 }
 
 export function buildReviewTaskExplainabilitySeed({
@@ -365,6 +551,7 @@ function mergeReviewTaskExplainability(existingTask = {}, candidateTask = {}) {
 export function buildReviewTaskExplainability(task = {}) {
   const successCriteria = normalizeObject(task?.success_criteria);
   const storedExplainability = normalizeObject(successCriteria.explainability);
+  const storedFactors = uniqueExplanationFactors(storedExplainability.factors);
   const attemptHistory = normalizeObject(storedExplainability.attempt_history);
   const evidence = normalizeObject(storedExplainability.evidence);
   const freshness = normalizeObject(storedExplainability.freshness);
@@ -449,7 +636,10 @@ export function buildReviewTaskExplainability(task = {}) {
       ),
     },
     summary: normalizeString(storedExplainability.summary),
+    factors: storedFactors,
   };
+
+  explanation.factors = buildStructuredExplainabilityFactors(task, explanation, storedFactors);
 
   if (!explanation.summary) {
     explanation.summary = summarizeExplainability(task, explanation);
@@ -627,6 +817,7 @@ export function deriveReviewQueueProjection(tasks = [], options = {}) {
       scheduler_state: buildSchedulerStateFromTask(task, { now: nowDate.toISOString() }),
       scheduler_reasons: [],
       explanation: null,
+      student_explanation: null,
     };
   });
 
@@ -713,11 +904,15 @@ export function deriveReviewQueueProjection(tasks = [], options = {}) {
       : null;
     task.scheduler_reasons = reason ? [reason] : [];
     task.explanation = buildReviewTaskExplainability(task);
+    task.student_explanation = buildStudentExplanation(task, task.explanation);
   }
 
   for (const task of items) {
     if (!task.explanation) {
       task.explanation = buildReviewTaskExplainability(task);
+    }
+    if (typeof task.student_explanation === 'undefined' || task.student_explanation === null) {
+      task.student_explanation = buildStudentExplanation(task, task.explanation);
     }
   }
 
@@ -830,17 +1025,19 @@ export function normalizeSchedulerProjectionItem(item = {}) {
   const schedulerPolicy = normalizeObject(item?.scheduler_policy);
   const schedulerState = normalizeObject(item?.scheduler_state);
   const schedulerReasons = normalizeArray(item?.scheduler_reasons);
+  const explanation = buildReviewTaskExplainability({
+    ...item,
+    scheduler_policy: schedulerPolicy,
+    scheduler_state: schedulerState,
+    scheduler_reasons: schedulerReasons,
+  });
 
   return {
     ...item,
     scheduler_policy: schedulerPolicy,
     scheduler_state: schedulerState,
     scheduler_reasons: schedulerReasons,
-    explanation: buildReviewTaskExplainability({
-      ...item,
-      scheduler_policy: schedulerPolicy,
-      scheduler_state: schedulerState,
-      scheduler_reasons: schedulerReasons,
-    }),
+    explanation,
+    student_explanation: buildStudentExplanation(item, explanation),
   };
 }

--- a/docs/reports/2026-04-17-issue-217-closeout.md
+++ b/docs/reports/2026-04-17-issue-217-closeout.md
@@ -1,0 +1,63 @@
+# Issue #217 Closeout
+
+## Scope shipped
+
+Implemented the student-facing scheduler explanation contract for the learning-runtime review queue behind `VITE_LEARNING_RUNTIME_SCHEDULER_EXPLANATION_ENABLED`.
+
+Shipped behavior:
+
+- backend review projection now emits grounded `student_explanation`
+- student explanation is fail-closed and only renders when it has exactly `1` summary sentence plus `2-4` frozen labels
+- labels are limited to:
+  - `最近出错`
+  - `间隔已到`
+  - `临近考试`
+  - `同题型回补`
+  - `回归风险`
+- provenance is carried from structured explanation factors into:
+  - `student_explanation.provenance.summary_factor_codes`
+  - `student_explanation.provenance.label_mappings`
+- when the flag is enabled, the student-facing queue panel hides the old internal scheduler copy and uses the compact student explanation instead
+
+Changed files:
+
+- `api/learning/lib/review/review-scheduler-policy.js`
+- `src/components/learning-runtime/view-models/review-queue-view-model.js`
+- `src/components/learning-runtime/ReviewQueuePanel.js`
+- `api/learning/__tests__/review-scheduler-policy.test.js`
+- `src/components/learning-runtime/__tests__/view-models.test.js`
+- `src/components/learning-runtime/__tests__/WorkspaceShell.test.js`
+
+## Verification
+
+1. `npm run workflow:baseline:sync`
+
+Outcome:
+
+```text
+> cie-copilot@0.0.1 workflow:baseline:sync
+> bash scripts/workflow/baseline-sync.sh
+
++ (cd /home/samsen/code/ciecopilot-home && git -C /home/samsen/code/ciecopilot-home fetch origin --prune)
++ (cd /home/samsen/code/ciecopilot-home && git -C /home/samsen/code/ciecopilot-home pull --ff-only)
+Already up to date.
+```
+
+2. `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/review-scheduler-policy.test.js src/components/learning-runtime/__tests__/view-models.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js`
+
+Outcome:
+
+```text
+PASS src/components/learning-runtime/__tests__/WorkspaceShell.test.js
+PASS src/components/learning-runtime/__tests__/view-models.test.js
+PASS api/learning/__tests__/review-scheduler-policy.test.js
+
+Test Suites: 3 passed, 3 total
+Tests:       30 passed, 30 total
+```
+
+## Residual risks / follow-up debt
+
+- The rollout gate is currently frontend-env driven via `VITE_LEARNING_RUNTIME_SCHEDULER_EXPLANATION_ENABLED`; if the product later needs server-driven flagging per user/session, that wiring is still outstanding.
+- The compact summary templates only cover grounded factor combinations available in the current scheduler contract. New structured factor families should map through the same frozen label set instead of adding vocabulary.
+- Teacher/debug surfaces still retain the richer internal explanation object by design; this change only constrains the student-facing render path.

--- a/src/components/learning-runtime/ReviewQueuePanel.js
+++ b/src/components/learning-runtime/ReviewQueuePanel.js
@@ -39,6 +39,33 @@ function renderSummaryChip(key, label, value) {
   ]);
 }
 
+function renderStudentExplanation(key, studentExplanation) {
+  if (!studentExplanation?.summary && !(Array.isArray(studentExplanation?.labels) && studentExplanation.labels.length > 0)) {
+    return null;
+  }
+
+  return h('div', {
+    key,
+    className: 'mt-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700',
+  }, [
+    studentExplanation.summary
+      ? h('p', {
+        key: 'summary',
+        className: 'leading-6 text-slate-900',
+      }, studentExplanation.summary)
+      : null,
+    Array.isArray(studentExplanation.labels) && studentExplanation.labels.length > 0
+      ? h('div', {
+        key: 'labels',
+        className: 'mt-3 flex flex-wrap gap-2',
+      }, studentExplanation.labels.map((label) => h('span', {
+        key: label,
+        className: 'rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700',
+      }, label)))
+      : null,
+  ].filter(Boolean));
+}
+
 function formatFreshnessLabel(explanation) {
   const bucket = explanation?.freshness?.bucket;
   if (!bucket) {
@@ -50,6 +77,7 @@ function formatFreshnessLabel(explanation) {
 
 function renderReviewItem(item, {
   drafts = {},
+  featureFlags = {},
   mutationStateByTaskId = {},
   onComplete = () => {},
   onDraftChange = () => {},
@@ -57,6 +85,8 @@ function renderReviewItem(item, {
   onOpenWorkspace = null,
   onReschedule = () => {},
 } = {}) {
+  const schedulerExplanationEnabled = featureFlags.schedulerExplanationEnabled === true;
+
   return h('li', {
     key: item.reviewTaskId,
     className: 'rounded-3xl border border-slate-200 bg-slate-50 p-5',
@@ -96,19 +126,21 @@ function renderReviewItem(item, {
       key: 'meta',
       className: 'mt-3 text-sm text-slate-600',
     }, `Due ${item.dueAtLabel} · ${item.estimatedMinutesLabel}`),
-    item.schedulerExplanation?.summary
-      ? h('div', {
-        key: 'scheduler-summary',
-        className: 'mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800',
-      }, item.schedulerExplanation.summary)
-      : null,
+    schedulerExplanationEnabled
+      ? renderStudentExplanation('student-explanation', item.studentExplanation)
+      : item.schedulerExplanation?.summary
+        ? h('div', {
+          key: 'scheduler-summary',
+          className: 'mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800',
+        }, item.schedulerExplanation.summary)
+        : null,
     item.resultFeedback?.summary
       ? h('div', {
         key: 'result-summary',
         className: 'mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800',
       }, item.resultFeedback.summary)
       : null,
-    item.explanation?.summary
+    !schedulerExplanationEnabled && item.explanation?.summary
       ? h('div', {
         key: 'explanation-summary',
         className: 'mt-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700',
@@ -190,6 +222,7 @@ export default function ReviewQueuePanel({
   reviewQueue,
 }) {
   const items = Array.isArray(reviewQueue?.items) ? reviewQueue.items : [];
+  const featureFlags = reviewQueue?.featureFlags || {};
   const summary = reviewQueue?.summary || {};
 
   return h('section', {
@@ -235,6 +268,7 @@ export default function ReviewQueuePanel({
         className: 'mt-5 space-y-4',
       }, items.map((item) => renderReviewItem(item, {
         drafts,
+        featureFlags,
         mutationStateByTaskId,
         onDraftChange,
         onLaunch,

--- a/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
+++ b/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
@@ -172,6 +172,23 @@ function createWorkspacePayload() {
               summary: 'Fresh repair evidence should be retried before it is spaced.',
             },
           ],
+          studentExplanation: {
+            summary: '你最近在这个题型上出错过，所以先安排一次同题型回补。',
+            labels: ['最近出错', '同题型回补'],
+            provenance: {
+              summaryFactorCodes: ['recent_error', 'same_question_type_repair'],
+              labelMappings: [
+                {
+                  label: '最近出错',
+                  factorCode: 'recent_error',
+                },
+                {
+                  label: '同题型回补',
+                  factorCode: 'same_question_type_repair',
+                },
+              ],
+            },
+          },
           explanation: {
             summary: 'Queued from interval-repair evidence while authoritative mastery stays conservative.',
             posture: 'conservative_fallback',
@@ -240,6 +257,9 @@ function createWorkspacePayload() {
           },
         ],
       },
+    },
+    featureFlags: {
+      learningRuntimeEnabled: true,
     },
   };
 }
@@ -382,6 +402,37 @@ describe('WorkspaceShell', () => {
     expect(html).toContain('Reschedule');
     expect(html).toContain('Open canonical queue');
     expect(html).toContain('Closed the interval mistake with a fresh variant.');
+  });
+
+  test('renders the compact scheduler explanation contract when the flag is enabled', () => {
+    const payload = createWorkspacePayload();
+    payload.reviewQueue.featureFlags = {
+      schedulerExplanationEnabled: true,
+    };
+
+    const workspaceVm = buildWorkspaceViewModel(payload, {
+      now: '2026-03-22T12:00:00.000Z',
+    });
+    const html = renderToStaticMarkup(
+      React.createElement(WorkspaceShell, {
+        viewModel: workspaceVm,
+        onOpenGlobalQueue: () => {},
+        reviewQueueDrafts: {
+          'review-task-1': {
+            completionSummary: 'Solved one more repair variant.',
+            dueAt: '2026-03-24T09:30',
+          },
+        },
+      }),
+    );
+
+    expect(html).toContain('你最近在这个题型上出错过，所以先安排一次同题型回补。');
+    expect(html).toContain('最近出错');
+    expect(html).toContain('同题型回补');
+    expect(html).not.toContain('Fresh repair evidence should be retried before it is spaced.');
+    expect(html).not.toContain('Queued from interval-repair evidence while authoritative mastery stays conservative.');
+    expect(html).not.toContain('Attempt history');
+    expect(html).not.toContain('Fresh evidence');
   });
 
   test('renders a read-only second-subject runtime posture banner', () => {

--- a/src/components/learning-runtime/__tests__/view-models.test.js
+++ b/src/components/learning-runtime/__tests__/view-models.test.js
@@ -279,6 +279,23 @@ function createWorkspacePayload() {
               summary: 'Fresh repair evidence should be retried before it is spaced.',
             },
           ],
+          studentExplanation: {
+            summary: '你最近在这个题型上出错过，所以先安排一次同题型回补。',
+            labels: ['最近出错', '同题型回补'],
+            provenance: {
+              summaryFactorCodes: ['recent_error', 'same_question_type_repair'],
+              labelMappings: [
+                {
+                  label: '最近出错',
+                  factorCode: 'recent_error',
+                },
+                {
+                  label: '同题型回补',
+                  factorCode: 'same_question_type_repair',
+                },
+              ],
+            },
+          },
         },
         {
           reviewTaskId: 'review-task-2',
@@ -306,6 +323,23 @@ function createWorkspacePayload() {
               summary: 'Deferred until the next spaced-review freshness window opens.',
             },
           ],
+          studentExplanation: {
+            summary: '现在到了这类内容的复习时间，所以安排一次回顾。',
+            labels: ['间隔已到', '同题型回补'],
+            provenance: {
+              summaryFactorCodes: ['interval_due', 'same_question_type_repair'],
+              labelMappings: [
+                {
+                  label: '间隔已到',
+                  factorCode: 'interval_due',
+                },
+                {
+                  label: '同题型回补',
+                  factorCode: 'same_question_type_repair',
+                },
+              ],
+            },
+          },
         },
         {
           reviewTaskId: 'review-task-3',
@@ -1015,6 +1049,32 @@ describe('learning runtime session view model', () => {
       completed: 1,
       blocked: 0,
     });
+  });
+
+  test('workspace view-model keeps compact student explanations behind the scheduler explanation flag', () => {
+    const payload = createWorkspacePayload();
+    payload.reviewQueue.featureFlags = {
+      schedulerExplanationEnabled: true,
+    };
+
+    const vm = buildWorkspaceViewModel(payload, {
+      now: '2026-03-22T12:00:00.000Z',
+    });
+
+    expect(vm.reviewQueue.featureFlags).toEqual(expect.objectContaining({
+      schedulerExplanationEnabled: true,
+    }));
+    expect(vm.reviewQueue.items[0].studentExplanation).toEqual(expect.objectContaining({
+      summary: '你最近在这个题型上出错过，所以先安排一次同题型回补。',
+      labels: ['最近出错', '同题型回补'],
+      provenance: expect.objectContaining({
+        summaryFactorCodes: ['recent_error', 'same_question_type_repair'],
+      }),
+    }));
+    expect(vm.reviewQueue.items[1].studentExplanation).toEqual(expect.objectContaining({
+      summary: '现在到了这类内容的复习时间，所以安排一次回顾。',
+      labels: ['间隔已到', '同题型回补'],
+    }));
   });
 
   test('workspace view-model exposes read-only runtime posture for second-subject topics', () => {

--- a/src/components/learning-runtime/__tests__/view-models.test.js
+++ b/src/components/learning-runtime/__tests__/view-models.test.js
@@ -1077,6 +1077,68 @@ describe('learning runtime session view model', () => {
     }));
   });
 
+  test('workspace view-model fail-closes partial or invalid student explanations', () => {
+    const payload = createWorkspacePayload();
+    payload.reviewQueue.featureFlags = {
+      schedulerExplanationEnabled: true,
+    };
+    payload.reviewQueue.items[0].studentExplanation = {
+      summary: '你最近在这个题型上出错过，所以先安排一次同题型回补。',
+      labels: ['最近出错'],
+      provenance: {
+        summaryFactorCodes: ['recent_error'],
+        labelMappings: [
+          {
+            label: '最近出错',
+            factorCode: 'recent_error',
+          },
+        ],
+      },
+    };
+    payload.reviewQueue.items[1].studentExplanation = {
+      summary: null,
+      labels: ['间隔已到', '同题型回补'],
+      provenance: {
+        summaryFactorCodes: ['interval_due', 'same_question_type_repair'],
+        labelMappings: [
+          {
+            label: '间隔已到',
+            factorCode: 'interval_due',
+          },
+          {
+            label: '同题型回补',
+            factorCode: 'same_question_type_repair',
+          },
+        ],
+      },
+    };
+    payload.reviewQueue.items[2].studentExplanation = {
+      summary: '无效标签不应继续暴露。',
+      labels: ['回归风险', '内部 route'],
+      provenance: {
+        summaryFactorCodes: ['regression_risk'],
+        labelMappings: [
+          {
+            label: '回归风险',
+            factorCode: 'regression_risk',
+          },
+          {
+            label: '内部 route',
+            factorCode: 'internal_route',
+          },
+        ],
+      },
+    };
+
+    const vm = buildWorkspaceViewModel(payload, {
+      now: '2026-03-22T12:00:00.000Z',
+    });
+
+    expect(vm.reviewQueue.items[0].studentExplanation).toBeNull();
+    expect(vm.reviewQueue.items[1].studentExplanation).toBeNull();
+    expect(vm.reviewQueue.items[2].studentExplanation).toBeNull();
+  });
+
   test('workspace view-model exposes read-only runtime posture for second-subject topics', () => {
     const vm = buildWorkspaceViewModel(createReadOnlyPhysicsWorkspacePayload(), {
       now: '2026-03-22T12:00:00.000Z',

--- a/src/components/learning-runtime/view-models/review-queue-view-model.js
+++ b/src/components/learning-runtime/view-models/review-queue-view-model.js
@@ -1,4 +1,6 @@
 const ACTIVE_REVIEW_TASK_STATUSES = new Set(['open', 'partial']);
+const META_ENV = typeof import.meta !== 'undefined' ? import.meta.env || {} : {};
+const SCHEDULER_EXPLANATION_ENV_FLAG = 'VITE_LEARNING_RUNTIME_SCHEDULER_EXPLANATION_ENABLED';
 
 function normalizeString(value, fallback = null) {
   if (typeof value !== 'string') {
@@ -151,6 +153,58 @@ function normalizeExplanationFactors(value) {
   })).filter((factor) => factor.code || factor.summary);
 }
 
+function normalizeReviewQueueFeatureFlags(value, env = META_ENV) {
+  const featureFlags = value && typeof value === 'object' ? value : {};
+  const explicitFlag = featureFlags.schedulerExplanationEnabled;
+  const snakeCaseFlag = featureFlags.scheduler_explanation_enabled;
+
+  return {
+    schedulerExplanationEnabled:
+      typeof explicitFlag === 'boolean'
+        ? explicitFlag
+        : typeof snakeCaseFlag === 'boolean'
+          ? snakeCaseFlag
+          : env[SCHEDULER_EXPLANATION_ENV_FLAG] === 'true',
+  };
+}
+
+function normalizeStudentExplanation(value) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const provenance = value.provenance ?? {};
+  const labels = (Array.isArray(value.labels) ? value.labels : [])
+    .map((label) => normalizeString(label))
+    .filter(Boolean)
+    .slice(0, 4);
+  const summary = normalizeString(value.summary);
+
+  if (!summary && labels.length === 0) {
+    return null;
+  }
+
+  return {
+    summary,
+    labels,
+    provenance: {
+      summaryFactorCodes: (
+        Array.isArray(provenance.summaryFactorCodes ?? provenance.summary_factor_codes)
+          ? (provenance.summaryFactorCodes ?? provenance.summary_factor_codes)
+          : []
+      ).map((code) => normalizeString(code)).filter(Boolean),
+      labelMappings: (
+        Array.isArray(provenance.labelMappings ?? provenance.label_mappings)
+          ? (provenance.labelMappings ?? provenance.label_mappings)
+          : []
+      ).map((mapping) => ({
+        label: normalizeString(mapping?.label),
+        factorCode: normalizeString(mapping?.factorCode ?? mapping?.factor_code),
+      })).filter((mapping) => mapping.label || mapping.factorCode),
+    },
+  };
+}
+
 function normalizeReviewTaskExplanation(value) {
   if (!value || typeof value !== 'object') {
     return null;
@@ -297,6 +351,10 @@ export function buildReviewQueueActionDrafts(items = [], currentDrafts = {}, opt
 export function buildReviewQueueViewModel(reviewQueue = {}, options = {}) {
   const now = normalizeString(options.now) || new Date().toISOString();
   const items = Array.isArray(reviewQueue?.items) ? reviewQueue.items : [];
+  const featureFlags = normalizeReviewQueueFeatureFlags(
+    reviewQueue?.featureFlags ?? reviewQueue?.feature_flags ?? {},
+    options.env,
+  );
   const normalizedItems = items.map((item) => {
     const status = normalizeString(item.status, 'open');
     const schedulerState = normalizeSchedulerState(item.schedulerState ?? item.scheduler_state);
@@ -338,6 +396,9 @@ export function buildReviewQueueViewModel(reviewQueue = {}, options = {}) {
         schedulerReasons,
         schedulerPolicy,
       ),
+      studentExplanation: normalizeStudentExplanation(
+        item.studentExplanation ?? item.student_explanation,
+      ),
       explanation: normalizeReviewTaskExplanation(item.explanation),
       launchPayload: buildLaunchPayload(item),
       workspaceLink: {
@@ -372,6 +433,7 @@ export function buildReviewQueueViewModel(reviewQueue = {}, options = {}) {
     scope: normalizeString(reviewQueue?.scope),
     topicId: normalizeString(reviewQueue?.topicId ?? reviewQueue?.topic_id),
     policy: normalizeSchedulerPolicy(reviewQueue?.policy),
+    featureFlags,
     items: normalizedItems,
     summary,
     actionDrafts: buildReviewQueueActionDrafts(normalizedItems, {}, { now }),

--- a/src/components/learning-runtime/view-models/review-queue-view-model.js
+++ b/src/components/learning-runtime/view-models/review-queue-view-model.js
@@ -1,6 +1,13 @@
 const ACTIVE_REVIEW_TASK_STATUSES = new Set(['open', 'partial']);
 const META_ENV = typeof import.meta !== 'undefined' ? import.meta.env || {} : {};
 const SCHEDULER_EXPLANATION_ENV_FLAG = 'VITE_LEARNING_RUNTIME_SCHEDULER_EXPLANATION_ENABLED';
+const FROZEN_STUDENT_EXPLANATION_LABELS = new Set([
+  '最近出错',
+  '间隔已到',
+  '临近考试',
+  '同题型回补',
+  '回归风险',
+]);
 
 function normalizeString(value, fallback = null) {
   if (typeof value !== 'string') {
@@ -176,11 +183,11 @@ function normalizeStudentExplanation(value) {
   const provenance = value.provenance ?? {};
   const labels = (Array.isArray(value.labels) ? value.labels : [])
     .map((label) => normalizeString(label))
-    .filter(Boolean)
+    .filter((label) => Boolean(label) && FROZEN_STUDENT_EXPLANATION_LABELS.has(label))
     .slice(0, 4);
   const summary = normalizeString(value.summary);
 
-  if (!summary && labels.length === 0) {
+  if (!summary || labels.length < 2 || labels.length > 4) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Implements issue #217 by freezing the student-facing scheduler explanation surface to a grounded compact contract behind `VITE_LEARNING_RUNTIME_SCHEDULER_EXPLANATION_ENABLED`.

This change adds a backend-shaped `student_explanation` payload that only renders when it has one grounded summary sentence plus 2-4 labels from the frozen set. It also records provenance from structured explanation factors into the compact copy and hides the older internal scheduler copy from the student surface when the flag is enabled.

## What Changed

- added structured-factor to frozen-label mapping in the review scheduler projection
- emitted fail-closed `student_explanation` payloads with provenance-backed summary and label mappings
- carried the scheduler-explanation flag through the review-queue view model
- switched the review queue panel to the compact student copy when the flag is enabled
- added focused backend/view-model/render tests plus a closeout report

## Verification

- `npm run workflow:baseline:sync`
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/review-scheduler-policy.test.js src/components/learning-runtime/__tests__/view-models.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js`

## Risks

- the rollout flag is currently frontend-env driven; per-user or server-driven gating would still need separate wiring if product wants that later
- new structured factor families must keep mapping back into the frozen five-label vocabulary rather than expanding the student surface

Closes #217.
