### PR TITLE
feat(learning): materialize LearningUpdateProposed receipts

### DIFF
--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -283,7 +283,7 @@ describe('attempt-event-service', () => {
       proposed_mastery_effects: [
         expect.objectContaining({
           effect_key:
-            'mastery:family:user-bridge-1:topic-trig-equations:9709.trigonometry_manipulation_equations',
+            'mastery:mark-run:mr-bridge-1:r1:family:user-bridge-1:topic-trig-equations:9709.trigonometry_manipulation_equations',
           user_id: 'user-bridge-1',
           level: 'family',
           topic_id: 'topic-trig-equations',
@@ -293,7 +293,7 @@ describe('attempt-event-service', () => {
       proposed_review_tasks: [
         expect.objectContaining({
           effect_key:
-            'review:user-bridge-1:topic-trig-equations:9709.trigonometry.equations:sign_error',
+            'review:mark-run:mr-bridge-1:r1:user-bridge-1:topic-trig-equations:9709.trigonometry.equations:sign_error',
           user_id: 'user-bridge-1',
           target_topic_id: 'topic-trig-equations',
           target_question_type_id: '9709.trigonometry.equations',
@@ -302,7 +302,7 @@ describe('attempt-event-service', () => {
       proposed_artifact_suggestions: [
         expect.objectContaining({
           effect_key:
-            'artifact:user-bridge-1:topic-trig-equations:misconception_card:sign_error',
+            'artifact:mark-run:mr-bridge-1:r1:user-bridge-1:topic-trig-equations:misconception_card:sign_error',
           artifact_kind: 'misconception_card',
           canonical_home_topic_id: 'topic-trig-equations',
           target_question_type_id: '9709.trigonometry.equations',
@@ -399,6 +399,7 @@ describe('attempt-event-service', () => {
 
     const result = await persistAttemptEventBridge(client, buildBridgeInput({
       markRunId: 'mr-bridge-2',
+      misconceptionTags: ['sign_error'],
       sourceMarkRunRef: {
         kind: 'mark_run',
         mark_run_id: 'mr-bridge-2',
@@ -427,6 +428,29 @@ describe('attempt-event-service', () => {
     records.learningEvents.forEach((event, index) => {
       expect(event.truth_revision).toBe(2);
       expect(event.sequence_no).toBe(index + 1);
+    });
+
+    const learningUpdateEvent = records.learningEvents.at(-1);
+    expect(learningUpdateEvent.payload).toMatchObject({
+      proposal_key: 'mark-run:mr-bridge-2',
+      proposed_mastery_effects: [
+        expect.objectContaining({
+          effect_key:
+            'mastery:mark-run:mr-bridge-2:r2:family:user-bridge-1:topic-trig-equations:9709.trigonometry_manipulation_equations',
+        }),
+      ],
+      proposed_review_tasks: [
+        expect.objectContaining({
+          effect_key:
+            'review:mark-run:mr-bridge-2:r2:user-bridge-1:topic-trig-equations:9709.trigonometry.equations:sign_error',
+        }),
+      ],
+      proposed_artifact_suggestions: [
+        expect.objectContaining({
+          effect_key:
+            'artifact:mark-run:mr-bridge-2:r2:user-bridge-1:topic-trig-equations:misconception_card:sign_error',
+        }),
+      ],
     });
   });
 

--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -267,6 +267,51 @@ describe('attempt-event-service', () => {
     expect(records.bridgeWarning).toBeNull();
   });
 
+  test('persists normalized downstream effect proposals with stable effect keys inside LearningUpdateProposed', async () => {
+    const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
+    const { client, records } = createMockClient();
+
+    await persistAttemptEventBridge(client, buildBridgeInput({
+      misconceptionTags: ['sign_error'],
+    }));
+
+    const learningUpdateEvent = records.learningEvents.at(-1);
+
+    expect(learningUpdateEvent.event_type).toBe('LearningUpdateProposed');
+    expect(learningUpdateEvent.payload).toMatchObject({
+      proposal_key: 'mark-run:mr-bridge-1',
+      proposed_mastery_effects: [
+        expect.objectContaining({
+          effect_key:
+            'mastery:family:user-bridge-1:topic-trig-equations:9709.trigonometry_manipulation_equations',
+          user_id: 'user-bridge-1',
+          level: 'family',
+          topic_id: 'topic-trig-equations',
+          family_id: '9709.trigonometry_manipulation_equations',
+        }),
+      ],
+      proposed_review_tasks: [
+        expect.objectContaining({
+          effect_key:
+            'review:user-bridge-1:topic-trig-equations:9709.trigonometry.equations:sign_error',
+          user_id: 'user-bridge-1',
+          target_topic_id: 'topic-trig-equations',
+          target_question_type_id: '9709.trigonometry.equations',
+        }),
+      ],
+      proposed_artifact_suggestions: [
+        expect.objectContaining({
+          effect_key:
+            'artifact:user-bridge-1:topic-trig-equations:misconception_card:sign_error',
+          artifact_kind: 'misconception_card',
+          canonical_home_topic_id: 'topic-trig-equations',
+          target_question_type_id: '9709.trigonometry.equations',
+          misconception_tags: ['sign_error'],
+        }),
+      ],
+    });
+  });
+
   test('reuses the same bridge delivery row and does not append duplicate events on repeated delivery', async () => {
     const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
     const { client, records } = createMockClient();

--- a/api/learning/__tests__/learning-effect-engine.test.js
+++ b/api/learning/__tests__/learning-effect-engine.test.js
@@ -110,11 +110,16 @@ function createInMemoryEffectRepository() {
   };
 }
 
-function buildProposalEvent() {
+function buildProposalEvent({
+  eventId = 'learning-update-event-1',
+  truthRevision = 1,
+} = {}) {
+  const proposalRevisionKey = `mark-run:mark-run-1:r${truthRevision}`;
+
   return {
-    event_id: 'learning-update-event-1',
+    event_id: eventId,
     aggregate_id: 'attempt-1',
-    truth_revision: 1,
+    truth_revision: truthRevision,
     payload: {
       attempt_id: 'attempt-1',
       proposal_key: 'mark-run:mark-run-1',
@@ -124,7 +129,8 @@ function buildProposalEvent() {
       },
       proposed_mastery_effects: [
         {
-          effect_key: 'mastery:family:user-1:topic-1:9709.trigonometry_manipulation_equations',
+          effect_key:
+            `mastery:${proposalRevisionKey}:family:user-1:topic-1:9709.trigonometry_manipulation_equations`,
           user_id: 'user-1',
           level: 'family',
           topic_id: 'topic-1',
@@ -141,7 +147,8 @@ function buildProposalEvent() {
       ],
       proposed_review_tasks: [
         {
-          effect_key: 'review:user-1:topic-1:9709.trigonometry.equations:sign_error',
+          effect_key:
+            `review:${proposalRevisionKey}:user-1:topic-1:9709.trigonometry.equations:sign_error`,
           user_id: 'user-1',
           target_kind: 'question_type',
           target_topic_id: 'topic-1',
@@ -163,7 +170,8 @@ function buildProposalEvent() {
       ],
       proposed_artifact_suggestions: [
         {
-          effect_key: 'artifact:user-1:topic-1:misconception_card:sign_error',
+          effect_key:
+            `artifact:${proposalRevisionKey}:user-1:topic-1:misconception_card:sign_error`,
           artifact_kind: 'misconception_card',
           canonical_home_topic_id: 'topic-1',
           canonical_home_topic_path: '9709/trigonometry/equations',
@@ -309,6 +317,86 @@ describe('learning-effect-engine', () => {
     expect(masteryHandler).toHaveBeenCalledTimes(1);
     expect(reviewHandler).toHaveBeenCalledTimes(1);
     expect(artifactHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('later proposal revisions for the same target execute instead of deduping prior receipts', async () => {
+    const { applyLearningUpdateProposal } = await import('../lib/events/learning-effect-engine.js');
+    const effectRepository = createInMemoryEffectRepository();
+    const masteryHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'family_mastery',
+      result_ref_id: 'family-mastery-1',
+    }));
+    const reviewHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'review_task',
+      result_ref_id: 'review-task-1',
+    }));
+    const artifactHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'artifact',
+      result_ref_id: 'artifact-1',
+    }));
+
+    const first = await applyLearningUpdateProposal(
+      { proposalEvent: buildProposalEvent({ eventId: 'learning-update-event-1', truthRevision: 1 }) },
+      {
+        effectRepository,
+        handlers: {
+          mastery: masteryHandler,
+          review_tasks: reviewHandler,
+          artifact_suggestions: artifactHandler,
+        },
+      },
+    );
+    const second = await applyLearningUpdateProposal(
+      { proposalEvent: buildProposalEvent({ eventId: 'learning-update-event-2', truthRevision: 2 }) },
+      {
+        effectRepository,
+        handlers: {
+          mastery: masteryHandler,
+          review_tasks: reviewHandler,
+          artifact_suggestions: artifactHandler,
+        },
+      },
+    );
+
+    expect(first.status).toBe('applied');
+    expect(second).toMatchObject({
+      ok: true,
+      status: 'applied',
+      proposal_key: 'mark-run:mark-run-1',
+      receipt_summary: {
+        total: 3,
+        persisted: 3,
+        retrying: 0,
+      },
+    });
+    expect(masteryHandler).toHaveBeenCalledTimes(2);
+    expect(reviewHandler).toHaveBeenCalledTimes(2);
+    expect(artifactHandler).toHaveBeenCalledTimes(2);
+    expect(await effectRepository.listEffectReceiptsByEventId('learning-update-event-2')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          handler_name: 'mastery',
+          truth_revision: 2,
+          effect_key:
+            'mastery:mark-run:mark-run-1:r2:family:user-1:topic-1:9709.trigonometry_manipulation_equations',
+        }),
+        expect.objectContaining({
+          handler_name: 'review_tasks',
+          truth_revision: 2,
+          effect_key:
+            'review:mark-run:mark-run-1:r2:user-1:topic-1:9709.trigonometry.equations:sign_error',
+        }),
+        expect.objectContaining({
+          handler_name: 'artifact_suggestions',
+          truth_revision: 2,
+          effect_key:
+            'artifact:mark-run:mark-run-1:r2:user-1:topic-1:misconception_card:sign_error',
+        }),
+      ]),
+    );
   });
 
   test('partial handler failure keeps successful receipts persisted and records retry debt for the failed handler', async () => {

--- a/api/learning/__tests__/learning-effect-engine.test.js
+++ b/api/learning/__tests__/learning-effect-engine.test.js
@@ -1,5 +1,7 @@
 import { jest } from '@jest/globals';
 
+const EFFECT_RECEIPT_STATUSES = new Set(['started', 'succeeded', 'failed', 'noop', 'superseded']);
+
 function clone(value) {
   return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
 }
@@ -75,6 +77,10 @@ function createInMemoryEffectRepository() {
       result_ref_type: resultRefType = null,
       result_ref_id: resultRefId = null,
     } = {}) {
+      if (!EFFECT_RECEIPT_STATUSES.has(status)) {
+        throw new Error(`invalid_effect_receipt_status:${status}`);
+      }
+
       const receipt = receipts.get(keyFor(handlerName, effectKey));
       receipt.status = status;
       receipt.receipt_state = 'persisted';
@@ -458,6 +464,57 @@ describe('learning-effect-engine', () => {
           handler_name: 'artifact_suggestions',
           status: 'succeeded',
           receipt_state: 'persisted',
+        }),
+      ]),
+    );
+  });
+
+  test('review-task domain status does not leak into the effect receipt status enum', async () => {
+    const { applyLearningUpdateProposal } = await import('../lib/events/learning-effect-engine.js');
+    const effectRepository = createInMemoryEffectRepository();
+    const reviewTaskService = {
+      async materializeProposedTask() {
+        return [{
+          review_task_id: 'review-task-1',
+          status: 'open',
+        }];
+      },
+    };
+    const masteryHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'family_mastery',
+      result_ref_id: 'family-mastery-1',
+    }));
+    const artifactHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'artifact',
+      result_ref_id: 'artifact-1',
+    }));
+
+    const result = await applyLearningUpdateProposal(
+      { proposalEvent: buildProposalEvent() },
+      {
+        effectRepository,
+        reviewTaskService,
+        handlers: {
+          mastery: masteryHandler,
+          artifact_suggestions: artifactHandler,
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 'applied',
+    });
+    expect(await effectRepository.listEffectReceiptsByEventId('learning-update-event-1')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          handler_name: 'review_tasks',
+          status: 'succeeded',
+          receipt_state: 'persisted',
+          result_ref_type: 'review_task',
+          result_ref_id: 'review-task-1',
         }),
       ]),
     );

--- a/api/learning/__tests__/learning-effect-engine.test.js
+++ b/api/learning/__tests__/learning-effect-engine.test.js
@@ -1,0 +1,377 @@
+import { jest } from '@jest/globals';
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function createInMemoryEffectRepository() {
+  const receipts = new Map();
+
+  function keyFor(handlerName, effectKey) {
+    return `${handlerName}::${effectKey}`;
+  }
+
+  function cloneReceipt(receipt) {
+    return clone(receipt);
+  }
+
+  return {
+    receipts,
+    async reserveEffectReceipt(input = {}) {
+      const key = keyFor(input.handler_name, input.effect_key);
+      const existing = receipts.get(key) ?? null;
+      const attemptedAt = '2026-04-17T10:00:00.000Z';
+
+      if (!existing) {
+        const receipt = {
+          effect_id: `effect-${receipts.size + 1}`,
+          proposal_key: input.proposal_key,
+          event_id: input.event_id,
+          aggregate_id: input.aggregate_id,
+          truth_revision: input.truth_revision,
+          handler_name: input.handler_name,
+          effect_key: input.effect_key,
+          status: 'started',
+          receipt_state: 'pending',
+          retry_count: 0,
+          attempt_count: 1,
+          last_attempted_at: attemptedAt,
+          last_error: null,
+          result_ref_type: null,
+          result_ref_id: null,
+        };
+        receipts.set(key, receipt);
+        return {
+          inserted: true,
+          reason_code: null,
+          receipt: cloneReceipt(receipt),
+        };
+      }
+
+      if (existing.receipt_state === 'retrying' && existing.status === 'failed') {
+        existing.status = 'started';
+        existing.receipt_state = 'pending';
+        existing.attempt_count += 1;
+        existing.last_attempted_at = attemptedAt;
+        existing.last_error = null;
+        return {
+          inserted: true,
+          reason_code: 'retry_failed_effect',
+          receipt: cloneReceipt(existing),
+        };
+      }
+
+      return {
+        inserted: false,
+        reason_code: 'duplicate_effect_key',
+        receipt: cloneReceipt(existing),
+      };
+    },
+
+    async markEffectReceiptSucceeded({
+      handler_name: handlerName,
+      effect_key: effectKey,
+      status = 'succeeded',
+      result_ref_type: resultRefType = null,
+      result_ref_id: resultRefId = null,
+    } = {}) {
+      const receipt = receipts.get(keyFor(handlerName, effectKey));
+      receipt.status = status;
+      receipt.receipt_state = 'persisted';
+      receipt.result_ref_type = resultRefType;
+      receipt.result_ref_id = resultRefId;
+      receipt.last_error = null;
+      return cloneReceipt(receipt);
+    },
+
+    async markEffectReceiptFailed({
+      handler_name: handlerName,
+      effect_key: effectKey,
+      error_code: errorCode = 'effect_failed',
+      error_message: errorMessage = 'effect failed',
+      receipt_state: receiptState = 'retrying',
+    } = {}) {
+      const receipt = receipts.get(keyFor(handlerName, effectKey));
+      receipt.status = 'failed';
+      receipt.receipt_state = receiptState;
+      receipt.retry_count += 1;
+      receipt.last_error = {
+        code: errorCode,
+        message: errorMessage,
+      };
+      return cloneReceipt(receipt);
+    },
+
+    async listEffectReceiptsByEventId(eventId) {
+      return [...receipts.values()]
+        .filter((receipt) => receipt.event_id === eventId)
+        .map((receipt) => cloneReceipt(receipt));
+    },
+  };
+}
+
+function buildProposalEvent() {
+  return {
+    event_id: 'learning-update-event-1',
+    aggregate_id: 'attempt-1',
+    truth_revision: 1,
+    payload: {
+      attempt_id: 'attempt-1',
+      proposal_key: 'mark-run:mark-run-1',
+      guardrail_decisions: {
+        authoritative_scoring_allowed: true,
+        release_scope_status: 'released_scoring',
+      },
+      proposed_mastery_effects: [
+        {
+          effect_key: 'mastery:family:user-1:topic-1:9709.trigonometry_manipulation_equations',
+          user_id: 'user-1',
+          level: 'family',
+          topic_id: 'topic-1',
+          family_id: '9709.trigonometry_manipulation_equations',
+          question_type_id: null,
+          mastery_state: {
+            signal_direction: 'diagnostic',
+            signal_weight: 'conservative',
+          },
+          signal_summary: {
+            source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
+          },
+        },
+      ],
+      proposed_review_tasks: [
+        {
+          effect_key: 'review:user-1:topic-1:9709.trigonometry.equations:sign_error',
+          user_id: 'user-1',
+          target_kind: 'question_type',
+          target_topic_id: 'topic-1',
+          target_topic_path: '9709/trigonometry/equations',
+          target_family_id: '9709.trigonometry_manipulation_equations',
+          target_question_type_id: '9709.trigonometry.equations',
+          target_misconception_tags: ['sign_error'],
+          source_question_id: 'question-1',
+          source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
+          trigger_type: 'repair',
+          mode: 'redo_variant',
+          due_at: '2026-04-18T10:00:00.000Z',
+          priority: 'high',
+          estimated_minutes: 15,
+          success_criteria: { posture: 'released_scoring_repair' },
+          completion_evidence: {},
+          status: 'open',
+        },
+      ],
+      proposed_artifact_suggestions: [
+        {
+          effect_key: 'artifact:user-1:topic-1:misconception_card:sign_error',
+          artifact_kind: 'misconception_card',
+          canonical_home_topic_id: 'topic-1',
+          canonical_home_topic_path: '9709/trigonometry/equations',
+          source_session_id: null,
+          source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
+          source_mark_run_ref: { kind: 'mark_run', mark_run_id: 'mark-run-1' },
+          target_family_id: '9709.trigonometry_manipulation_equations',
+          target_question_type_id: '9709.trigonometry.equations',
+          slot_key: 'common_traps',
+          misconception_tags: ['sign_error'],
+        },
+      ],
+    },
+  };
+}
+
+describe('learning-effect-engine', () => {
+  test('a persisted LearningUpdateProposed payload can drive mastery, review, and artifact handlers with persisted receipts', async () => {
+    const { applyLearningUpdateProposal } = await import('../lib/events/learning-effect-engine.js');
+    const effectRepository = createInMemoryEffectRepository();
+    const masteryHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'family_mastery',
+      result_ref_id: 'family-mastery-1',
+    }));
+    const reviewHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'review_task',
+      result_ref_id: 'review-task-1',
+    }));
+    const artifactHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'artifact',
+      result_ref_id: 'artifact-1',
+    }));
+
+    const result = await applyLearningUpdateProposal(
+      {
+        proposalEvent: buildProposalEvent(),
+      },
+      {
+        effectRepository,
+        handlers: {
+          mastery: masteryHandler,
+          review_tasks: reviewHandler,
+          artifact_suggestions: artifactHandler,
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 'applied',
+      proposal_key: 'mark-run:mark-run-1',
+      receipt_summary: {
+        total: 3,
+        persisted: 3,
+        retrying: 0,
+      },
+    });
+    expect(masteryHandler).toHaveBeenCalledTimes(1);
+    expect(reviewHandler).toHaveBeenCalledTimes(1);
+    expect(artifactHandler).toHaveBeenCalledTimes(1);
+    expect(await effectRepository.listEffectReceiptsByEventId('learning-update-event-1')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          handler_name: 'mastery',
+          status: 'succeeded',
+          receipt_state: 'persisted',
+          result_ref_type: 'family_mastery',
+          result_ref_id: 'family-mastery-1',
+        }),
+        expect.objectContaining({
+          handler_name: 'review_tasks',
+          status: 'succeeded',
+          receipt_state: 'persisted',
+          result_ref_type: 'review_task',
+          result_ref_id: 'review-task-1',
+        }),
+        expect.objectContaining({
+          handler_name: 'artifact_suggestions',
+          status: 'succeeded',
+          receipt_state: 'persisted',
+          result_ref_type: 'artifact',
+          result_ref_id: 'artifact-1',
+        }),
+      ]),
+    );
+  });
+
+  test('re-running the same proposal converges to the stored receipt outcome instead of duplicating downstream writes', async () => {
+    const { applyLearningUpdateProposal } = await import('../lib/events/learning-effect-engine.js');
+    const effectRepository = createInMemoryEffectRepository();
+    const masteryHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'family_mastery',
+      result_ref_id: 'family-mastery-1',
+    }));
+    const reviewHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'review_task',
+      result_ref_id: 'review-task-1',
+    }));
+    const artifactHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'artifact',
+      result_ref_id: 'artifact-1',
+    }));
+
+    const first = await applyLearningUpdateProposal(
+      { proposalEvent: buildProposalEvent() },
+      {
+        effectRepository,
+        handlers: {
+          mastery: masteryHandler,
+          review_tasks: reviewHandler,
+          artifact_suggestions: artifactHandler,
+        },
+      },
+    );
+    const second = await applyLearningUpdateProposal(
+      { proposalEvent: buildProposalEvent() },
+      {
+        effectRepository,
+        handlers: {
+          mastery: masteryHandler,
+          review_tasks: reviewHandler,
+          artifact_suggestions: artifactHandler,
+        },
+      },
+    );
+
+    expect(first.status).toBe('applied');
+    expect(second).toMatchObject({
+      ok: true,
+      status: 'deduped',
+      receipt_summary: {
+        total: 3,
+        persisted: 3,
+        retrying: 0,
+      },
+    });
+    expect(masteryHandler).toHaveBeenCalledTimes(1);
+    expect(reviewHandler).toHaveBeenCalledTimes(1);
+    expect(artifactHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('partial handler failure keeps successful receipts persisted and records retry debt for the failed handler', async () => {
+    const { applyLearningUpdateProposal } = await import('../lib/events/learning-effect-engine.js');
+    const effectRepository = createInMemoryEffectRepository();
+    const masteryHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'family_mastery',
+      result_ref_id: 'family-mastery-1',
+    }));
+    const reviewHandler = jest.fn(async () => {
+      throw new Error('review task write failed');
+    });
+    const artifactHandler = jest.fn(async () => ({
+      status: 'succeeded',
+      result_ref_type: 'artifact',
+      result_ref_id: 'artifact-1',
+    }));
+
+    const result = await applyLearningUpdateProposal(
+      { proposalEvent: buildProposalEvent() },
+      {
+        effectRepository,
+        handlers: {
+          mastery: masteryHandler,
+          review_tasks: reviewHandler,
+          artifact_suggestions: artifactHandler,
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 'partial_failure',
+      receipt_summary: {
+        total: 3,
+        persisted: 2,
+        retrying: 1,
+      },
+    });
+    expect(await effectRepository.listEffectReceiptsByEventId('learning-update-event-1')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          handler_name: 'mastery',
+          status: 'succeeded',
+          receipt_state: 'persisted',
+        }),
+        expect.objectContaining({
+          handler_name: 'review_tasks',
+          status: 'failed',
+          receipt_state: 'retrying',
+          retry_count: 1,
+          last_error: {
+            code: 'effect_execution_failed',
+            message: 'review task write failed',
+          },
+        }),
+        expect.objectContaining({
+          handler_name: 'artifact_suggestions',
+          status: 'succeeded',
+          receipt_state: 'persisted',
+        }),
+      ]),
+    );
+  });
+});

