### PR TITLE
feat: add attempt bridge delivery reliability

### DIFF
--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -476,4 +476,69 @@ describe('attempt-event-service', () => {
       reconciliation_id: 'recon-auto-1',
     });
   });
+
+  test('retrying a prior pipeline-state failure can recover without re-inserting already-persisted bridge events', async () => {
+    const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
+    const { client, records } = createMockClient({
+      existingStreamHead: {
+        truth_revision: 1,
+        sequence_no: 4,
+      },
+      existingDeliveryRow: {
+        delivery_id: 'delivery-retry-1',
+        stable_idempotency_key: 'attempt_event_bridge:mr-bridge-1',
+        attempt_id: 'att-bridge-1',
+        learner_id: 'user-bridge-1',
+        subject_code: '9709',
+        mark_run_id: 'mr-bridge-1',
+        truth_revision: 1,
+        delivery_state: 'retrying',
+        retry_count: 1,
+        last_attempted_at: '2026-04-16T15:01:00.000Z',
+        last_error: {
+          code: 'attempt_event_bridge_failed',
+          message: 'attempt_pipeline_state upsert failed',
+          failed_stage: 'attempt_pipeline_state_upsert',
+        },
+        persisted_event_types: [
+          'AttemptSubmitted',
+          'QuestionClassified',
+          'MarkingCompleted',
+          'LearningUpdateProposed',
+        ],
+        persisted_event_ids: [
+          'event-1',
+          'event-2',
+          'event-3',
+          'event-4',
+        ],
+        reconciliation_id: null,
+      },
+    });
+
+    const result = await persistAttemptEventBridge(client, buildBridgeInput());
+
+    expect(result).toMatchObject({
+      ok: true,
+      warningRecorded: false,
+      deduped: false,
+      pipeline_state: {
+        attempt_id: 'att-bridge-1',
+        current_truth_revision: 1,
+        last_sequence_no: 4,
+      },
+      delivery: {
+        delivery_state: 'persisted',
+        retry_count: 1,
+        last_error: null,
+      },
+    });
+    expect(records.learningEventsInsertCount).toBe(0);
+    expect(records.learningEvents).toBeNull();
+    expect(records.pipelineState).toMatchObject({
+      attempt_id: 'att-bridge-1',
+      current_truth_revision: 1,
+      last_sequence_no: 4,
+    });
+  });
 });

