### PR TITLE
fix: propagate imported-attempt non-authoritative posture

### DIFF
--- a/api/learning/__tests__/artifact-service.test.js
+++ b/api/learning/__tests__/artifact-service.test.js
@@ -79,6 +79,38 @@ function createArtifactRepositoryFixture() {
       },
     ],
     [
+      'art-successor-non-authoritative',
+      {
+        artifact_id: 'art-successor-non-authoritative',
+        artifact_kind: 'misconception_card',
+        canonical_home_topic_id: 'repair-target-topic',
+        slot_key: 'common_traps',
+        trust_status: 'grounded',
+        placement_status: 'inbox',
+        lifecycle_status: 'active',
+        artifact_state: 'verified',
+        verified_by: 'operator-8',
+        verified_at: '2026-03-20T08:07:00.000Z',
+        verification_evidence_ref: { kind: 'review_run', review_run_id: 'review-8' },
+        released_by: null,
+        released_at: null,
+        release_evidence_ref: null,
+        contested_by: null,
+        contested_at: null,
+        contested_reason: null,
+        grounding_refs: [
+          {
+            kind: 'attempt',
+            attempt_id: 'attempt-imported-successor-1',
+            runtime_authority_posture: 'non_authoritative',
+            runtime_authority_reason_code: 'imported_question_attempt',
+          },
+        ],
+        superseded_by_artifact_id: null,
+        superseded_at: null,
+      },
+    ],
+    [
       'art-successor-unverified',
       {
         artifact_id: 'art-successor-unverified',
@@ -172,6 +204,27 @@ function createArtifactRepositoryFixture() {
         contested_reason: null,
         superseded_by_artifact_id: null,
         superseded_at: null,
+      },
+    ],
+    [
+      'art-non-authoritative',
+      {
+        artifact_id: 'art-non-authoritative',
+        artifact_kind: 'misconception_card',
+        canonical_home_topic_id: 'topic-trig-identities',
+        slot_key: 'common_traps',
+        trust_status: 'grounded',
+        placement_status: 'inbox',
+        lifecycle_status: 'active',
+        grounding_refs: [
+          {
+            kind: 'attempt',
+            attempt_id: 'attempt-imported-1',
+            runtime_authority_posture: 'non_authoritative',
+            runtime_authority_reason_code: 'imported_question_attempt',
+          },
+        ],
+        superseded_by_artifact_id: null,
       },
     ],
   ]);
@@ -601,6 +654,47 @@ describe('artifact-service', () => {
     });
   });
 