--- a/api/learning/__tests__/schema-contract.test.js
+++ b/api/learning/__tests__/schema-contract.test.js
@@ -12,6 +12,7 @@ const LEARNING_RUNTIME_MIGRATIONS = [
   'supabase/migrations/20260324110000_promote_learning_runtime_integration_application.sql',
   'supabase/migrations/20260412103000_expand_learning_question_analysis_snapshots_phase_a.sql',
   'supabase/migrations/20260417110000_create_learning_event_deliveries.sql',
+  'supabase/migrations/20260417120000_create_learning_runtime_effect_receipts.sql',
   'supabase/migrations/20260413110000_phase_a_question_classified_events.sql',
   LEARNING_QUESTION_SEARCH_MIGRATION
 ];
@@ -246,6 +247,23 @@ describe('learning runtime schema contract', () => {
       "delivery_state in ('pending', 'persisted', 'retrying', 'reconciled', 'needs_manual_review')",
       'unique (stable_idempotency_key)'
     ].forEach((token) => expect(deliverySql).toContain(token));
+
+    const effectReceiptSql = normalizeSql(readMigration(
+      'supabase/migrations/20260417120000_create_learning_runtime_effect_receipts.sql'
+    ));
+
+    [
+      'alter table public.learning_event_effects',
+      'proposal_key',
+      'receipt_state',
+      "receipt_state in ('pending', 'persisted', 'retrying', 'reconciled', 'needs_manual_review')",
+      'retry_count',
+      'last_attempted_at',
+      'last_error',
+      'completed_at',
+      'idx_learning_event_effects_proposal_receipt',
+      'idx_learning_event_effects_retry_attention'
+    ].forEach((token) => expect(effectReceiptSql).toContain(token));
 
     const registryProjectionSql = normalizeSql(readMigration(
       'supabase/migrations/20260413110000_phase_a_question_classified_events.sql'

--- a/api/learning/lib/artifacts/artifact-service.js
+++ b/api/learning/lib/artifacts/artifact-service.js
@@ -120,7 +120,7 @@ function buildCandidateHome(input = {}) {
   };
 }
 
-function buildArtifactCandidate(input = {}, timestamp) {
+export function buildArtifactCandidate(input = {}, timestamp) {
   const home = buildCandidateHome(input);
   const sourceAttemptGroundingRef = buildAttemptGroundingRef(input.source_attempt_ref, input);
 
@@ -158,6 +158,29 @@ function buildArtifactCandidate(input = {}, timestamp) {
     created_at: timestamp,
     updated_at: timestamp,
   };
+}
+
+async function materializeArtifactCandidate({
+  candidate,
+  artifactRepository,
+  lifecycleFlagEnabled,
+} = {}) {
+  if (!candidate || !candidate.canonical_home_topic_id) {
+    return [];
+  }
+
+  if (!artifactRepository?.insertArtifact) {
+    return [normalizeArtifactResult(candidate, lifecycleFlagEnabled)];
+  }
+
+  const stored = await artifactRepository.insertArtifact(candidate);
+  return [
+    normalizeArtifactResult({
+      ...stored,
+      canonical_home_topic_path: candidate.canonical_home_topic_path,
+      misconception_tags: candidate.misconception_tags,
+    }, lifecycleFlagEnabled),
+  ];
 }
 
 function hasVerificationAuditEvidence(artifact = {}) {
@@ -302,23 +325,19 @@ export function createArtifactService({
       }
 
       const candidate = buildArtifactCandidate(input, now().toISOString());
+      return materializeArtifactCandidate({
+        candidate,
+        artifactRepository,
+        lifecycleFlagEnabled,
+      });
+    },
 
-      if (!candidate.canonical_home_topic_id) {
-        return [];
-      }
-
-      if (!artifactRepository?.insertArtifact) {
-        return [normalizeArtifactResult(candidate, lifecycleFlagEnabled)];
-      }
-
-      const stored = await artifactRepository.insertArtifact(candidate);
-      return [
-        normalizeArtifactResult({
-          ...stored,
-          canonical_home_topic_path: candidate.canonical_home_topic_path,
-          misconception_tags: candidate.misconception_tags,
-        }, lifecycleFlagEnabled),
-      ];
+    async materializeProposedArtifactSuggestion(candidate = {}) {
+      return materializeArtifactCandidate({
+        candidate,
+        artifactRepository,
+        lifecycleFlagEnabled,
+      });
     },
 
     async patchArtifact({

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -466,6 +466,7 @@ function buildBridgeEvents(input = {}) {
     source_session_id: sessionId,
     decisions: input.decisions,
     marking_result: input.markingResult,
+    truth_revision: truthRevision,
     uncertainty_validated: input.uncertaintyValidated ?? true,
     release_scope_posture: runtimeAuthorityPosture,
     misconception_tags: input.misconceptionTags ?? input.misconception_tags ?? [],

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { projectAttemptPipelineState } from './event-service.js';
 import { buildRuntimeAuthorityPosture } from '../contracts/runtime-authority-posture.js';
+import { buildLearningUpdateProposal } from '../mastery/mastery-orchestrator.js';
 
 const BRIDGE_EVENT_TYPES = Object.freeze([
   'AttemptSubmitted',
@@ -257,24 +258,40 @@ function buildLearningUpdateProposedPayload({
   attemptId,
   authorityPosture,
   markRunId,
+  proposal = null,
 } = {}) {
   const fallbackReason = normalizeString(authorityPosture.fallback_reason_code) || null;
+  const normalizedProposal = proposal && typeof proposal === 'object' ? proposal : {};
+  const proposalKey = normalizeString(normalizedProposal.proposal_key)
+    || (normalizeString(markRunId) ? `mark-run:${markRunId}` : `attempt:${attemptId}`);
 
   return {
     attempt_id: attemptId,
     authority_posture: cloneJson(authorityPosture),
-    proposal_key: normalizeString(markRunId) ? `mark-run:${markRunId}` : `attempt:${attemptId}`,
-    guardrail_decisions: {
+    proposal_key: proposalKey,
+    guardrail_decisions: cloneJson(normalizedProposal.guardrail_decisions ?? {
       authoritative_scoring_allowed: Boolean(authorityPosture.authoritative_scoring_allowed),
       release_scope_status: normalizeString(authorityPosture.release_scope_status) || null,
       learning_signal_posture: normalizeString(authorityPosture.learning_signal_posture) || null,
       fallback_mode: normalizeString(authorityPosture.fallback_mode) || null,
       fallback_reason_code: fallbackReason,
       reasons: fallbackReason ? [fallbackReason] : ['released_scoring'],
-    },
-    proposed_mastery_effects: [],
-    proposed_review_tasks: [],
-    proposed_artifact_suggestions: [],
+    }),
+    proposed_mastery_effects: cloneJson(
+      normalizedProposal.proposedMasteryEffects
+      ?? normalizedProposal.proposed_mastery_effects
+      ?? [],
+    ),
+    proposed_review_tasks: cloneJson(
+      normalizedProposal.proposedReviewTasks
+      ?? normalizedProposal.proposed_review_tasks
+      ?? [],
+    ),
+    proposed_artifact_suggestions: cloneJson(
+      normalizedProposal.proposedArtifactSuggestions
+      ?? normalizedProposal.proposed_artifact_suggestions
+      ?? [],
+    ),
   };
 }
 
@@ -426,6 +443,33 @@ function buildBridgeEvents(input = {}) {
     questionContext,
     attemptContext,
   });
+  const learningUpdateProposal = buildLearningUpdateProposal({
+    user_id: learnerId,
+    subject_code: subjectCode,
+    question_id: questionId,
+    question_context: {
+      source_kind: questionContext.source_kind,
+      family_id: questionContext.family_id,
+      question_type_id: questionContext.question_type_id,
+      question_type_release_state: questionContext.question_type_release_state,
+      primary_topic_id: questionContext.primary_topic_id,
+      primary_topic_path: questionContext.primary_topic_path,
+      classification_confidence: questionContext.classification_confidence,
+      candidate_rubric_refs: questionContext.candidate_rubric_refs,
+      release_scope_status: questionContext.release_scope_status,
+    },
+    attempt_id: attemptId,
+    mark_run_id: markRunId,
+    source_attempt_ref: sourceAttemptRef,
+    source_mark_run_ref: sourceMarkRunRef,
+    source_attempt_context: attemptContext,
+    source_session_id: sessionId,
+    decisions: input.decisions,
+    marking_result: input.markingResult,
+    uncertainty_validated: input.uncertaintyValidated ?? true,
+    release_scope_posture: runtimeAuthorityPosture,
+    misconception_tags: input.misconceptionTags ?? input.misconception_tags ?? [],
+  });
 
   const payloads = [
     buildAttemptSubmittedPayload({
@@ -459,6 +503,7 @@ function buildBridgeEvents(input = {}) {
       attemptId,
       authorityPosture: runtimeAuthorityPosture,
       markRunId,
+      proposal: learningUpdateProposal,
     }),
   ];
 

--- a/api/learning/lib/events/learning-effect-engine.js
+++ b/api/learning/lib/events/learning-effect-engine.js
@@ -22,6 +22,8 @@ const HANDLER_CONFIG = Object.freeze([
   },
 ]);
 
+const EFFECT_RECEIPT_SUCCESS_STATUSES = new Set(['succeeded', 'noop', 'superseded']);
+
 function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
 }
@@ -40,8 +42,15 @@ function buildReceiptSummary(receipts = []) {
 }
 
 function normalizeHandlerResult(result = {}, fallback = {}) {
+  const effectStatusCandidate =
+    normalizeString(result?.effect_status)
+    || normalizeString(result?.effectStatus)
+    || normalizeString(result?.status);
+
   return {
-    status: normalizeString(result?.status) || fallback.status || 'succeeded',
+    effect_status: EFFECT_RECEIPT_SUCCESS_STATUSES.has(effectStatusCandidate)
+      ? effectStatusCandidate
+      : (fallback.effect_status || 'succeeded'),
     result_ref_type:
       normalizeString(result?.result_ref_type)
       || normalizeString(result?.resultRefType)
@@ -204,7 +213,7 @@ export function createLearningEffectEngine({
             const receipt = await resolvedEffectRepository.markEffectReceiptSucceeded({
               handler_name: config.handlerName,
               effect_key: effect.effect_key,
-              status: normalizedResult.status,
+              status: normalizedResult.effect_status,
               result_ref_type: normalizedResult.result_ref_type,
               result_ref_id: normalizedResult.result_ref_id,
             });

--- a/api/learning/lib/events/learning-effect-engine.js
+++ b/api/learning/lib/events/learning-effect-engine.js
@@ -1,0 +1,249 @@
+import { createArtifactService } from '../artifacts/artifact-service.js';
+import { createMasteryOrchestrator } from '../mastery/mastery-orchestrator.js';
+import { createArtifactRepository } from '../repositories/artifact-repository.js';
+import { createLearningEventEffectRepository } from '../repositories/learning-event-effect-repository.js';
+import {
+  createDefaultReviewTaskService,
+  createReviewTaskService,
+} from '../review/review-task-service.js';
+
+const HANDLER_CONFIG = Object.freeze([
+  {
+    payloadKey: 'proposed_mastery_effects',
+    handlerName: 'mastery',
+  },
+  {
+    payloadKey: 'proposed_review_tasks',
+    handlerName: 'review_tasks',
+  },
+  {
+    payloadKey: 'proposed_artifact_suggestions',
+    handlerName: 'artifact_suggestions',
+  },
+]);
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function buildReceiptSummary(receipts = []) {
+  return {
+    total: receipts.length,
+    persisted: receipts.filter((receipt) => receipt?.receipt_state === 'persisted').length,
+    retrying: receipts.filter((receipt) => receipt?.receipt_state === 'retrying').length,
+    needs_manual_review: receipts.filter((receipt) => receipt?.receipt_state === 'needs_manual_review').length,
+  };
+}
+
+function normalizeHandlerResult(result = {}, fallback = {}) {
+  return {
+    status: normalizeString(result?.status) || fallback.status || 'succeeded',
+    result_ref_type:
+      normalizeString(result?.result_ref_type)
+      || normalizeString(result?.resultRefType)
+      || fallback.result_ref_type
+      || null,
+    result_ref_id:
+      normalizeString(result?.result_ref_id)
+      || normalizeString(result?.resultRefId)
+      || fallback.result_ref_id
+      || null,
+  };
+}
+
+function assertProposalEvent(proposalEvent = {}) {
+  if (!proposalEvent || typeof proposalEvent !== 'object' || Array.isArray(proposalEvent)) {
+    throw new Error('invalid_learning_update_event');
+  }
+
+  if (!normalizeString(proposalEvent.event_id)) {
+    throw new Error('missing_learning_update_event_id');
+  }
+
+  if (!normalizeString(proposalEvent.aggregate_id)) {
+    throw new Error('missing_learning_update_aggregate_id');
+  }
+
+  if (!Number.isInteger(Number(proposalEvent.truth_revision)) || Number(proposalEvent.truth_revision) < 1) {
+    throw new Error('invalid_learning_update_truth_revision');
+  }
+
+  const payload = proposalEvent.payload && typeof proposalEvent.payload === 'object'
+    ? proposalEvent.payload
+    : null;
+
+  if (!payload) {
+    throw new Error('missing_learning_update_payload');
+  }
+
+  if (!normalizeString(payload.proposal_key)) {
+    throw new Error('missing_learning_update_proposal_key');
+  }
+
+  return {
+    proposalEvent,
+    payload,
+  };
+}
+
+function buildDefaultHandlers({
+  supabase,
+  reviewTaskService,
+  artifactService,
+  masteryOrchestrator,
+} = {}) {
+  const resolvedReviewTaskService = reviewTaskService
+    || (supabase ? createDefaultReviewTaskService(supabase) : createReviewTaskService());
+  const resolvedArtifactService = artifactService
+    || createArtifactService({
+      artifactRepository: supabase ? createArtifactRepository(supabase) : null,
+    });
+  const resolvedMasteryOrchestrator = masteryOrchestrator
+    || createMasteryOrchestrator({
+      supabase,
+      reviewTaskService: resolvedReviewTaskService,
+      artifactService: resolvedArtifactService,
+    });
+
+  return {
+    mastery: async (effect) => {
+      const stored = await resolvedMasteryOrchestrator.materializeProposedMasteryEffect(effect);
+      return normalizeHandlerResult(stored, {
+        result_ref_type: effect.level === 'question_type' ? 'type_mastery' : 'family_mastery',
+        result_ref_id:
+          effect.level === 'question_type'
+            ? stored?.type_mastery_id ?? null
+            : stored?.family_mastery_id ?? null,
+      });
+    },
+    review_tasks: async (effect) => {
+      const [task] = await resolvedReviewTaskService.materializeProposedTask(effect);
+      return normalizeHandlerResult(task, {
+        result_ref_type: 'review_task',
+        result_ref_id: task?.review_task_id ?? null,
+      });
+    },
+    artifact_suggestions: async (effect) => {
+      const [artifact] = await resolvedArtifactService.materializeProposedArtifactSuggestion(effect);
+      return normalizeHandlerResult(artifact, {
+        result_ref_type: 'artifact',
+        result_ref_id: artifact?.artifact_id ?? null,
+      });
+    },
+  };
+}
+
+export function createLearningEffectEngine({
+  effectRepository,
+  handlers = {},
+  supabase = null,
+  reviewTaskService = null,
+  artifactService = null,
+  masteryOrchestrator = null,
+} = {}) {
+  const resolvedEffectRepository = effectRepository
+    || (supabase ? createLearningEventEffectRepository(supabase) : null);
+  if (!resolvedEffectRepository) {
+    throw new Error('effectRepository is required for learning-effect execution.');
+  }
+
+  const resolvedHandlers = {
+    ...buildDefaultHandlers({
+      supabase,
+      reviewTaskService,
+      artifactService,
+      masteryOrchestrator,
+    }),
+    ...handlers,
+  };
+
+  return {
+    async applyLearningUpdateProposal({
+      proposalEvent,
+    } = {}) {
+      const { payload } = assertProposalEvent(proposalEvent);
+      const receipts = [];
+      let failedCount = 0;
+      let dedupedCount = 0;
+
+      for (const config of HANDLER_CONFIG) {
+        const effects = normalizeArray(payload[config.payloadKey]);
+        const handler = resolvedHandlers[config.handlerName];
+
+        if (effects.length > 0 && typeof handler !== 'function') {
+          throw new Error(`missing_effect_handler:${config.handlerName}`);
+        }
+
+        for (const effect of effects) {
+          const reservation = await resolvedEffectRepository.reserveEffectReceipt({
+            proposal_key: payload.proposal_key,
+            event_id: proposalEvent.event_id,
+            aggregate_id: proposalEvent.aggregate_id,
+            truth_revision: Number(proposalEvent.truth_revision),
+            handler_name: config.handlerName,
+            effect_key: effect.effect_key,
+            reconciliation_id: proposalEvent.reconciliation_id ?? null,
+          });
+
+          if (!reservation.inserted && reservation.reason_code === 'duplicate_effect_key') {
+            dedupedCount += 1;
+            receipts.push(reservation.receipt);
+            continue;
+          }
+
+          try {
+            const handlerResult = await handler(effect, {
+              proposalEvent,
+              proposalPayload: payload,
+            });
+            const normalizedResult = normalizeHandlerResult(handlerResult);
+            const receipt = await resolvedEffectRepository.markEffectReceiptSucceeded({
+              handler_name: config.handlerName,
+              effect_key: effect.effect_key,
+              status: normalizedResult.status,
+              result_ref_type: normalizedResult.result_ref_type,
+              result_ref_id: normalizedResult.result_ref_id,
+            });
+            receipts.push(receipt);
+          } catch (error) {
+            failedCount += 1;
+            const receipt = await resolvedEffectRepository.markEffectReceiptFailed({
+              handler_name: config.handlerName,
+              effect_key: effect.effect_key,
+              error_code: 'effect_execution_failed',
+              error_message: error?.message || String(error),
+              receipt_state: error?.receipt_state ?? 'retrying',
+            });
+            receipts.push(receipt);
+          }
+        }
+      }
+
+      const receiptSummary = buildReceiptSummary(receipts);
+      const status = failedCount > 0
+        ? 'partial_failure'
+        : (dedupedCount === receipts.length && receipts.length > 0 ? 'deduped' : 'applied');
+
+      return {
+        ok: failedCount === 0,
+        status,
+        proposal_key: payload.proposal_key,
+        receipts,
+        receipt_summary: receiptSummary,
+      };
+    },
+  };
+}
+
+export async function applyLearningUpdateProposal(input = {}, dependencies = {}) {
+  const engine = createLearningEffectEngine({
+    ...dependencies,
+    supabase: dependencies.supabase || input.supabase || null,
+  });
+
+  return engine.applyLearningUpdateProposal(input);
+}

--- a/api/learning/lib/mastery/mastery-orchestrator.js
+++ b/api/learning/lib/mastery/mastery-orchestrator.js
@@ -58,7 +58,19 @@ function buildProposalKey(input = {}) {
   return `attempt:${renderEffectKeyFragment(input.attempt_id ?? input.attemptId, 'unknown-attempt')}`;
 }
 
-function buildMasteryEffectKey(effect = {}) {
+function buildProposalRevisionKey({
+  proposalKey,
+  truthRevision,
+} = {}) {
+  const normalizedProposalKey = normalizeString(proposalKey) || 'proposal:unknown';
+  const normalizedTruthRevision = Number.isInteger(Number(truthRevision)) && Number(truthRevision) >= 1
+    ? Number(truthRevision)
+    : 1;
+
+  return `${normalizedProposalKey}:r${normalizedTruthRevision}`;
+}
+
+function buildMasteryEffectKey(effect = {}, proposalRevisionKey = 'proposal:unknown:r1') {
   const level = normalizeString(effect.level) || 'family';
   const userId = renderEffectKeyFragment(effect.user_id, 'anonymous');
   const topicId = renderEffectKeyFragment(effect.topic_id, 'unknown-topic');
@@ -66,10 +78,10 @@ function buildMasteryEffectKey(effect = {}) {
     ? renderEffectKeyFragment(effect.question_type_id, 'unknown-type')
     : renderEffectKeyFragment(effect.family_id, 'unknown-family');
 
-  return `mastery:${level}:${userId}:${topicId}:${targetId}`;
+  return `mastery:${proposalRevisionKey}:${level}:${userId}:${topicId}:${targetId}`;
 }
 
-function buildReviewTaskEffectKey(payload = {}) {
+function buildReviewTaskEffectKey(payload = {}, proposalRevisionKey = 'proposal:unknown:r1') {
   const userId = renderEffectKeyFragment(payload.user_id, 'anonymous');
   const topicId = renderEffectKeyFragment(payload.target_topic_id, 'unknown-topic');
   const targetId = renderEffectKeyFragment(
@@ -78,16 +90,20 @@ function buildReviewTaskEffectKey(payload = {}) {
   );
   const tags = renderEffectTagFragment(payload.target_misconception_tags);
 
-  return `review:${userId}:${topicId}:${targetId}:${tags}`;
+  return `review:${proposalRevisionKey}:${userId}:${topicId}:${targetId}:${tags}`;
 }
 
-function buildArtifactSuggestionEffectKey(candidate = {}, userId = null) {
+function buildArtifactSuggestionEffectKey(
+  candidate = {},
+  userId = null,
+  proposalRevisionKey = 'proposal:unknown:r1',
+) {
   const normalizedUserId = renderEffectKeyFragment(userId, 'anonymous');
   const topicId = renderEffectKeyFragment(candidate.canonical_home_topic_id, 'unknown-topic');
   const artifactKind = renderEffectKeyFragment(candidate.artifact_kind, 'artifact');
   const tags = renderEffectTagFragment(candidate.misconception_tags);
 
-  return `artifact:${normalizedUserId}:${topicId}:${artifactKind}:${tags}`;
+  return `artifact:${proposalRevisionKey}:${normalizedUserId}:${topicId}:${artifactKind}:${tags}`;
 }
 
 function buildGuardrailDecisions(releaseScopePosture = {}) {
@@ -179,6 +195,7 @@ function buildNormalizedMasteryEffect({
   releaseScopePosture,
   sourceAttemptRef,
   sourceMarkRunRef,
+  proposalRevisionKey,
 } = {}) {
   const effect = {
     effect_key: null,
@@ -204,12 +221,12 @@ function buildNormalizedMasteryEffect({
 
   return {
     ...effect,
-    effect_key: buildMasteryEffectKey(effect),
+    effect_key: buildMasteryEffectKey(effect, proposalRevisionKey),
   };
 }
 
-function buildNormalizedReviewTaskProposal(payload = {}) {
-  const effectKey = buildReviewTaskEffectKey(payload);
+function buildNormalizedReviewTaskProposal(payload = {}, proposalRevisionKey) {
+  const effectKey = buildReviewTaskEffectKey(payload, proposalRevisionKey);
 
   return {
     effect_key: effectKey,
@@ -217,8 +234,8 @@ function buildNormalizedReviewTaskProposal(payload = {}) {
   };
 }
 
-function buildNormalizedArtifactSuggestion(candidate = {}, userId = null) {
-  const effectKey = buildArtifactSuggestionEffectKey(candidate, userId);
+function buildNormalizedArtifactSuggestion(candidate = {}, userId = null, proposalRevisionKey) {
+  const effectKey = buildArtifactSuggestionEffectKey(candidate, userId, proposalRevisionKey);
 
   return {
     effect_key: effectKey,
@@ -308,9 +325,14 @@ export function buildLearningUpdateProposal(input = {}, { now = new Date() } = {
   )
     ? null
     : buildArtifactCandidate(artifactInput, now.toISOString());
+  const proposalKey = buildProposalKey(input);
+  const proposalRevisionKey = buildProposalRevisionKey({
+    proposalKey,
+    truthRevision: input.truth_revision ?? input.truthRevision ?? null,
+  });
 
   return {
-    proposal_key: buildProposalKey(input),
+    proposal_key: proposalKey,
     guardrail_decisions: buildGuardrailDecisions(releaseScopePosture),
     releaseScopePosture,
     sourceAttemptRef,
@@ -326,12 +348,13 @@ export function buildLearningUpdateProposal(input = {}, { now = new Date() } = {
         releaseScopePosture,
         sourceAttemptRef,
         sourceMarkRunRef,
+        proposalRevisionKey,
       })),
     proposedReviewTasks: reviewTaskPayload
-      ? [buildNormalizedReviewTaskProposal(reviewTaskPayload)]
+      ? [buildNormalizedReviewTaskProposal(reviewTaskPayload, proposalRevisionKey)]
       : [],
     proposedArtifactSuggestions: artifactCandidate?.canonical_home_topic_id
-      ? [buildNormalizedArtifactSuggestion(artifactCandidate, input.user_id)]
+      ? [buildNormalizedArtifactSuggestion(artifactCandidate, input.user_id, proposalRevisionKey)]
       : [],
   };
 }

--- a/api/learning/lib/mastery/mastery-orchestrator.js
+++ b/api/learning/lib/mastery/mastery-orchestrator.js
@@ -3,10 +3,13 @@ import {
   buildRuntimeAuthorityPosture,
   isNonAuthoritativeRuntimeInput,
 } from '../contracts/runtime-authority-posture.js';
-import { createReviewTaskService } from '../review/review-task-service.js';
-import { createDefaultReviewTaskService } from '../review/review-task-service.js';
-import { shouldGenerateReviewTaskFromOutcome } from '../review/review-task-service.js';
-import { createArtifactService } from '../artifacts/artifact-service.js';
+import {
+  buildReviewTaskPayload,
+  createDefaultReviewTaskService,
+  createReviewTaskService,
+  shouldGenerateReviewTaskFromOutcome,
+} from '../review/review-task-service.js';
+import { buildArtifactCandidate, createArtifactService } from '../artifacts/artifact-service.js';
 import { createArtifactRepository } from '../repositories/artifact-repository.js';
 import { createReconciliationService } from '../reconciliation/reconciliation-service.js';
 import { createDefaultReconciliationService } from '../reconciliation/reconciliation-service.js';
@@ -21,8 +24,83 @@ function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
 function getQuestionContext(input = {}) {
   return input.question_context || {};
+}
+
+function renderEffectKeyFragment(value, fallback = 'none') {
+  const normalized = normalizeString(value);
+  return normalized || fallback;
+}
+
+function renderEffectTagFragment(tags = []) {
+  const normalized = normalizeArray(tags)
+    .map((tag) => normalizeString(tag))
+    .filter(Boolean);
+
+  return normalized.length > 0 ? normalized.join('+') : 'none';
+}
+
+function buildProposalKey(input = {}) {
+  const markRunId = normalizeString(input.mark_run_id ?? input.markRunId);
+  if (markRunId) {
+    return `mark-run:${markRunId}`;
+  }
+
+  return `attempt:${renderEffectKeyFragment(input.attempt_id ?? input.attemptId, 'unknown-attempt')}`;
+}
+
+function buildMasteryEffectKey(effect = {}) {
+  const level = normalizeString(effect.level) || 'family';
+  const userId = renderEffectKeyFragment(effect.user_id, 'anonymous');
+  const topicId = renderEffectKeyFragment(effect.topic_id, 'unknown-topic');
+  const targetId = level === 'question_type'
+    ? renderEffectKeyFragment(effect.question_type_id, 'unknown-type')
+    : renderEffectKeyFragment(effect.family_id, 'unknown-family');
+
+  return `mastery:${level}:${userId}:${topicId}:${targetId}`;
+}
+
+function buildReviewTaskEffectKey(payload = {}) {
+  const userId = renderEffectKeyFragment(payload.user_id, 'anonymous');
+  const topicId = renderEffectKeyFragment(payload.target_topic_id, 'unknown-topic');
+  const targetId = renderEffectKeyFragment(
+    payload.target_question_type_id ?? payload.target_family_id,
+    payload.target_kind,
+  );
+  const tags = renderEffectTagFragment(payload.target_misconception_tags);
+
+  return `review:${userId}:${topicId}:${targetId}:${tags}`;
+}
+
+function buildArtifactSuggestionEffectKey(candidate = {}, userId = null) {
+  const normalizedUserId = renderEffectKeyFragment(userId, 'anonymous');
+  const topicId = renderEffectKeyFragment(candidate.canonical_home_topic_id, 'unknown-topic');
+  const artifactKind = renderEffectKeyFragment(candidate.artifact_kind, 'artifact');
+  const tags = renderEffectTagFragment(candidate.misconception_tags);
+
+  return `artifact:${normalizedUserId}:${topicId}:${artifactKind}:${tags}`;
+}
+
+function buildGuardrailDecisions(releaseScopePosture = {}) {
+  const fallbackReason = normalizeString(releaseScopePosture.fallback_reason_code) || null;
+
+  return {
+    authoritative_scoring_allowed: Boolean(releaseScopePosture.authoritative_scoring_allowed),
+    release_scope_status: normalizeString(releaseScopePosture.release_scope_status) || null,
+    learning_signal_posture: normalizeString(releaseScopePosture.learning_signal_posture) || null,
+    fallback_mode: normalizeString(releaseScopePosture.fallback_mode) || null,
+    fallback_reason_code: fallbackReason,
+    reasons: fallbackReason ? [fallbackReason] : ['released_scoring'],
+  };
 }
 
 function buildErrorBookHooks({
@@ -95,54 +173,245 @@ function resolveLearningEffectsPosture({
   });
 }
 
+function buildNormalizedMasteryEffect({
+  masteryUpdate,
+  input,
+  releaseScopePosture,
+  sourceAttemptRef,
+  sourceMarkRunRef,
+} = {}) {
+  const effect = {
+    effect_key: null,
+    user_id: input.user_id ?? null,
+    level: masteryUpdate.level,
+    topic_id: masteryUpdate.topic_id ?? null,
+    family_id: masteryUpdate.family_id ?? null,
+    question_type_id: masteryUpdate.question_type_id ?? null,
+    mastery_state: {
+      signal_direction: masteryUpdate.signal_direction ?? null,
+      signal_weight: masteryUpdate.signal_weight ?? null,
+      release_scope_status: masteryUpdate.release_scope_status ?? releaseScopePosture.release_scope_status ?? null,
+      runtime_authority_posture: releaseScopePosture.runtime_authority_posture ?? null,
+    },
+    signal_summary: {
+      release_scope_status: releaseScopePosture.release_scope_status ?? null,
+      source_attempt_ref: clone(sourceAttemptRef ?? null),
+      source_mark_run_ref: clone(sourceMarkRunRef ?? null),
+      fallback_reason_code: releaseScopePosture.fallback_reason_code ?? null,
+      learning_signal_posture: releaseScopePosture.learning_signal_posture ?? null,
+    },
+  };
+
+  return {
+    ...effect,
+    effect_key: buildMasteryEffectKey(effect),
+  };
+}
+
+function buildNormalizedReviewTaskProposal(payload = {}) {
+  const effectKey = buildReviewTaskEffectKey(payload);
+
+  return {
+    effect_key: effectKey,
+    ...clone(payload),
+  };
+}
+
+function buildNormalizedArtifactSuggestion(candidate = {}, userId = null) {
+  const effectKey = buildArtifactSuggestionEffectKey(candidate, userId);
+
+  return {
+    effect_key: effectKey,
+    ...clone(candidate),
+  };
+}
+
+export function buildLearningUpdateProposal(input = {}, { now = new Date() } = {}) {
+  const questionContext = getQuestionContext(input);
+  const subjectCode = resolveSubjectCodeFromRuntimeInput(input, questionContext);
+  const adapter = getSubjectAdapter(subjectCode);
+  const releaseScopePosture = resolveLearningEffectsPosture({
+    input,
+    questionContext,
+    adapter,
+  });
+  const nonAuthoritativeRuntimeInput = isNonAuthoritativeRuntimeInput({
+    ...input,
+    release_scope_posture: releaseScopePosture,
+    question_context: questionContext,
+  });
+  const sourceAttemptRef = input.source_attempt_ref
+    || (input.attempt_id ? buildAttemptRef(input.attempt_id) : null);
+  const sourceMarkRunRef = input.source_mark_run_ref
+    || (input.mark_run_id ? buildMarkRunRef(input.mark_run_id) : null);
+  const repairTopicId =
+    input.repair_target_topic_id
+    || questionContext.primary_topic_id
+    || input.source_attempt_context?.topic_id
+    || null;
+  const repairTopicPath =
+    input.repair_target_topic_path
+    || questionContext.primary_topic_path
+    || input.source_attempt_context?.topic_path
+    || null;
+  const reviewTaskInput = {
+    ...input,
+    subject_code: subjectCode,
+    authoritative_scoring_allowed: releaseScopePosture.authoritative_scoring_allowed,
+    fallback_reason_code: releaseScopePosture.fallback_reason_code,
+    repair_target_topic_id: repairTopicId,
+    repair_target_topic_path: repairTopicPath,
+    repair_target_question_type_id:
+      input.repair_target_question_type_id || questionContext.question_type_id || null,
+    source_attempt_ref: sourceAttemptRef,
+    runtime_authority_posture: releaseScopePosture.runtime_authority_posture,
+    runtime_authority_reason_code: releaseScopePosture.runtime_authority_reason_code,
+    question_source_kind: releaseScopePosture.question_source_kind,
+  };
+  const artifactInput = {
+    artifact_kind: 'misconception_card',
+    canonical_home_topic_id:
+      questionContext.primary_topic_id || input.source_attempt_context?.topic_id || null,
+    canonical_home_topic_path:
+      questionContext.primary_topic_path || input.source_attempt_context?.topic_path || null,
+    repair_target_topic_id: repairTopicId,
+    repair_target_topic_path: repairTopicPath,
+    target_family_id: questionContext.family_id ?? null,
+    target_question_type_id:
+      input.repair_target_question_type_id || questionContext.question_type_id || null,
+    misconception_tags: normalizeArray(input.misconception_tags),
+    source_attempt_ref: sourceAttemptRef,
+    source_mark_run_ref: sourceMarkRunRef,
+    source_session_id: input.source_session_id ?? null,
+    runtime_authority_posture: releaseScopePosture.runtime_authority_posture,
+    runtime_authority_reason_code: releaseScopePosture.runtime_authority_reason_code,
+    question_source_kind: releaseScopePosture.question_source_kind,
+    blocked_materializers: releaseScopePosture.blocked_materializers,
+  };
+  const masteryProjection = adapter.mastery.buildMasteryProjection({
+    input,
+    questionContext,
+    releaseScopePosture,
+  });
+  const localSignals = masteryProjection.localSignals;
+  const masteryUpdates = nonAuthoritativeRuntimeInput ? [] : masteryProjection.masteryUpdates;
+  const reviewCapabilityPosture = adapter.meta.capability_posture?.review
+    ?? SUBJECT_ADAPTER_CAPABILITY_POSTURES.SUPPORTED;
+  const reviewTaskPayload = reviewCapabilityPosture !== SUBJECT_ADAPTER_CAPABILITY_POSTURES.SUPPORTED
+    || nonAuthoritativeRuntimeInput
+    || !shouldGenerateReviewTaskFromOutcome(reviewTaskInput)
+    ? null
+    : buildReviewTaskPayload(reviewTaskInput, now);
+  const artifactCandidate = (
+    (artifactInput.artifact_kind || 'misconception_card') === 'misconception_card'
+    && normalizeArray(artifactInput.misconception_tags).length === 0
+  )
+    ? null
+    : buildArtifactCandidate(artifactInput, now.toISOString());
+
+  return {
+    proposal_key: buildProposalKey(input),
+    guardrail_decisions: buildGuardrailDecisions(releaseScopePosture),
+    releaseScopePosture,
+    sourceAttemptRef,
+    sourceMarkRunRef,
+    repairTopicId,
+    repairTopicPath,
+    localSignals,
+    masteryUpdates,
+    proposedMasteryEffects: masteryUpdates.map((masteryUpdate) =>
+      buildNormalizedMasteryEffect({
+        masteryUpdate,
+        input,
+        releaseScopePosture,
+        sourceAttemptRef,
+        sourceMarkRunRef,
+      })),
+    proposedReviewTasks: reviewTaskPayload
+      ? [buildNormalizedReviewTaskProposal(reviewTaskPayload)]
+      : [],
+    proposedArtifactSuggestions: artifactCandidate?.canonical_home_topic_id
+      ? [buildNormalizedArtifactSuggestion(artifactCandidate, input.user_id)]
+      : [],
+  };
+}
+
+async function upsertMasteryEffect(client, effect = {}) {
+  if (!client) {
+    return clone(effect);
+  }
+
+  const tableName = effect.level === 'question_type'
+    ? 'learning_type_masteries'
+    : 'learning_family_masteries';
+  const conflictColumns = effect.level === 'question_type'
+    ? 'user_id,topic_id,question_type_id'
+    : 'user_id,topic_id,family_id';
+  const row = {
+    user_id: effect.user_id,
+    topic_id: effect.topic_id,
+    family_id: effect.family_id,
+    mastery_state: clone(effect.mastery_state ?? {}),
+    signal_summary: clone(effect.signal_summary ?? {}),
+    updated_at: new Date().toISOString(),
+  };
+
+  if (effect.level === 'question_type') {
+    row.question_type_id = effect.question_type_id;
+  }
+
+  const { data, error } = await client
+    .from(tableName)
+    .upsert(row, {
+      onConflict: conflictColumns,
+    })
+    .select('*')
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message || `Failed to upsert ${tableName}.`);
+  }
+
+  return data;
+}
+
 export function createMasteryOrchestrator({
   reviewTaskService = null,
   artifactService = null,
   reconciliationService = null,
+  supabase = null,
   now = () => new Date(),
 } = {}) {
   return {
+    buildLearningUpdateProposal(input = {}) {
+      return buildLearningUpdateProposal(input, {
+        now: now(),
+      });
+    },
+
+    async materializeProposedMasteryEffect(effect = {}) {
+      return upsertMasteryEffect(supabase, effect);
+    },
+
     async applyLearningEffects(input = {}) {
       const questionContext = getQuestionContext(input);
       const subjectCode = resolveSubjectCodeFromRuntimeInput(input, questionContext);
-      const adapter = getSubjectAdapter(subjectCode);
-      const releaseScopePosture = resolveLearningEffectsPosture({
-        input,
-        questionContext,
-        adapter,
+      const proposal = buildLearningUpdateProposal(input, {
+        now: now(),
       });
-      const nonAuthoritativeRuntimeInput = isNonAuthoritativeRuntimeInput({
-        ...input,
-        release_scope_posture: releaseScopePosture,
-        question_context: questionContext,
-      });
-      const sourceAttemptRef = input.source_attempt_ref
-        || (input.attempt_id ? buildAttemptRef(input.attempt_id) : null);
-      const sourceMarkRunRef = input.source_mark_run_ref
-        || (input.mark_run_id ? buildMarkRunRef(input.mark_run_id) : null);
-      const repairTopicId =
-        input.repair_target_topic_id
-        || questionContext.primary_topic_id
-        || input.source_attempt_context?.topic_id
-        || null;
-      const repairTopicPath =
-        input.repair_target_topic_path
-        || questionContext.primary_topic_path
-        || input.source_attempt_context?.topic_path
-        || null;
       const reviewTaskInput = {
         ...input,
         subject_code: subjectCode,
-        authoritative_scoring_allowed: releaseScopePosture.authoritative_scoring_allowed,
-        fallback_reason_code: releaseScopePosture.fallback_reason_code,
-        repair_target_topic_id: repairTopicId,
-        repair_target_topic_path: repairTopicPath,
+        authoritative_scoring_allowed: proposal.releaseScopePosture.authoritative_scoring_allowed,
+        fallback_reason_code: proposal.releaseScopePosture.fallback_reason_code,
+        repair_target_topic_id: proposal.repairTopicId,
+        repair_target_topic_path: proposal.repairTopicPath,
         repair_target_question_type_id:
           input.repair_target_question_type_id || questionContext.question_type_id || null,
-        source_attempt_ref: sourceAttemptRef,
-        runtime_authority_posture: releaseScopePosture.runtime_authority_posture,
-        runtime_authority_reason_code: releaseScopePosture.runtime_authority_reason_code,
-        question_source_kind: releaseScopePosture.question_source_kind,
+        source_attempt_ref: proposal.sourceAttemptRef,
+        runtime_authority_posture: proposal.releaseScopePosture.runtime_authority_posture,
+        runtime_authority_reason_code: proposal.releaseScopePosture.runtime_authority_reason_code,
+        question_source_kind: proposal.releaseScopePosture.question_source_kind,
       };
       const artifactInput = {
         artifact_kind: 'misconception_card',
@@ -150,31 +419,29 @@ export function createMasteryOrchestrator({
           questionContext.primary_topic_id || input.source_attempt_context?.topic_id || null,
         canonical_home_topic_path:
           questionContext.primary_topic_path || input.source_attempt_context?.topic_path || null,
-        repair_target_topic_id: repairTopicId,
-        repair_target_topic_path: repairTopicPath,
+        repair_target_topic_id: proposal.repairTopicId,
+        repair_target_topic_path: proposal.repairTopicPath,
         target_family_id: questionContext.family_id ?? null,
         target_question_type_id:
           input.repair_target_question_type_id || questionContext.question_type_id || null,
         misconception_tags: normalizeArray(input.misconception_tags),
-        source_attempt_ref: sourceAttemptRef,
-        source_mark_run_ref: sourceMarkRunRef,
+        source_attempt_ref: proposal.sourceAttemptRef,
+        source_mark_run_ref: proposal.sourceMarkRunRef,
         source_session_id: input.source_session_id ?? null,
-        runtime_authority_posture: releaseScopePosture.runtime_authority_posture,
-        runtime_authority_reason_code: releaseScopePosture.runtime_authority_reason_code,
-        question_source_kind: releaseScopePosture.question_source_kind,
-        blocked_materializers: releaseScopePosture.blocked_materializers,
+        runtime_authority_posture: proposal.releaseScopePosture.runtime_authority_posture,
+        runtime_authority_reason_code: proposal.releaseScopePosture.runtime_authority_reason_code,
+        question_source_kind: proposal.releaseScopePosture.question_source_kind,
+        blocked_materializers: proposal.releaseScopePosture.blocked_materializers,
       };
-      const masteryProjection = adapter.mastery.buildMasteryProjection({
-        input,
-        questionContext,
-        releaseScopePosture,
-      });
-      const localSignals = masteryProjection.localSignals;
-      const masteryUpdates = nonAuthoritativeRuntimeInput ? [] : masteryProjection.masteryUpdates;
+      const adapter = getSubjectAdapter(subjectCode);
       const reviewCapabilityPosture = adapter.meta.capability_posture?.review
         ?? SUBJECT_ADAPTER_CAPABILITY_POSTURES.SUPPORTED;
       const reviewTasks = reviewCapabilityPosture !== SUBJECT_ADAPTER_CAPABILITY_POSTURES.SUPPORTED
-        || nonAuthoritativeRuntimeInput
+        || isNonAuthoritativeRuntimeInput({
+          ...input,
+          release_scope_posture: proposal.releaseScopePosture,
+          question_context: questionContext,
+        })
         || !shouldGenerateReviewTaskFromOutcome(reviewTaskInput)
         ? []
         : await reviewTaskService.generateTasksFromOutcome(reviewTaskInput);
@@ -183,34 +450,39 @@ export function createMasteryOrchestrator({
         input,
         subjectCode,
         artifactCandidates,
-        repairTopicId,
-        repairTopicPath,
+        repairTopicId: proposal.repairTopicId,
+        repairTopicPath: proposal.repairTopicPath,
       });
       const reconciliation = await reconciliationService.reconcileDerivedState({
         triggerSource: input.reconciliation_trigger_source || 'marking_correction',
-        sourceRef: sourceMarkRunRef || sourceAttemptRef,
+        sourceRef: proposal.sourceMarkRunRef || proposal.sourceAttemptRef,
         historical: buildReconciliationHistorical(input),
         derivedState: {
-          family_masteries: masteryUpdates.filter((item) => item.level === 'family'),
-          type_masteries: masteryUpdates.filter((item) => item.level === 'question_type'),
+          family_masteries: proposal.masteryUpdates.filter((item) => item.level === 'family'),
+          type_masteries: proposal.masteryUpdates.filter((item) => item.level === 'question_type'),
           review_tasks: reviewTasks,
           artifacts: artifactCandidates,
           error_book_hooks: errorBookHooks,
-          local_signals: localSignals,
+          local_signals: proposal.localSignals,
           marking_result: input.marking_result ?? null,
         },
         oldSnapshotRefs: normalizeArray(input.old_snapshot_refs),
         newSnapshotRefs: normalizeArray(
           normalizeArray(input.new_snapshot_refs).length > 0
             ? input.new_snapshot_refs
-            : [sourceMarkRunRef],
+            : [proposal.sourceMarkRunRef],
         ).filter(Boolean),
       });
 
       return {
-        ...releaseScopePosture,
-        mastery_updates: masteryUpdates,
-        local_signals: localSignals,
+        ...proposal.releaseScopePosture,
+        proposal_key: proposal.proposal_key,
+        guardrail_decisions: proposal.guardrail_decisions,
+        proposed_mastery_effects: proposal.proposedMasteryEffects,
+        proposed_review_tasks: proposal.proposedReviewTasks,
+        proposed_artifact_suggestions: proposal.proposedArtifactSuggestions,
+        mastery_updates: proposal.masteryUpdates,
+        local_signals: proposal.localSignals,
         review_tasks: reviewTasks,
         artifact_candidates: artifactCandidates,
         error_book_hooks: errorBookHooks,
@@ -225,6 +497,7 @@ export async function applyLearningEffects(input = {}, dependencies = {}) {
   const supabase = dependencies.supabase || input.supabase || null;
   const orchestrator = createMasteryOrchestrator({
     ...dependencies,
+    supabase,
     reviewTaskService:
       dependencies.reviewTaskService
       || (supabase ? createDefaultReviewTaskService(supabase) : createReviewTaskService()),

--- a/api/learning/lib/repositories/learning-event-effect-repository.js
+++ b/api/learning/lib/repositories/learning-event-effect-repository.js
@@ -1,0 +1,205 @@
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+async function maybeSingle(promise, message) {
+  const { data, error } = await promise;
+
+  if (error) {
+    throw new Error(`${message}: ${error.message}`);
+  }
+
+  return data ?? null;
+}
+
+async function getEffectReceiptByIdentity(client, {
+  handlerName,
+  effectKey,
+} = {}) {
+  return maybeSingle(
+    client
+      .from('learning_event_effects')
+      .select('*')
+      .eq('handler_name', handlerName)
+      .eq('effect_key', effectKey)
+      .maybeSingle(),
+    'Failed to load learning event effect receipt',
+  );
+}
+
+async function updateEffectReceipt(client, {
+  handlerName,
+  effectKey,
+  patch,
+} = {}) {
+  return maybeSingle(
+    client
+      .from('learning_event_effects')
+      .update({
+        ...clone(patch),
+        last_updated_at: new Date().toISOString(),
+      })
+      .eq('handler_name', handlerName)
+      .eq('effect_key', effectKey)
+      .select('*')
+      .single(),
+    'Failed to update learning event effect receipt',
+  );
+}
+
+export function createLearningEventEffectRepository(client) {
+  return {
+    async getEffectReceiptByIdentity(identity = {}) {
+      return getEffectReceiptByIdentity(client, identity);
+    },
+
+    async reserveEffectReceipt(input = {}) {
+      const handlerName = normalizeString(input.handler_name);
+      const effectKey = normalizeString(input.effect_key);
+      const attemptedAt = new Date().toISOString();
+      const existing = await getEffectReceiptByIdentity(client, {
+        handlerName,
+        effectKey,
+      });
+
+      if (existing) {
+        if (existing.status === 'failed' && existing.receipt_state === 'retrying') {
+          const retried = await updateEffectReceipt(client, {
+            handlerName,
+            effectKey,
+            patch: {
+              event_id: input.event_id,
+              aggregate_id: input.aggregate_id,
+              truth_revision: input.truth_revision,
+              reconciliation_id: input.reconciliation_id ?? null,
+              proposal_key: input.proposal_key ?? existing.proposal_key ?? null,
+              status: 'started',
+              receipt_state: 'pending',
+              attempt_count: Number(existing.attempt_count ?? 0) + 1,
+              last_attempted_at: attemptedAt,
+              last_error: null,
+            },
+          });
+
+          return {
+            inserted: true,
+            reason_code: 'retry_failed_effect',
+            receipt: retried,
+          };
+        }
+
+        return {
+          inserted: false,
+          reason_code: 'duplicate_effect_key',
+          receipt: existing,
+        };
+      }
+
+      const { data, error } = await client
+        .from('learning_event_effects')
+        .insert({
+          proposal_key: input.proposal_key ?? null,
+          event_id: input.event_id,
+          handler_name: handlerName,
+          effect_key: effectKey,
+          aggregate_id: input.aggregate_id,
+          truth_revision: input.truth_revision,
+          reconciliation_id: input.reconciliation_id ?? null,
+          status: 'started',
+          receipt_state: 'pending',
+          retry_count: 0,
+          attempt_count: 1,
+          last_attempted_at: attemptedAt,
+          last_error: null,
+        })
+        .select('*')
+        .single();
+
+      if (error?.code === '23505') {
+        const replay = await getEffectReceiptByIdentity(client, {
+          handlerName,
+          effectKey,
+        });
+
+        if (replay) {
+          return {
+            inserted: false,
+            reason_code: 'duplicate_effect_key',
+            receipt: replay,
+          };
+        }
+      }
+
+      if (error || !data) {
+        throw new Error(error?.message || 'Failed to insert learning event effect receipt.');
+      }
+
+      return {
+        inserted: true,
+        reason_code: null,
+        receipt: data,
+      };
+    },
+
+    async markEffectReceiptSucceeded(input = {}) {
+      const handlerName = normalizeString(input.handler_name);
+      const effectKey = normalizeString(input.effect_key);
+      return updateEffectReceipt(client, {
+        handlerName,
+        effectKey,
+        patch: {
+          status: input.status ?? 'succeeded',
+          receipt_state: 'persisted',
+          result_ref_type: input.result_ref_type ?? null,
+          result_ref_id: input.result_ref_id ?? null,
+          last_attempted_at: new Date().toISOString(),
+          last_error: null,
+          completed_at: new Date().toISOString(),
+        },
+      });
+    },
+
+    async markEffectReceiptFailed(input = {}) {
+      const handlerName = normalizeString(input.handler_name);
+      const effectKey = normalizeString(input.effect_key);
+      const existing = await getEffectReceiptByIdentity(client, {
+        handlerName,
+        effectKey,
+      });
+
+      return updateEffectReceipt(client, {
+        handlerName,
+        effectKey,
+        patch: {
+          status: 'failed',
+          receipt_state: input.receipt_state ?? 'retrying',
+          retry_count: Number(existing?.retry_count ?? 0) + 1,
+          last_attempted_at: new Date().toISOString(),
+          last_error: {
+            code: input.error_code ?? 'effect_execution_failed',
+            message: input.error_message ?? 'effect execution failed',
+          },
+        },
+      });
+    },
+
+    async listEffectReceiptsByEventId(eventId) {
+      const { data, error } = await client
+        .from('learning_event_effects')
+        .select('*')
+        .eq('event_id', eventId)
+        .order('handler_name', { ascending: true })
+        .order('effect_key', { ascending: true });
+
+      if (error) {
+        throw new Error(`Failed to list learning event effect receipts: ${error.message}`);
+      }
+
+      return Array.isArray(data) ? data : [];
+    },
+  };
+}

--- a/api/learning/lib/review/review-task-service.js
+++ b/api/learning/lib/review/review-task-service.js
@@ -343,7 +343,7 @@ export function shouldGenerateReviewTaskFromOutcome(input = {}) {
   return hasRepairSignal(input);
 }
 
-function buildReviewTaskPayload(input = {}, now = new Date()) {
+export function buildReviewTaskPayload(input = {}, now = new Date()) {
   const targetQuestionTypeId =
     input.repair_target_question_type_id
     || input.question_context?.question_type_id
@@ -428,6 +428,51 @@ function buildReviewTaskPayload(input = {}, now = new Date()) {
   };
 }
 
+async function materializeReviewTaskPayload({
+  payload,
+  reviewTaskRepository,
+  timestamp,
+} = {}) {
+  if (!payload) {
+    return [];
+  }
+
+  if (!reviewTaskRepository) {
+    return [normalizeSchedulerProjectionItem(payload)];
+  }
+
+  const activeTasks = await reviewTaskRepository.listReviewTaskProjectionsByUser?.(payload.user_id)
+    ?? [];
+  const mergeCandidate = pickReviewTaskMergeCandidate(activeTasks, payload);
+  if (mergeCandidate?.review_task_id) {
+    const mergedPatch = mergeReviewTaskPayload(
+      mergeCandidate,
+      payload,
+      timestamp,
+    );
+    const merged = await reviewTaskRepository.updateReviewTask(
+      mergeCandidate.review_task_id,
+      mergedPatch,
+    );
+    return [
+      normalizeSchedulerProjectionItem({
+        ...mergeCandidate,
+        ...merged,
+        target_topic_path:
+          payload.target_topic_path ?? mergeCandidate.target_topic_path ?? null,
+      }),
+    ];
+  }
+
+  const stored = await reviewTaskRepository.insertReviewTask(payload);
+  return [
+    normalizeSchedulerProjectionItem({
+      ...stored,
+      target_topic_path: payload.target_topic_path,
+    }),
+  ];
+}
+
 export function createReviewTaskService({
   reviewTaskRepository = null,
   now = () => new Date(),
@@ -435,44 +480,19 @@ export function createReviewTaskService({
   return {
     async generateTasksFromOutcome(input = {}) {
       const payload = buildReviewTaskPayload(input, now());
-      if (!payload) {
-        return [];
-      }
+      return materializeReviewTaskPayload({
+        payload,
+        reviewTaskRepository,
+        timestamp: now().toISOString(),
+      });
+    },
 
-      if (!reviewTaskRepository) {
-        return [normalizeSchedulerProjectionItem(payload)];
-      }
-
-      const activeTasks = await reviewTaskRepository.listReviewTaskProjectionsByUser?.(payload.user_id)
-        ?? [];
-      const mergeCandidate = pickReviewTaskMergeCandidate(activeTasks, payload);
-      if (mergeCandidate?.review_task_id) {
-        const mergedPatch = mergeReviewTaskPayload(
-          mergeCandidate,
-          payload,
-          now().toISOString(),
-        );
-        const merged = await reviewTaskRepository.updateReviewTask(
-          mergeCandidate.review_task_id,
-          mergedPatch,
-        );
-        return [
-          normalizeSchedulerProjectionItem({
-            ...mergeCandidate,
-            ...merged,
-            target_topic_path:
-              payload.target_topic_path ?? mergeCandidate.target_topic_path ?? null,
-          }),
-        ];
-      }
-
-      const stored = await reviewTaskRepository.insertReviewTask(payload);
-      return [
-        normalizeSchedulerProjectionItem({
-          ...stored,
-          target_topic_path: payload.target_topic_path,
-        }),
-      ];
+    async materializeProposedTask(payload = {}) {
+      return materializeReviewTaskPayload({
+        payload,
+        reviewTaskRepository,
+        timestamp: now().toISOString(),
+      });
     },
 
     async patchReviewTask({

--- a/supabase/migrations/20260417120000_create_learning_runtime_effect_receipts.sql
+++ b/supabase/migrations/20260417120000_create_learning_runtime_effect_receipts.sql
@@ -1,0 +1,27 @@
+ALTER TABLE public.learning_event_effects
+  ADD COLUMN IF NOT EXISTS proposal_key TEXT;
+
+ALTER TABLE public.learning_event_effects
+  ADD COLUMN IF NOT EXISTS receipt_state TEXT NOT NULL DEFAULT 'pending'
+  CHECK (
+    receipt_state IN ('pending', 'persisted', 'retrying', 'reconciled', 'needs_manual_review')
+  );
+
+ALTER TABLE public.learning_event_effects
+  ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE public.learning_event_effects
+  ADD COLUMN IF NOT EXISTS last_attempted_at TIMESTAMPTZ;
+
+ALTER TABLE public.learning_event_effects
+  ADD COLUMN IF NOT EXISTS last_error JSONB;
+
+ALTER TABLE public.learning_event_effects
+  ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_learning_event_effects_proposal_receipt
+  ON public.learning_event_effects (proposal_key, receipt_state, last_attempted_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_learning_event_effects_retry_attention
+  ON public.learning_event_effects (receipt_state, retry_count DESC, last_attempted_at DESC)
+  WHERE receipt_state IN ('retrying', 'needs_manual_review');


### PR DESCRIPTION
## Summary
- materialize `LearningUpdateProposed` into normalized downstream mastery, review-task, and artifact-suggestion effect payloads
- add an idempotent learning effect engine plus repository-backed per-handler receipt/debt tracking
- reuse `learning_event_effects` as the core receipt ledger and extend it with additive receipt/debt columns instead of introducing a second overlapping table
- keep request-path invocation semantics unchanged in this slice; full bridge/reconciliation wiring remains follow-up work in `#229`

## Verification
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/learning-effect-engine.test.js api/learning/__tests__/attempt-event-service.test.js --verbose`
  - PASS (`2` suites, `11` tests)
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/review-task-service.test.js api/learning/__tests__/mastery-orchestrator.test.js api/learning/__tests__/artifact-service.test.js --verbose`
  - PASS (`3` suites, `46` tests)
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/learning-effect-engine.test.js api/learning/__tests__/attempt-event-service.test.js api/learning/__tests__/mastery-orchestrator.test.js api/learning/__tests__/review-task-service.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/schema-contract.test.js --verbose`
  - PASS (`6` suites, `61` tests)
- `git diff --check`
  - PASS

Closes #228