### PR TITLE
feat(learning): wire bridge-driven effect execution

### DIFF
--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -129,6 +129,7 @@ function createMockClient({
   warningError = null,
   existingStreamHead = null,
   existingDeliveryRow = null,
+  existingMarkRun = null,
   existingLearningEvents = [],
   failLearningEventReads = false,
 } = {}) {
@@ -256,6 +257,33 @@ function createMockClient({
               return { error: pipelineStateError };
             },
           };
+        }
+
+        if (table === 'mark_runs') {
+          const filters = [];
+          const query = {
+            select: () => query,
+            eq: (field, value) => {
+              filters.push({ field, value });
+              return query;
+            },
+            maybeSingle: async () => {
+              const markRunId = filters.find((filter) => filter.field === 'mark_run_id')?.value ?? null;
+              if (markRunId && existingMarkRun?.mark_run_id === markRunId) {
+                return {
+                  data: clone(existingMarkRun),
+                  error: null,
+                };
+              }
+
+              return {
+                data: null,
+                error: null,
+              };
+            },
+          };
+
+          return query;
         }
 
         if (table === 'error_events') {
@@ -943,6 +971,165 @@ describe('attempt-event-service', () => {
         last_error: null,
       },
       learning_effects: {
+        authoritative_scoring_allowed: true,
+        release_scope_status: 'released_scoring',
+        learning_signal_posture: 'authoritative_scoring',
+        runtime_authority_posture: 'default_durable',
+        runtime_authority_reason_code: null,
+        question_source_kind: 'paper_question',
+        effect_execution: {
+          ok: false,
+          status: 'failed',
+          debt_pending: true,
+          error: {
+            code: 'effect_execution_failed',
+            message: 'learning_update_proposed_event_not_found',
+          },
+        },
+      },
+    });
+  });
+
+  test('downstream-effect read failures preserve imported-question non-authoritative posture', async () => {
+    const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
+    const { client } = createMockClient({
+      failLearningEventReads: true,
+    });
+
+    const result = await persistAttemptEventBridge(
+      client,
+      buildBridgeInput({
+        questionContext: {
+          source_kind: 'imported_question',
+          family_id: '9709.trigonometry_manipulation_equations',
+          question_type_id: '9709.trigonometry.identities',
+          question_type_release_state: 'released',
+          primary_topic_id: 'topic-trig-identities',
+          primary_topic_path: '9709/trigonometry/identities',
+          classification_confidence: 0.95,
+          candidate_rubric_refs: [
+            {
+              kind: 'rubric_release',
+              rubric_version_id: 'trig-identities-v1',
+              release_state: 'released',
+            },
+          ],
+          release_scope_status: 'released_scoring',
+        },
+        authorityPosture: {
+          release_scope_status: 'released_scoring',
+          authoritative_scoring_allowed: true,
+          fallback_mode: null,
+          fallback_reason_code: null,
+          classification_confidence: 0.95,
+          learning_signal_posture: 'authoritative_scoring',
+        },
+      }),
+      {
+        applyDownstreamEffects: true,
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      warningRecorded: false,
+      deduped: false,
+      delivery: {
+        delivery_state: 'persisted',
+        retry_count: 0,
+        last_error: null,
+      },
+      learning_effects: {
+        authoritative_scoring_allowed: false,
+        release_scope_status: 'released_scoring',
+        learning_signal_posture: 'conservative_fallback',
+        runtime_authority_posture: 'non_authoritative',
+        runtime_authority_reason_code: 'imported_question_attempt',
+        question_source_kind: 'imported_question',
+        effect_execution: {
+          ok: false,
+          status: 'failed',
+          debt_pending: true,
+          error: {
+            code: 'effect_execution_failed',
+            message: 'learning_update_proposed_event_not_found',
+          },
+        },
+      },
+    });
+  });
+
+  test('replayed persisted deliveries preserve durable authority posture when proposal-event reload fails', async () => {
+    const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
+    const { client } = createMockClient({
+      failLearningEventReads: true,
+      existingMarkRun: {
+        mark_run_id: 'mr-bridge-1',
+        response_summary: {
+          authority_posture: {
+            release_scope_status: 'released_scoring',
+            authoritative_scoring_allowed: true,
+            fallback_mode: null,
+            fallback_reason_code: null,
+            learning_signal_posture: 'authoritative_scoring',
+            runtime_authority_posture: 'default_durable',
+            runtime_authority_reason_code: null,
+            question_source_kind: 'paper_question',
+          },
+        },
+      },
+      existingDeliveryRow: {
+        delivery_id: 'delivery-persisted-1',
+        stable_idempotency_key: 'attempt_event_bridge:mr-bridge-1',
+        attempt_id: 'att-bridge-1',
+        learner_id: 'user-bridge-1',
+        subject_code: '9709',
+        mark_run_id: 'mr-bridge-1',
+        truth_revision: 1,
+        delivery_state: 'persisted',
+        retry_count: 0,
+        last_attempted_at: '2026-04-17T00:00:00.000Z',
+        last_error: null,
+        persisted_event_types: [
+          'AttemptSubmitted',
+          'QuestionClassified',
+          'MarkingCompleted',
+          'LearningUpdateProposed',
+        ],
+        persisted_event_ids: [
+          'event-1',
+          'event-2',
+          'event-3',
+          'event-4',
+        ],
+        reconciliation_id: null,
+      },
+    });
+
+    const result = await persistAttemptEventBridge(
+      client,
+      buildBridgeInput(),
+      {
+        applyDownstreamEffects: true,
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      warningRecorded: false,
+      deduped: true,
+      delivery: {
+        delivery_state: 'persisted',
+        retry_count: 0,
+        last_error: null,
+      },
+      learning_effects: {
+        authoritative_scoring_allowed: true,
+        release_scope_status: 'released_scoring',
+        learning_signal_posture: 'authoritative_scoring',
+        runtime_authority_posture: 'default_durable',
+        runtime_authority_reason_code: null,
+        question_source_kind: 'paper_question',
         effect_execution: {
           ok: false,
           status: 'failed',

--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -2,36 +2,176 @@ function clone(value) {
   return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
 }
 
+function createInMemoryEffectRepository() {
+  const receipts = new Map();
+
+  function keyFor(handlerName, effectKey) {
+    return `${handlerName}::${effectKey}`;
+  }
+
+  return {
+    async reserveEffectReceipt(input = {}) {
+      const key = keyFor(input.handler_name, input.effect_key);
+      const existing = receipts.get(key) ?? null;
+
+      if (existing) {
+        if (existing.status === 'failed' && existing.receipt_state === 'retrying') {
+          const retried = {
+            ...existing,
+            event_id: input.event_id,
+            aggregate_id: input.aggregate_id,
+            truth_revision: input.truth_revision,
+            reconciliation_id: input.reconciliation_id ?? null,
+            proposal_key: input.proposal_key ?? existing.proposal_key ?? null,
+            status: 'started',
+            receipt_state: 'pending',
+            attempt_count: Number(existing.attempt_count ?? 0) + 1,
+            last_attempted_at: '2026-04-17T10:05:00.000Z',
+            last_error: null,
+          };
+          receipts.set(key, retried);
+          return {
+            inserted: true,
+            reason_code: 'retry_failed_effect',
+            receipt: clone(retried),
+          };
+        }
+
+        return {
+          inserted: false,
+          reason_code: 'duplicate_effect_key',
+          receipt: clone(existing),
+        };
+      }
+
+      const receipt = {
+        effect_id: `effect-${receipts.size + 1}`,
+        proposal_key: input.proposal_key ?? null,
+        event_id: input.event_id,
+        aggregate_id: input.aggregate_id,
+        truth_revision: input.truth_revision,
+        reconciliation_id: input.reconciliation_id ?? null,
+        handler_name: input.handler_name,
+        effect_key: input.effect_key,
+        status: 'started',
+        receipt_state: 'pending',
+        retry_count: 0,
+        attempt_count: 1,
+        last_attempted_at: '2026-04-17T10:00:00.000Z',
+        last_error: null,
+        result_ref_type: null,
+        result_ref_id: null,
+      };
+      receipts.set(key, receipt);
+
+      return {
+        inserted: true,
+        reason_code: null,
+        receipt: clone(receipt),
+      };
+    },
+
+    async markEffectReceiptSucceeded({
+      handler_name: handlerName,
+      effect_key: effectKey,
+      status = 'succeeded',
+      result_ref_type: resultRefType = null,
+      result_ref_id: resultRefId = null,
+    } = {}) {
+      const key = keyFor(handlerName, effectKey);
+      const receipt = receipts.get(key);
+      const succeeded = {
+        ...receipt,
+        status,
+        receipt_state: 'persisted',
+        result_ref_type: resultRefType,
+        result_ref_id: resultRefId,
+        last_error: null,
+      };
+      receipts.set(key, succeeded);
+      return clone(succeeded);
+    },
+
+    async markEffectReceiptFailed({
+      handler_name: handlerName,
+      effect_key: effectKey,
+      error_code: errorCode = 'effect_execution_failed',
+      error_message: errorMessage = 'effect execution failed',
+      receipt_state: receiptState = 'retrying',
+    } = {}) {
+      const key = keyFor(handlerName, effectKey);
+      const receipt = receipts.get(key);
+      const failed = {
+        ...receipt,
+        status: 'failed',
+        receipt_state: receiptState,
+        retry_count: Number(receipt?.retry_count ?? 0) + 1,
+        last_error: {
+          code: errorCode,
+          message: errorMessage,
+        },
+      };
+      receipts.set(key, failed);
+      return clone(failed);
+    },
+
+    async listEffectReceiptsByEventId(eventId) {
+      return [...receipts.values()]
+        .filter((receipt) => receipt.event_id === eventId)
+        .map((receipt) => clone(receipt));
+    },
+  };
+}
+
 function createMockClient({
   learningEventsError = null,
   pipelineStateError = null,
   warningError = null,
   existingStreamHead = null,
   existingDeliveryRow = null,
+  existingLearningEvents = [],
 } = {}) {
   const records = {
     learningEvents: null,
     learningEventsInsertCount: 0,
+    learningEventsById: Object.fromEntries(
+      existingLearningEvents.map((event) => [event.event_id, clone(event)]),
+    ),
     pipelineState: null,
     bridgeWarning: null,
     deliveryRow: clone(existingDeliveryRow) ?? null,
     deliveryInsertCount: 0,
     deliveryUpdates: [],
+    reconciliationRuns: [],
   };
 
   return {
     client: {
       from(table) {
         if (table === 'learning_events') {
+          const filters = [];
           const query = {
             select: () => query,
-            eq: () => query,
+            eq: (field, value) => {
+              filters.push({ field, value });
+              return query;
+            },
             order: () => query,
             limit: () => query,
-            maybeSingle: async () => ({
-              data: existingStreamHead,
-              error: null,
-            }),
+            maybeSingle: async () => {
+              const eventId = filters.find((filter) => filter.field === 'event_id')?.value ?? null;
+              if (eventId) {
+                return {
+                  data: clone(records.learningEventsById[eventId] ?? null),
+                  error: null,
+                };
+              }
+
+              return {
+                data: existingStreamHead,
+                error: null,
+              };
+            },
           };
 
           return {
@@ -39,6 +179,9 @@ function createMockClient({
             insert: async (rows) => {
               records.learningEventsInsertCount += 1;
               records.learningEvents = rows;
+              rows.forEach((event) => {
+                records.learningEventsById[event.event_id] = clone(event);
+              });
               return { error: learningEventsError };
             },
           };
@@ -114,6 +257,25 @@ function createMockClient({
               return { error: warningError };
             },
           };
+        }
+
+        if (table === 'learning_reconciliation_runs') {
+          const query = {
+            select: () => query,
+            single: async () => ({
+              data: records.reconciliationRuns.at(-1) ?? null,
+              error: null,
+            }),
+            insert: (payload) => {
+              records.reconciliationRuns.push({
+                reconciliation_run_id: `recon-${records.reconciliationRuns.length + 1}`,
+                ...clone(payload),
+              });
+              return query;
+            },
+          };
+
+          return query;
         }
 
         throw new Error(`unexpected_table:${table}`);
@@ -310,6 +472,82 @@ describe('attempt-event-service', () => {
         }),
       ],
     });
+  });
+
+  test('executes downstream effects only after bridge persistence succeeds and surfaces durable retry debt', async () => {
+    const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
+    const { client, records } = createMockClient();
+    const effectRepository = createInMemoryEffectRepository();
+    let masteryCalls = 0;
+    let reviewCalls = 0;
+    let artifactCalls = 0;
+
+    const result = await persistAttemptEventBridge(
+      client,
+      buildBridgeInput({
+        misconceptionTags: ['sign_error'],
+      }),
+      {
+        applyDownstreamEffects: true,
+        effectRepository,
+        handlers: {
+          mastery: async () => {
+            masteryCalls += 1;
+            return {
+              status: 'succeeded',
+              result_ref_type: 'family_mastery',
+              result_ref_id: 'family-mastery-1',
+            };
+          },
+          review_tasks: async () => {
+            reviewCalls += 1;
+            throw new Error('review task write failed');
+          },
+          artifact_suggestions: async () => {
+            artifactCalls += 1;
+            return {
+              status: 'succeeded',
+              result_ref_type: 'artifact',
+              result_ref_id: 'artifact-1',
+            };
+          },
+        },
+      },
+    );
+
+    expect(records.learningEventsInsertCount).toBe(1);
+    expect(masteryCalls).toBe(1);
+    expect(reviewCalls).toBe(1);
+    expect(artifactCalls).toBe(1);
+    expect(result.learning_effects).toMatchObject({
+      authoritative_scoring_allowed: true,
+      release_scope_status: 'released_scoring',
+      learning_signal_posture: 'authoritative_scoring',
+      effect_execution: {
+        ok: false,
+        status: 'partial_failure',
+        debt_pending: true,
+        receipt_summary: {
+          total: 3,
+          persisted: 2,
+          retrying: 1,
+        },
+      },
+    });
+    expect(await effectRepository.listEffectReceiptsByEventId(records.learningEvents.at(-1).event_id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          handler_name: 'review_tasks',
+          status: 'failed',
+          receipt_state: 'retrying',
+          retry_count: 1,
+          last_error: {
+            code: 'effect_execution_failed',
+            message: 'review task write failed',
+          },
+        }),
+      ]),
+    );
   });
 
   test('reuses the same bridge delivery row and does not append duplicate events on repeated delivery', async () => {
@@ -543,6 +781,133 @@ describe('attempt-event-service', () => {
     expect(reconciled).toMatchObject({
       delivery_state: 'reconciled',
       reconciliation_id: 'recon-auto-1',
+    });
+  });
+
+  test('reconciliation can retry failed downstream effect receipts from the persisted proposal event', async () => {
+    const {
+      persistAttemptEventBridge,
+      reconcileAttemptEventBridgeEffects,
+    } = await import('../lib/events/attempt-event-service.js');
+    const { client, records } = createMockClient();
+    const effectRepository = createInMemoryEffectRepository();
+    let masteryCalls = 0;
+    let reviewCalls = 0;
+    let artifactCalls = 0;
+
+    const first = await persistAttemptEventBridge(
+      client,
+      buildBridgeInput({
+        misconceptionTags: ['sign_error'],
+      }),
+      {
+        applyDownstreamEffects: true,
+        effectRepository,
+        handlers: {
+          mastery: async () => {
+            masteryCalls += 1;
+            return {
+              status: 'succeeded',
+              result_ref_type: 'family_mastery',
+              result_ref_id: 'family-mastery-1',
+            };
+          },
+          review_tasks: async () => {
+            reviewCalls += 1;
+            if (reviewCalls === 1) {
+              throw new Error('review task write failed');
+            }
+
+            return {
+              status: 'succeeded',
+              result_ref_type: 'review_task',
+              result_ref_id: 'review-task-1',
+            };
+          },
+          artifact_suggestions: async () => {
+            artifactCalls += 1;
+            return {
+              status: 'succeeded',
+              result_ref_type: 'artifact',
+              result_ref_id: 'artifact-1',
+            };
+          },
+        },
+      },
+    );
+
+    expect(first.learning_effects?.effect_execution).toMatchObject({
+      ok: false,
+      status: 'partial_failure',
+      debt_pending: true,
+    });
+
+    const retried = await reconcileAttemptEventBridgeEffects(
+      client,
+      {
+        stableIdempotencyKey: first.delivery.stable_idempotency_key,
+      },
+      {
+        effectRepository,
+        handlers: {
+          mastery: async () => {
+            masteryCalls += 1;
+            return {
+              status: 'succeeded',
+              result_ref_type: 'family_mastery',
+              result_ref_id: 'family-mastery-1',
+            };
+          },
+          review_tasks: async () => {
+            reviewCalls += 1;
+            return {
+              status: 'succeeded',
+              result_ref_type: 'review_task',
+              result_ref_id: 'review-task-1',
+            };
+          },
+          artifact_suggestions: async () => {
+            artifactCalls += 1;
+            return {
+              status: 'succeeded',
+              result_ref_type: 'artifact',
+              result_ref_id: 'artifact-1',
+            };
+          },
+        },
+      },
+    );
+
+    expect(masteryCalls).toBe(1);
+    expect(reviewCalls).toBe(2);
+    expect(artifactCalls).toBe(1);
+    expect(retried).toMatchObject({
+      reconciliation_run_id: 'recon-1',
+      status: 'completed',
+      learning_effects: {
+        effect_execution: {
+          ok: true,
+          status: 'applied',
+          debt_pending: false,
+          receipt_summary: {
+            total: 3,
+            persisted: 3,
+            retrying: 0,
+          },
+        },
+      },
+    });
+    expect(records.reconciliationRuns.at(-1)).toMatchObject({
+      trigger_source: 'attempt_event_effect_retry',
+      source_ref: {
+        kind: 'mark_run',
+        mark_run_id: 'mr-bridge-1',
+      },
+      status: 'completed',
+      result_summary: {
+        retrying_receipt_count: 0,
+        persisted_receipt_count: 3,
+      },
     });
   });
 

--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -130,6 +130,7 @@ function createMockClient({
   existingStreamHead = null,
   existingDeliveryRow = null,
   existingLearningEvents = [],
+  failLearningEventReads = false,
 } = {}) {
   const records = {
     learningEvents: null,
@@ -161,6 +162,13 @@ function createMockClient({
             maybeSingle: async () => {
               const eventId = filters.find((filter) => filter.field === 'event_id')?.value ?? null;
               if (eventId) {
+                if (failLearningEventReads) {
+                  return {
+                    data: null,
+                    error: null,
+                  };
+                }
+
                 return {
                   data: clone(records.learningEventsById[eventId] ?? null),
                   error: null,
@@ -907,6 +915,43 @@ describe('attempt-event-service', () => {
       result_summary: {
         retrying_receipt_count: 0,
         persisted_receipt_count: 3,
+      },
+    });
+  });
+
+  test('downstream-effect read failures after persisted event writes do not downgrade the delivery row', async () => {
+    const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
+    const { client } = createMockClient({
+      failLearningEventReads: true,
+    });
+
+    const result = await persistAttemptEventBridge(
+      client,
+      buildBridgeInput(),
+      {
+        applyDownstreamEffects: true,
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      warningRecorded: false,
+      deduped: false,
+      delivery: {
+        delivery_state: 'persisted',
+        retry_count: 0,
+        last_error: null,
+      },
+      learning_effects: {
+        effect_execution: {
+          ok: false,
+          status: 'failed',
+          debt_pending: true,
+          error: {
+            code: 'effect_execution_failed',
+            message: 'learning_update_proposed_event_not_found',
+          },
+        },
       },
     });
   });

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -1,7 +1,13 @@
 import { randomUUID } from 'node:crypto';
 import { projectAttemptPipelineState } from './event-service.js';
+import { applyLearningUpdateProposal } from './learning-effect-engine.js';
 import { buildRuntimeAuthorityPosture } from '../contracts/runtime-authority-posture.js';
+import {
+  buildArtifactRef,
+  buildReviewTaskRef,
+} from '../contracts/runtime-contract.js';
 import { buildLearningUpdateProposal } from '../mastery/mastery-orchestrator.js';
+import { createReconciliationRepository } from '../repositories/reconciliation-repository.js';
 
 const BRIDGE_EVENT_TYPES = Object.freeze([
   'AttemptSubmitted',
@@ -593,6 +599,95 @@ function buildAttemptEventBridgeDeliveryIdempotencyKey({
   return `attempt_event_bridge:${normalizeString(markRunId) || normalizeString(attemptId)}`;
 }
 
+function buildLearningEffectsReceiptSummary(effectExecution = {}) {
+  const receiptSummary = effectExecution?.receipt_summary;
+  return {
+    total: Number(receiptSummary?.total ?? 0),
+    persisted: Number(receiptSummary?.persisted ?? 0),
+    retrying: Number(receiptSummary?.retrying ?? 0),
+    needs_manual_review: Number(receiptSummary?.needs_manual_review ?? 0),
+  };
+}
+
+function buildLearningEffectsResponse(proposalEvent = {}, effectExecution = {}) {
+  const payload = proposalEvent?.payload && typeof proposalEvent.payload === 'object'
+    ? cloneJson(proposalEvent.payload)
+    : {};
+  const authorityPosture = payload.authority_posture && typeof payload.authority_posture === 'object'
+    ? cloneJson(payload.authority_posture)
+    : {};
+  const guardrailDecisions = payload.guardrail_decisions && typeof payload.guardrail_decisions === 'object'
+    ? cloneJson(payload.guardrail_decisions)
+    : {};
+  const receiptSummary = buildLearningEffectsReceiptSummary(effectExecution);
+
+  return {
+    proposal_key: normalizeString(payload.proposal_key) || null,
+    guardrail_decisions: guardrailDecisions,
+    authoritative_scoring_allowed: Boolean(
+      guardrailDecisions.authoritative_scoring_allowed ?? authorityPosture.authoritative_scoring_allowed,
+    ),
+    release_scope_status:
+      normalizeString(guardrailDecisions.release_scope_status)
+      || normalizeString(authorityPosture.release_scope_status)
+      || null,
+    learning_signal_posture:
+      normalizeString(guardrailDecisions.learning_signal_posture)
+      || normalizeString(authorityPosture.learning_signal_posture)
+      || null,
+    fallback_mode:
+      normalizeString(guardrailDecisions.fallback_mode)
+      || normalizeString(authorityPosture.fallback_mode)
+      || null,
+    fallback_reason_code:
+      normalizeString(guardrailDecisions.fallback_reason_code)
+      || normalizeString(authorityPosture.fallback_reason_code)
+      || null,
+    runtime_authority_posture: normalizeString(authorityPosture.runtime_authority_posture) || null,
+    runtime_authority_reason_code: normalizeString(authorityPosture.runtime_authority_reason_code) || null,
+    question_source_kind: normalizeString(authorityPosture.question_source_kind) || null,
+    proposed_mastery_effects: normalizeArray(payload.proposed_mastery_effects).map((effect) => cloneJson(effect)),
+    proposed_review_tasks: normalizeArray(payload.proposed_review_tasks).map((effect) => cloneJson(effect)),
+    proposed_artifact_suggestions:
+      normalizeArray(payload.proposed_artifact_suggestions).map((effect) => cloneJson(effect)),
+    effect_execution: {
+      ok: Boolean(effectExecution?.ok),
+      status: normalizeString(effectExecution?.status) || 'unknown',
+      debt_pending: receiptSummary.retrying > 0 || receiptSummary.needs_manual_review > 0,
+      receipt_summary: receiptSummary,
+      receipts: normalizeArray(effectExecution?.receipts).map((receipt) => cloneJson(receipt)),
+      error: effectExecution?.error ? cloneJson(effectExecution.error) : null,
+    },
+  };
+}
+
+function buildReconciliationSourceRef(deliveryRow = {}) {
+  if (normalizeString(deliveryRow.mark_run_id)) {
+    return {
+      kind: 'mark_run',
+      mark_run_id: normalizeString(deliveryRow.mark_run_id),
+    };
+  }
+
+  return {
+    kind: 'attempt',
+    attempt_id: normalizeString(deliveryRow.attempt_id),
+  };
+}
+
+function buildAffectedObjectRefsFromReceipts(receipts = []) {
+  return normalizeArray(receipts).flatMap((receipt) => {
+    switch (normalizeString(receipt?.result_ref_type)) {
+      case 'review_task':
+        return receipt?.result_ref_id ? [buildReviewTaskRef(receipt.result_ref_id)] : [];
+      case 'artifact':
+        return receipt?.result_ref_id ? [buildArtifactRef(receipt.result_ref_id)] : [];
+      default:
+        return [];
+    }
+  });
+}
+
 async function getAttemptEventBridgeDelivery(client, {
   stableIdempotencyKey,
 } = {}) {
@@ -612,6 +707,109 @@ async function getAttemptEventBridgeDelivery(client, {
   }
 
   return data ?? null;
+}
+
+async function loadPersistedLearningEvent(client, {
+  eventId,
+} = {}) {
+  const normalizedEventId = normalizeString(eventId);
+  if (!normalizedEventId) {
+    throw new Error('missing_learning_event_id');
+  }
+
+  const { data, error } = await client
+    .from('learning_events')
+    .select('*')
+    .eq('event_id', normalizedEventId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message || 'Failed to load learning_events row.');
+  }
+
+  return data ?? null;
+}
+
+async function loadPersistedLearningUpdateProposalEvent(client, deliveryRow = {}) {
+  const persistedEventTypes = normalizeArray(deliveryRow.persisted_event_types);
+  const persistedEventIds = normalizeArray(deliveryRow.persisted_event_ids);
+  const learningUpdateIndex = persistedEventTypes.lastIndexOf('LearningUpdateProposed');
+
+  if (learningUpdateIndex === -1) {
+    throw new Error('missing_learning_update_proposed_event');
+  }
+
+  const eventId = normalizeString(persistedEventIds[learningUpdateIndex]);
+  if (!eventId) {
+    throw new Error('missing_learning_update_proposed_event_id');
+  }
+
+  const proposalEvent = await loadPersistedLearningEvent(client, {
+    eventId,
+  });
+
+  if (!proposalEvent) {
+    throw new Error('learning_update_proposed_event_not_found');
+  }
+
+  if (proposalEvent.event_type !== 'LearningUpdateProposed') {
+    throw new Error('learning_update_proposed_event_type_mismatch');
+  }
+
+  return proposalEvent;
+}
+
+async function executePersistedLearningUpdateEffects(client, {
+  deliveryRow,
+} = {}, dependencies = {}) {
+  const proposalEvent = await loadPersistedLearningUpdateProposalEvent(client, deliveryRow);
+  const effectExecution = await applyLearningUpdateProposal(
+    {
+      proposalEvent,
+    },
+    {
+      supabase: client,
+      ...dependencies,
+    },
+  );
+
+  return {
+    proposalEvent,
+    learningEffects: buildLearningEffectsResponse(proposalEvent, effectExecution),
+  };
+}
+
+async function executePersistedLearningUpdateEffectsSafely(client, {
+  deliveryRow,
+} = {}, dependencies = {}) {
+  try {
+    return await executePersistedLearningUpdateEffects(client, {
+      deliveryRow,
+    }, dependencies);
+  } catch (error) {
+    const proposalEvent = await loadPersistedLearningUpdateProposalEvent(client, deliveryRow);
+    const learningEffects = buildLearningEffectsResponse(proposalEvent, {
+      ok: false,
+      status: 'failed',
+      receipt_summary: {
+        total: 0,
+        persisted: 0,
+        retrying: 0,
+        needs_manual_review: 0,
+      },
+      receipts: [],
+      error: {
+        code: 'effect_execution_failed',
+        message: error?.message || String(error),
+      },
+    });
+    learningEffects.effect_execution.debt_pending = true;
+
+    return {
+      proposalEvent,
+      learningEffects,
+    };
+  }
 }
 
 async function reserveAttemptEventBridgeDelivery(client, {
@@ -707,7 +905,7 @@ async function updateAttemptEventBridgeDelivery(client, {
   return data;
 }
 
-export async function persistAttemptEventBridge(client, input = {}) {
+export async function persistAttemptEventBridge(client, input = {}, options = {}) {
   const attemptId = assertImmutableAttemptId(input);
   const authorityPosture = buildRuntimeAuthorityPosture(
     normalizeAuthorityPosture(input.authorityPosture),
@@ -733,6 +931,11 @@ export async function persistAttemptEventBridge(client, input = {}) {
 
     if (deliveryReservation.state === 'replay') {
       if (['persisted', 'reconciled'].includes(deliveryReservation.row.delivery_state)) {
+        const replayLearningEffects = options.applyDownstreamEffects
+          ? await executePersistedLearningUpdateEffectsSafely(client, {
+            deliveryRow: deliveryReservation.row,
+          }, options)
+          : null;
         return {
           ok: true,
           warningRecorded: false,
@@ -740,6 +943,7 @@ export async function persistAttemptEventBridge(client, input = {}) {
           persisted_event_types: normalizeArray(deliveryReservation.row.persisted_event_types),
           pipeline_state: null,
           delivery: deliveryReservation.row,
+          learning_effects: replayLearningEffects?.learningEffects ?? null,
         };
       }
 
@@ -767,6 +971,11 @@ export async function persistAttemptEventBridge(client, input = {}) {
             last_error: null,
           },
         });
+        const recoveredLearningEffects = options.applyDownstreamEffects
+          ? await executePersistedLearningUpdateEffectsSafely(client, {
+            deliveryRow: finalizedDelivery,
+          }, options)
+          : null;
 
         return {
           ok: true,
@@ -775,6 +984,7 @@ export async function persistAttemptEventBridge(client, input = {}) {
           persisted_event_types: normalizeArray(deliveryReservation.row.persisted_event_types),
           pipeline_state: pipelineState,
           delivery: finalizedDelivery,
+          learning_effects: recoveredLearningEffects?.learningEffects ?? null,
         };
       }
     }
@@ -811,6 +1021,11 @@ export async function persistAttemptEventBridge(client, input = {}) {
         persisted_event_ids: events.map((event) => event.event_id),
       },
     });
+    const downstreamLearningEffects = options.applyDownstreamEffects
+      ? await executePersistedLearningUpdateEffectsSafely(client, {
+        deliveryRow: finalizedDelivery,
+      }, options)
+      : null;
 
     return {
       ok: true,
@@ -819,6 +1034,7 @@ export async function persistAttemptEventBridge(client, input = {}) {
       persisted_event_types: events.map((event) => event.event_type),
       pipeline_state: pipelineState,
       delivery: finalizedDelivery,
+      learning_effects: downstreamLearningEffects?.learningEffects ?? null,
     };
   } catch (error) {
     const errorMessage = error?.message || String(error);
@@ -879,4 +1095,48 @@ export async function reconcileAttemptEventBridgeDelivery(client, {
       reconciliation_id: normalizeString(reconciliationId) || null,
     },
   });
+}
+
+export async function reconcileAttemptEventBridgeEffects(client, {
+  stableIdempotencyKey,
+} = {}, dependencies = {}) {
+  const deliveryRow = await getAttemptEventBridgeDelivery(client, {
+    stableIdempotencyKey,
+  });
+
+  if (!deliveryRow) {
+    throw new Error('attempt_event_bridge_delivery_not_found');
+  }
+
+  const { learningEffects } = await executePersistedLearningUpdateEffectsSafely(client, {
+    deliveryRow,
+  }, dependencies);
+  const receiptSummary = learningEffects.effect_execution.receipt_summary;
+  const reconciliationRepository = createReconciliationRepository(client);
+  const timestamp = new Date().toISOString();
+  const run = await reconciliationRepository.insertRun({
+    trigger_source: 'attempt_event_effect_retry',
+    source_ref: buildReconciliationSourceRef(deliveryRow),
+    affected_object_refs: buildAffectedObjectRefsFromReceipts(
+      learningEffects.effect_execution.receipts,
+    ),
+    old_snapshot_refs: [],
+    new_snapshot_refs: [],
+    status: learningEffects.effect_execution.ok ? 'completed' : 'failed',
+    result_summary: {
+      effect_execution_status: learningEffects.effect_execution.status,
+      total_receipt_count: receiptSummary.total,
+      persisted_receipt_count: receiptSummary.persisted,
+      retrying_receipt_count: receiptSummary.retrying,
+      needs_manual_review_receipt_count: receiptSummary.needs_manual_review,
+    },
+    started_at: timestamp,
+    completed_at: timestamp,
+  });
+
+  return {
+    reconciliation_run_id: run?.reconciliation_run_id ?? null,
+    status: run?.status ?? (learningEffects.effect_execution.ok ? 'completed' : 'failed'),
+    learning_effects: learningEffects,
+  };
 }

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -661,6 +661,44 @@ function buildLearningEffectsResponse(proposalEvent = {}, effectExecution = {}) 
   };
 }
 
+function buildFallbackLearningEffectsResponseFromDeliveryRow(deliveryRow = {}, error = null) {
+  const proposalKey = normalizeString(deliveryRow.mark_run_id)
+    ? `mark-run:${normalizeString(deliveryRow.mark_run_id)}`
+    : (normalizeString(deliveryRow.attempt_id) ? `attempt:${normalizeString(deliveryRow.attempt_id)}` : null);
+
+  return {
+    proposal_key: proposalKey,
+    guardrail_decisions: {},
+    authoritative_scoring_allowed: false,
+    release_scope_status: null,
+    learning_signal_posture: null,
+    fallback_mode: null,
+    fallback_reason_code: null,
+    runtime_authority_posture: null,
+    runtime_authority_reason_code: null,
+    question_source_kind: null,
+    proposed_mastery_effects: [],
+    proposed_review_tasks: [],
+    proposed_artifact_suggestions: [],
+    effect_execution: {
+      ok: false,
+      status: 'failed',
+      debt_pending: true,
+      receipt_summary: {
+        total: 0,
+        persisted: 0,
+        retrying: 0,
+        needs_manual_review: 0,
+      },
+      receipts: [],
+      error: {
+        code: 'effect_execution_failed',
+        message: error?.message || String(error),
+      },
+    },
+  };
+}
+
 function buildReconciliationSourceRef(deliveryRow = {}) {
   if (normalizeString(deliveryRow.mark_run_id)) {
     return {
@@ -759,51 +797,45 @@ async function loadPersistedLearningUpdateProposalEvent(client, deliveryRow = {}
   return proposalEvent;
 }
 
-async function executePersistedLearningUpdateEffects(client, {
-  deliveryRow,
-} = {}, dependencies = {}) {
-  const proposalEvent = await loadPersistedLearningUpdateProposalEvent(client, deliveryRow);
-  const effectExecution = await applyLearningUpdateProposal(
-    {
-      proposalEvent,
-    },
-    {
-      supabase: client,
-      ...dependencies,
-    },
-  );
-
-  return {
-    proposalEvent,
-    learningEffects: buildLearningEffectsResponse(proposalEvent, effectExecution),
-  };
-}
-
 async function executePersistedLearningUpdateEffectsSafely(client, {
   deliveryRow,
 } = {}, dependencies = {}) {
+  let proposalEvent = null;
+
   try {
-    return await executePersistedLearningUpdateEffects(client, {
-      deliveryRow,
-    }, dependencies);
+    proposalEvent = await loadPersistedLearningUpdateProposalEvent(client, deliveryRow);
+    const effectExecution = await applyLearningUpdateProposal(
+      {
+        proposalEvent,
+      },
+      {
+        supabase: client,
+        ...dependencies,
+      },
+    );
+
+    return {
+      proposalEvent,
+      learningEffects: buildLearningEffectsResponse(proposalEvent, effectExecution),
+    };
   } catch (error) {
-    const proposalEvent = await loadPersistedLearningUpdateProposalEvent(client, deliveryRow);
-    const learningEffects = buildLearningEffectsResponse(proposalEvent, {
-      ok: false,
-      status: 'failed',
-      receipt_summary: {
-        total: 0,
-        persisted: 0,
-        retrying: 0,
-        needs_manual_review: 0,
-      },
-      receipts: [],
-      error: {
-        code: 'effect_execution_failed',
-        message: error?.message || String(error),
-      },
-    });
-    learningEffects.effect_execution.debt_pending = true;
+    const learningEffects = proposalEvent
+      ? buildLearningEffectsResponse(proposalEvent, {
+        ok: false,
+        status: 'failed',
+        receipt_summary: {
+          total: 0,
+          persisted: 0,
+          retrying: 0,
+          needs_manual_review: 0,
+        },
+        receipts: [],
+        error: {
+          code: 'effect_execution_failed',
+          message: error?.message || String(error),
+        },
+      })
+      : buildFallbackLearningEffectsResponseFromDeliveryRow(deliveryRow, error);
 
     return {
       proposalEvent,

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -266,7 +266,6 @@ function buildLearningUpdateProposedPayload({
   markRunId,
   proposal = null,
 } = {}) {
-  const fallbackReason = normalizeString(authorityPosture.fallback_reason_code) || null;
   const normalizedProposal = proposal && typeof proposal === 'object' ? proposal : {};
   const proposalKey = normalizeString(normalizedProposal.proposal_key)
     || (normalizeString(markRunId) ? `mark-run:${markRunId}` : `attempt:${attemptId}`);
@@ -275,14 +274,9 @@ function buildLearningUpdateProposedPayload({
     attempt_id: attemptId,
     authority_posture: cloneJson(authorityPosture),
     proposal_key: proposalKey,
-    guardrail_decisions: cloneJson(normalizedProposal.guardrail_decisions ?? {
-      authoritative_scoring_allowed: Boolean(authorityPosture.authoritative_scoring_allowed),
-      release_scope_status: normalizeString(authorityPosture.release_scope_status) || null,
-      learning_signal_posture: normalizeString(authorityPosture.learning_signal_posture) || null,
-      fallback_mode: normalizeString(authorityPosture.fallback_mode) || null,
-      fallback_reason_code: fallbackReason,
-      reasons: fallbackReason ? [fallbackReason] : ['released_scoring'],
-    }),
+    guardrail_decisions: cloneJson(
+      normalizedProposal.guardrail_decisions ?? buildLearningEffectGuardrailDecisions(authorityPosture),
+    ),
     proposed_mastery_effects: cloneJson(
       normalizedProposal.proposedMasteryEffects
       ?? normalizedProposal.proposed_mastery_effects
@@ -609,6 +603,38 @@ function buildLearningEffectsReceiptSummary(effectExecution = {}) {
   };
 }
 
+function buildLearningEffectGuardrailDecisions(authorityPosture = {}) {
+  const fallbackReason = normalizeString(authorityPosture.fallback_reason_code) || null;
+
+  return {
+    authoritative_scoring_allowed: Boolean(authorityPosture.authoritative_scoring_allowed),
+    release_scope_status: normalizeString(authorityPosture.release_scope_status) || null,
+    learning_signal_posture: normalizeString(authorityPosture.learning_signal_posture) || null,
+    fallback_mode: normalizeString(authorityPosture.fallback_mode) || null,
+    fallback_reason_code: fallbackReason,
+    reasons: fallbackReason ? [fallbackReason] : ['released_scoring'],
+  };
+}
+
+function buildFailedLearningEffectExecution(error = null) {
+  return {
+    ok: false,
+    status: 'failed',
+    debt_pending: true,
+    receipt_summary: {
+      total: 0,
+      persisted: 0,
+      retrying: 0,
+      needs_manual_review: 0,
+    },
+    receipts: [],
+    error: {
+      code: 'effect_execution_failed',
+      message: error?.message || String(error),
+    },
+  };
+}
+
 function buildLearningEffectsResponse(proposalEvent = {}, effectExecution = {}) {
   const payload = proposalEvent?.payload && typeof proposalEvent.payload === 'object'
     ? cloneJson(proposalEvent.payload)
@@ -653,7 +679,10 @@ function buildLearningEffectsResponse(proposalEvent = {}, effectExecution = {}) 
     effect_execution: {
       ok: Boolean(effectExecution?.ok),
       status: normalizeString(effectExecution?.status) || 'unknown',
-      debt_pending: receiptSummary.retrying > 0 || receiptSummary.needs_manual_review > 0,
+      debt_pending:
+        Boolean(effectExecution?.debt_pending)
+        || receiptSummary.retrying > 0
+        || receiptSummary.needs_manual_review > 0,
       receipt_summary: receiptSummary,
       receipts: normalizeArray(effectExecution?.receipts).map((receipt) => cloneJson(receipt)),
       error: effectExecution?.error ? cloneJson(effectExecution.error) : null,
@@ -661,42 +690,34 @@ function buildLearningEffectsResponse(proposalEvent = {}, effectExecution = {}) 
   };
 }
 
-function buildFallbackLearningEffectsResponseFromDeliveryRow(deliveryRow = {}, error = null) {
+function buildFallbackLearningEffectsResponseFromDeliveryRow(
+  deliveryRow = {},
+  {
+    authorityPosture = null,
+    error = null,
+  } = {},
+) {
   const proposalKey = normalizeString(deliveryRow.mark_run_id)
     ? `mark-run:${normalizeString(deliveryRow.mark_run_id)}`
     : (normalizeString(deliveryRow.attempt_id) ? `attempt:${normalizeString(deliveryRow.attempt_id)}` : null);
+  const normalizedAuthorityPosture =
+    authorityPosture && typeof authorityPosture === 'object'
+      ? buildRuntimeAuthorityPosture(authorityPosture, authorityPosture)
+      : {};
 
-  return {
-    proposal_key: proposalKey,
-    guardrail_decisions: {},
-    authoritative_scoring_allowed: false,
-    release_scope_status: null,
-    learning_signal_posture: null,
-    fallback_mode: null,
-    fallback_reason_code: null,
-    runtime_authority_posture: null,
-    runtime_authority_reason_code: null,
-    question_source_kind: null,
-    proposed_mastery_effects: [],
-    proposed_review_tasks: [],
-    proposed_artifact_suggestions: [],
-    effect_execution: {
-      ok: false,
-      status: 'failed',
-      debt_pending: true,
-      receipt_summary: {
-        total: 0,
-        persisted: 0,
-        retrying: 0,
-        needs_manual_review: 0,
-      },
-      receipts: [],
-      error: {
-        code: 'effect_execution_failed',
-        message: error?.message || String(error),
+  return buildLearningEffectsResponse(
+    {
+      payload: {
+        proposal_key: proposalKey,
+        authority_posture: cloneJson(normalizedAuthorityPosture),
+        guardrail_decisions: buildLearningEffectGuardrailDecisions(normalizedAuthorityPosture),
+        proposed_mastery_effects: [],
+        proposed_review_tasks: [],
+        proposed_artifact_suggestions: [],
       },
     },
-  };
+    buildFailedLearningEffectExecution(error),
+  );
 }
 
 function buildReconciliationSourceRef(deliveryRow = {}) {
@@ -797,8 +818,37 @@ async function loadPersistedLearningUpdateProposalEvent(client, deliveryRow = {}
   return proposalEvent;
 }
 
+async function loadPersistedMarkRunAuthorityPosture(client, deliveryRow = {}) {
+  const markRunId = normalizeString(deliveryRow.mark_run_id);
+  if (!markRunId) {
+    return null;
+  }
+
+  try {
+    const { data, error } = await client
+      .from('mark_runs')
+      .select('response_summary')
+      .eq('mark_run_id', markRunId)
+      .maybeSingle();
+
+    if (error) {
+      return null;
+    }
+
+    const authorityPosture = data?.response_summary?.authority_posture;
+    if (!authorityPosture || typeof authorityPosture !== 'object' || Array.isArray(authorityPosture)) {
+      return null;
+    }
+
+    return buildRuntimeAuthorityPosture(authorityPosture, authorityPosture);
+  } catch {
+    return null;
+  }
+}
+
 async function executePersistedLearningUpdateEffectsSafely(client, {
   deliveryRow,
+  fallbackProposalEvent = null,
 } = {}, dependencies = {}) {
   let proposalEvent = null;
 
@@ -819,23 +869,15 @@ async function executePersistedLearningUpdateEffectsSafely(client, {
       learningEffects: buildLearningEffectsResponse(proposalEvent, effectExecution),
     };
   } catch (error) {
+    const failedEffectExecution = buildFailedLearningEffectExecution(error);
     const learningEffects = proposalEvent
-      ? buildLearningEffectsResponse(proposalEvent, {
-        ok: false,
-        status: 'failed',
-        receipt_summary: {
-          total: 0,
-          persisted: 0,
-          retrying: 0,
-          needs_manual_review: 0,
-        },
-        receipts: [],
-        error: {
-          code: 'effect_execution_failed',
-          message: error?.message || String(error),
-        },
-      })
-      : buildFallbackLearningEffectsResponseFromDeliveryRow(deliveryRow, error);
+      ? buildLearningEffectsResponse(proposalEvent, failedEffectExecution)
+      : fallbackProposalEvent
+        ? buildLearningEffectsResponse(fallbackProposalEvent, failedEffectExecution)
+        : buildFallbackLearningEffectsResponseFromDeliveryRow(deliveryRow, {
+          authorityPosture: await loadPersistedMarkRunAuthorityPosture(client, deliveryRow),
+          error,
+        });
 
     return {
       proposalEvent,
@@ -1056,6 +1098,8 @@ export async function persistAttemptEventBridge(client, input = {}, options = {}
     const downstreamLearningEffects = options.applyDownstreamEffects
       ? await executePersistedLearningUpdateEffectsSafely(client, {
         deliveryRow: finalizedDelivery,
+        fallbackProposalEvent:
+          events.find((event) => event.event_type === 'LearningUpdateProposed') ?? null,
       }, options)
       : null;
 

--- a/api/marking/__tests__/evaluate-v1.test.js
+++ b/api/marking/__tests__/evaluate-v1.test.js
@@ -138,6 +138,31 @@ const mockPersistAttemptEventBridge = jest.fn(async () => ({
     current_status: 'running',
     last_sequence_no: 4,
   },
+  learning_effects: {
+    proposal_key: 'mark-run:mr-001',
+    guardrail_decisions: {
+      authoritative_scoring_allowed: true,
+      release_scope_status: 'released_scoring',
+      learning_signal_posture: 'authoritative_scoring',
+      fallback_mode: null,
+      fallback_reason_code: null,
+      reasons: ['released_scoring'],
+    },
+    authoritative_scoring_allowed: true,
+    release_scope_status: 'released_scoring',
+    learning_signal_posture: 'authoritative_scoring',
+    effect_execution: {
+      ok: true,
+      status: 'applied',
+      debt_pending: false,
+      receipt_summary: {
+        total: 3,
+        persisted: 3,
+        retrying: 0,
+        needs_manual_review: 0,
+      },
+    },
+  },
 }));
 
 jest.unstable_mockModule('../lib/auth-helper.js', () => ({
@@ -630,7 +655,18 @@ describe('learning-runtime orchestration', () => {
           learning_signal_posture: 'authoritative_scoring',
         }),
       }),
+      {
+        applyDownstreamEffects: true,
+      },
     );
+    expect(mockApplyLearningEffects).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].learning_effects).toMatchObject({
+      proposal_key: 'mark-run:mr-001',
+      effect_execution: {
+        ok: true,
+        status: 'applied',
+      },
+    });
   });
 
   it('executes a released 9709 pilot rubric through the adapter runtime behind the runtime flag', async () => {
@@ -784,16 +820,49 @@ describe('learning-runtime orchestration', () => {
       family_id: '9709.trigonometry_manipulation_equations',
       primary_question_type_id: '9709.trigonometry.identities',
     });
-    mockApplyLearningEffects.mockResolvedValueOnce({
-      release_scope_status: 'released_scoring',
-      authoritative_scoring_allowed: false,
-      learning_signal_posture: 'conservative_fallback',
-      runtime_authority_posture: 'non_authoritative',
-      runtime_authority_reason_code: 'imported_question_attempt',
-      mastery_updates: [],
-      review_tasks: [],
-      artifact_candidates: [],
-      reconciliation: null,
+    mockPersistAttemptEventBridge.mockResolvedValueOnce({
+      ok: true,
+      warningRecorded: false,
+      persisted_event_types: [
+        'AttemptSubmitted',
+        'QuestionClassified',
+        'MarkingCompleted',
+        'LearningUpdateProposed',
+      ],
+      pipeline_state: {
+        attempt_id: 'att-001',
+        current_stage: 'LearningUpdateProposed',
+        current_status: 'running',
+        last_sequence_no: 4,
+      },
+      learning_effects: {
+        proposal_key: 'mark-run:mr-001',
+        guardrail_decisions: {
+          authoritative_scoring_allowed: false,
+          release_scope_status: 'released_scoring',
+          learning_signal_posture: 'conservative_fallback',
+          fallback_mode: null,
+          fallback_reason_code: 'imported_question_attempt',
+          reasons: ['imported_question_attempt'],
+        },
+        authoritative_scoring_allowed: false,
+        release_scope_status: 'released_scoring',
+        learning_signal_posture: 'conservative_fallback',
+        runtime_authority_posture: 'non_authoritative',
+        runtime_authority_reason_code: 'imported_question_attempt',
+        question_source_kind: 'imported_question',
+        effect_execution: {
+          ok: true,
+          status: 'applied',
+          debt_pending: false,
+          receipt_summary: {
+            total: 0,
+            persisted: 0,
+            retrying: 0,
+            needs_manual_review: 0,
+          },
+        },
+      },
     });
 
     const req = mockReq();
@@ -823,27 +892,89 @@ describe('learning-runtime orchestration', () => {
           question_source_kind: 'imported_question',
         }),
       }),
+      {
+        applyDownstreamEffects: true,
+      },
     );
-    expect(mockApplyLearningEffects).toHaveBeenCalledWith(
-      expect.objectContaining({
-        question_context: expect.objectContaining({
-          source_kind: 'imported_question',
-        }),
-        release_scope_posture: expect.objectContaining({
-          authoritative_scoring_allowed: false,
-          runtime_authority_posture: 'non_authoritative',
-          runtime_authority_reason_code: 'imported_question_attempt',
-          question_source_kind: 'imported_question',
-        }),
-      }),
-      expect.any(Object),
-    );
+    expect(mockApplyLearningEffects).not.toHaveBeenCalled();
 
     const body = res.json.mock.calls[0][0];
     expect(body.learning_effects).toMatchObject({
       authoritative_scoring_allowed: false,
       runtime_authority_posture: 'non_authoritative',
       runtime_authority_reason_code: 'imported_question_attempt',
+      effect_execution: {
+        ok: true,
+        status: 'applied',
+      },
+    });
+  });
+
+  it('surfaces durable downstream effect retry debt without breaking the scoring response', async () => {
+    process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'true';
+    mockPersistAttemptEventBridge.mockResolvedValueOnce({
+      ok: true,
+      warningRecorded: false,
+      persisted_event_types: [
+        'AttemptSubmitted',
+        'QuestionClassified',
+        'MarkingCompleted',
+        'LearningUpdateProposed',
+      ],
+      pipeline_state: {
+        attempt_id: 'att-001',
+        current_stage: 'LearningUpdateProposed',
+        current_status: 'running',
+        last_sequence_no: 4,
+      },
+      learning_effects: {
+        proposal_key: 'mark-run:mr-001',
+        guardrail_decisions: {
+          authoritative_scoring_allowed: true,
+          release_scope_status: 'released_scoring',
+          learning_signal_posture: 'authoritative_scoring',
+          fallback_mode: null,
+          fallback_reason_code: null,
+          reasons: ['released_scoring'],
+        },
+        authoritative_scoring_allowed: true,
+        release_scope_status: 'released_scoring',
+        learning_signal_posture: 'authoritative_scoring',
+        effect_execution: {
+          ok: false,
+          status: 'partial_failure',
+          debt_pending: true,
+          receipt_summary: {
+            total: 3,
+            persisted: 2,
+            retrying: 1,
+            needs_manual_review: 0,
+          },
+        },
+      },
+    });
+
+    const req = mockReq();
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockApplyLearningEffects).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0]).toMatchObject({
+      ledger_write_status: 'success',
+      learning_effects: {
+        effect_execution: {
+          ok: false,
+          status: 'partial_failure',
+          debt_pending: true,
+          receipt_summary: {
+            total: 3,
+            persisted: 2,
+            retrying: 1,
+          },
+        },
+      },
     });
   });
 
@@ -865,7 +996,8 @@ describe('learning-runtime orchestration', () => {
     expect(res.json.mock.calls[0][0]).toMatchObject({
       ledger_write_status: 'success',
     });
+    expect(res.json.mock.calls[0][0].learning_effects).toBeUndefined();
     expect(mockPersistAttemptEventBridge).toHaveBeenCalled();
-    expect(mockApplyLearningEffects).toHaveBeenCalled();
+    expect(mockApplyLearningEffects).not.toHaveBeenCalled();
   });
 });

--- a/api/marking/__tests__/evaluate-v1.test.js
+++ b/api/marking/__tests__/evaluate-v1.test.js
@@ -766,15 +766,48 @@ describe('learning-runtime orchestration', () => {
         step_index: 2,
       }),
     ];
-    mockApplyLearningEffects.mockResolvedValueOnce({
-      release_scope_status: 'non_released_fallback',
-      authoritative_scoring_allowed: false,
-      learning_signal_posture: 'conservative_fallback',
-      fallback_reason_code: 'low_classification_confidence',
-      mastery_updates: [],
-      review_tasks: [],
-      artifact_candidates: [],
-      reconciliation: null,
+    mockPersistAttemptEventBridge.mockResolvedValueOnce({
+      ok: true,
+      warningRecorded: false,
+      persisted_event_types: [
+        'AttemptSubmitted',
+        'QuestionClassified',
+        'MarkingCompleted',
+        'LearningUpdateProposed',
+      ],
+      pipeline_state: {
+        attempt_id: 'att-001',
+        current_stage: 'LearningUpdateProposed',
+        current_status: 'running',
+        last_sequence_no: 4,
+      },
+      learning_effects: {
+        proposal_key: 'mark-run:mr-001',
+        guardrail_decisions: {
+          authoritative_scoring_allowed: false,
+          release_scope_status: 'non_released_fallback',
+          learning_signal_posture: 'conservative_fallback',
+          fallback_mode: 'classification_guardrail',
+          fallback_reason_code: 'low_classification_confidence',
+          reasons: ['low_classification_confidence'],
+        },
+        authoritative_scoring_allowed: false,
+        release_scope_status: 'non_released_fallback',
+        learning_signal_posture: 'conservative_fallback',
+        fallback_mode: 'classification_guardrail',
+        fallback_reason_code: 'low_classification_confidence',
+        effect_execution: {
+          ok: true,
+          status: 'applied',
+          debt_pending: false,
+          receipt_summary: {
+            total: 0,
+            persisted: 0,
+            retrying: 0,
+            needs_manual_review: 0,
+          },
+        },
+      },
     });
 
     const req = mockReq({
@@ -790,16 +823,20 @@ describe('learning-runtime orchestration', () => {
 
     await handler(req, res);
 
-    expect(mockApplyLearningEffects).toHaveBeenCalledWith(
+    expect(mockPersistAttemptEventBridge).toHaveBeenCalledWith(
+      expect.any(Object),
       expect.objectContaining({
-        release_scope_posture: expect.objectContaining({
+        authorityPosture: expect.objectContaining({
           authoritative_scoring_allowed: false,
           fallback_reason_code: 'low_classification_confidence',
           learning_signal_posture: 'conservative_fallback',
         }),
       }),
-      expect.any(Object),
+      {
+        applyDownstreamEffects: true,
+      },
     );
+    expect(mockApplyLearningEffects).not.toHaveBeenCalled();
 
     const body = res.json.mock.calls[0][0];
     expect(body.decisions[0]).toMatchObject({
@@ -809,6 +846,10 @@ describe('learning-runtime orchestration', () => {
     expect(body.learning_effects).toMatchObject({
       authoritative_scoring_allowed: false,
       fallback_reason_code: 'low_classification_confidence',
+      effect_execution: expect.objectContaining({
+        ok: true,
+        status: 'applied',
+      }),
     });
   });
 

--- a/api/marking/evaluate-v1.js
+++ b/api/marking/evaluate-v1.js
@@ -442,6 +442,40 @@ export default async function handler(req, res) {
       }));
 
       if (ledgerResult.decision_write_status === 'success') {
+        const learningEffectsInput = {
+          supabase,
+          user_id,
+          subject_code: subjectCode,
+          question_id,
+          question_context: {
+            source_kind: questionContext.source_kind,
+            family_id: questionContext.family_id,
+            question_type_id: questionContext.question_type_id,
+            question_type_release_state: questionContext.question_type_release_state,
+            primary_topic_id:
+              questionContext.primary_topic_id ?? ledgerResult.attempt_context?.topic_id ?? null,
+            primary_topic_path: ledgerResult.attempt_context?.topic_path ?? null,
+            classification_confidence: questionContext.classification_confidence,
+            candidate_rubric_refs: questionContext.candidate_rubric_refs,
+            release_scope_status: questionContext.release_scope_status,
+          },
+          attempt_id: ledgerResult.attempt_id,
+          mark_run_id: ledgerResult.mark_run_id,
+          source_attempt_ref: {
+            kind: 'attempt',
+            attempt_id: ledgerResult.attempt_id,
+          },
+          source_mark_run_ref: {
+            kind: 'mark_run',
+            mark_run_id: ledgerResult.mark_run_id,
+          },
+          source_attempt_context: ledgerResult.attempt_context ?? null,
+          decisions,
+          marking_result: markingResult,
+          uncertainty_validated: true,
+          release_scope_posture: runtimeAuthorityPosture,
+        };
+
         if (isRuntimeBridgeEnabled()) {
           try {
             const bridgeResult = await persistAttemptEventBridge(supabase, {
@@ -472,7 +506,11 @@ export default async function handler(req, res) {
               },
               correlationId: run_id,
               emittedBy: 'evaluate-v1',
+            }, {
+              applyDownstreamEffects: true,
             });
+
+            learningEffects = bridgeResult.learning_effects ?? null;
 
             if (!bridgeResult.ok) {
               console.warn(JSON.stringify({
@@ -496,51 +534,19 @@ export default async function handler(req, res) {
               ts: new Date().toISOString(),
             }));
           }
-        }
-
-        try {
-          learningEffects = await applyLearningEffects({
-            supabase,
-            user_id,
-            subject_code: subjectCode,
-            question_id,
-            question_context: {
-              source_kind: questionContext.source_kind,
-              family_id: questionContext.family_id,
-              question_type_id: questionContext.question_type_id,
-              question_type_release_state: questionContext.question_type_release_state,
-              primary_topic_id:
-                questionContext.primary_topic_id ?? ledgerResult.attempt_context?.topic_id ?? null,
-              primary_topic_path: ledgerResult.attempt_context?.topic_path ?? null,
-              classification_confidence: questionContext.classification_confidence,
-              candidate_rubric_refs: questionContext.candidate_rubric_refs,
-              release_scope_status: questionContext.release_scope_status,
-            },
-            attempt_id: ledgerResult.attempt_id,
-            mark_run_id: ledgerResult.mark_run_id,
-            source_attempt_ref: {
-              kind: 'attempt',
-              attempt_id: ledgerResult.attempt_id,
-            },
-            source_mark_run_ref: {
-              kind: 'mark_run',
-              mark_run_id: ledgerResult.mark_run_id,
-            },
-            source_attempt_context: ledgerResult.attempt_context ?? null,
-            decisions,
-            marking_result: markingResult,
-            uncertainty_validated: true,
-            release_scope_posture: runtimeAuthorityPosture,
-          }, {
-            supabase,
-          });
-        } catch (learningEffectsError) {
-          console.warn(JSON.stringify({
-            event: 'evaluate_v1_learning_effects_error',
-            run_id,
-            error: learningEffectsError?.message || String(learningEffectsError),
-            ts: new Date().toISOString(),
-          }));
+        } else {
+          try {
+            learningEffects = await applyLearningEffects(learningEffectsInput, {
+              supabase,
+            });
+          } catch (learningEffectsError) {
+            console.warn(JSON.stringify({
+              event: 'evaluate_v1_learning_effects_error',
+              run_id,
+              error: learningEffectsError?.message || String(learningEffectsError),
+              ts: new Date().toISOString(),
+            }));
+          }
         }
       }
     } catch (ledgerErr) {


### PR DESCRIPTION
## Summary
- run downstream learning-effect execution from the persisted `LearningUpdateProposed` bridge event instead of the old parallel request-path call
- keep `evaluate-v1` non-blocking when downstream execution fails, while surfacing receipt-backed retry debt in the response
- add a deterministic retry/reconciliation entry point that replays failed effect receipts from the persisted proposal event and records reconciliation evidence

## Verification
- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/attempt-event-service.test.js api/marking/__tests__/evaluate-v1.test.js --verbose`
- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/learning-effect-engine.test.js api/learning/__tests__/attempt-event-service.test.js api/marking/__tests__/evaluate-v1.test.js api/learning/__tests__/reconciliation-service.test.js --verbose`
- `git diff --check`

Closes #229