+  test('superseding a pinned artifact with a non-authoritative imported successor is rejected and keeps the current resident stable', async () => {
+    const repository = createArtifactRepositoryFixture();
+    const service = createArtifactService({
+      artifactRepository: repository,
+      lifecycleFlagEnabled: true,
+    });
+
+    await expect(
+      service.patchArtifact({
+        userId: 'student-1',
+        artifactId: 'art-pinned',
+        intent: 'attach_superseded_by',
+        successorArtifactRef: {
+          kind: 'artifact',
+          artifact_id: 'art-successor-non-authoritative',
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'artifact_state_conflict',
+      status: 409,
+    });
+
+    const snapshot = repository.snapshot();
+    expect(snapshot.artifacts.get('art-pinned')).toMatchObject({
+      placement_status: 'pinned',
+      artifact_state: 'verified',
+      lifecycle_status: 'active',
+      superseded_by_artifact_id: null,
+    });
+    expect(snapshot.artifacts.get('art-successor-non-authoritative')).toMatchObject({
+      placement_status: 'inbox',
+      artifact_state: 'verified',
+    });
+    expect(snapshot.workspaceSlots.get('student-1:repair-target-topic:common_traps')).toMatchObject({
+      primary_artifact_ref: {
+        kind: 'artifact',
+        artifact_id: 'art-pinned',
+      },
+    });
+  });
+
   test('set_placement_status rejects pinning a contested artifact', async () => {
     const service = createArtifactService({
       artifactRepository: createArtifactRepositoryFixture(),
@@ -649,6 +743,24 @@ describe('artifact-service', () => {
       service.patchArtifact({
         userId: 'student-1',
         artifactId: 'art-incompatible',
+        intent: 'set_placement_status',
+        placementStatus: 'pinned',
+      }),
+    ).rejects.toMatchObject({
+      code: 'artifact_state_conflict',
+      status: 409,
+    });
+  });
+
+  test('set_placement_status rejects pinning an artifact grounded only by a non-authoritative imported attempt', async () => {
+    const service = createArtifactService({
+      artifactRepository: createArtifactRepositoryFixture(),
+    });
+
+    await expect(
+      service.patchArtifact({
+        userId: 'student-1',
+        artifactId: 'art-non-authoritative',
         intent: 'set_placement_status',
         placementStatus: 'pinned',
       }),

--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -80,6 +80,7 @@ function buildBridgeInput(overrides = {}) {
       },
     ],
     questionContext: {
+      source_kind: 'paper_question',
       family_id: '9709.trigonometry_manipulation_equations',
       question_type_id: '9709.trigonometry.equations',
       question_type_release_state: 'released',
@@ -258,6 +259,66 @@ describe('attempt-event-service', () => {
     records.learningEvents.forEach((event, index) => {
       expect(event.truth_revision).toBe(2);
       expect(event.sequence_no).toBe(index + 1);
+    });
+  });
+
+  test('imported-question attempts stay durable while persisting explicit non-authoritative posture', async () => {
+    const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
+    const { client, records } = createMockClient();
+
+    const result = await persistAttemptEventBridge(client, buildBridgeInput({
+      questionContext: {
+        source_kind: 'imported_question',
+        family_id: '9709.trigonometry_manipulation_equations',
+        question_type_id: '9709.trigonometry.identities',
+        question_type_release_state: 'released',
+        primary_topic_id: 'topic-trig-identities',
+        primary_topic_path: '9709/trigonometry/identities',
+        classification_confidence: 0.95,
+        candidate_rubric_refs: [
+          {
+            kind: 'rubric_release',
+            rubric_version_id: 'trig-identities-v1',
+            release_state: 'released',
+          },
+        ],
+        release_scope_status: 'released_scoring',
+      },
+      authorityPosture: {
+        release_scope_status: 'released_scoring',
+        authoritative_scoring_allowed: true,
+        fallback_mode: null,
+        fallback_reason_code: null,
+        classification_confidence: 0.95,
+        learning_signal_posture: 'authoritative_scoring',
+      },
+    }));
+
+    expect(result).toMatchObject({
+      ok: true,
+      warningRecorded: false,
+      persisted_event_types: [
+        'AttemptSubmitted',
+        'QuestionClassified',
+        'MarkingCompleted',
+        'LearningUpdateProposed',
+      ],
+    });
+
+    expect(records.learningEvents).toHaveLength(4);
+    records.learningEvents.forEach((event) => {
+      expect(event.payload.authority_posture).toMatchObject({
+        authoritative_scoring_allowed: false,
+        runtime_authority_posture: 'non_authoritative',
+        runtime_authority_reason_code: 'imported_question_attempt',
+        question_source_kind: 'imported_question',
+      });
+      expect(event.provenance.trust.authority_posture).toMatchObject({
+        authoritative_scoring_allowed: false,
+        runtime_authority_posture: 'non_authoritative',
+        runtime_authority_reason_code: 'imported_question_attempt',
+        question_source_kind: 'imported_question',
+      });
     });
   });
 });

--- a/api/learning/__tests__/review-task-service.test.js
+++ b/api/learning/__tests__/review-task-service.test.js
@@ -395,7 +395,7 @@ describe('learning orchestration', () => {
           question_type_release_state: 'released',
           primary_topic_id: 'source-topic',
           primary_topic_path: '9709/integration/source',
-          classification_confidence: 0.78,
+          classification_confidence: 0.86,
           candidate_rubric_refs: [
             {
               kind: 'rubric_release',
@@ -440,6 +440,120 @@ describe('learning orchestration', () => {
     });
   });
 
+  test('imported-question attempts keep local feedback and artifact candidates but suppress durable mastery and review writes', async () => {
+    const reviewTaskService = createSpyService('generateTasksFromOutcome', async () => [
+      {
+        review_task_id: 'review-task-imported',
+      },
+    ]);
+    const artifactService = createSpyService('buildArtifactCandidates', async () => [
+      {
+        artifact_id: 'artifact-imported-1',
+        artifact_kind: 'misconception_card',
+      },
+    ]);
+    const reconciliationService = createSpyService('reconcileDerivedState', async ({ derivedState }) => ({
+      reconciliation_run_id: 'recon-imported-1',
+      status: 'completed',
+      derived_state: derivedState,
+    }));
+
+    const result = await applyLearningEffects(
+      {
+        user_id: 'student-1',
+        question_id: 'question-imported-1',
+        question_context: {
+          source_kind: 'imported_question',
+          family_id: '9709.trigonometry_manipulation_equations',
+          question_type_id: '9709.trigonometry.identities',
+          question_type_release_state: 'released',
+          primary_topic_id: 'topic-trig-identities',
+          primary_topic_path: '9709/trigonometry/identities',
+          classification_confidence: 0.95,
+          candidate_rubric_refs: [
+            {
+              kind: 'rubric_release',
+              rubric_version_id: 'trig-identities-v1',
+              release_state: 'released',
+            },
+          ],
+        },
+        source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-imported-1' },
+        source_mark_run_ref: { kind: 'mark_run', mark_run_id: 'mark-run-imported-1' },
+        decisions: [
+          {
+            awarded: true,
+            awarded_marks: 1,
+            alignment_confidence: 0.94,
+          },
+        ],
+        misconception_tags: ['identity:rewrite'],
+        marking_result: {
+          marking_summary: {
+            coverage_scope: 'subpart',
+            local_signal_only: true,
+            ambiguous_rubric_point_result_count: 0,
+          },
+          part_results: [
+            {
+              part_id: 'a',
+              subpart_id: 'a_i',
+              score_awarded: 1,
+              score_max: 1,
+            },
+          ],
+        },
+        uncertainty_validated: true,
+        release_scope_posture: {
+          release_scope_status: 'released_scoring',
+          authoritative_scoring_allowed: true,
+          fallback_mode: null,
+          fallback_reason_code: null,
+          classification_confidence: 0.95,
+          learning_signal_posture: 'authoritative_scoring',
+        },
+      },
+      {
+        reviewTaskService,
+        artifactService,
+        reconciliationService,
+      },
+    );
+
+    expect(result).toMatchObject({
+      release_scope_status: 'released_scoring',
+      authoritative_scoring_allowed: false,
+      runtime_authority_posture: 'non_authoritative',
+      runtime_authority_reason_code: 'imported_question_attempt',
+      mastery_updates: [],
+      review_tasks: [],
+      artifact_candidates: [
+        {
+          artifact_id: 'artifact-imported-1',
+        },
+      ],
+      local_signals: [
+        expect.objectContaining({
+          scope_kind: 'subpart',
+          part_id: 'a',
+          subpart_id: 'a_i',
+        }),
+      ],
+    });
+    expect(reviewTaskService.calls).toHaveLength(0);
+    expect(artifactService.calls).toHaveLength(1);
+    expect(reconciliationService.calls[0].derivedState).toMatchObject({
+      family_masteries: [],
+      type_masteries: [],
+      review_tasks: [],
+      artifacts: [
+        {
+          artifact_id: 'artifact-imported-1',
+        },
+      ],
+    });
+  });
+
   test('incorrect released-scoring outcomes still emit repair tasks without positive type mastery', async () => {
     const reviewTaskService = createSpyService('generateTasksFromOutcome', async (input) => [
       {
@@ -467,7 +581,7 @@ describe('learning orchestration', () => {
           question_type_release_state: 'released',
           primary_topic_id: 'source-topic',
           primary_topic_path: '9709/integration/source',
-          classification_confidence: 0.78,
+          classification_confidence: 0.86,
           candidate_rubric_refs: [
             {
               kind: 'rubric_release',
@@ -542,7 +656,7 @@ describe('learning orchestration', () => {
           question_type_release_state: 'released',
           primary_topic_id: 'source-topic',
           primary_topic_path: '9709/integration/source',
-          classification_confidence: 0.78,
+          classification_confidence: 0.86,
           candidate_rubric_refs: [
             {
               kind: 'rubric_release',
@@ -604,6 +718,33 @@ describe('learning orchestration', () => {
 });
 
 describe('review task service generation', () => {
+  test('non-authoritative imported attempts do not enqueue default durable review tasks', async () => {
+    const service = createReviewTaskService({
+      now: () => new Date('2026-03-24T10:00:00.000Z'),
+    });
+
+    const tasks = await service.generateTasksFromOutcome({
+      user_id: 'student-1',
+      question_id: 'question-imported-queue-1',
+      authoritative_scoring_allowed: false,
+      runtime_authority_posture: 'non_authoritative',
+      runtime_authority_reason_code: 'imported_question_attempt',
+      question_source_kind: 'imported_question',
+      fallback_reason_code: 'imported_question_attempt',
+      repair_target_topic_id: 'topic-1',
+      repair_target_topic_path: '9709/trigonometry/identities',
+      source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-imported-queue-1' },
+      misconception_tags: ['identity:rewrite'],
+      question_context: {
+        source_kind: 'imported_question',
+        family_id: '9709.trigonometry_manipulation_equations',
+        question_type_id: '9709.trigonometry.identities',
+      },
+    });
+
+    expect(tasks).toEqual([]);
+  });
+
   test('fallback review tasks now route through immediate repair with explicit scheduler policy', async () => {
     const service = createReviewTaskService({
       now: () => new Date('2026-03-24T10:00:00.000Z'),

--- a/api/learning/lib/artifacts/artifact-service.js
+++ b/api/learning/lib/artifacts/artifact-service.js
@@ -3,6 +3,10 @@ import {
   buildArtifactRef,
   isCompatibleArtifactKindForSlot,
 } from '../contracts/runtime-contract.js';
+import {
+  buildAttemptGroundingRef,
+  hasNonAuthoritativeAttemptGrounding,
+} from '../contracts/runtime-authority-posture.js';
 import { createArtifactRepository } from '../repositories/artifact-repository.js';
 
 const LEGACY_ARTIFACT_INTENTS = new Set([
@@ -118,6 +122,7 @@ function buildCandidateHome(input = {}) {
 
 function buildArtifactCandidate(input = {}, timestamp) {
   const home = buildCandidateHome(input);
+  const sourceAttemptGroundingRef = buildAttemptGroundingRef(input.source_attempt_ref, input);
 
   return {
     artifact_kind: input.artifact_kind || 'misconception_card',
@@ -146,7 +151,7 @@ function buildArtifactCandidate(input = {}, timestamp) {
     superseded_at: null,
     grounding_refs: [
       ...normalizeArray(input.grounding_refs),
-      ...normalizeArray(input.source_attempt_ref ? [input.source_attempt_ref] : []),
+      ...normalizeArray(sourceAttemptGroundingRef ? [sourceAttemptGroundingRef] : []),
       ...normalizeArray(input.source_mark_run_ref ? [input.source_mark_run_ref] : []),
     ],
     misconception_tags: normalizeArray(input.misconception_tags),
@@ -428,6 +433,15 @@ async function handlePlacementIntent({
     });
   }
 
+  if (placementStatus === 'pinned' && hasNonAuthoritativeAttemptGrounding(artifact.grounding_refs)) {
+    throw buildArtifactConflict(
+      'Artifacts grounded by non-authoritative imported attempts cannot gain stable-slot residency.',
+      {
+        artifact_id: artifact.artifact_id,
+      },
+    );
+  }
+
   if (
     placementStatus === 'pinned'
     && artifact.slot_key
@@ -704,6 +718,15 @@ async function handleSupersedeIntent({
       successor_artifact_id: successor.artifact_id,
       successor_artifact_state: successor.artifact_state,
     });
+  }
+
+  if (artifact.placement_status === 'pinned' && hasNonAuthoritativeAttemptGrounding(successor.grounding_refs)) {
+    throw buildArtifactConflict(
+      'Artifacts grounded by non-authoritative imported attempts cannot gain stable-slot residency.',
+      {
+        artifact_id: successor.artifact_id,
+      },
+    );
   }
 
   const timestamp = now().toISOString();

--- a/api/learning/lib/contracts/runtime-authority-posture.js
+++ b/api/learning/lib/contracts/runtime-authority-posture.js
@@ -1,0 +1,134 @@
+import { LEARNING_SIGNAL_POSTURES } from './released-scope-core.js';
+
+export const RUNTIME_AUTHORITY_POSTURES = Object.freeze({
+  DEFAULT_DURABLE: 'default_durable',
+  NON_AUTHORITATIVE: 'non_authoritative',
+});
+
+export const RUNTIME_AUTHORITY_REASON_CODES = Object.freeze({
+  IMPORTED_QUESTION_ATTEMPT: 'imported_question_attempt',
+});
+
+export const NON_AUTHORITATIVE_BLOCKED_MATERIALIZERS = Object.freeze([
+  'authoritative_scoring_aggregate',
+  'mastery',
+  'review_queue',
+  'stable_slot_residency',
+]);
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function normalizePosture(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? clone(value)
+    : {};
+}
+
+function resolveQuestionSourceKind(posture = {}, options = {}) {
+  return normalizeString(
+    options.questionSourceKind
+    ?? options.question_source_kind
+    ?? options.questionContext?.source_kind
+    ?? options.question_context?.source_kind
+    ?? posture.question_source_kind,
+  ) || null;
+}
+
+function buildNonAuthoritativeExplanation(questionSourceKind) {
+  return {
+    posture: 'non_authoritative',
+    summary:
+      'Imported-question attempts are durable runtime inputs, but they cannot mutate authoritative product truth.',
+    factors: [
+      {
+        code: 'question_source_kind',
+        status: 'non_authoritative',
+        summary:
+          'Imported-question attempts stay queryable in runtime surfaces while authoritative downstream materializers remain blocked.',
+        value: questionSourceKind,
+      },
+    ],
+  };
+}
+
+export function buildRuntimeAuthorityPosture(posture = {}, options = {}) {
+  const normalized = normalizePosture(posture);
+  const questionSourceKind = resolveQuestionSourceKind(normalized, options);
+
+  if (questionSourceKind === 'imported_question') {
+    return {
+      ...normalized,
+      authoritative_scoring_allowed: false,
+      fallback_reason_code:
+        normalized.fallback_reason_code
+        || RUNTIME_AUTHORITY_REASON_CODES.IMPORTED_QUESTION_ATTEMPT,
+      learning_signal_posture: LEARNING_SIGNAL_POSTURES.CONSERVATIVE_FALLBACK,
+      runtime_authority_posture: RUNTIME_AUTHORITY_POSTURES.NON_AUTHORITATIVE,
+      runtime_authority_reason_code: RUNTIME_AUTHORITY_REASON_CODES.IMPORTED_QUESTION_ATTEMPT,
+      blocked_materializers: [...NON_AUTHORITATIVE_BLOCKED_MATERIALIZERS],
+      question_source_kind: questionSourceKind,
+      explanation: buildNonAuthoritativeExplanation(questionSourceKind),
+    };
+  }
+
+  return {
+    ...normalized,
+    runtime_authority_posture:
+      normalizeString(normalized.runtime_authority_posture)
+      || RUNTIME_AUTHORITY_POSTURES.DEFAULT_DURABLE,
+    runtime_authority_reason_code:
+      normalizeString(normalized.runtime_authority_reason_code) || null,
+    blocked_materializers: normalizeArray(normalized.blocked_materializers),
+    question_source_kind: questionSourceKind,
+  };
+}
+
+export function extractRuntimeAuthorityPosture(input = {}) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return buildRuntimeAuthorityPosture();
+  }
+
+  const posture = input.release_scope_posture
+    || input.authorityPosture
+    || input.authority_posture
+    || input;
+
+  return buildRuntimeAuthorityPosture(posture, input);
+}
+
+export function isNonAuthoritativeRuntimeInput(input = {}) {
+  return extractRuntimeAuthorityPosture(input).runtime_authority_posture
+    === RUNTIME_AUTHORITY_POSTURES.NON_AUTHORITATIVE;
+}
+
+export function buildAttemptGroundingRef(sourceAttemptRef = null, postureInput = {}) {
+  if (!sourceAttemptRef || typeof sourceAttemptRef !== 'object' || Array.isArray(sourceAttemptRef)) {
+    return null;
+  }
+
+  const runtimeAuthorityPosture = extractRuntimeAuthorityPosture(postureInput);
+  return {
+    ...clone(sourceAttemptRef),
+    runtime_authority_posture: runtimeAuthorityPosture.runtime_authority_posture,
+    runtime_authority_reason_code: runtimeAuthorityPosture.runtime_authority_reason_code,
+    question_source_kind: runtimeAuthorityPosture.question_source_kind,
+    blocked_materializers: runtimeAuthorityPosture.blocked_materializers,
+  };
+}
+
+export function hasNonAuthoritativeAttemptGrounding(groundingRefs = []) {
+  return normalizeArray(groundingRefs).some((groundingRef) =>
+    normalizeString(groundingRef?.kind) === 'attempt'
+    && normalizeString(groundingRef?.runtime_authority_posture)
+      === RUNTIME_AUTHORITY_POSTURES.NON_AUTHORITATIVE);
+}

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { projectAttemptPipelineState } from './event-service.js';
+import { buildRuntimeAuthorityPosture } from '../contracts/runtime-authority-posture.js';
 
 const BRIDGE_EVENT_TYPES = Object.freeze([
   'AttemptSubmitted',
@@ -355,6 +356,9 @@ function buildBridgeEvents(input = {}) {
   const questionId = normalizeString(input.questionId) || null;
   const sessionId = normalizeString(input.sessionId) || null;
   const questionContext = cloneJson(input.questionContext ?? {}) ?? {};
+  const runtimeAuthorityPosture = buildRuntimeAuthorityPosture(authorityPosture, {
+    questionContext,
+  });
   const attemptContext = cloneJson(input.attemptContext ?? {}) ?? {};
   const sourceAttemptRef = cloneJson(input.sourceAttemptRef ?? null);
   const sourceMarkRunRef = cloneJson(input.sourceMarkRunRef ?? null);
@@ -370,7 +374,7 @@ function buildBridgeEvents(input = {}) {
 
   const baseProvenance = buildBaseProvenance({
     subjectCode,
-    authorityPosture,
+    authorityPosture: runtimeAuthorityPosture,
     correlationId,
     sourceAttemptRef,
     sourceMarkRunRef,
@@ -382,7 +386,7 @@ function buildBridgeEvents(input = {}) {
   const payloads = [
     buildAttemptSubmittedPayload({
       attemptId,
-      authorityPosture,
+      authorityPosture: runtimeAuthorityPosture,
       submittedAt,
       questionId,
       markRunId,
@@ -393,7 +397,7 @@ function buildBridgeEvents(input = {}) {
     }),
     buildQuestionClassifiedPayload({
       attemptId,
-      authorityPosture,
+      authorityPosture: runtimeAuthorityPosture,
       questionId,
       questionContext,
       attemptContext,
@@ -401,7 +405,7 @@ function buildBridgeEvents(input = {}) {
     }),
     buildMarkingCompletedPayload({
       attemptId,
-      authorityPosture,
+      authorityPosture: runtimeAuthorityPosture,
       questionContext,
       markRunId,
       decisions: input.decisions,
@@ -409,7 +413,7 @@ function buildBridgeEvents(input = {}) {
     }),
     buildLearningUpdateProposedPayload({
       attemptId,
-      authorityPosture,
+      authorityPosture: runtimeAuthorityPosture,
       markRunId,
     }),
   ];
@@ -494,7 +498,12 @@ async function writeBridgeWarning(client, {
 
 export async function persistAttemptEventBridge(client, input = {}) {
   const attemptId = assertImmutableAttemptId(input);
-  const authorityPosture = normalizeAuthorityPosture(input.authorityPosture);
+  const authorityPosture = buildRuntimeAuthorityPosture(
+    normalizeAuthorityPosture(input.authorityPosture),
+    {
+      questionContext: cloneJson(input.questionContext ?? {}) ?? {},
+    },
+  );
   const attemptContext = cloneJson(input.attemptContext ?? {}) ?? {};
   const markRunId = normalizeString(input.markRunId) || null;
 

--- a/api/learning/lib/mastery/mastery-orchestrator.js
+++ b/api/learning/lib/mastery/mastery-orchestrator.js
@@ -1,4 +1,8 @@
 import { buildAttemptRef, buildMarkRunRef } from '../contracts/runtime-contract.js';
+import {
+  buildRuntimeAuthorityPosture,
+  isNonAuthoritativeRuntimeInput,
+} from '../contracts/runtime-authority-posture.js';
 import { createReviewTaskService } from '../review/review-task-service.js';
 import { createDefaultReviewTaskService } from '../review/review-task-service.js';
 import { shouldGenerateReviewTaskFromOutcome } from '../review/review-task-service.js';
@@ -75,7 +79,7 @@ function resolveLearningEffectsPosture({
   questionContext,
   adapter,
 } = {}) {
-  return input.release_scope_posture || adapter.marking.resolveReleasedScoringPosture({
+  const basePosture = input.release_scope_posture || adapter.marking.resolveReleasedScoringPosture({
     questionTypeId: questionContext.question_type_id,
     questionTypeReleaseState:
       questionContext.question_type_release_state
@@ -84,6 +88,10 @@ function resolveLearningEffectsPosture({
     candidateRubricRefs: questionContext.candidate_rubric_refs,
     classificationConfidence: questionContext.classification_confidence,
     uncertaintyValidated: input.uncertainty_validated ?? false,
+  });
+
+  return buildRuntimeAuthorityPosture(basePosture, {
+    questionContext,
   });
 }
 
@@ -102,6 +110,11 @@ export function createMasteryOrchestrator({
         input,
         questionContext,
         adapter,
+      });
+      const nonAuthoritativeRuntimeInput = isNonAuthoritativeRuntimeInput({
+        ...input,
+        release_scope_posture: releaseScopePosture,
+        question_context: questionContext,
       });
       const sourceAttemptRef = input.source_attempt_ref
         || (input.attempt_id ? buildAttemptRef(input.attempt_id) : null);
@@ -127,6 +140,9 @@ export function createMasteryOrchestrator({
         repair_target_question_type_id:
           input.repair_target_question_type_id || questionContext.question_type_id || null,
         source_attempt_ref: sourceAttemptRef,
+        runtime_authority_posture: releaseScopePosture.runtime_authority_posture,
+        runtime_authority_reason_code: releaseScopePosture.runtime_authority_reason_code,
+        question_source_kind: releaseScopePosture.question_source_kind,
       };
       const artifactInput = {
         artifact_kind: 'misconception_card',
@@ -143,6 +159,10 @@ export function createMasteryOrchestrator({
         source_attempt_ref: sourceAttemptRef,
         source_mark_run_ref: sourceMarkRunRef,
         source_session_id: input.source_session_id ?? null,
+        runtime_authority_posture: releaseScopePosture.runtime_authority_posture,
+        runtime_authority_reason_code: releaseScopePosture.runtime_authority_reason_code,
+        question_source_kind: releaseScopePosture.question_source_kind,
+        blocked_materializers: releaseScopePosture.blocked_materializers,
       };
       const masteryProjection = adapter.mastery.buildMasteryProjection({
         input,
@@ -150,10 +170,11 @@ export function createMasteryOrchestrator({
         releaseScopePosture,
       });
       const localSignals = masteryProjection.localSignals;
-      const masteryUpdates = masteryProjection.masteryUpdates;
+      const masteryUpdates = nonAuthoritativeRuntimeInput ? [] : masteryProjection.masteryUpdates;
       const reviewCapabilityPosture = adapter.meta.capability_posture?.review
         ?? SUBJECT_ADAPTER_CAPABILITY_POSTURES.SUPPORTED;
       const reviewTasks = reviewCapabilityPosture !== SUBJECT_ADAPTER_CAPABILITY_POSTURES.SUPPORTED
+        || nonAuthoritativeRuntimeInput
         || !shouldGenerateReviewTaskFromOutcome(reviewTaskInput)
         ? []
         : await reviewTaskService.generateTasksFromOutcome(reviewTaskInput);

--- a/api/learning/lib/review/review-task-service.js
+++ b/api/learning/lib/review/review-task-service.js
@@ -1,5 +1,6 @@
 import { createReviewTaskRepository } from '../repositories/review-task-repository.js';
 import { LEARNING_ERROR_CODES } from '../contracts/error-contract.js';
+import { isNonAuthoritativeRuntimeInput } from '../contracts/runtime-authority-posture.js';
 import { LearningHttpError } from '../http/learning-http.js';
 import {
   buildReviewTaskExplainabilitySeed,
@@ -328,6 +329,10 @@ function hasRepairSignal(input = {}) {
 
 export function shouldGenerateReviewTaskFromOutcome(input = {}) {
   if (!input.repair_target_topic_id) {
+    return false;
+  }
+
+  if (isNonAuthoritativeRuntimeInput(input)) {
     return false;
   }
 

--- a/api/marking/__tests__/evaluate-v1.test.js
+++ b/api/marking/__tests__/evaluate-v1.test.js
@@ -30,6 +30,29 @@ const MOCK_READY_POINT = {
   updated_at: '2026-02-15T10:00:00Z',
 };
 
+function buildLearningQuestionProjectionRow(overrides = {}) {
+  return {
+    question_id: 'q-001',
+    source_kind: 'paper_question',
+    primary_topic_id: 'topic-trig-equations',
+    family_id: '9709.trigonometry_manipulation_equations',
+    primary_question_type_id: '9709.trigonometry.equations',
+    primary_question_type_release_state: 'released',
+    classification_confidence: 0.93,
+    candidate_rubric_refs: [
+      {
+        kind: 'rubric_release',
+        rubric_version_id: 'trig-v1',
+        release_state: 'released',
+      },
+    ],
+    release_scope_status: 'released_scoring',
+    ...overrides,
+  };
+}
+
+let learningQuestionProjectionRow = buildLearningQuestionProjectionRow();
+
 function createChainMock(data) {
   const chain = {};
   const methods = ['select', 'eq', 'or', 'order', 'limit'];
@@ -52,22 +75,7 @@ const mockFrom = jest.fn((table) => {
     return createChainMock([MOCK_READY_POINT]);
   }
   if (table === 'learning_question_registry_projection') {
-    return createChainMock({
-      question_id: 'q-001',
-      primary_topic_id: 'topic-trig-equations',
-      family_id: '9709.trigonometry_manipulation_equations',
-      primary_question_type_id: '9709.trigonometry.equations',
-      primary_question_type_release_state: 'released',
-      classification_confidence: 0.93,
-      candidate_rubric_refs: [
-        {
-          kind: 'rubric_release',
-          rubric_version_id: 'trig-v1',
-          release_state: 'released',
-        },
-      ],
-      release_scope_status: 'released_scoring',
-    });
+    return createChainMock(learningQuestionProjectionRow);
   }
   return createChainMock([]);
 });
@@ -182,6 +190,7 @@ beforeEach(() => {
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
   process.env.EVIDENCE_LEDGER_ENABLED = 'false';
   process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'false';
+  learningQuestionProjectionRow = buildLearningQuestionProjectionRow();
   jest.clearAllMocks();
   mockApplyLearningEffects.mockResolvedValue({
     release_scope_status: 'released_scoring',
@@ -554,6 +563,77 @@ describe('learning-runtime orchestration', () => {
         }),
       }),
     );
+  });
+
+  it('marks imported-question attempts as explicit non-authoritative runtime inputs across ledger, bridge, and learning effects', async () => {
+    process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'true';
+    learningQuestionProjectionRow = buildLearningQuestionProjectionRow({
+      source_kind: 'imported_question',
+      primary_topic_id: 'topic-trig-identities',
+      family_id: '9709.trigonometry_manipulation_equations',
+      primary_question_type_id: '9709.trigonometry.identities',
+    });
+    mockApplyLearningEffects.mockResolvedValueOnce({
+      release_scope_status: 'released_scoring',
+      authoritative_scoring_allowed: false,
+      learning_signal_posture: 'conservative_fallback',
+      runtime_authority_posture: 'non_authoritative',
+      runtime_authority_reason_code: 'imported_question_attempt',
+      mastery_updates: [],
+      review_tasks: [],
+      artifact_candidates: [],
+      reconciliation: null,
+    });
+
+    const req = mockReq();
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(mockWriteLedger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        response_summary: expect.objectContaining({
+          authority_posture: expect.objectContaining({
+            authoritative_scoring_allowed: false,
+            runtime_authority_posture: 'non_authoritative',
+            runtime_authority_reason_code: 'imported_question_attempt',
+            question_source_kind: 'imported_question',
+          }),
+        }),
+      }),
+    );
+    expect(mockPersistAttemptEventBridge).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        authorityPosture: expect.objectContaining({
+          authoritative_scoring_allowed: false,
+          runtime_authority_posture: 'non_authoritative',
+          runtime_authority_reason_code: 'imported_question_attempt',
+          question_source_kind: 'imported_question',
+        }),
+      }),
+    );
+    expect(mockApplyLearningEffects).toHaveBeenCalledWith(
+      expect.objectContaining({
+        question_context: expect.objectContaining({
+          source_kind: 'imported_question',
+        }),
+        release_scope_posture: expect.objectContaining({
+          authoritative_scoring_allowed: false,
+          runtime_authority_posture: 'non_authoritative',
+          runtime_authority_reason_code: 'imported_question_attempt',
+          question_source_kind: 'imported_question',
+        }),
+      }),
+      expect.any(Object),
+    );
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.learning_effects).toMatchObject({
+      authoritative_scoring_allowed: false,
+      runtime_authority_posture: 'non_authoritative',
+      runtime_authority_reason_code: 'imported_question_attempt',
+    });
   });
 
   it('returns 200 when the attempt-event bridge fails after scoring + ledger succeed', async () => {

--- a/api/marking/evaluate-v1.js
+++ b/api/marking/evaluate-v1.js
@@ -12,6 +12,7 @@ import { resolveQuestionId, ValidationError } from './lib/attempt-repository.js'
 import { writeLedger } from './lib/ledger-orchestrator.js';
 import { buildMarkingResult } from './lib/marking-result-contract.js';
 import { resolveReleasedScoringPosture } from '../learning/lib/contracts/released-scope.js';
+import { buildRuntimeAuthorityPosture } from '../learning/lib/contracts/runtime-authority-posture.js';
 import { persistAttemptEventBridge } from '../learning/lib/events/attempt-event-service.js';
 import { applyLearningEffects } from '../learning/lib/mastery/mastery-orchestrator.js';
 
@@ -131,7 +132,7 @@ async function loadLearningQuestionContext(supabase, questionId) {
   const { data, error } = await supabase
     .from('learning_question_registry_projection')
     .select(
-      'question_id, primary_topic_id, family_id, primary_question_type_id, primary_question_type_release_state, classification_confidence, candidate_rubric_refs, release_scope_status',
+      'question_id, source_kind, primary_topic_id, family_id, primary_question_type_id, primary_question_type_release_state, classification_confidence, candidate_rubric_refs, release_scope_status',
     )
     .eq('question_id', questionId)
     .maybeSingle();
@@ -143,6 +144,7 @@ async function loadLearningQuestionContext(supabase, questionId) {
   return data
     ? {
       question_id: data.question_id,
+      source_kind: data.source_kind ?? null,
       primary_topic_id: data.primary_topic_id ?? null,
       family_id: data.family_id ?? null,
       question_type_id: data.primary_question_type_id ?? null,
@@ -155,6 +157,7 @@ async function loadLearningQuestionContext(supabase, questionId) {
     }
     : {
       question_id: questionId,
+      source_kind: null,
       primary_topic_id: null,
       family_id: null,
       question_type_id: null,
@@ -168,6 +171,7 @@ async function loadLearningQuestionContext(supabase, questionId) {
 function getEmptyLearningQuestionContext(questionId) {
   return {
     question_id: questionId,
+    source_kind: null,
     primary_topic_id: null,
     family_id: null,
     question_type_id: null,
@@ -328,6 +332,18 @@ export default async function handler(req, res) {
     let markingResult = null;
     const requestScopedPartId = part_id;
     const requestScopedSubpartId = subpart_id ?? subpart ?? null;
+    const runtimeAuthorityPosture = buildRuntimeAuthorityPosture(
+      resolveReleasedScoringPosture({
+        questionTypeId: questionContext.question_type_id,
+        questionTypeReleaseState: questionContext.question_type_release_state,
+        candidateRubricRefs: questionContext.candidate_rubric_refs,
+        classificationConfidence: questionContext.classification_confidence,
+        uncertaintyValidated: true,
+      }),
+      {
+        questionContext,
+      },
+    );
 
     try {
       const baseMarkingResult = buildMarkingResult({
@@ -362,6 +378,7 @@ export default async function handler(req, res) {
           decisions,
           rubric_rows_used,
           marking_result: baseMarkingResult,
+          authority_posture: runtimeAuthorityPosture,
         },
       });
 
@@ -389,14 +406,6 @@ export default async function handler(req, res) {
       }));
 
       if (ledgerResult.decision_write_status === 'success') {
-        const releaseScopePosture = resolveReleasedScoringPosture({
-          questionTypeId: questionContext.question_type_id,
-          questionTypeReleaseState: questionContext.question_type_release_state,
-          candidateRubricRefs: questionContext.candidate_rubric_refs,
-          classificationConfidence: questionContext.classification_confidence,
-          uncertaintyValidated: true,
-        });
-
         if (isRuntimeBridgeEnabled()) {
           try {
             const bridgeResult = await persistAttemptEventBridge(supabase, {
@@ -415,7 +424,7 @@ export default async function handler(req, res) {
                 primary_topic_path: ledgerResult.attempt_context?.topic_path ?? null,
               },
               attemptContext: ledgerResult.attempt_context ?? null,
-              authorityPosture: releaseScopePosture,
+              authorityPosture: runtimeAuthorityPosture,
               markingResult: markingResult,
               sourceAttemptRef: {
                 kind: 'attempt',
@@ -460,6 +469,7 @@ export default async function handler(req, res) {
             subject_code: subjectCode,
             question_id,
             question_context: {
+              source_kind: questionContext.source_kind,
               family_id: questionContext.family_id,
               question_type_id: questionContext.question_type_id,
               question_type_release_state: questionContext.question_type_release_state,
@@ -484,7 +494,7 @@ export default async function handler(req, res) {
             decisions,
             marking_result: markingResult,
             uncertainty_validated: true,
-            release_scope_posture: releaseScopePosture,
+            release_scope_posture: runtimeAuthorityPosture,
           }, {
             supabase,
           });

--- a/docs/reports/2026-04-17-issue-213-closeout.md
+++ b/docs/reports/2026-04-17-issue-213-closeout.md
@@ -2,7 +2,7 @@
 
 ## Scope Shipped
 
-- restacked `feat/213` onto `feat/211` so the posture work builds on the runtime bridge foundation instead of `main`
+- restacked `feat/213` onto current `main` after the runtime bridge foundation landed there
 - introduced a shared runtime-authority posture contract for imported-question attempts
 - forced imported attempts into explicit `non_authoritative` posture before ledger/event/materialization handoff
 - kept imported attempts durable in the mark ledger and attempt-scoped event stream
@@ -57,7 +57,7 @@ Outcome:
 
 - Passed.
 - Test suites: `5 passed, 5 total`
-- Tests: `53 passed, 53 total`
+- Tests: `74 passed, 74 total`
 
 ### Diff hygiene
 
@@ -73,5 +73,5 @@ Outcome:
 
 ## Notes / Risks
 
-- The AO-referenced decision file `docs/reports/2026-04-16-ao-execution-decision-alignment.md` is still absent on this branch, so implementation aligned to the issue body, frozen runtime docs present in-tree, and the AO continuation note that required restacking onto `feat/211`.
+- The AO-referenced decision file `docs/reports/2026-04-16-ao-execution-decision-alignment.md` is still absent on this branch, so implementation aligned to the issue body, frozen runtime docs present in-tree, and the AO continuation note that required restacking onto current `main`.
 - Two pre-existing review-task fixtures were below the frozen `0.8` released-scoring confidence threshold while still expecting released-scoring behavior. Their fixture confidence was corrected to keep the focused verification set aligned to the current contract.

--- a/docs/reports/2026-04-17-issue-213-closeout.md
+++ b/docs/reports/2026-04-17-issue-213-closeout.md
@@ -1,0 +1,77 @@
+# Issue 213 Closeout
+
+## Scope Shipped
+
+- restacked `feat/213` onto `feat/211` so the posture work builds on the runtime bridge foundation instead of `main`
+- introduced a shared runtime-authority posture contract for imported-question attempts
+- forced imported attempts into explicit `non_authoritative` posture before ledger/event/materialization handoff
+- kept imported attempts durable in the mark ledger and attempt-scoped event stream
+- blocked non-authoritative imported attempts from durable mastery mutation, default review-queue writes, and stable-slot residency writes
+- preserved session-local feedback, artifact candidate generation, and audit/reconciliation visibility
+
+## Runtime Authority Posture Matrix
+
+| Surface / write path | Standard released attempt | Imported-question attempt |
+| --- | --- | --- |
+| Mark ledger `mark_runs.response_summary.authority_posture` | allowed, `default_durable` | allowed, `non_authoritative` |
+| Attempt event stream (`AttemptSubmitted` -> `LearningUpdateProposed`) | allowed | allowed |
+| Event/provenance posture payload | authoritative or fallback posture | explicit `runtime_authority_posture = non_authoritative` |
+| Type/family mastery updates | allowed per released-scope contract | blocked |
+| Default durable review-task writes | allowed per review contract | blocked |
+| Artifact candidate generation | allowed | allowed |
+| Stable-slot residency / pin writes | allowed per artifact rules | blocked |
+| Reconciliation / audit visibility | allowed | allowed |
+
+## Files Changed
+
+- `api/learning/lib/contracts/runtime-authority-posture.js`
+- `api/marking/evaluate-v1.js`
+- `api/learning/lib/events/attempt-event-service.js`
+- `api/learning/lib/mastery/mastery-orchestrator.js`
+- `api/learning/lib/review/review-task-service.js`
+- `api/learning/lib/artifacts/artifact-service.js`
+- `api/marking/__tests__/evaluate-v1.test.js`
+- `api/learning/__tests__/attempt-event-service.test.js`
+- `api/learning/__tests__/review-task-service.test.js`
+- `api/learning/__tests__/artifact-service.test.js`
+
+## Verification
+
+### Focused Jest suites
+
+Command:
+
+```bash
+NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules \
+node --experimental-vm-modules \
+  /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js \
+  --runInBand \
+  api/learning/__tests__/mastery-orchestrator.test.js \
+  api/learning/__tests__/attempt-event-service.test.js \
+  api/learning/__tests__/review-task-service.test.js \
+  api/learning/__tests__/artifact-service.test.js \
+  api/marking/__tests__/evaluate-v1.test.js
+```
+
+Outcome:
+
+- Passed.
+- Test suites: `5 passed, 5 total`
+- Tests: `53 passed, 53 total`
+
+### Diff hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Outcome:
+
+- Passed with no diff hygiene errors.
+
+## Notes / Risks
+
+- The AO-referenced decision file `docs/reports/2026-04-16-ao-execution-decision-alignment.md` is still absent on this branch, so implementation aligned to the issue body, frozen runtime docs present in-tree, and the AO continuation note that required restacking onto `feat/211`.
+- Two pre-existing review-task fixtures were below the frozen `0.8` released-scoring confidence threshold while still expecting released-scoring behavior. Their fixture confidence was corrected to keep the focused verification set aligned to the current contract.


### PR DESCRIPTION
## Summary
- add a shared runtime-authority posture contract that marks imported-question attempts as `non_authoritative`
- persist that posture through `evaluate-v1`, the attempt-event bridge, and mark-run ledger summaries
- block non-authoritative imported attempts from durable mastery writes, default review-task writes, and stable-slot pinning while preserving local feedback, artifact candidates, and reconciliation visibility

## Verification
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/mastery-orchestrator.test.js api/learning/__tests__/attempt-event-service.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-service.test.js api/marking/__tests__/evaluate-v1.test.js`
- `git diff --check`

## Notes
- Stacked on `feat/211`
- Closeout report: `docs/reports/2026-04-17-issue-213-closeout.md`
- Closes #213