--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -1,13 +1,22 @@
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
 function createMockClient({
   learningEventsError = null,
   pipelineStateError = null,
   warningError = null,
   existingStreamHead = null,
+  existingDeliveryRow = null,
 } = {}) {
   const records = {
     learningEvents: null,
+    learningEventsInsertCount: 0,
     pipelineState: null,
     bridgeWarning: null,
+    deliveryRow: clone(existingDeliveryRow) ?? null,
+    deliveryInsertCount: 0,
+    deliveryUpdates: [],
   };
 
   return {
@@ -28,10 +37,65 @@ function createMockClient({
           return {
             ...query,
             insert: async (rows) => {
+              records.learningEventsInsertCount += 1;
               records.learningEvents = rows;
               return { error: learningEventsError };
             },
           };
+        }
+
+        if (table === 'learning_event_deliveries') {
+          const filters = [];
+          const query = {
+            select: () => query,
+            eq: (field, value) => {
+              filters.push({ field, value });
+              return query;
+            },
+            maybeSingle: async () => {
+              const stableIdempotencyKey =
+                filters.find((filter) => filter.field === 'stable_idempotency_key')?.value ?? null;
+
+              if (
+                stableIdempotencyKey
+                && records.deliveryRow?.stable_idempotency_key === stableIdempotencyKey
+              ) {
+                return {
+                  data: clone(records.deliveryRow),
+                  error: null,
+                };
+              }
+
+              return {
+                data: null,
+                error: null,
+              };
+            },
+            single: async () => ({
+              data: records.deliveryRow ? clone(records.deliveryRow) : null,
+              error: null,
+            }),
+            insert: (row) => {
+              records.deliveryInsertCount += 1;
+              records.deliveryRow = {
+                delivery_id: row.delivery_id ?? 'delivery-1',
+                created_at: row.created_at ?? '2026-04-17T00:00:00.000Z',
+                updated_at: row.updated_at ?? '2026-04-17T00:00:00.000Z',
+                ...clone(row),
+              };
+              return query;
+            },
+            update: (payload) => {
+              records.deliveryUpdates.push(clone(payload));
+              records.deliveryRow = {
+                ...records.deliveryRow,
+                ...clone(payload),
+              };
+              return query;
+            },
+          };
+
+          return query;
         }
 
         if (table === 'attempt_pipeline_state') {
@@ -132,7 +196,7 @@ function buildBridgeInput(overrides = {}) {
 }
 
 describe('attempt-event-service', () => {
-  test('persists ordered attempt events through LearningUpdateProposed and upserts pipeline state', async () => {
+  test('persists ordered attempt events through LearningUpdateProposed, upserts pipeline state, and finalizes a persisted delivery row', async () => {
     const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
     const { client, records } = createMockClient();
 
@@ -141,6 +205,7 @@ describe('attempt-event-service', () => {
     expect(result).toMatchObject({
       ok: true,
       warningRecorded: false,
+      deduped: false,
       persisted_event_types: [
         'AttemptSubmitted',
         'QuestionClassified',
@@ -152,6 +217,13 @@ describe('attempt-event-service', () => {
         current_stage: 'LearningUpdateProposed',
         current_status: 'running',
         last_sequence_no: 4,
+      },
+      delivery: {
+        delivery_state: 'persisted',
+        retry_count: 0,
+        last_attempted_at: expect.any(String),
+        last_error: null,
+        stable_idempotency_key: expect.any(String),
       },
     });
 
@@ -185,10 +257,42 @@ describe('attempt-event-service', () => {
       current_status: 'running',
       last_sequence_no: 4,
     });
+    expect(records.deliveryRow).toMatchObject({
+      delivery_state: 'persisted',
+      retry_count: 0,
+      last_attempted_at: expect.any(String),
+      last_error: null,
+      stable_idempotency_key: expect.any(String),
+    });
     expect(records.bridgeWarning).toBeNull();
   });
 
-  test('records a durable bridge warning/debt row when persistence fails', async () => {
+  test('reuses the same bridge delivery row and does not append duplicate events on repeated delivery', async () => {
+    const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
+    const { client, records } = createMockClient();
+
+    const first = await persistAttemptEventBridge(client, buildBridgeInput());
+    const firstLearningEvents = records.learningEvents;
+
+    const second = await persistAttemptEventBridge(client, buildBridgeInput());
+
+    expect(first.delivery.stable_idempotency_key).toBe(second.delivery.stable_idempotency_key);
+    expect(second).toMatchObject({
+      ok: true,
+      warningRecorded: false,
+      deduped: true,
+      delivery: {
+        delivery_state: 'persisted',
+        retry_count: 0,
+        last_error: null,
+      },
+    });
+    expect(records.deliveryInsertCount).toBe(1);
+    expect(records.learningEventsInsertCount).toBe(1);
+    expect(records.learningEvents).toBe(firstLearningEvents);
+  });
+
+  test('records a durable bridge warning/debt row and retry metadata when persistence fails', async () => {
     const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
     const { client, records } = createMockClient({
       learningEventsError: { message: 'learning_events insert failed' },
@@ -201,8 +305,26 @@ describe('attempt-event-service', () => {
       warningRecorded: true,
       reason_code: 'attempt_event_bridge_failed',
       failed_stage: 'learning_events_insert',
+      delivery: {
+        delivery_state: 'retrying',
+        retry_count: 1,
+        last_attempted_at: expect.any(String),
+        last_error: {
+          code: 'attempt_event_bridge_failed',
+          message: 'learning_events insert failed',
+        },
+      },
     });
     expect(records.pipelineState).toBeNull();
+    expect(records.deliveryRow).toMatchObject({
+      delivery_state: 'retrying',
+      retry_count: 1,
+      last_attempted_at: expect.any(String),
+      last_error: {
+        code: 'attempt_event_bridge_failed',
+        message: 'learning_events insert failed',
+      },
+    });
     expect(records.bridgeWarning).toHaveLength(1);
     expect(records.bridgeWarning[0]).toMatchObject({
       attempt_id: 'att-bridge-1',
@@ -248,6 +370,7 @@ describe('attempt-event-service', () => {
     expect(result).toMatchObject({
       ok: true,
       warningRecorded: false,
+      deduped: false,
       pipeline_state: {
         attempt_id: 'att-bridge-1',
         current_truth_revision: 2,
@@ -319,6 +442,38 @@ describe('attempt-event-service', () => {
         runtime_authority_reason_code: 'imported_question_attempt',
         question_source_kind: 'imported_question',
       });
+    });
+  });
+
+  test('reconciliation can move failed bridge delivery rows into terminal outcomes', async () => {
+    const {
+      persistAttemptEventBridge,
+      reconcileAttemptEventBridgeDelivery,
+    } = await import('../lib/events/attempt-event-service.js');
+    const { client } = createMockClient({
+      learningEventsError: { message: 'learning_events insert failed' },
+    });
+
+    const failed = await persistAttemptEventBridge(client, buildBridgeInput());
+
+    const manualReview = await reconcileAttemptEventBridgeDelivery(client, {
+      stableIdempotencyKey: failed.delivery.stable_idempotency_key,
+      deliveryState: 'needs_manual_review',
+      reconciliationId: 'recon-manual-1',
+    });
+    expect(manualReview).toMatchObject({
+      delivery_state: 'needs_manual_review',
+      reconciliation_id: 'recon-manual-1',
+    });
+
+    const reconciled = await reconcileAttemptEventBridgeDelivery(client, {
+      stableIdempotencyKey: failed.delivery.stable_idempotency_key,
+      deliveryState: 'reconciled',
+      reconciliationId: 'recon-auto-1',
+    });
+    expect(reconciled).toMatchObject({
+      delivery_state: 'reconciled',
+      reconciliation_id: 'recon-auto-1',
     });
   });
 });

--- a/api/learning/__tests__/event-service.test.js
+++ b/api/learning/__tests__/event-service.test.js
@@ -396,4 +396,83 @@ describe('learning event service', () => {
       reconciliation_id: 'recon-auto-1',
     });
   });
+
+  test('duplicate replay preserves terminal reconciliation delivery states', async () => {
+    const {
+      appendLearningEvent,
+      buildSyntheticAttemptEventFlow,
+      createEmptyLearningEventStore,
+      reconcileLearningEventDelivery,
+      runLearningEventDelivery,
+    } = await import('../lib/events/event-service.js');
+
+    const store = createEmptyLearningEventStore();
+    const flow = buildSyntheticAttemptEventFlow({
+      attemptId: 'attempt-terminal-replay',
+      learnerId: 'learner-1',
+      sessionId: 'session-1',
+      subjectCode: '9709',
+      emittedBy: 'jest',
+    });
+
+    flow.forEach((event) => appendLearningEvent(store, event));
+    const targetEvent = flow.at(-1);
+    const execute = jest.fn(async () => ({
+      status: 'succeeded',
+      resultRefType: 'artifact_suggestion_version',
+      resultRefId: 'artifact-suggestion-1',
+    }));
+
+    const first = await runLearningEventDelivery(store, {
+      eventId: targetEvent.event_id,
+      handlerName: 'project:artifact-suggestions',
+      effectKey: 'artifact-slot:review_queue:terminal-replay',
+      aggregateId: targetEvent.aggregate_id,
+      truthRevision: targetEvent.truth_revision,
+      execute,
+    });
+
+    const reconciled = reconcileLearningEventDelivery(store, {
+      stableIdempotencyKey: first.delivery.stable_idempotency_key,
+      deliveryState: 'reconciled',
+      reconciliationId: 'recon-keep-1',
+    });
+    const replayAfterReconciled = await runLearningEventDelivery(store, {
+      eventId: targetEvent.event_id,
+      handlerName: 'project:artifact-suggestions',
+      effectKey: 'artifact-slot:review_queue:terminal-replay',
+      aggregateId: targetEvent.aggregate_id,
+      truthRevision: targetEvent.truth_revision,
+      execute,
+    });
+
+    expect(reconciled.delivery_state).toBe('reconciled');
+    expect(replayAfterReconciled.reason_code).toBe('duplicate_effect_key');
+    expect(replayAfterReconciled.delivery).toMatchObject({
+      delivery_state: 'reconciled',
+      reconciliation_id: 'recon-keep-1',
+    });
+
+    const manualReview = reconcileLearningEventDelivery(store, {
+      stableIdempotencyKey: first.delivery.stable_idempotency_key,
+      deliveryState: 'needs_manual_review',
+      reconciliationId: 'recon-keep-2',
+    });
+    const replayAfterManualReview = await runLearningEventDelivery(store, {
+      eventId: targetEvent.event_id,
+      handlerName: 'project:artifact-suggestions',
+      effectKey: 'artifact-slot:review_queue:terminal-replay',
+      aggregateId: targetEvent.aggregate_id,
+      truthRevision: targetEvent.truth_revision,
+      execute,
+    });
+
+    expect(manualReview.delivery_state).toBe('needs_manual_review');
+    expect(replayAfterManualReview.reason_code).toBe('duplicate_effect_key');
+    expect(replayAfterManualReview.delivery).toMatchObject({
+      delivery_state: 'needs_manual_review',
+      reconciliation_id: 'recon-keep-2',
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
 });

--- a/api/learning/__tests__/event-service.test.js
+++ b/api/learning/__tests__/event-service.test.js
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 describe('learning event service', () => {
   test('synthetic pipeline preserves strict phase ordering and completes attempt state', async () => {
     const {
@@ -222,5 +224,176 @@ describe('learning event service', () => {
       aggregateId: 'attempt-missing-event',
       truthRevision: 1,
     })).toThrow('unknown_effect_event_id');
+  });
+
+  test('delivery reservation reuses one stable idempotency key and exposes the pending row contract', async () => {
+    const {
+      appendLearningEvent,
+      buildSyntheticAttemptEventFlow,
+      createEmptyLearningEventStore,
+      reserveLearningEventDelivery,
+    } = await import('../lib/events/event-service.js');
+
+    const store = createEmptyLearningEventStore();
+    const [attemptSubmitted] = buildSyntheticAttemptEventFlow({
+      attemptId: 'attempt-delivery-reserve',
+      learnerId: 'learner-1',
+      sessionId: 'session-1',
+      subjectCode: '9709',
+      emittedBy: 'jest',
+    });
+
+    appendLearningEvent(store, attemptSubmitted);
+
+    const input = {
+      eventId: attemptSubmitted.event_id,
+      handlerName: 'bridge:attempt-events',
+      effectKey: 'attempt-delivery:attempt-delivery-reserve:submitted',
+      aggregateId: attemptSubmitted.aggregate_id,
+      truthRevision: attemptSubmitted.truth_revision,
+    };
+
+    const first = reserveLearningEventDelivery(store, input);
+    const second = reserveLearningEventDelivery(store, input);
+
+    expect(first.delivery).toMatchObject({
+      delivery_state: 'pending',
+      retry_count: 0,
+      last_attempted_at: null,
+      last_error: null,
+    });
+    expect(second.delivery.delivery_id).toBe(first.delivery.delivery_id);
+    expect(second.delivery.stable_idempotency_key).toBe(first.delivery.stable_idempotency_key);
+    expect(store.deliveries).toHaveLength(1);
+  });
+
+  test('delivery execution dedupes downstream side effects across repeated attempts', async () => {
+    const {
+      appendLearningEvent,
+      buildSyntheticAttemptEventFlow,
+      createEmptyLearningEventStore,
+      runLearningEventDelivery,
+    } = await import('../lib/events/event-service.js');
+
+    const store = createEmptyLearningEventStore();
+    const flow = buildSyntheticAttemptEventFlow({
+      attemptId: 'attempt-delivery-dedupe',
+      learnerId: 'learner-1',
+      sessionId: 'session-1',
+      subjectCode: '9709',
+      emittedBy: 'jest',
+    });
+
+    flow.forEach((event) => appendLearningEvent(store, event));
+    const targetEvent = flow.at(-1);
+    const execute = jest.fn(async () => ({
+      status: 'succeeded',
+      resultRefType: 'artifact_suggestion_version',
+      resultRefId: 'artifact-suggestion-1',
+    }));
+
+    const first = await runLearningEventDelivery(store, {
+      eventId: targetEvent.event_id,
+      handlerName: 'project:artifact-suggestions',
+      effectKey: 'artifact-slot:review_queue:stable-output',
+      aggregateId: targetEvent.aggregate_id,
+      truthRevision: targetEvent.truth_revision,
+      execute,
+    });
+    const second = await runLearningEventDelivery(store, {
+      eventId: targetEvent.event_id,
+      handlerName: 'project:artifact-suggestions',
+      effectKey: 'artifact-slot:review_queue:stable-output',
+      aggregateId: targetEvent.aggregate_id,
+      truthRevision: targetEvent.truth_revision,
+      execute,
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(first.delivery).toMatchObject({
+      delivery_state: 'persisted',
+      retry_count: 0,
+      last_error: null,
+    });
+    expect(second.delivery.delivery_id).toBe(first.delivery.delivery_id);
+    expect(second.reason_code).toBe('duplicate_effect_key');
+    expect(store.effects).toHaveLength(1);
+  });
+
+  test('delivery failures record retry metadata and reconciliation can move rows into terminal outcomes', async () => {
+    const {
+      appendLearningEvent,
+      buildSyntheticAttemptEventFlow,
+      createEmptyLearningEventStore,
+      reconcileLearningEventDelivery,
+      runLearningEventDelivery,
+    } = await import('../lib/events/event-service.js');
+
+    const store = createEmptyLearningEventStore();
+    const flow = buildSyntheticAttemptEventFlow({
+      attemptId: 'attempt-delivery-reconcile',
+      learnerId: 'learner-1',
+      sessionId: 'session-1',
+      subjectCode: '9709',
+      emittedBy: 'jest',
+    });
+
+    flow.forEach((event) => appendLearningEvent(store, event));
+
+    const retrying = await runLearningEventDelivery(store, {
+      eventId: flow[3].event_id,
+      handlerName: 'bridge:learning-update',
+      effectKey: 'proposal:attempt-delivery-reconcile',
+      aggregateId: flow[3].aggregate_id,
+      truthRevision: flow[3].truth_revision,
+      execute: async () => {
+        throw new Error('temporary bridge failure');
+      },
+    });
+
+    expect(retrying.delivery).toMatchObject({
+      delivery_state: 'retrying',
+      retry_count: 1,
+      last_attempted_at: expect.any(String),
+      last_error: {
+        code: 'delivery_failed',
+        message: 'temporary bridge failure',
+      },
+    });
+
+    const manualReview = reconcileLearningEventDelivery(store, {
+      stableIdempotencyKey: retrying.delivery.stable_idempotency_key,
+      deliveryState: 'needs_manual_review',
+      reconciliationId: 'recon-manual-1',
+    });
+
+    expect(manualReview).toMatchObject({
+      delivery_state: 'needs_manual_review',
+      reconciliation_id: 'recon-manual-1',
+    });
+
+    const persisted = await runLearningEventDelivery(store, {
+      eventId: flow[4].event_id,
+      handlerName: 'bridge:mastery-update',
+      effectKey: 'mastery:attempt-delivery-reconcile',
+      aggregateId: flow[4].aggregate_id,
+      truthRevision: flow[4].truth_revision,
+      execute: async () => ({
+        status: 'succeeded',
+        resultRefType: 'mastery_update',
+        resultRefId: 'mastery-1',
+      }),
+    });
+
+    const reconciled = reconcileLearningEventDelivery(store, {
+      stableIdempotencyKey: persisted.delivery.stable_idempotency_key,
+      deliveryState: 'reconciled',
+      reconciliationId: 'recon-auto-1',
+    });
+
+    expect(reconciled).toMatchObject({
+      delivery_state: 'reconciled',
+      reconciliation_id: 'recon-auto-1',
+    });
   });
 });

--- a/api/learning/__tests__/schema-contract.test.js
+++ b/api/learning/__tests__/schema-contract.test.js
@@ -11,6 +11,7 @@ const LEARNING_RUNTIME_MIGRATIONS = [
   'supabase/migrations/20260320112000_create_learning_runtime_read_models.sql',
   'supabase/migrations/20260324110000_promote_learning_runtime_integration_application.sql',
   'supabase/migrations/20260412103000_expand_learning_question_analysis_snapshots_phase_a.sql',
+  'supabase/migrations/20260417110000_create_learning_event_deliveries.sql',
   'supabase/migrations/20260413110000_phase_a_question_classified_events.sql',
   LEARNING_QUESTION_SEARCH_MIGRATION
 ];
@@ -103,6 +104,7 @@ describe('learning runtime schema contract', () => {
     expect(sql).toContain('create table if not exists public.learning_family_masteries');
     expect(sql).toContain('create table if not exists public.learning_type_masteries');
     expect(sql).toContain('create table if not exists public.learning_reconciliation_runs');
+    expect(sql).toContain('create table if not exists public.learning_event_deliveries');
     expect(sql).toContain('unique (user_id, topic_id)');
     expect(sql).toContain('unique (workspace_id, slot_key)');
     expect(sql).toContain("check (mode in ('learn_concept', 'guided_solve', 'timed_practice', 'post_mortem_review', 'spaced_review'))");
@@ -231,6 +233,19 @@ describe('learning runtime schema contract', () => {
       'started_at',
       'completed_at'
     ].forEach((token) => expect(reconciliationSql).toContain(token));
+
+    const deliverySql = normalizeSql(extractTableBlock(sql, 'public.learning_event_deliveries'));
+    [
+      'stable_idempotency_key',
+      'attempt_id',
+      'mark_run_id',
+      'delivery_state',
+      'retry_count',
+      'last_attempted_at',
+      'last_error',
+      "delivery_state in ('pending', 'persisted', 'retrying', 'reconciled', 'needs_manual_review')",
+      'unique (stable_idempotency_key)'
+    ].forEach((token) => expect(deliverySql).toContain(token));
 
     const registryProjectionSql = normalizeSql(readMigration(
       'supabase/migrations/20260413110000_phase_a_question_classified_events.sql'

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -496,6 +496,127 @@ async function writeBridgeWarning(client, {
   return !error;
 }
 
+function buildAttemptEventBridgeDeliveryIdempotencyKey({
+  attemptId,
+  markRunId,
+} = {}) {
+  return `attempt_event_bridge:${normalizeString(markRunId) || normalizeString(attemptId)}`;
+}
+
+async function getAttemptEventBridgeDelivery(client, {
+  stableIdempotencyKey,
+} = {}) {
+  const normalizedKey = normalizeString(stableIdempotencyKey);
+  if (!normalizedKey) {
+    throw new Error('missing_stable_idempotency_key');
+  }
+
+  const { data, error } = await client
+    .from('learning_event_deliveries')
+    .select('*')
+    .eq('stable_idempotency_key', normalizedKey)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message || 'Failed to load learning_event_deliveries row.');
+  }
+
+  return data ?? null;
+}
+
+async function reserveAttemptEventBridgeDelivery(client, {
+  attemptId,
+  learnerId,
+  subjectCode,
+  markRunId,
+} = {}) {
+  const stableIdempotencyKey = buildAttemptEventBridgeDeliveryIdempotencyKey({
+    attemptId,
+    markRunId,
+  });
+  const existing = await getAttemptEventBridgeDelivery(client, {
+    stableIdempotencyKey,
+  });
+
+  if (existing) {
+    return {
+      state: 'replay',
+      row: existing,
+      stableIdempotencyKey,
+    };
+  }
+
+  const { data, error } = await client
+    .from('learning_event_deliveries')
+    .insert({
+      stable_idempotency_key: stableIdempotencyKey,
+      attempt_id: attemptId,
+      learner_id: learnerId,
+      subject_code: subjectCode,
+      mark_run_id: normalizeString(markRunId) || null,
+      delivery_state: 'pending',
+      retry_count: 0,
+      last_attempted_at: null,
+      last_error: null,
+      truth_revision: null,
+      persisted_event_types: [],
+      persisted_event_ids: [],
+      reconciliation_id: null,
+    })
+    .select('*')
+    .single();
+
+  if (error?.code === '23505') {
+    const replay = await getAttemptEventBridgeDelivery(client, {
+      stableIdempotencyKey,
+    });
+
+    if (replay) {
+      return {
+        state: 'replay',
+        row: replay,
+        stableIdempotencyKey,
+      };
+    }
+  }
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Failed to insert learning_event_deliveries row.');
+  }
+
+  return {
+    state: 'reserved',
+    row: data,
+    stableIdempotencyKey,
+  };
+}
+
+async function updateAttemptEventBridgeDelivery(client, {
+  stableIdempotencyKey,
+  patch,
+} = {}) {
+  const normalizedKey = normalizeString(stableIdempotencyKey);
+  if (!normalizedKey) {
+    throw new Error('missing_stable_idempotency_key');
+  }
+
+  const { data, error } = await client
+    .from('learning_event_deliveries')
+    .update({
+      ...cloneJson(patch),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('stable_idempotency_key', normalizedKey)
+    .select('*')
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Failed to update learning_event_deliveries row.');
+  }
+
+  return data;
+}
+
 export async function persistAttemptEventBridge(client, input = {}) {
   const attemptId = assertImmutableAttemptId(input);
   const authorityPosture = buildRuntimeAuthorityPosture(
@@ -506,8 +627,43 @@ export async function persistAttemptEventBridge(client, input = {}) {
   );
   const attemptContext = cloneJson(input.attemptContext ?? {}) ?? {};
   const markRunId = normalizeString(input.markRunId) || null;
+  const learnerId = normalizeString(input.learnerId);
+  const subjectCode = normalizeString(input.subjectCode);
+  let deliveryReservation = null;
 
   try {
+    deliveryReservation = await reserveAttemptEventBridgeDelivery(client, {
+      attemptId,
+      learnerId,
+      subjectCode,
+      markRunId,
+    });
+
+    if (deliveryReservation.state === 'replay') {
+      if (['persisted', 'reconciled'].includes(deliveryReservation.row.delivery_state)) {
+        return {
+          ok: true,
+          warningRecorded: false,
+          deduped: true,
+          persisted_event_types: normalizeArray(deliveryReservation.row.persisted_event_types),
+          pipeline_state: null,
+          delivery: deliveryReservation.row,
+        };
+      }
+
+      if (deliveryReservation.row.delivery_state === 'needs_manual_review') {
+        return {
+          ok: false,
+          warningRecorded: false,
+          deduped: true,
+          reason_code: 'attempt_event_bridge_needs_manual_review',
+          failed_stage: 'manual_review',
+          error_message: 'attempt-event delivery row already requires manual review',
+          delivery: deliveryReservation.row,
+        };
+      }
+    }
+
     const streamHead = await loadExistingStreamHead(client, attemptId);
     const events = buildBridgeEvents({
       ...input,
@@ -520,12 +676,26 @@ export async function persistAttemptEventBridge(client, input = {}) {
 
     await insertLearningEvents(client, events);
     await upsertAttemptPipelineState(client, pipelineState);
+    const finalizedDelivery = await updateAttemptEventBridgeDelivery(client, {
+      stableIdempotencyKey: deliveryReservation.stableIdempotencyKey,
+      patch: {
+        delivery_state: 'persisted',
+        retry_count: Number(deliveryReservation.row.retry_count ?? 0),
+        last_attempted_at: new Date().toISOString(),
+        last_error: null,
+        truth_revision: pipelineState.current_truth_revision ?? null,
+        persisted_event_types: events.map((event) => event.event_type),
+        persisted_event_ids: events.map((event) => event.event_id),
+      },
+    });
 
     return {
       ok: true,
       warningRecorded: false,
+      deduped: false,
       persisted_event_types: events.map((event) => event.event_type),
       pipeline_state: pipelineState,
+      delivery: finalizedDelivery,
     };
   } catch (error) {
     const errorMessage = error?.message || String(error);
@@ -542,6 +712,21 @@ export async function persistAttemptEventBridge(client, input = {}) {
       failedStage,
       errorMessage,
     });
+    const failedDelivery = deliveryReservation
+      ? await updateAttemptEventBridgeDelivery(client, {
+        stableIdempotencyKey: deliveryReservation.stableIdempotencyKey,
+        patch: {
+          delivery_state: 'retrying',
+          retry_count: Number(deliveryReservation.row.retry_count ?? 0) + 1,
+          last_attempted_at: new Date().toISOString(),
+          last_error: {
+            code: 'attempt_event_bridge_failed',
+            message: errorMessage,
+            failed_stage: failedStage,
+          },
+        },
+      })
+      : null;
 
     return {
       ok: false,
@@ -549,6 +734,26 @@ export async function persistAttemptEventBridge(client, input = {}) {
       reason_code: 'attempt_event_bridge_failed',
       failed_stage: failedStage,
       error_message: errorMessage,
+      delivery: failedDelivery,
     };
   }
+}
+
+export async function reconcileAttemptEventBridgeDelivery(client, {
+  stableIdempotencyKey,
+  deliveryState,
+  reconciliationId = null,
+} = {}) {
+  const normalizedState = normalizeString(deliveryState);
+  if (!['reconciled', 'needs_manual_review'].includes(normalizedState)) {
+    throw new Error('invalid_reconciliation_delivery_state');
+  }
+
+  return updateAttemptEventBridgeDelivery(client, {
+    stableIdempotencyKey,
+    patch: {
+      delivery_state: normalizedState,
+      reconciliation_id: normalizeString(reconciliationId) || null,
+    },
+  });
 }

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -343,6 +343,50 @@ function buildProjectionSeedState(attemptId, streamHead) {
   };
 }
 
+function getLastPersistedBridgeEventType(deliveryRow = {}) {
+  const persistedEventTypes = normalizeArray(deliveryRow.persisted_event_types)
+    .filter((eventType) => BRIDGE_EVENT_TYPES.includes(eventType));
+
+  return persistedEventTypes.at(-1) ?? null;
+}
+
+function canRecoverPipelineStateFromDelivery(deliveryRow = {}) {
+  return deliveryRow?.delivery_state === 'retrying'
+    && normalizeString(deliveryRow?.last_error?.failed_stage) === 'attempt_pipeline_state_upsert'
+    && Boolean(getLastPersistedBridgeEventType(deliveryRow))
+    && Number.isInteger(Number(deliveryRow?.truth_revision))
+    && Number(deliveryRow.truth_revision) >= 1;
+}
+
+function buildPipelineStateFromDeliveryRow(deliveryRow = {}) {
+  const currentStage = getLastPersistedBridgeEventType(deliveryRow);
+
+  if (!currentStage) {
+    throw new Error('missing_persisted_delivery_stage');
+  }
+
+  return {
+    attempt_id: deliveryRow.attempt_id,
+    learner_id: deliveryRow.learner_id,
+    session_id: null,
+    subject_code: deliveryRow.subject_code,
+    current_truth_revision: Number(deliveryRow.truth_revision),
+    last_sequence_no: normalizeArray(deliveryRow.persisted_event_types).length,
+    current_stage: currentStage,
+    current_status: currentStage === 'LearningUpdateProposed' ? 'running' : 'completed',
+    last_event_id: null,
+    active_classification_event_id: null,
+    active_marking_event_id: null,
+    active_learning_update_event_id: null,
+    active_mastery_event_id: null,
+    active_review_tasks_event_id: null,
+    active_artifact_suggestions_event_id: null,
+    last_error_code: null,
+    last_error_message: null,
+    updated_at: new Date().toISOString(),
+  };
+}
+
 function buildBridgeEvents(input = {}) {
   const attemptId = assertImmutableAttemptId(input);
   const learnerId = normalizeString(input.learnerId);
@@ -630,6 +674,7 @@ export async function persistAttemptEventBridge(client, input = {}) {
   const learnerId = normalizeString(input.learnerId);
   const subjectCode = normalizeString(input.subjectCode);
   let deliveryReservation = null;
+  let currentDeliveryRow = null;
 
   try {
     deliveryReservation = await reserveAttemptEventBridgeDelivery(client, {
@@ -638,6 +683,7 @@ export async function persistAttemptEventBridge(client, input = {}) {
       subjectCode,
       markRunId,
     });
+    currentDeliveryRow = deliveryReservation.row;
 
     if (deliveryReservation.state === 'replay') {
       if (['persisted', 'reconciled'].includes(deliveryReservation.row.delivery_state)) {
@@ -662,6 +708,29 @@ export async function persistAttemptEventBridge(client, input = {}) {
           delivery: deliveryReservation.row,
         };
       }
+
+      if (canRecoverPipelineStateFromDelivery(deliveryReservation.row)) {
+        const pipelineState = buildPipelineStateFromDeliveryRow(deliveryReservation.row);
+        await upsertAttemptPipelineState(client, pipelineState);
+        const finalizedDelivery = await updateAttemptEventBridgeDelivery(client, {
+          stableIdempotencyKey: deliveryReservation.stableIdempotencyKey,
+          patch: {
+            delivery_state: 'persisted',
+            retry_count: Number(deliveryReservation.row.retry_count ?? 0),
+            last_attempted_at: new Date().toISOString(),
+            last_error: null,
+          },
+        });
+
+        return {
+          ok: true,
+          warningRecorded: false,
+          deduped: false,
+          persisted_event_types: normalizeArray(deliveryReservation.row.persisted_event_types),
+          pipeline_state: pipelineState,
+          delivery: finalizedDelivery,
+        };
+      }
     }
 
     const streamHead = await loadExistingStreamHead(client, attemptId);
@@ -675,12 +744,20 @@ export async function persistAttemptEventBridge(client, input = {}) {
     );
 
     await insertLearningEvents(client, events);
+    currentDeliveryRow = await updateAttemptEventBridgeDelivery(client, {
+      stableIdempotencyKey: deliveryReservation.stableIdempotencyKey,
+      patch: {
+        truth_revision: events[0]?.truth_revision ?? null,
+        persisted_event_types: events.map((event) => event.event_type),
+        persisted_event_ids: events.map((event) => event.event_id),
+      },
+    });
     await upsertAttemptPipelineState(client, pipelineState);
     const finalizedDelivery = await updateAttemptEventBridgeDelivery(client, {
       stableIdempotencyKey: deliveryReservation.stableIdempotencyKey,
       patch: {
         delivery_state: 'persisted',
-        retry_count: Number(deliveryReservation.row.retry_count ?? 0),
+        retry_count: Number(currentDeliveryRow?.retry_count ?? deliveryReservation.row.retry_count ?? 0),
         last_attempted_at: new Date().toISOString(),
         last_error: null,
         truth_revision: pipelineState.current_truth_revision ?? null,
@@ -717,7 +794,7 @@ export async function persistAttemptEventBridge(client, input = {}) {
         stableIdempotencyKey: deliveryReservation.stableIdempotencyKey,
         patch: {
           delivery_state: 'retrying',
-          retry_count: Number(deliveryReservation.row.retry_count ?? 0) + 1,
+          retry_count: Number(currentDeliveryRow?.retry_count ?? deliveryReservation.row.retry_count ?? 0) + 1,
           last_attempted_at: new Date().toISOString(),
           last_error: {
             code: 'attempt_event_bridge_failed',

--- a/api/learning/lib/events/event-service.js
+++ b/api/learning/lib/events/event-service.js
@@ -36,6 +36,10 @@ function effectRef(handlerName, effectKey) {
   return `${handlerName}::${effectKey}`;
 }
 
+function deliveryRef(stableIdempotencyKey) {
+  return stableIdempotencyKey;
+}
+
 function getNowIso() {
   return new Date().toISOString();
 }
@@ -283,6 +287,37 @@ function cloneEffect(effect) {
   return cloneJson(effect);
 }
 
+function cloneDelivery(delivery) {
+  return cloneJson(delivery);
+}
+
+function buildLearningEventDeliveryIdempotencyKey({
+  event_id,
+  handler_name,
+  effect_key,
+} = {}) {
+  return `${event_id}::${handler_name}::${effect_key}`;
+}
+
+function getLearningEventDelivery(store, stableIdempotencyKey) {
+  return store.deliveryRefs.get(deliveryRef(stableIdempotencyKey)) ?? null;
+}
+
+function assertDeliveryState(value) {
+  const normalized = normalizeString(value);
+  if (![
+    'pending',
+    'persisted',
+    'retrying',
+    'reconciled',
+    'needs_manual_review',
+  ].includes(normalized)) {
+    throw new Error('invalid_delivery_state');
+  }
+
+  return normalized;
+}
+
 export function createEmptyLearningEventStore() {
   return {
     events: [],
@@ -292,6 +327,8 @@ export function createEmptyLearningEventStore() {
     streamRefs: new Set(),
     revisionStageRefs: new Set(),
     effectRefs: new Map(),
+    deliveries: [],
+    deliveryRefs: new Map(),
     attemptLockRefs: new Set(),
     pipelineStateByAttempt: new Map(),
   };
@@ -471,6 +508,26 @@ export function tryStartLearningEventEffect(store, input) {
   const existing = store.effectRefs.get(ref) ?? null;
 
   if (existing) {
+    if (existing.status === 'failed') {
+      existing.event_id = normalizedInput.event_id;
+      existing.aggregate_id = normalizedInput.aggregate_id;
+      existing.truth_revision = normalizedInput.truth_revision;
+      existing.reconciliation_id = normalizedInput.reconciliation_id;
+      existing.status = 'started';
+      existing.result_ref_type = null;
+      existing.result_ref_id = null;
+      existing.error_code = null;
+      existing.error_message = null;
+      existing.attempt_count += 1;
+      existing.last_updated_at = nowIso;
+
+      return {
+        inserted: true,
+        reason_code: 'retry_failed_effect',
+        effect: cloneEffect(existing),
+      };
+    }
+
     return {
       inserted: false,
       reason_code: 'duplicate_effect_key',
@@ -542,6 +599,156 @@ export function markLearningEventEffectStatus(store, {
   effect.last_updated_at = getNowIso();
 
   return cloneEffect(effect);
+}
+
+export function reserveLearningEventDelivery(store, input) {
+  const normalizedInput = assertEffectInput(input);
+
+  if (!store.eventsById.has(normalizedInput.event_id)) {
+    throw new Error('unknown_effect_event_id');
+  }
+
+  const stableIdempotencyKey = buildLearningEventDeliveryIdempotencyKey(normalizedInput);
+  const existing = getLearningEventDelivery(store, stableIdempotencyKey);
+  if (existing) {
+    return {
+      inserted: false,
+      reason_code: 'duplicate_delivery_key',
+      delivery: cloneDelivery(existing),
+    };
+  }
+
+  const nowIso = getNowIso();
+  const delivery = {
+    delivery_id: randomUUID(),
+    stable_idempotency_key: stableIdempotencyKey,
+    ...normalizedInput,
+    delivery_state: 'pending',
+    retry_count: 0,
+    last_attempted_at: null,
+    last_error: null,
+    reconciliation_id: null,
+    created_at: nowIso,
+    updated_at: nowIso,
+  };
+
+  store.deliveries.push(delivery);
+  store.deliveryRefs.set(deliveryRef(stableIdempotencyKey), delivery);
+
+  return {
+    inserted: true,
+    reason_code: null,
+    delivery: cloneDelivery(delivery),
+  };
+}
+
+function updateLearningEventDelivery(store, stableIdempotencyKey, mutate) {
+  const delivery = getLearningEventDelivery(store, stableIdempotencyKey);
+  if (!delivery) {
+    throw new Error('delivery_not_found');
+  }
+
+  mutate(delivery);
+  delivery.updated_at = getNowIso();
+  return cloneDelivery(delivery);
+}
+
+export async function runLearningEventDelivery(store, {
+  execute,
+  ...input
+} = {}) {
+  const reservation = reserveLearningEventDelivery(store, input);
+  const stableIdempotencyKey = reservation.delivery.stable_idempotency_key;
+  const attemptedAt = getNowIso();
+
+  const effectStart = tryStartLearningEventEffect(store, input);
+
+  if (!effectStart.inserted && effectStart.reason_code === 'duplicate_effect_key') {
+    return {
+      inserted: false,
+      reason_code: 'duplicate_effect_key',
+      delivery: updateLearningEventDelivery(store, stableIdempotencyKey, (delivery) => {
+        delivery.delivery_state = 'persisted';
+        delivery.last_attempted_at = attemptedAt;
+        delivery.last_error = null;
+      }),
+      effect: effectStart.effect,
+    };
+  }
+
+  try {
+    const result = typeof execute === 'function'
+      ? await execute()
+      : { status: 'succeeded' };
+    const normalizedStatus = LEARNING_EVENT_EFFECT_STATUSES.includes(normalizeString(result?.status))
+      ? normalizeString(result.status)
+      : 'succeeded';
+    const effect = markLearningEventEffectStatus(store, {
+      handlerName: input.handlerName ?? input.handler_name,
+      effectKey: input.effectKey ?? input.effect_key,
+      status: normalizedStatus,
+      resultRefType: result?.resultRefType ?? result?.result_ref_type ?? null,
+      resultRefId: result?.resultRefId ?? result?.result_ref_id ?? null,
+      errorCode: result?.errorCode ?? result?.error_code ?? null,
+      errorMessage: result?.errorMessage ?? result?.error_message ?? null,
+    });
+
+    return {
+      inserted: reservation.inserted || effectStart.reason_code === 'retry_failed_effect',
+      reason_code: effectStart.reason_code === 'retry_failed_effect' ? 'retried_delivery' : null,
+      delivery: updateLearningEventDelivery(store, stableIdempotencyKey, (delivery) => {
+        delivery.delivery_state = 'persisted';
+        delivery.last_attempted_at = attemptedAt;
+        delivery.last_error = null;
+      }),
+      effect,
+    };
+  } catch (error) {
+    const message = error?.message || String(error);
+    const effect = markLearningEventEffectStatus(store, {
+      handlerName: input.handlerName ?? input.handler_name,
+      effectKey: input.effectKey ?? input.effect_key,
+      status: 'failed',
+      errorCode: 'delivery_failed',
+      errorMessage: message,
+    });
+
+    return {
+      inserted: reservation.inserted || effectStart.reason_code === 'retry_failed_effect',
+      reason_code: 'delivery_failed',
+      delivery: updateLearningEventDelivery(store, stableIdempotencyKey, (delivery) => {
+        delivery.delivery_state = 'retrying';
+        delivery.retry_count += 1;
+        delivery.last_attempted_at = attemptedAt;
+        delivery.last_error = {
+          code: 'delivery_failed',
+          message,
+        };
+      }),
+      effect,
+    };
+  }
+}
+
+export function reconcileLearningEventDelivery(store, {
+  stableIdempotencyKey,
+  deliveryState,
+  reconciliationId = null,
+} = {}) {
+  const normalizedKey = normalizeString(stableIdempotencyKey);
+  if (!normalizedKey) {
+    throw new Error('missing_stable_idempotency_key');
+  }
+
+  const normalizedDeliveryState = assertDeliveryState(deliveryState);
+  if (!['reconciled', 'needs_manual_review'].includes(normalizedDeliveryState)) {
+    throw new Error('invalid_reconciliation_delivery_state');
+  }
+
+  return updateLearningEventDelivery(store, normalizedKey, (delivery) => {
+    delivery.delivery_state = normalizedDeliveryState;
+    delivery.reconciliation_id = normalizeString(reconciliationId) || null;
+  });
 }
 
 export function acquireAttemptStreamLock(store, attemptId) {

--- a/api/learning/lib/events/event-service.js
+++ b/api/learning/lib/events/event-service.js
@@ -291,6 +291,10 @@ function cloneDelivery(delivery) {
   return cloneJson(delivery);
 }
 
+function isTerminalReconciledDeliveryState(deliveryState) {
+  return ['reconciled', 'needs_manual_review'].includes(normalizeString(deliveryState));
+}
+
 function buildLearningEventDeliveryIdempotencyKey({
   event_id,
   handler_name,
@@ -668,9 +672,12 @@ export async function runLearningEventDelivery(store, {
       inserted: false,
       reason_code: 'duplicate_effect_key',
       delivery: updateLearningEventDelivery(store, stableIdempotencyKey, (delivery) => {
-        delivery.delivery_state = 'persisted';
         delivery.last_attempted_at = attemptedAt;
-        delivery.last_error = null;
+
+        if (!isTerminalReconciledDeliveryState(delivery.delivery_state)) {
+          delivery.delivery_state = 'persisted';
+          delivery.last_error = null;
+        }
       }),
       effect: effectStart.effect,
     };

--- a/docs/reports/2026-04-17-issue-212-closeout.md
+++ b/docs/reports/2026-04-17-issue-212-closeout.md
@@ -1,0 +1,68 @@
+# Issue 212 Closeout
+
+## Scope
+
+Issue `#212` adds delivery reliability on top of the stacked `#211` attempt-event bridge without reopening request-path bridge semantics.
+
+## Final Delivery Contract
+
+- Stable delivery row key: `attempt_event_bridge:${mark_run_id || attempt_id}`.
+- Durable delivery table: `public.learning_event_deliveries`.
+- Frozen delivery states:
+  - `pending`
+  - `persisted`
+  - `retrying`
+  - `reconciled`
+  - `needs_manual_review`
+- Frozen minimum retry fields:
+  - `retry_count`
+  - `last_attempted_at`
+  - `last_error`
+- Bridge success path:
+  - appends ordered attempt events through `LearningUpdateProposed`
+  - upserts `attempt_pipeline_state`
+  - finalizes the delivery row to `persisted`
+- Bridge failure path:
+  - keeps the request path non-blocking
+  - records the existing durable warning/debt row in `error_events`
+  - updates the delivery row to `retrying` with `retry_count`, `last_attempted_at`, and `last_error`
+- Replay / dedupe path:
+  - if the delivery row is already `persisted` or `reconciled`, bridge replay returns a deduped success result and does not append duplicate attempt events
+  - unique delivery-key conflicts recover by reloading the existing row instead of creating a second delivery row
+- Reconciliation path:
+  - `reconcileAttemptEventBridgeDelivery()` can move a failed row into `reconciled` or `needs_manual_review`
+- Observability surface:
+  - delivery rows are queryable by `delivery_state`
+  - indexes prioritize stale or repeated rows via `(delivery_state, last_attempted_at)` and `(retry_count, updated_at)`
+
+## Verification
+
+Environment note:
+
+- This AO worktree did not have a local `node_modules`, so verification used the repo install already present at `/home/samsen/code/ciecopilot-home/node_modules` via a local symlink:
+  - `ln -s /home/samsen/code/ciecopilot-home/node_modules node_modules`
+
+Commands and outcomes:
+
+```bash
+node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand \
+  api/learning/__tests__/event-service.test.js \
+  api/learning/__tests__/attempt-event-service.test.js \
+  api/learning/__tests__/schema-contract.test.js \
+  api/marking/__tests__/evaluate-v1.test.js --verbose
+```
+
+- Outcome: PASS
+- Detail: `4` suites passed, `42` tests passed, `0` failed
+
+```bash
+git diff --check
+```
+
+- Outcome: PASS
+
+## Residual Risks
+
+- There is still no automated retry worker in this slice. `retrying` and `needs_manual_review` rows are the durable reconciliation surface, but replay/remediation still requires an explicit follow-up actor.
+- Observability is DB-surface only in this batch. The new indexes make stuck or repeated deliveries queryable, but there is no dedicated CLI/dashboard in this issue.
+- Deduped replays return the durable delivery row and persisted event types, but they do not rebuild and return a fresh `attempt_pipeline_state` snapshot when short-circuiting.

--- a/supabase/migrations/20260417110000_create_learning_event_deliveries.sql
+++ b/supabase/migrations/20260417110000_create_learning_event_deliveries.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS public.learning_event_deliveries (
+  delivery_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  stable_idempotency_key TEXT NOT NULL,
+  attempt_id UUID NOT NULL REFERENCES public.attempts(attempt_id) ON DELETE CASCADE,
+  learner_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
+  subject_code TEXT NOT NULL,
+  mark_run_id UUID REFERENCES public.mark_runs(mark_run_id) ON DELETE SET NULL,
+  truth_revision INTEGER NULL CHECK (truth_revision IS NULL OR truth_revision >= 1),
+  delivery_state TEXT NOT NULL DEFAULT 'pending' CHECK (
+    delivery_state IN ('pending', 'persisted', 'retrying', 'reconciled', 'needs_manual_review')
+  ),
+  retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+  last_attempted_at TIMESTAMPTZ NULL,
+  last_error JSONB NULL,
+  persisted_event_types JSONB NOT NULL DEFAULT '[]'::jsonb,
+  persisted_event_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+  reconciliation_id TEXT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (stable_idempotency_key),
+  CHECK (last_error IS NULL OR jsonb_typeof(last_error) = 'object'),
+  CHECK (jsonb_typeof(persisted_event_types) = 'array'),
+  CHECK (jsonb_typeof(persisted_event_ids) = 'array')
+);
+
+CREATE INDEX IF NOT EXISTS idx_learning_event_deliveries_state_attempted
+  ON public.learning_event_deliveries (delivery_state, last_attempted_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_learning_event_deliveries_retry_attention
+  ON public.learning_event_deliveries (retry_count DESC, updated_at DESC)
+  WHERE delivery_state IN ('pending', 'retrying', 'needs_manual_review');
+
+CREATE INDEX IF NOT EXISTS idx_learning_event_deliveries_attempt
+  ON public.learning_event_deliveries (attempt_id, mark_run_id);


### PR DESCRIPTION
## Summary
- add a durable `learning_event_deliveries` ledger for attempt-event bridge idempotency, retry metadata, and reconciliation outcomes
- dedupe repeated bridge delivery by stable key and keep downstream event/effect replays from duplicating side effects
- preserve the non-blocking request-path bridge behavior while recording retrying/manual-review delivery debt and documenting the final contract in `docs/reports/2026-04-17-issue-212-closeout.md`

## Verification
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/event-service.test.js api/learning/__tests__/attempt-event-service.test.js api/learning/__tests__/schema-contract.test.js api/marking/__tests__/evaluate-v1.test.js --verbose`
- `git diff --check`

## Notes
- stacked on #220
- closeout report: `docs/reports/2026-04-17-issue-212-closeout.md`
- residual risks: no automated retry worker in this slice; observability is DB-surface/index backed rather than a dedicated CLI/dashboard

Closes #212