### PR TITLE
fix(learning): enforce artifact residency projection

### DIFF
--- a/api/learning/__tests__/artifact-service.test.js
+++ b/api/learning/__tests__/artifact-service.test.js
@@ -513,34 +513,91 @@ describe('artifact-service', () => {
     });
   });
 
-  test('superseding a pinned artifact with an unverified successor clears the slot instead of transferring the pin', async () => {
+  test('pinning a new resident-eligible artifact demotes the prior primary so the slot keeps exactly one resident', async () => {
+    const repository = createArtifactRepositoryFixture();
+    const service = createArtifactService({
+      artifactRepository: repository,
+      lifecycleFlagEnabled: true,
+      now: () => new Date('2026-03-22T08:45:00.000Z'),
+    });
+
+    const result = await service.patchArtifact({
+      userId: 'student-1',
+      artifactId: 'art-successor',
+      intent: 'set_placement_status',
+      placementStatus: 'pinned',
+    });
+
+    expect(result.artifact).toMatchObject({
+      artifact_id: 'art-successor',
+      placement_status: 'pinned',
+      artifact_state: 'verified',
+    });
+    expect(result.slot_transition).toMatchObject({
+      outcome: 'pinned_to_slot',
+      slot_key: 'common_traps',
+    });
+
+    const snapshot = repository.snapshot();
+    expect(snapshot.artifacts.get('art-pinned')).toMatchObject({
+      placement_status: 'inbox',
+      artifact_state: 'verified',
+      lifecycle_status: 'active',
+    });
+    expect(snapshot.artifacts.get('art-successor')).toMatchObject({
+      placement_status: 'pinned',
+    });
+    expect(
+      [...snapshot.artifacts.values()].filter((artifact) =>
+        artifact.slot_key === 'common_traps' && artifact.placement_status === 'pinned'
+      ),
+    ).toHaveLength(1);
+    expect(snapshot.workspaceSlots.get('student-1:repair-target-topic:common_traps')).toMatchObject({
+      primary_artifact_ref: {
+        kind: 'artifact',
+        artifact_id: 'art-successor',
+      },
+    });
+  });
+
+  test('superseding a pinned artifact with an unverified successor is rejected and keeps the current resident stable', async () => {
     const repository = createArtifactRepositoryFixture();
     const service = createArtifactService({
       artifactRepository: repository,
       lifecycleFlagEnabled: true,
     });
 
-    const result = await service.patchArtifact({
-      userId: 'student-1',
-      artifactId: 'art-pinned',
-      intent: 'attach_superseded_by',
-      successorArtifactRef: {
-        kind: 'artifact',
-        artifact_id: 'art-successor-unverified',
-      },
-    });
-
-    expect(result.slot_transition).toMatchObject({
-      outcome: 'slot_cleared_pending_confirmation',
-      slot_key: 'common_traps',
+    await expect(
+      service.patchArtifact({
+        userId: 'student-1',
+        artifactId: 'art-pinned',
+        intent: 'attach_superseded_by',
+        successorArtifactRef: {
+          kind: 'artifact',
+          artifact_id: 'art-successor-unverified',
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'artifact_state_conflict',
+      status: 409,
     });
 
     const snapshot = repository.snapshot();
+    expect(snapshot.artifacts.get('art-pinned')).toMatchObject({
+      placement_status: 'pinned',
+      artifact_state: 'verified',
+      lifecycle_status: 'active',
+      superseded_by_artifact_id: null,
+    });
     expect(snapshot.artifacts.get('art-successor-unverified')).toMatchObject({
       placement_status: 'inbox',
+      artifact_state: 'unverified',
     });
     expect(snapshot.workspaceSlots.get('student-1:repair-target-topic:common_traps')).toMatchObject({
-      primary_artifact_ref: null,
+      primary_artifact_ref: {
+        kind: 'artifact',
+        artifact_id: 'art-pinned',
+      },
     });
   });
 

--- a/api/learning/__tests__/workspace-read-service.test.js
+++ b/api/learning/__tests__/workspace-read-service.test.js
@@ -969,6 +969,53 @@ describe('workspace read service', () => {
       expectedInboxArtifactId: 'artifact-successor-unverified',
     },
     {
+      label: 'resident projection preserves stale warning state',
+      workspaceProjection: {
+        workspace_id: 'workspace-1',
+        user_id: 'student-1',
+        topic_id: 'topic-1',
+        topic_path: '9709/trigonometry/equations',
+        slot_state: {
+          common_traps: 'stale',
+        },
+        linked_reference_summary: {
+          total_linked_references: 0,
+        },
+        updated_at: '2026-03-22T08:03:00.000Z',
+        slots: [
+          {
+            workspace_slot_id: 'slot-common-traps',
+            slot_key: 'common_traps',
+            primary_artifact_ref: {
+              kind: 'artifact',
+              artifact_id: 'artifact-primary',
+            },
+            linked_reference_refs: [],
+            updated_at: '2026-03-22T08:03:00.000Z',
+          },
+        ],
+      },
+      artifactRows: [
+        {
+          artifact_id: 'artifact-primary',
+          artifact_kind: 'misconception_card',
+          canonical_home_topic_id: 'topic-1',
+          slot_key: 'common_traps',
+          trust_status: 'grounded',
+          placement_status: 'pinned',
+          lifecycle_status: 'active',
+          artifact_state: 'verified',
+          verified_by: 'operator-1',
+          verified_at: '2026-03-22T07:40:00.000Z',
+          verification_evidence_ref: { kind: 'review_run', review_run_id: 'review-1' },
+          updated_at: '2026-03-22T08:03:00.000Z',
+        },
+      ],
+      expectedPrimaryArtifactId: 'artifact-primary',
+      expectedSlotState: 'stale',
+      expectedInboxArtifactId: null,
+    },
+    {
       label: 'awaiting_verification appears only when the slot has no displayable resident',
       workspaceProjection: {
         workspace_id: 'workspace-1',
@@ -1042,15 +1089,19 @@ describe('workspace read service', () => {
         }
         : null,
     );
-    expect(payload.workspace.artifact_inbox.items).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          artifact_id: expectedInboxArtifactId,
-          slot_key: 'common_traps',
-          placement_status: 'inbox',
-        }),
-      ]),
-    );
+    if (expectedInboxArtifactId) {
+      expect(payload.workspace.artifact_inbox.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            artifact_id: expectedInboxArtifactId,
+            slot_key: 'common_traps',
+            placement_status: 'inbox',
+          }),
+        ]),
+      );
+    } else {
+      expect(payload.workspace.artifact_inbox.items).toEqual([]);
+    }
   });
 
   test('workspace revisit payload keeps last-session continuity separate from slot and queue changes', async () => {

--- a/api/learning/__tests__/workspace-read-service.test.js
+++ b/api/learning/__tests__/workspace-read-service.test.js
@@ -217,6 +217,37 @@ function createLearningDb(overrides = {}) {
     },
   ];
 
+  const artifactRows = overrides.artifactRows ?? [
+    {
+      artifact_id: 'artifact-primary',
+      artifact_kind: 'misconception_card',
+      canonical_home_topic_id: 'topic-1',
+      slot_key: 'common_traps',
+      trust_status: 'grounded',
+      placement_status: 'pinned',
+      lifecycle_status: 'active',
+      artifact_state: 'verified',
+      verified_by: 'operator-1',
+      verified_at: '2026-03-22T07:40:00.000Z',
+      verification_evidence_ref: { kind: 'review_run', review_run_id: 'review-1' },
+      updated_at: '2026-03-22T08:00:00.000Z',
+    },
+    {
+      artifact_id: 'artifact-successor-unverified',
+      artifact_kind: 'misconception_card',
+      canonical_home_topic_id: 'topic-1',
+      slot_key: 'common_traps',
+      trust_status: 'unverified',
+      placement_status: 'inbox',
+      lifecycle_status: 'active',
+      artifact_state: 'unverified',
+      verified_by: null,
+      verified_at: null,
+      verification_evidence_ref: null,
+      updated_at: '2026-03-22T08:04:00.000Z',
+    },
+  ];
+
   const sessionRows = overrides.sessionRows ?? [
     {
       session_id: 'session-topic-2-later',
@@ -382,6 +413,18 @@ function createLearningDb(overrides = {}) {
 
       if (this.table === 'learning_session_resume_projection') {
         let rows = [...sessionRows];
+
+        for (const filter of this.filters) {
+          if (filter.type === 'eq') {
+            rows = rows.filter((row) => row[filter.column] === filter.value);
+          }
+        }
+
+        return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+      }
+
+      if (this.table === 'learning_artifacts') {
+        let rows = [...artifactRows];
 
         for (const filter of this.filters) {
           if (filter.type === 'eq') {
@@ -835,6 +878,7 @@ describe('workspace read service', () => {
     const payload = await getWorkspaceView(db, {
       userId: 'student-1',
       topicId: 'topic-1',
+      residencyFlagEnabled: true,
     });
 
     expect(payload.workspace.workspace_id).toBe('workspace-1');
@@ -860,6 +904,153 @@ describe('workspace read service', () => {
     ]);
     expect(payload.review_queue.items).toHaveLength(1);
     expect(payload.review_queue.items[0].review_task_id).toBe('review-queued-1');
+  });
+
+  test.each([
+    {
+      label: 'verified resident stays active when an unverified successor exists',
+      workspaceProjection: {
+        workspace_id: 'workspace-1',
+        user_id: 'student-1',
+        topic_id: 'topic-1',
+        topic_path: '9709/trigonometry/equations',
+        slot_state: {
+          common_traps: 'active',
+        },
+        linked_reference_summary: {
+          total_linked_references: 0,
+        },
+        updated_at: '2026-03-22T08:00:00.000Z',
+        slots: [
+          {
+            workspace_slot_id: 'slot-common-traps',
+            slot_key: 'common_traps',
+            primary_artifact_ref: {
+              kind: 'artifact',
+              artifact_id: 'artifact-primary',
+            },
+            linked_reference_refs: [],
+            updated_at: '2026-03-22T08:00:00.000Z',
+          },
+        ],
+      },
+      artifactRows: [
+        {
+          artifact_id: 'artifact-primary',
+          artifact_kind: 'misconception_card',
+          canonical_home_topic_id: 'topic-1',
+          slot_key: 'common_traps',
+          trust_status: 'grounded',
+          placement_status: 'pinned',
+          lifecycle_status: 'active',
+          artifact_state: 'verified',
+          verified_by: 'operator-1',
+          verified_at: '2026-03-22T07:40:00.000Z',
+          verification_evidence_ref: { kind: 'review_run', review_run_id: 'review-1' },
+          updated_at: '2026-03-22T08:00:00.000Z',
+        },
+        {
+          artifact_id: 'artifact-successor-unverified',
+          artifact_kind: 'misconception_card',
+          canonical_home_topic_id: 'topic-1',
+          slot_key: 'common_traps',
+          trust_status: 'unverified',
+          placement_status: 'inbox',
+          lifecycle_status: 'active',
+          artifact_state: 'unverified',
+          verified_by: null,
+          verified_at: null,
+          verification_evidence_ref: null,
+          updated_at: '2026-03-22T08:04:00.000Z',
+        },
+      ],
+      expectedPrimaryArtifactId: 'artifact-primary',
+      expectedSlotState: 'active',
+      expectedInboxArtifactId: 'artifact-successor-unverified',
+    },
+    {
+      label: 'awaiting_verification appears only when the slot has no displayable resident',
+      workspaceProjection: {
+        workspace_id: 'workspace-1',
+        user_id: 'student-1',
+        topic_id: 'topic-1',
+        topic_path: '9709/trigonometry/equations',
+        slot_state: {
+          common_traps: 'active',
+        },
+        linked_reference_summary: {
+          total_linked_references: 0,
+        },
+        updated_at: '2026-03-22T08:05:00.000Z',
+        slots: [
+          {
+            workspace_slot_id: 'slot-common-traps',
+            slot_key: 'common_traps',
+            primary_artifact_ref: {
+              kind: 'artifact',
+              artifact_id: 'artifact-awaiting-verification',
+            },
+            linked_reference_refs: [],
+            updated_at: '2026-03-22T08:05:00.000Z',
+          },
+        ],
+      },
+      artifactRows: [
+        {
+          artifact_id: 'artifact-awaiting-verification',
+          artifact_kind: 'misconception_card',
+          canonical_home_topic_id: 'topic-1',
+          slot_key: 'common_traps',
+          trust_status: 'unverified',
+          placement_status: 'pinned',
+          lifecycle_status: 'active',
+          artifact_state: 'unverified',
+          verified_by: null,
+          verified_at: null,
+          verification_evidence_ref: null,
+          updated_at: '2026-03-22T08:05:00.000Z',
+        },
+      ],
+      expectedPrimaryArtifactId: null,
+      expectedSlotState: 'awaiting_verification',
+      expectedInboxArtifactId: 'artifact-awaiting-verification',
+    },
+  ])('workspace residency matrix: $label', async ({
+    workspaceProjection,
+    artifactRows,
+    expectedPrimaryArtifactId,
+    expectedSlotState,
+    expectedInboxArtifactId,
+  }) => {
+    const db = createLearningDb({
+      workspaceProjection,
+      artifactRows,
+    });
+
+    const payload = await getWorkspaceView(db, {
+      userId: 'student-1',
+      topicId: 'topic-1',
+      residencyFlagEnabled: true,
+    });
+
+    expect(payload.workspace.slot_state.common_traps).toBe(expectedSlotState);
+    expect(payload.workspace.slots.common_traps.primary_artifact_ref).toEqual(
+      expectedPrimaryArtifactId
+        ? {
+          kind: 'artifact',
+          artifact_id: expectedPrimaryArtifactId,
+        }
+        : null,
+    );
+    expect(payload.workspace.artifact_inbox.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          artifact_id: expectedInboxArtifactId,
+          slot_key: 'common_traps',
+          placement_status: 'inbox',
+        }),
+      ]),
+    );
   });
 
   test('workspace revisit payload keeps last-session continuity separate from slot and queue changes', async () => {

--- a/api/learning/lib/artifacts/artifact-service.js
+++ b/api/learning/lib/artifacts/artifact-service.js
@@ -441,11 +441,31 @@ async function handlePlacementIntent({
   }
 
   let slotTransition = null;
+  const timestamp = now().toISOString();
   const topic = artifact.slot_key
     ? await artifactRepository?.getTopicById?.(artifact.canonical_home_topic_id)
     : null;
+  const existingSlot = artifact.slot_key
+    ? await artifactRepository?.getWorkspaceSlotByTopicAndKey?.({
+      userId,
+      topicId: artifact.canonical_home_topic_id,
+      slotKey: artifact.slot_key,
+    })
+    : null;
 
   if (artifact.slot_key && placementStatus === 'pinned') {
+    const priorPrimaryArtifactId = existingSlot?.primary_artifact_ref?.artifact_id ?? null;
+
+    if (priorPrimaryArtifactId && priorPrimaryArtifactId !== artifact.artifact_id) {
+      const priorPrimaryArtifact = await artifactRepository?.getArtifactById?.(priorPrimaryArtifactId);
+      if (priorPrimaryArtifact?.placement_status === 'pinned') {
+        await artifactRepository.updateArtifact(priorPrimaryArtifactId, {
+          placement_status: 'inbox',
+          updated_at: timestamp,
+        });
+      }
+    }
+
     const slot = await artifactRepository?.setWorkspaceSlotPrimaryArtifact?.({
       userId,
       topicId: artifact.canonical_home_topic_id,
@@ -483,7 +503,7 @@ async function handlePlacementIntent({
 
   const updated = await artifactRepository.updateArtifact(artifact.artifact_id, {
     placement_status: placementStatus,
-    updated_at: now().toISOString(),
+    updated_at: timestamp,
   });
 
   return {
@@ -675,6 +695,14 @@ async function handleSupersedeIntent({
     throw buildArtifactConflict('Successor artifact kind is not compatible with the slot.', {
       slot_key: successor.slot_key,
       artifact_kind: successor.artifact_kind,
+    });
+  }
+
+  if (lifecycleFlagEnabled && !successor.capabilities.resident_eligible) {
+    throw buildArtifactConflict('Successor artifact is not eligible for stable residency.', {
+      artifact_id: artifact.artifact_id,
+      successor_artifact_id: successor.artifact_id,
+      successor_artifact_state: successor.artifact_state,
     });
   }
 

--- a/api/learning/lib/repositories/artifact-repository.js
+++ b/api/learning/lib/repositories/artifact-repository.js
@@ -57,6 +57,10 @@ export function createArtifactRepository(client) {
       return getArtifactById(client, artifactId);
     },
 
+    async listArtifactsByTopic({ topicId }) {
+      return listArtifactsByTopic(client, { topicId });
+    },
+
     async insertArtifact(input) {
       return insertArtifact(client, input);
     },
@@ -99,6 +103,21 @@ export async function insertArtifact(client, input = {}) {
       .single(),
     'Failed to insert learning artifact',
   );
+}
+
+export async function listArtifactsByTopic(client, { topicId } = {}) {
+  const { data, error } = await client
+    .from('learning_artifacts')
+    .select('*')
+    .eq('canonical_home_topic_id', topicId)
+    .order('updated_at', { ascending: false })
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to load learning artifacts for topic: ${error.message}`);
+  }
+
+  return Array.isArray(data) ? data : [];
 }
 
 export async function updateArtifact(client, artifactId, patch = {}) {

--- a/api/learning/lib/workspaces/workspace-read-service.js
+++ b/api/learning/lib/workspaces/workspace-read-service.js
@@ -203,6 +203,14 @@ function isPendingVerificationArtifact(artifact = {}) {
     && artifact.artifact_state === 'unverified';
 }
 
+function shouldResetSlotStateToActive(currentState) {
+  const normalizedState = normalizeString(currentState);
+  return !normalizedState
+    || normalizedState === 'idle'
+    || normalizedState === 'awaiting_verification'
+    || normalizedState === 'active';
+}
+
 function resolveResidentArtifact(slot = null, slotArtifacts = []) {
   const residentArtifacts = (Array.isArray(slotArtifacts) ? slotArtifacts : []).filter(isResidentArtifact);
   const primaryArtifactId = slot?.primary_artifact_ref?.artifact_id ?? null;
@@ -272,7 +280,7 @@ function projectWorkspaceResidency(workspaceProjection, topicArtifacts = []) {
       return;
     }
 
-    if (residentArtifact) {
+    if (residentArtifact && shouldResetSlotStateToActive(projectedSlotState[slotKey])) {
       projectedSlotState[slotKey] = 'active';
     }
   });

--- a/api/learning/lib/workspaces/workspace-read-service.js
+++ b/api/learning/lib/workspaces/workspace-read-service.js
@@ -1,5 +1,10 @@
-import { STABLE_SLOT_KEYS } from '../contracts/runtime-contract.js';
+import { buildArtifactRef, STABLE_SLOT_KEYS } from '../contracts/runtime-contract.js';
 import { LearningHttpError } from '../http/learning-http.js';
+import {
+  isArtifactLifecycleEnabled,
+  normalizeArtifactLifecycleArtifact,
+} from '../artifacts/artifact-service.js';
+import { listArtifactsByTopic } from '../repositories/artifact-repository.js';
 import { fetchWorkspaceProjection } from '../repositories/workspace-repository.js';
 import {
   deriveReviewQueueProjection,
@@ -15,6 +20,7 @@ import {
 } from '../session-runtime/session-handoff.js';
 
 const ACTIVE_REVIEW_TASK_STATUSES = new Set(['open', 'partial']);
+const ARTIFACT_SLOT_KEYS = new Set(STABLE_SLOT_KEYS.filter((slotKey) => slotKey !== 'review_queue'));
 
 function normalizeString(value) {
   if (value === null || value === undefined) {
@@ -141,6 +147,144 @@ function buildStableSlots(workspaceProjection, { reviewQueueItems = [] } = {}) {
       ];
     }),
   );
+}
+
+function compareArtifactsForProjection(left = {}, right = {}) {
+  const leftUpdatedAt = parseTimestamp(left.updated_at)?.getTime() ?? 0;
+  const rightUpdatedAt = parseTimestamp(right.updated_at)?.getTime() ?? 0;
+  if (leftUpdatedAt !== rightUpdatedAt) {
+    return rightUpdatedAt - leftUpdatedAt;
+  }
+
+  const leftCreatedAt = parseTimestamp(left.created_at)?.getTime() ?? 0;
+  const rightCreatedAt = parseTimestamp(right.created_at)?.getTime() ?? 0;
+  if (leftCreatedAt !== rightCreatedAt) {
+    return rightCreatedAt - leftCreatedAt;
+  }
+
+  return String(left.artifact_id ?? '').localeCompare(String(right.artifact_id ?? ''));
+}
+
+function normalizeTopicArtifacts(artifacts = []) {
+  return (Array.isArray(artifacts) ? artifacts : [])
+    .map((artifact) => normalizeArtifactLifecycleArtifact(artifact))
+    .sort(compareArtifactsForProjection);
+}
+
+function groupArtifactsBySlot(artifacts = []) {
+  return (Array.isArray(artifacts) ? artifacts : []).reduce((acc, artifact) => {
+    const slotKey = normalizeString(artifact?.slot_key);
+    if (!slotKey || !ARTIFACT_SLOT_KEYS.has(slotKey)) {
+      return acc;
+    }
+
+    if (!acc[slotKey]) {
+      acc[slotKey] = [];
+    }
+
+    acc[slotKey].push(artifact);
+    return acc;
+  }, {});
+}
+
+function isActiveArtifact(artifact = {}) {
+  return artifact.lifecycle_status !== 'superseded'
+    && artifact.placement_status !== 'archived';
+}
+
+function isResidentArtifact(artifact = {}) {
+  return isActiveArtifact(artifact)
+    && artifact.placement_status === 'pinned'
+    && artifact.capabilities?.resident_eligible;
+}
+
+function isPendingVerificationArtifact(artifact = {}) {
+  return isActiveArtifact(artifact)
+    && artifact.artifact_state === 'unverified';
+}
+
+function resolveResidentArtifact(slot = null, slotArtifacts = []) {
+  const residentArtifacts = (Array.isArray(slotArtifacts) ? slotArtifacts : []).filter(isResidentArtifact);
+  const primaryArtifactId = slot?.primary_artifact_ref?.artifact_id ?? null;
+
+  if (primaryArtifactId) {
+    const pointerResident = residentArtifacts.find((artifact) => artifact.artifact_id === primaryArtifactId);
+    if (pointerResident) {
+      return pointerResident;
+    }
+  }
+
+  return residentArtifacts[0] ?? null;
+}
+
+function buildProjectedArtifactInboxItem(artifact = {}, residentArtifactIds = new Set()) {
+  return {
+    ...artifact,
+    placement_status: residentArtifactIds.has(artifact.artifact_id)
+      ? 'pinned'
+      : artifact.placement_status === 'pinned'
+        ? 'inbox'
+        : artifact.placement_status,
+  };
+}
+
+function buildArtifactInboxProjection(topicArtifacts = [], residentArtifactIds = new Set()) {
+  return {
+    items: (Array.isArray(topicArtifacts) ? topicArtifacts : [])
+      .filter((artifact) =>
+        ARTIFACT_SLOT_KEYS.has(normalizeString(artifact?.slot_key))
+        && isActiveArtifact(artifact)
+        && artifact.capabilities?.shell_visible
+        && !residentArtifactIds.has(artifact.artifact_id))
+      .map((artifact) => buildProjectedArtifactInboxItem(artifact, residentArtifactIds)),
+  };
+}
+
+function projectWorkspaceResidency(workspaceProjection, topicArtifacts = []) {
+  const normalizedArtifacts = normalizeTopicArtifacts(topicArtifacts);
+  const artifactsBySlot = groupArtifactsBySlot(normalizedArtifacts);
+  const projectedSlots = {
+    ...(workspaceProjection?.slots ?? {}),
+  };
+  const projectedSlotState = {
+    ...(workspaceProjection?.slot_state ?? {}),
+  };
+  const residentArtifactIds = new Set();
+
+  ARTIFACT_SLOT_KEYS.forEach((slotKey) => {
+    const slot = projectedSlots[slotKey] ?? null;
+    const slotArtifacts = artifactsBySlot[slotKey] ?? [];
+    const residentArtifact = resolveResidentArtifact(slot, slotArtifacts);
+
+    if (slot) {
+      projectedSlots[slotKey] = {
+        ...slot,
+        primary_artifact_ref: residentArtifact ? buildArtifactRef(residentArtifact.artifact_id) : null,
+      };
+    }
+
+    if (residentArtifact) {
+      residentArtifactIds.add(residentArtifact.artifact_id);
+    }
+
+    if (!residentArtifact && slotArtifacts.some(isPendingVerificationArtifact)) {
+      projectedSlotState[slotKey] = 'awaiting_verification';
+      return;
+    }
+
+    if (residentArtifact) {
+      projectedSlotState[slotKey] = 'active';
+    }
+  });
+
+  return {
+    workspaceProjection: {
+      ...workspaceProjection,
+      slot_state: projectedSlotState,
+      slots: projectedSlots,
+    },
+    artifactInbox: buildArtifactInboxProjection(normalizedArtifacts, residentArtifactIds),
+  };
 }
 
 function buildWorkspaceNotFound(topicId) {
@@ -381,6 +525,7 @@ export async function getWorkspaceView(
     topicId,
     reviewStatus = null,
     reviewDueBefore = null,
+    residencyFlagEnabled = isArtifactLifecycleEnabled(),
   } = {},
 ) {
   const workspaceProjection = await fetchWorkspaceProjection(client, {
@@ -393,7 +538,10 @@ export async function getWorkspaceView(
   }
 
   const shouldLoadUnfilteredTopicQueue = Boolean(reviewStatus || reviewDueBefore);
-  const [reviewQueue, unfilteredTopicReviewQueue, lastSession] = await Promise.all([
+  const [topicArtifacts, reviewQueue, unfilteredTopicReviewQueue, lastSession] = await Promise.all([
+    residencyFlagEnabled
+      ? listArtifactsByTopic(client, { topicId })
+      : Promise.resolve([]),
     listReviewTasks(client, {
       userId,
       topicId,
@@ -412,29 +560,38 @@ export async function getWorkspaceView(
       topicPath: workspaceProjection.topic_path,
     }),
   ]);
+  const projectedWorkspace = residencyFlagEnabled
+    ? projectWorkspaceResidency(workspaceProjection, topicArtifacts)
+    : {
+      workspaceProjection,
+      artifactInbox: {
+        items: [],
+      },
+    };
   const reviewQueueSlotItems = shouldLoadUnfilteredTopicQueue
     ? unfilteredTopicReviewQueue?.items ?? []
     : reviewQueue.items;
 
   return {
     workspace: {
-      workspace_id: workspaceProjection.workspace_id,
-      user_id: workspaceProjection.user_id,
-      topic_id: workspaceProjection.topic_id,
-      topic_path: workspaceProjection.topic_path,
-      slot_state: workspaceProjection.slot_state ?? {},
-      linked_reference_summary: workspaceProjection.linked_reference_summary ?? {},
-      updated_at: workspaceProjection.updated_at ?? null,
-      slots: buildStableSlots(workspaceProjection, {
+      workspace_id: projectedWorkspace.workspaceProjection.workspace_id,
+      user_id: projectedWorkspace.workspaceProjection.user_id,
+      topic_id: projectedWorkspace.workspaceProjection.topic_id,
+      topic_path: projectedWorkspace.workspaceProjection.topic_path,
+      slot_state: projectedWorkspace.workspaceProjection.slot_state ?? {},
+      linked_reference_summary: projectedWorkspace.workspaceProjection.linked_reference_summary ?? {},
+      ...(residencyFlagEnabled ? { artifact_inbox: projectedWorkspace.artifactInbox } : {}),
+      updated_at: projectedWorkspace.workspaceProjection.updated_at ?? null,
+      slots: buildStableSlots(projectedWorkspace.workspaceProjection, {
         reviewQueueItems: reviewQueueSlotItems,
       }),
     },
-    runtime_posture: buildWorkspaceRuntimePosture(workspaceProjection),
+    runtime_posture: buildWorkspaceRuntimePosture(projectedWorkspace.workspaceProjection),
     review_queue: reviewQueue,
     revisit: buildWorkspaceRevisit({
       lastSession,
       reviewQueueItems: reviewQueueSlotItems,
-      workspaceProjection,
+      workspaceProjection: projectedWorkspace.workspaceProjection,
     }),
   };
 }

--- a/docs/reports/2026-04-17-issue-215-closeout.md
+++ b/docs/reports/2026-04-17-issue-215-closeout.md
@@ -1,0 +1,38 @@
+# Issue #215 Closeout
+
+## Scope Shipped
+
+- Enforced single-resident slot behavior in the artifact service so pinning a new resident-eligible artifact demotes the prior primary instead of leaving multiple pinned residents.
+- Rejected `attach_superseded_by` when the successor is not resident-eligible under `LEARNING_ARTIFACT_LIFECYCLE_ENABLED`, keeping the current resident pointer stable.
+- Added topic-artifact workspace projection reads behind `LEARNING_ARTIFACT_LIFECYCLE_ENABLED` so slot residency resolves from resident-eligible artifacts only and pending unverified artifacts stay in `artifact_inbox`.
+- Derived `slot_state = awaiting_verification` only when a slot has no displayable resident but does have a pending unverified candidate.
+- Updated workspace view-model and shell behavior so unverified candidates cannot be pinned or offered as supersede successors, and the placeholder does not hide a still-valid resident.
+
+## Residency Matrix
+
+| Scenario | Projected primary resident | Slot state | Candidate surface |
+| --- | --- | --- | --- |
+| Verified resident + unverified successor | Existing verified resident stays primary | `active` | Unverified successor stays in `artifact_inbox` |
+| No resident + unverified candidate | No primary resident | `awaiting_verification` | Candidate stays in `artifact_inbox` |
+| Verified inbox candidate pinned into occupied slot | New verified artifact becomes sole resident | `active` | Prior pinned resident is demoted out of primary residency |
+| Pinned resident supersede request with unverified successor | Existing resident stays primary | `active` | Request is rejected with `409 artifact_state_conflict` |
+
+## Verification
+
+1. `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/artifact-service.test.js`
+   Outcome: `PASS`, 24 tests passed.
+
+2. `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/workspace-read-service.test.js -t "workspace returns stable slots plus linked references from secondary topics|workspace residency matrix|marking effect -> review task -> workspace projection -> artifact patch keeps lifecycle and ownership consistent|GET /api/learning/workspaces/:topicId returns stable slots and linked references"`
+   Outcome: `PASS`, 5 selected tests passed and 7 were skipped by the test filter.
+
+3. `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand src/components/learning-runtime/__tests__/view-models.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js`
+   Outcome: `PASS`, 26 tests passed.
+
+## Additional Observation
+
+- Running the full `api/learning/__tests__/workspace-read-service.test.js` file still reports one unrelated pre-existing failure in `review-task writes update topic projections and active review-queue references`, where the released-scope expectation is `released_scoring` but the current branch returns `non_released_fallback`. This issue was not changed in `#215`.
+
+## Residual Risks
+
+- The residency projection rewrite is intentionally gated by `LEARNING_ARTIFACT_LIFECYCLE_ENABLED`; with the flag off, legacy workspace behavior remains unchanged.
+- Topic artifact projection still reads by canonical-home topic because the frozen schema does not add a separate artifact owner column in this batch.

--- a/docs/reports/2026-04-17-issue-215-closeout.md
+++ b/docs/reports/2026-04-17-issue-215-closeout.md
@@ -6,6 +6,7 @@
 - Rejected `attach_superseded_by` when the successor is not resident-eligible under `LEARNING_ARTIFACT_LIFECYCLE_ENABLED`, keeping the current resident pointer stable.
 - Added topic-artifact workspace projection reads behind `LEARNING_ARTIFACT_LIFECYCLE_ENABLED` so slot residency resolves from resident-eligible artifacts only and pending unverified artifacts stay in `artifact_inbox`.
 - Derived `slot_state = awaiting_verification` only when a slot has no displayable resident but does have a pending unverified candidate.
+- Preserved precomputed non-residency slot warning states such as `stale` while resolving the resident pointer, instead of rewriting every resident slot to `active`.
 - Updated workspace view-model and shell behavior so unverified candidates cannot be pinned or offered as supersede successors, and the placeholder does not hide a still-valid resident.
 
 ## Residency Matrix
@@ -13,6 +14,7 @@
 | Scenario | Projected primary resident | Slot state | Candidate surface |
 | --- | --- | --- | --- |
 | Verified resident + unverified successor | Existing verified resident stays primary | `active` | Unverified successor stays in `artifact_inbox` |
+| Verified resident + precomputed warning state | Existing verified resident stays primary | Preserve upstream warning state such as `stale` | No placeholder or resident loss |
 | No resident + unverified candidate | No primary resident | `awaiting_verification` | Candidate stays in `artifact_inbox` |
 | Verified inbox candidate pinned into occupied slot | New verified artifact becomes sole resident | `active` | Prior pinned resident is demoted out of primary residency |
 | Pinned resident supersede request with unverified successor | Existing resident stays primary | `active` | Request is rejected with `409 artifact_state_conflict` |
@@ -27,6 +29,9 @@
 
 3. `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand src/components/learning-runtime/__tests__/view-models.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js`
    Outcome: `PASS`, 26 tests passed.
+
+4. `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/workspace-read-service.test.js -t "resident projection preserves stale warning state|workspace residency matrix"`
+   Outcome: `PASS`, 3 selected residency-matrix tests passed and 10 were skipped by the test filter.
 
 ## Additional Observation
 

--- a/src/components/learning-runtime/WorkspaceShell.js
+++ b/src/components/learning-runtime/WorkspaceShell.js
@@ -55,7 +55,7 @@ function getSlotDescription(slotKey) {
 }
 
 function buildArtifactState(card) {
-  if (card?.lifecycleStatus === 'superseded') {
+  if (card?.artifactState === 'superseded' || card?.lifecycleStatus === 'superseded') {
     return {
       value: 'superseded',
       label: 'Superseded artifact',
@@ -64,7 +64,7 @@ function buildArtifactState(card) {
     };
   }
 
-  if (card?.trustStatus === 'contested') {
+  if (card?.artifactState === 'contested' || card?.trustStatus === 'contested') {
     return {
       value: 'contested',
       label: 'Contested artifact',
@@ -85,6 +85,14 @@ function buildArtifactState(card) {
   return card?.state?.value === 'missing_content' ? card.state : null;
 }
 
+function isResidentEligibleCard(card = {}) {
+  if (typeof card?.capabilities?.residentEligible === 'boolean') {
+    return card.capabilities.residentEligible;
+  }
+
+  return card?.artifactState === 'verified' || card?.artifactState === 'released';
+}
+
 function buildAvailableActions(card, workspaceTopicId) {
   const sameCanonicalHome =
     !card?.canonicalHomeTopicId || card.canonicalHomeTopicId === workspaceTopicId;
@@ -92,12 +100,15 @@ function buildAvailableActions(card, workspaceTopicId) {
     Boolean(card?.slotKey)
     && Boolean(card?.artifactKind)
     && isCompatibleArtifactKindForSlot(card.slotKey, card.artifactKind);
+  const contested = card?.artifactState === 'contested' || card?.trustStatus === 'contested';
+  const residentEligible = isResidentEligibleCard(card);
   const canPin =
     card?.source === 'artifact_inbox'
     && sameCanonicalHome
     && card?.placementStatus !== 'pinned'
     && card?.lifecycleStatus !== 'superseded'
-    && card?.trustStatus !== 'contested'
+    && !contested
+    && residentEligible
     && Boolean(card?.slotKey)
     && card?.slotKey !== 'review_queue'
     && hasCompatibleSlotMetadata;
@@ -107,7 +118,7 @@ function buildAvailableActions(card, workspaceTopicId) {
     canUnpin: card?.placementStatus === 'pinned',
     canMarkContested:
       card?.lifecycleStatus !== 'superseded'
-      && card?.trustStatus !== 'contested'
+      && !contested
       && card?.placementStatus !== 'pinned',
     canSupersede: Boolean(card?.artifactId) && card?.lifecycleStatus !== 'superseded',
     pinBlockedReason:
@@ -115,8 +126,10 @@ function buildAvailableActions(card, workspaceTopicId) {
         ? null
         : !sameCanonicalHome
           ? 'Secondary-topic artifacts cannot be pinned into this workspace.'
-          : card?.trustStatus === 'contested'
+          : contested
             ? 'Contested artifacts cannot be pinned.'
+            : !residentEligible
+              ? 'This artifact is not eligible for stable residency.'
             : card?.lifecycleStatus === 'superseded'
               ? 'Superseded artifacts cannot be pinned.'
               : card?.slotKey === 'review_queue'
@@ -148,6 +161,8 @@ function refreshCard(card, artifact = {}, viewModel, overrides = {}) {
       ?? workspaceTopicId,
     placementStatus:
       artifact.placementStatus ?? overrides.placementStatus ?? card?.placementStatus ?? 'inbox',
+    artifactState: artifact.artifactState ?? overrides.artifactState ?? card?.artifactState ?? null,
+    capabilities: artifact.capabilities ?? overrides.capabilities ?? card?.capabilities ?? null,
     trustStatus: artifact.trustStatus ?? overrides.trustStatus ?? card?.trustStatus ?? null,
     lifecycleStatus:
       artifact.lifecycleStatus ?? overrides.lifecycleStatus ?? card?.lifecycleStatus ?? 'active',
@@ -287,7 +302,9 @@ export function getArtifactSupersedeCandidates(viewModel, artifactCard) {
     && card.slotKey === artifactCard?.slotKey
     && (card.canonicalHomeTopicId ?? workspaceTopicId) === (artifactCard?.canonicalHomeTopicId ?? workspaceTopicId)
     && card.lifecycleStatus !== 'superseded'
+    && card.artifactState !== 'contested'
     && card.trustStatus !== 'contested'
+    && isResidentEligibleCard(card)
     && card.placementStatus !== 'archived'
   ));
 }

--- a/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
+++ b/src/components/learning-runtime/__tests__/WorkspaceShell.test.js
@@ -41,6 +41,13 @@ function createWorkspacePayload() {
             canonicalHomeTopicId: 'topic-trig-equations',
             slotKey: 'common_traps',
             placementStatus: 'inbox',
+            artifactState: 'verified',
+            capabilities: {
+              shellVisible: true,
+              bodyVisible: true,
+              residentEligible: true,
+              authoritativeAutomationEligible: false,
+            },
             trustStatus: 'grounded',
             lifecycleStatus: 'active',
             updatedAt: '2026-03-22T07:56:00.000Z',
@@ -52,7 +59,14 @@ function createWorkspacePayload() {
             canonicalHomeTopicId: 'topic-trig-equations',
             slotKey: 'my_notes',
             placementStatus: 'inbox',
-            trustStatus: 'user_confirmed',
+            artifactState: 'verified',
+            capabilities: {
+              shellVisible: true,
+              bodyVisible: true,
+              residentEligible: true,
+              authoritativeAutomationEligible: false,
+            },
+            trustStatus: 'grounded',
             lifecycleStatus: 'active',
             updatedAt: '2026-03-22T07:57:00.000Z',
             title: 'My note candidate',
@@ -63,6 +77,13 @@ function createWorkspacePayload() {
             canonicalHomeTopicId: 'topic-trig-identities',
             slotKey: 'common_traps',
             placementStatus: 'inbox',
+            artifactState: 'verified',
+            capabilities: {
+              shellVisible: true,
+              bodyVisible: true,
+              residentEligible: true,
+              authoritativeAutomationEligible: false,
+            },
             trustStatus: 'grounded',
             lifecycleStatus: 'active',
             updatedAt: '2026-03-22T07:55:00.000Z',
@@ -73,6 +94,13 @@ function createWorkspacePayload() {
             canonicalHomeTopicId: 'topic-trig-equations',
             slotKey: 'common_traps',
             placementStatus: 'inbox',
+            artifactState: 'contested',
+            capabilities: {
+              shellVisible: true,
+              bodyVisible: false,
+              residentEligible: false,
+              authoritativeAutomationEligible: false,
+            },
             trustStatus: 'contested',
             lifecycleStatus: 'active',
             updatedAt: '2026-03-22T07:54:00.000Z',
@@ -403,7 +431,25 @@ describe('WorkspaceShell', () => {
   });
 
   test('getArtifactSupersedeCandidates keeps successor choices conservative', () => {
-    const workspaceVm = buildWorkspaceViewModel(createWorkspacePayload());
+    const payload = createWorkspacePayload();
+    payload.workspace.artifactInbox.items.push({
+      artifactId: 'artifact-awaiting-verification',
+      artifactKind: 'misconception_card',
+      canonicalHomeTopicId: 'topic-trig-equations',
+      slotKey: 'common_traps',
+      placementStatus: 'inbox',
+      artifactState: 'unverified',
+      capabilities: {
+        shellVisible: true,
+        bodyVisible: false,
+        residentEligible: false,
+        authoritativeAutomationEligible: false,
+      },
+      trustStatus: 'unverified',
+      lifecycleStatus: 'active',
+      updatedAt: '2026-03-22T08:06:00.000Z',
+    });
+    const workspaceVm = buildWorkspaceViewModel(payload);
 
     expect(
       getArtifactSupersedeCandidates(
@@ -411,6 +457,43 @@ describe('WorkspaceShell', () => {
         workspaceVm.slots.common_traps.primaryArtifactCard,
       ).map((card) => card.artifactId),
     ).toEqual(['artifact-successor']);
+  });
+
+  test('renders awaiting verification only when the slot has no resident', () => {
+    const payload = createWorkspacePayload();
+    payload.workspace.slotState.commonTraps = 'awaiting_verification';
+    payload.workspace.slots.commonTraps.primaryArtifactRef = null;
+    payload.workspace.artifactInbox.items = [
+      {
+        artifactId: 'artifact-awaiting-verification',
+        artifactKind: 'misconception_card',
+        canonicalHomeTopicId: 'topic-trig-equations',
+        slotKey: 'common_traps',
+        placementStatus: 'inbox',
+        artifactState: 'unverified',
+        capabilities: {
+          shellVisible: true,
+          bodyVisible: false,
+          residentEligible: false,
+          authoritativeAutomationEligible: false,
+        },
+        trustStatus: 'unverified',
+        lifecycleStatus: 'active',
+        updatedAt: '2026-03-22T08:06:00.000Z',
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      React.createElement(WorkspaceShell, {
+        viewModel: buildWorkspaceViewModel(payload, {
+          now: '2026-03-22T12:00:00.000Z',
+        }),
+        onOpenGlobalQueue: () => {},
+      }),
+    );
+
+    expect(html).toContain('Awaiting verification');
+    expect(html).not.toContain('artifact-primary');
   });
 
   test('applyArtifactLifecycleUpdate moves a pinned slot to the successor and removes the candidate from inbox', () => {

--- a/src/components/learning-runtime/__tests__/view-models.test.js
+++ b/src/components/learning-runtime/__tests__/view-models.test.js
@@ -140,6 +140,13 @@ function createWorkspacePayload() {
             canonicalHomeTopicId: 'topic-trig-equations',
             slotKey: 'common_traps',
             placementStatus: 'inbox',
+            artifactState: 'verified',
+            capabilities: {
+              shellVisible: true,
+              bodyVisible: true,
+              residentEligible: true,
+              authoritativeAutomationEligible: false,
+            },
             trustStatus: 'grounded',
             lifecycleStatus: 'active',
             updatedAt: '2026-03-22T07:56:00.000Z',
@@ -151,7 +158,14 @@ function createWorkspacePayload() {
             canonicalHomeTopicId: 'topic-trig-equations',
             slotKey: 'my_notes',
             placementStatus: 'inbox',
-            trustStatus: 'user_confirmed',
+            artifactState: 'verified',
+            capabilities: {
+              shellVisible: true,
+              bodyVisible: true,
+              residentEligible: true,
+              authoritativeAutomationEligible: false,
+            },
+            trustStatus: 'grounded',
             lifecycleStatus: 'active',
             updatedAt: '2026-03-22T07:57:00.000Z',
             title: 'My note candidate',
@@ -162,6 +176,13 @@ function createWorkspacePayload() {
             canonicalHomeTopicId: 'topic-trig-identities',
             slotKey: 'common_traps',
             placementStatus: 'inbox',
+            artifactState: 'verified',
+            capabilities: {
+              shellVisible: true,
+              bodyVisible: true,
+              residentEligible: true,
+              authoritativeAutomationEligible: false,
+            },
             trustStatus: 'grounded',
             lifecycleStatus: 'active',
             updatedAt: '2026-03-22T07:55:00.000Z',
@@ -172,6 +193,13 @@ function createWorkspacePayload() {
             canonicalHomeTopicId: 'topic-trig-equations',
             slotKey: 'common_traps',
             placementStatus: 'inbox',
+            artifactState: 'contested',
+            capabilities: {
+              shellVisible: true,
+              bodyVisible: false,
+              residentEligible: false,
+              authoritativeAutomationEligible: false,
+            },
             trustStatus: 'contested',
             lifecycleStatus: 'active',
             updatedAt: '2026-03-22T07:54:00.000Z',
@@ -1203,6 +1231,76 @@ describe('learning runtime session view model', () => {
       label: 'Contested artifact',
       tone: 'warning',
       message: 'This artifact is contested and cannot be pinned until the conflict is resolved.',
+    });
+  });
+
+  test('workspace view-model keeps a resident visible while an unverified successor stays in the inbox only', () => {
+    const payload = createWorkspacePayload();
+    payload.workspace.artifactInbox.items.unshift({
+      artifactId: 'artifact-awaiting-verification',
+      artifactKind: 'misconception_card',
+      canonicalHomeTopicId: 'topic-trig-equations',
+      slotKey: 'common_traps',
+      placementStatus: 'inbox',
+      artifactState: 'unverified',
+      capabilities: {
+        shellVisible: true,
+        bodyVisible: false,
+        residentEligible: false,
+        authoritativeAutomationEligible: false,
+      },
+      trustStatus: 'unverified',
+      lifecycleStatus: 'active',
+      updatedAt: '2026-03-22T08:06:00.000Z',
+      summary: 'Pending verification before it can replace the resident.',
+    });
+
+    const vm = buildWorkspaceViewModel(payload, {
+      now: '2026-03-22T12:00:00.000Z',
+    });
+
+    expect(vm.slots.common_traps.primaryArtifactCard.artifactId).toBe('artifact-primary');
+    expect(vm.slots.common_traps.emptyState).toBeNull();
+
+    const pendingCandidate = vm.artifactInbox.items.find((card) => card.artifactId === 'artifact-awaiting-verification');
+    expect(pendingCandidate.availableActions.canPin).toBe(false);
+    expect(pendingCandidate.availableActions.pinBlockedReason)
+      .toBe('This artifact is not eligible for stable residency.');
+  });
+
+  test('workspace view-model shows awaiting verification only when the slot has no resident', () => {
+    const payload = createWorkspacePayload();
+    payload.workspace.slotState.commonTraps = 'awaiting_verification';
+    payload.workspace.slots.commonTraps.primaryArtifactRef = null;
+    payload.workspace.artifactInbox.items = [
+      {
+        artifactId: 'artifact-awaiting-verification',
+        artifactKind: 'misconception_card',
+        canonicalHomeTopicId: 'topic-trig-equations',
+        slotKey: 'common_traps',
+        placementStatus: 'inbox',
+        artifactState: 'unverified',
+        capabilities: {
+          shellVisible: true,
+          bodyVisible: false,
+          residentEligible: false,
+          authoritativeAutomationEligible: false,
+        },
+        trustStatus: 'unverified',
+        lifecycleStatus: 'active',
+        updatedAt: '2026-03-22T08:06:00.000Z',
+        summary: 'Pending verification before it can replace the resident.',
+      },
+    ];
+
+    const vm = buildWorkspaceViewModel(payload, {
+      now: '2026-03-22T12:00:00.000Z',
+    });
+
+    expect(vm.slots.common_traps.primaryArtifactCard).toBeNull();
+    expect(vm.slots.common_traps.emptyState).toEqual({
+      label: 'Awaiting verification',
+      message: 'A candidate artifact is visible in the inbox, but this slot has no resident until verification completes.',
     });
   });
 

--- a/src/components/learning-runtime/view-models/workspace-view-model.js
+++ b/src/components/learning-runtime/view-models/workspace-view-model.js
@@ -89,6 +89,39 @@ function buildWorkspaceSummary(workspace = {}) {
   };
 }
 
+function normalizeCapabilities(capabilities = null) {
+  if (!capabilities || typeof capabilities !== 'object' || Array.isArray(capabilities)) {
+    return null;
+  }
+
+  return {
+    shellVisible:
+      typeof capabilities.shellVisible === 'boolean'
+        ? capabilities.shellVisible
+        : capabilities.shell_visible ?? null,
+    bodyVisible:
+      typeof capabilities.bodyVisible === 'boolean'
+        ? capabilities.bodyVisible
+        : capabilities.body_visible ?? null,
+    residentEligible:
+      typeof capabilities.residentEligible === 'boolean'
+        ? capabilities.residentEligible
+        : capabilities.resident_eligible ?? null,
+    authoritativeAutomationEligible:
+      typeof capabilities.authoritativeAutomationEligible === 'boolean'
+        ? capabilities.authoritativeAutomationEligible
+        : capabilities.authoritative_automation_eligible ?? null,
+  };
+}
+
+function isResidentEligibleRecord(record = {}) {
+  if (typeof record?.capabilities?.residentEligible === 'boolean') {
+    return record.capabilities.residentEligible;
+  }
+
+  return record?.artifactState === 'verified' || record?.artifactState === 'released';
+}
+
 function normalizeCapabilityList(values) {
   return (Array.isArray(values) ? values : [])
     .map((value) => normalizeString(value))
@@ -342,6 +375,8 @@ function normalizeArtifactRecord(artifact = {}, { source = 'artifact_inbox' } = 
     title: normalizeString(artifact.title, artifactId),
     summary: normalizeString(artifact.summary ?? artifact.description, null),
     artifactKind: normalizeString(artifact.artifactKind ?? artifact.artifact_kind, null),
+    artifactState: normalizeString(artifact.artifactState ?? artifact.artifact_state, null),
+    capabilities: normalizeCapabilities(artifact.capabilities),
     canonicalHomeTopicId: normalizeString(
       artifact.canonicalHomeTopicId ?? artifact.canonical_home_topic_id,
       null,
@@ -363,7 +398,7 @@ function normalizeArtifactRecord(artifact = {}, { source = 'artifact_inbox' } = 
 }
 
 function buildArtifactStatusState(record, fallbackState = null) {
-  if (record?.lifecycleStatus === 'superseded') {
+  if (record?.artifactState === 'superseded' || record?.lifecycleStatus === 'superseded') {
     return {
       value: 'superseded',
       label: 'Superseded artifact',
@@ -372,7 +407,7 @@ function buildArtifactStatusState(record, fallbackState = null) {
     };
   }
 
-  if (record?.trustStatus === 'contested') {
+  if (record?.artifactState === 'contested' || record?.trustStatus === 'contested') {
     return {
       value: 'contested',
       label: 'Contested artifact',
@@ -400,12 +435,15 @@ function buildArtifactActionState(record, workspace) {
     Boolean(record?.slotKey)
     && Boolean(record?.artifactKind)
     && isCompatibleArtifactKindForSlot(record.slotKey, record.artifactKind);
+  const residentEligible = isResidentEligibleRecord(record);
+  const contested = record?.artifactState === 'contested' || record?.trustStatus === 'contested';
 
   const canPin =
     record?.source === 'artifact_inbox'
     && record?.placementStatus !== 'pinned'
     && record?.lifecycleStatus !== 'superseded'
-    && record?.trustStatus !== 'contested'
+    && !contested
+    && residentEligible
     && record?.slotKey !== 'review_queue'
     && sameCanonicalHome
     && hasCompatibleSlotMetadata;
@@ -415,7 +453,7 @@ function buildArtifactActionState(record, workspace) {
     canUnpin: record?.placementStatus === 'pinned',
     canMarkContested:
       record?.lifecycleStatus !== 'superseded'
-      && record?.trustStatus !== 'contested'
+      && !contested
       && record?.placementStatus !== 'pinned',
     canSupersede: Boolean(record?.artifactId) && record?.lifecycleStatus !== 'superseded',
     pinBlockedReason:
@@ -423,8 +461,10 @@ function buildArtifactActionState(record, workspace) {
         ? null
         : !sameCanonicalHome
           ? 'Secondary-topic artifacts cannot be pinned into this workspace.'
-          : record?.trustStatus === 'contested'
+          : contested
             ? 'Contested artifacts cannot be pinned.'
+            : !residentEligible
+              ? 'This artifact is not eligible for stable residency.'
             : record?.lifecycleStatus === 'superseded'
               ? 'Superseded artifacts cannot be pinned.'
               : record?.placementStatus === 'pinned'
@@ -453,6 +493,8 @@ function buildArtifactCard(record, {
   return {
     artifactId: record.artifactId,
     artifactKind: record.artifactKind,
+    artifactState: record.artifactState,
+    capabilities: record.capabilities,
     canonicalHomeTopicId: record.canonicalHomeTopicId,
     placementStatus: record.placementStatus,
     trustStatus: record.trustStatus,
@@ -492,6 +534,17 @@ function buildCardViewModel(ref, {
     state,
     launch: launch || buildReferenceLaunch(ref, workspace),
   };
+}
+
+function buildSlotEmptyState(rawState) {
+  if (rawState === 'awaiting_verification') {
+    return {
+      label: 'Awaiting verification',
+      message: 'A candidate artifact is visible in the inbox, but this slot has no resident until verification completes.',
+    };
+  }
+
+  return SLOT_EMPTY_STATE;
 }
 
 function buildSlotViewModel(definition, slots, slotState, workspace) {
@@ -560,7 +613,7 @@ function buildSlotViewModel(definition, slots, slotState, workspace) {
     updatedAtLabel: buildUpdatedAtLabel(updatedAt),
     surfaceState,
     contentState,
-    emptyState: primaryArtifact ? null : SLOT_EMPTY_STATE,
+    emptyState: primaryArtifact ? null : buildSlotEmptyState(rawState),
     slotLaunch: buildSlotLaunch(workspace, definition.key),
   };
 }


### PR DESCRIPTION
## Summary

This stacked PR implements issue #215 on top of the lifecycle contract from #214. It keeps a single resident pointer per workspace slot, prevents unverified successors from displacing a verified or released resident, and only projects `awaiting_verification` when a slot truly has no displayable resident.

## What Changed

- demote the prior pinned resident when a new resident-eligible artifact is pinned into the same slot
- reject `attach_superseded_by` for unverified successors under `LEARNING_ARTIFACT_LIFECYCLE_ENABLED`
- load topic artifacts into workspace reads behind `LEARNING_ARTIFACT_LIFECYCLE_ENABLED` and resolve exactly one resident pointer per slot
- project pending unverified artifacts into `artifact_inbox` and derive `slot_state = awaiting_verification` only when no displayable resident remains
- block unverified candidates from pin and supersede actions in the workspace view-model and shell

## Verification

- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/artifact-service.test.js`
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/workspace-read-service.test.js -t "workspace returns stable slots plus linked references from secondary topics|workspace residency matrix|marking effect -> review task -> workspace projection -> artifact patch keeps lifecycle and ownership consistent|GET /api/learning/workspaces/:topicId returns stable slots and linked references"`
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand src/components/learning-runtime/__tests__/view-models.test.js src/components/learning-runtime/__tests__/WorkspaceShell.test.js`

## Notes

- Closeout evidence: `docs/reports/2026-04-17-issue-215-closeout.md`
- Running the full `api/learning/__tests__/workspace-read-service.test.js` file still shows one unrelated pre-existing released-scope failure on this stack: `review-task writes update topic projections and active review-queue references` currently expects `released_scoring` but receives `non_released_fallback`.

Closes #215.
Stacked on #214.