### PR TITLE
feat: activate artifact content for pilot residents

### DIFF
--- a/api/learning/__tests__/artifact-content-repository.test.js
+++ b/api/learning/__tests__/artifact-content-repository.test.js
@@ -1,0 +1,219 @@
+import {
+  createArtifactContentRepository,
+} from '../lib/repositories/artifact-content-repository.js';
+
+function createArtifactContentDb() {
+  const versions = new Map();
+  let nextVersionId = 1;
+
+  function clone(value) {
+    return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+  }
+
+  function listVersions(filters = []) {
+    let rows = [...versions.values()];
+
+    for (const filter of filters) {
+      if (filter.type === 'eq') {
+        rows = rows.filter((row) => row[filter.column] === filter.value);
+      }
+    }
+
+    return rows;
+  }
+
+  class QueryBuilder {
+    constructor(table) {
+      this.table = table;
+      this.operation = 'select';
+      this.payload = null;
+      this.filters = [];
+      this.orders = [];
+    }
+
+    select() {
+      return this;
+    }
+
+    insert(payload) {
+      this.operation = 'insert';
+      this.payload = payload;
+      return this;
+    }
+
+    update(payload) {
+      this.operation = 'update';
+      this.payload = payload;
+      return this;
+    }
+
+    eq(column, value) {
+      this.filters.push({ type: 'eq', column, value });
+      return this;
+    }
+
+    order(column, options = {}) {
+      this.orders.push({ column, options });
+      return this;
+    }
+
+    single() {
+      return this.#resolve({ single: true });
+    }
+
+    maybeSingle() {
+      return this.#resolve({ maybeSingle: true });
+    }
+
+    then(resolve, reject) {
+      return this.#resolve({}).then(resolve, reject);
+    }
+
+    #resolve(extra = {}) {
+      if (this.table !== 'learning_artifact_content_versions') {
+        return Promise.reject(new Error(`Unexpected table: ${this.table}`));
+      }
+
+      if (this.operation === 'insert') {
+        const row = {
+          artifact_content_version_id: `artifact-content-version-${nextVersionId++}`,
+          created_at: this.payload.created_at ?? '2026-04-17T12:00:00.000Z',
+          ...clone(this.payload),
+        };
+        versions.set(row.artifact_content_version_id, row);
+        return Promise.resolve({ data: clone(row), error: null });
+      }
+
+      if (this.operation === 'update') {
+        const rows = listVersions(this.filters);
+        const current = rows[0] ?? null;
+        const next = current ? { ...current, ...clone(this.payload) } : null;
+        if (next) {
+          versions.set(next.artifact_content_version_id, next);
+        }
+        return Promise.resolve({ data: clone(next), error: null });
+      }
+
+      let rows = listVersions(this.filters);
+
+      for (const order of this.orders) {
+        rows = rows.sort((left, right) => {
+          const leftValue = left[order.column];
+          const rightValue = right[order.column];
+          const direction = order.options?.ascending === false ? -1 : 1;
+
+          if (leftValue === rightValue) {
+            return 0;
+          }
+
+          return leftValue > rightValue ? direction : -direction;
+        });
+      }
+
+      if (extra.single || extra.maybeSingle) {
+        return Promise.resolve({ data: clone(rows[0] ?? null), error: null });
+      }
+
+      return Promise.resolve({ data: clone(rows), error: null });
+    }
+  }
+
+  return {
+    snapshot() {
+      return new Map(versions);
+    },
+    from(table) {
+      return new QueryBuilder(table);
+    },
+  };
+}
+
+describe('artifact-content-repository', () => {
+  test('persists the first content version as the stable current version for an artifact', async () => {
+    const db = createArtifactContentDb();
+    const repository = createArtifactContentRepository(db);
+
+    const stored = await repository.createArtifactContentVersion({
+      artifact_id: 'artifact-1',
+      title: 'Common trap: sign slip',
+      summary: 'Watch for sign changes when rearranging terms.',
+      body_markdown: '## Why this happens\n\nSigns flip when terms move across the equals sign.',
+      content_format: 'markdown',
+      render_payload: {
+        schema_version: 'learning_artifact_render.v1',
+      },
+      materialization_kind: 'runtime_candidate',
+      source_refs: [
+        { kind: 'attempt', attempt_id: 'attempt-1' },
+      ],
+    });
+
+    expect(stored).toMatchObject({
+      artifact_id: 'artifact-1',
+      version_number: 1,
+      is_current: true,
+      lineage_parent_version_id: null,
+      title: 'Common trap: sign slip',
+      content_format: 'markdown',
+      materialization_kind: 'runtime_candidate',
+    });
+
+    await expect(repository.getCurrentArtifactContentByArtifactId('artifact-1')).resolves.toMatchObject({
+      artifact_content_version_id: stored.artifact_content_version_id,
+      version_number: 1,
+      is_current: true,
+      title: 'Common trap: sign slip',
+    });
+  });
+
+  test('promotes a new current version while preserving historical lineage for prior versions', async () => {
+    const db = createArtifactContentDb();
+    const repository = createArtifactContentRepository(db);
+
+    const first = await repository.createArtifactContentVersion({
+      artifact_id: 'artifact-1',
+      title: 'Common trap: sign slip',
+      summary: 'First summary.',
+      body_markdown: 'Initial explanation.',
+    });
+
+    const second = await repository.createArtifactContentVersion({
+      artifact_id: 'artifact-1',
+      title: 'Common trap: sign slip',
+      summary: 'Updated summary.',
+      body_markdown: 'Updated explanation with a corrected example.',
+    });
+
+    expect(second).toMatchObject({
+      artifact_id: 'artifact-1',
+      version_number: 2,
+      is_current: true,
+      lineage_parent_version_id: first.artifact_content_version_id,
+      summary: 'Updated summary.',
+    });
+
+    await expect(repository.getCurrentArtifactContentByArtifactId('artifact-1')).resolves.toMatchObject({
+      artifact_content_version_id: second.artifact_content_version_id,
+      version_number: 2,
+      is_current: true,
+      lineage_parent_version_id: first.artifact_content_version_id,
+    });
+
+    await expect(repository.listArtifactContentVersionsByArtifactId('artifact-1')).resolves.toEqual([
+      expect.objectContaining({
+        artifact_content_version_id: second.artifact_content_version_id,
+        version_number: 2,
+        is_current: true,
+      }),
+      expect.objectContaining({
+        artifact_content_version_id: first.artifact_content_version_id,
+        version_number: 1,
+        is_current: false,
+      }),
+    ]);
+
+    expect(db.snapshot().get(first.artifact_content_version_id)).toMatchObject({
+      is_current: false,
+    });
+  });
+});

--- a/api/learning/__tests__/artifact-content-repository.test.js
+++ b/api/learning/__tests__/artifact-content-repository.test.js
@@ -5,6 +5,7 @@ import {
 function createArtifactContentDb() {
   const versions = new Map();
   let nextVersionId = 1;
+  let nextInsertError = null;
 
   function clone(value) {
     return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
@@ -75,6 +76,12 @@ function createArtifactContentDb() {
       }
 
       if (this.operation === 'insert') {
+        if (nextInsertError) {
+          const error = nextInsertError;
+          nextInsertError = null;
+          return Promise.resolve({ data: null, error });
+        }
+
         const row = {
           artifact_content_version_id: `artifact-content-version-${nextVersionId++}`,
           created_at: this.payload.created_at ?? '2026-04-17T12:00:00.000Z',
@@ -119,6 +126,52 @@ function createArtifactContentDb() {
   }
 
   return {
+    setNextInsertError(error) {
+      nextInsertError = error;
+    },
+    async rpc(name, params) {
+      if (name !== 'create_learning_artifact_content_version') {
+        throw new Error(`Unexpected rpc: ${name}`);
+      }
+
+      if (nextInsertError) {
+        const error = nextInsertError;
+        nextInsertError = null;
+        return { data: null, error };
+      }
+
+      const current = listVersions([
+        { type: 'eq', column: 'artifact_id', value: params.p_artifact_id },
+        { type: 'eq', column: 'is_current', value: true },
+      ])[0] ?? null;
+
+      if (params.p_is_current ?? true) {
+        if (current) {
+          versions.set(current.artifact_content_version_id, {
+            ...current,
+            is_current: false,
+          });
+        }
+      }
+
+      const row = {
+        artifact_content_version_id: `artifact-content-version-${nextVersionId++}`,
+        artifact_id: params.p_artifact_id,
+        version_number: params.p_version_number,
+        lineage_parent_version_id: params.p_lineage_parent_version_id,
+        is_current: params.p_is_current,
+        title: params.p_title,
+        summary: params.p_summary,
+        body_markdown: params.p_body_markdown,
+        content_format: params.p_content_format,
+        render_payload: params.p_render_payload,
+        materialization_kind: params.p_materialization_kind,
+        source_refs: params.p_source_refs,
+        created_at: params.p_created_at ?? '2026-04-17T12:00:00.000Z',
+      };
+      versions.set(row.artifact_content_version_id, clone(row));
+      return { data: clone(row), error: null };
+    },
     snapshot() {
       return new Map(versions);
     },
@@ -214,6 +267,40 @@ describe('artifact-content-repository', () => {
 
     expect(db.snapshot().get(first.artifact_content_version_id)).toMatchObject({
       is_current: false,
+    });
+  });
+
+  test('failed replacement inserts do not clear the previous current version', async () => {
+    const db = createArtifactContentDb();
+    const repository = createArtifactContentRepository(db);
+
+    const first = await repository.createArtifactContentVersion({
+      artifact_id: 'artifact-1',
+      title: 'Common trap: sign slip',
+      summary: 'First summary.',
+      body_markdown: 'Initial explanation.',
+    });
+
+    db.setNextInsertError({
+      message: 'simulated insert failure',
+    });
+
+    await expect(repository.createArtifactContentVersion({
+      artifact_id: 'artifact-1',
+      title: 'Common trap: sign slip',
+      summary: 'Replacement summary.',
+      body_markdown: 'Replacement explanation.',
+    })).rejects.toThrow('Failed to insert learning artifact content version');
+
+    await expect(repository.getCurrentArtifactContentByArtifactId('artifact-1')).resolves.toMatchObject({
+      artifact_content_version_id: first.artifact_content_version_id,
+      version_number: 1,
+      is_current: true,
+      summary: 'First summary.',
+    });
+
+    expect(db.snapshot().get(first.artifact_content_version_id)).toMatchObject({
+      is_current: true,
     });
   });
 });

--- a/api/learning/__tests__/artifact-repository.test.js
+++ b/api/learning/__tests__/artifact-repository.test.js
@@ -1,0 +1,195 @@
+import { listArtifactsByTopic } from '../lib/repositories/artifact-repository.js';
+
+function createArtifactRepositoryDb() {
+  const queries = [];
+  const artifactRows = [
+    {
+      artifact_id: 'artifact-2',
+      artifact_kind: 'misconception_card',
+      canonical_home_topic_id: 'topic-1',
+      slot_key: 'common_traps',
+      placement_status: 'inbox',
+      lifecycle_status: 'active',
+      trust_status: 'grounded',
+      artifact_state: 'verified',
+      updated_at: '2026-04-17T12:01:00.000Z',
+      created_at: '2026-04-17T12:01:00.000Z',
+    },
+    {
+      artifact_id: 'artifact-1',
+      artifact_kind: 'misconception_card',
+      canonical_home_topic_id: 'topic-1',
+      slot_key: 'common_traps',
+      placement_status: 'pinned',
+      lifecycle_status: 'active',
+      trust_status: 'grounded',
+      artifact_state: 'verified',
+      updated_at: '2026-04-17T12:00:00.000Z',
+      created_at: '2026-04-17T12:00:00.000Z',
+    },
+  ];
+  const contentRows = [
+    {
+      artifact_content_version_id: 'content-1',
+      artifact_id: 'artifact-1',
+      version_number: 3,
+      is_current: true,
+      title: 'Resident content',
+      summary: 'Pinned resident summary.',
+      body_markdown: 'Resident content body.',
+      content_format: 'markdown',
+      render_payload: {},
+      source_refs: [],
+    },
+    {
+      artifact_content_version_id: 'content-2',
+      artifact_id: 'artifact-2',
+      version_number: 1,
+      is_current: true,
+      title: 'Inbox content',
+      summary: 'Inbox summary.',
+      body_markdown: 'Inbox body.',
+      content_format: 'markdown',
+      render_payload: {},
+      source_refs: [],
+    },
+  ];
+
+  function applyFilters(rows, filters = []) {
+    let nextRows = [...rows];
+
+    for (const filter of filters) {
+      if (filter.type === 'eq') {
+        nextRows = nextRows.filter((row) => row[filter.column] === filter.value);
+      }
+
+      if (filter.type === 'in') {
+        nextRows = nextRows.filter((row) => filter.values.includes(row[filter.column]));
+      }
+    }
+
+    return nextRows;
+  }
+
+  function applyOrders(rows, orders = []) {
+    let nextRows = [...rows];
+
+    for (const order of orders) {
+      nextRows = nextRows.sort((left, right) => {
+        const leftValue = left[order.column];
+        const rightValue = right[order.column];
+        const direction = order.options?.ascending === false ? -1 : 1;
+
+        if (leftValue === rightValue) {
+          return 0;
+        }
+
+        return leftValue > rightValue ? direction : -direction;
+      });
+    }
+
+    return nextRows;
+  }
+
+  class QueryBuilder {
+    constructor(table) {
+      this.table = table;
+      this.filters = [];
+      this.orders = [];
+      this.selection = null;
+    }
+
+    select(selection) {
+      this.selection = selection;
+      return this;
+    }
+
+    eq(column, value) {
+      this.filters.push({ type: 'eq', column, value });
+      return this;
+    }
+
+    in(column, values) {
+      this.filters.push({ type: 'in', column, values });
+      return this;
+    }
+
+    order(column, options = {}) {
+      this.orders.push({ column, options });
+      return this;
+    }
+
+    maybeSingle() {
+      return this.#resolve({ maybeSingle: true });
+    }
+
+    then(resolve, reject) {
+      return this.#resolve({}).then(resolve, reject);
+    }
+
+    #resolve(extra = {}) {
+      queries.push({
+        table: this.table,
+        selection: this.selection,
+        filters: [...this.filters],
+        orders: [...this.orders],
+        options: { ...extra },
+      });
+
+      if (this.table === 'learning_artifacts') {
+        const rows = applyOrders(applyFilters(artifactRows, this.filters), this.orders);
+        return Promise.resolve({ data: rows, error: null });
+      }
+
+      if (this.table === 'learning_artifact_content_versions') {
+        const rows = applyOrders(applyFilters(contentRows, this.filters), this.orders);
+        if (extra.maybeSingle) {
+          return Promise.resolve({ data: rows[0] ?? null, error: null });
+        }
+
+        return Promise.resolve({ data: rows, error: null });
+      }
+
+      return Promise.reject(new Error(`Unexpected table: ${this.table}`));
+    }
+  }
+
+  return {
+    queries,
+    from(table) {
+      return new QueryBuilder(table);
+    },
+  };
+}
+
+describe('artifact-repository', () => {
+  test('listArtifactsByTopic batches current content loading into a single query', async () => {
+    const db = createArtifactRepositoryDb();
+
+    const rows = await listArtifactsByTopic(db, {
+      topicId: 'topic-1',
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        artifact_id: 'artifact-2',
+        title: 'Inbox content',
+        summary: 'Inbox summary.',
+        current_content_version_number: 1,
+      }),
+      expect.objectContaining({
+        artifact_id: 'artifact-1',
+        title: 'Resident content',
+        summary: 'Pinned resident summary.',
+        current_content_version_number: 3,
+      }),
+    ]);
+
+    const contentQueries = db.queries.filter((query) => query.table === 'learning_artifact_content_versions');
+    expect(contentQueries).toHaveLength(1);
+    expect(contentQueries[0].filters).toEqual(expect.arrayContaining([
+      { type: 'eq', column: 'is_current', value: true },
+      { type: 'in', column: 'artifact_id', values: ['artifact-2', 'artifact-1'] },
+    ]));
+  });
+});

--- a/api/learning/__tests__/artifact-service.test.js
+++ b/api/learning/__tests__/artifact-service.test.js
@@ -229,6 +229,8 @@ function createArtifactRepositoryFixture() {
     ],
   ]);
 
+  let nextArtifactId = 1;
+
   const workspaceSlots = new Map([
     [
       'student-1:repair-target-topic:common_traps',
@@ -245,6 +247,19 @@ function createArtifactRepositoryFixture() {
   ]);
 
   return {
+    async insertArtifact(input) {
+      const artifactId = input.artifact_id ?? `art-generated-${nextArtifactId++}`;
+      const row = {
+        artifact_id: artifactId,
+        created_at: input.created_at ?? '2026-03-22T08:00:00.000Z',
+        updated_at: input.updated_at ?? '2026-03-22T08:00:00.000Z',
+        ...input,
+        artifact_id: artifactId,
+      };
+      artifacts.set(artifactId, row);
+      return row;
+    },
+
     async getArtifactById(artifactId) {
       return artifacts.get(artifactId) || null;
     },
@@ -280,6 +295,65 @@ function createArtifactRepositoryFixture() {
         artifacts: new Map(artifacts),
         workspaceSlots: new Map(workspaceSlots),
       };
+    },
+  };
+}
+
+function createArtifactContentRepositoryFixture() {
+  const versionsByArtifactId = new Map();
+
+  function clone(value) {
+    return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+  }
+
+  return {
+    async createArtifactContentVersion(input = {}) {
+      const existing = versionsByArtifactId.get(input.artifact_id) ?? [];
+      const current = existing.find((version) => version.is_current) ?? null;
+      const next = {
+        artifact_content_version_id: `content-version-${input.artifact_id}-${existing.length + 1}`,
+        artifact_id: input.artifact_id,
+        version_number: current ? Number(current.version_number) + 1 : 1,
+        lineage_parent_version_id: current?.artifact_content_version_id ?? null,
+        is_current: true,
+        title: input.title,
+        summary: input.summary ?? null,
+        body_markdown: input.body_markdown,
+        content_format: input.content_format ?? 'markdown',
+        render_payload: clone(input.render_payload ?? {}),
+        materialization_kind: input.materialization_kind ?? 'runtime_candidate',
+        source_refs: clone(input.source_refs ?? []),
+        created_at: input.created_at ?? '2026-03-22T08:00:00.000Z',
+      };
+
+      versionsByArtifactId.set(
+        input.artifact_id,
+        [
+          ...existing.map((version) => ({ ...version, is_current: false })),
+          next,
+        ],
+      );
+
+      return clone(next);
+    },
+
+    async getCurrentArtifactContentByArtifactId(artifactId) {
+      const current = (versionsByArtifactId.get(artifactId) ?? []).find((version) => version.is_current) ?? null;
+      return clone(current);
+    },
+
+    async listArtifactContentVersionsByArtifactId(artifactId) {
+      return clone(
+        (versionsByArtifactId.get(artifactId) ?? [])
+          .slice()
+          .sort((left, right) => Number(right.version_number) - Number(left.version_number)),
+      );
+    },
+
+    snapshot() {
+      return new Map(
+        [...versionsByArtifactId.entries()].map(([artifactId, versions]) => [artifactId, clone(versions)]),
+      );
     },
   };
 }
@@ -426,6 +500,51 @@ describe('artifact-service', () => {
       slot_key: 'common_traps',
       target_question_type_id: '9709.trigonometry.equations',
     });
+  });
+
+  test('runtime candidate materialization persists an initial content version alongside artifact metadata', async () => {
+    const artifactRepository = createArtifactRepositoryFixture();
+    const artifactContentRepository = createArtifactContentRepositoryFixture();
+    const service = createArtifactService({
+      artifactRepository,
+      artifactContentRepository,
+      lifecycleFlagEnabled: true,
+      now: () => new Date('2026-03-22T08:25:00.000Z'),
+    });
+
+    const [candidate] = await service.buildArtifactCandidates({
+      artifact_kind: 'misconception_card',
+      canonical_home_topic_id: 'topic-trig-equations',
+      canonical_home_topic_path: '9709/trigonometry/equations',
+      repair_target_topic_id: 'repair-target-topic',
+      repair_target_topic_path: '9709/trigonometry/repair',
+      target_family_id: '9709.trigonometry_manipulation_equations',
+      target_question_type_id: '9709.trigonometry.equations',
+      misconception_tags: ['sign_slip'],
+      source_attempt_ref: { kind: 'attempt', attempt_id: 'attempt-1' },
+      source_mark_run_ref: { kind: 'mark_run', mark_run_id: 'mark-run-1' },
+    });
+
+    expect(candidate).toMatchObject({
+      artifact_kind: 'misconception_card',
+      canonical_home_topic_id: 'repair-target-topic',
+      slot_key: 'common_traps',
+      title: 'Common trap: sign slip',
+      current_content_version_number: 1,
+      content_format: 'markdown',
+    });
+    expect(candidate.summary).toContain('9709.trigonometry.equations');
+    expect(candidate.body_markdown).toContain('sign slip');
+    expect(candidate.body_markdown).toContain('mark-run-1');
+
+    expect(artifactContentRepository.snapshot().get(candidate.artifact_id)).toEqual([
+      expect.objectContaining({
+        artifact_id: candidate.artifact_id,
+        version_number: 1,
+        is_current: true,
+        title: 'Common trap: sign slip',
+      }),
+    ]);
   });
 
   test('mark_verified requires explicit operator evidence and keeps released distinct from verified', async () => {

--- a/api/learning/__tests__/workspace-read-service.test.js
+++ b/api/learning/__tests__/workspace-read-service.test.js
@@ -371,6 +371,11 @@ function createLearningDb(overrides = {}) {
       return this;
     }
 
+    in(column, values) {
+      this.filters.push({ type: 'in', column, values });
+      return this;
+    }
+
     lte(column, value) {
       this.filters.push({ type: 'lte', column, value });
       return this;
@@ -396,6 +401,10 @@ function createLearningDb(overrides = {}) {
         for (const filter of this.filters) {
           if (filter.type === 'eq') {
             rows = rows.filter((row) => row[filter.column] === filter.value);
+          }
+
+          if (filter.type === 'in') {
+            rows = rows.filter((row) => filter.values.includes(row[filter.column]));
           }
         }
 
@@ -458,6 +467,10 @@ function createLearningDb(overrides = {}) {
           if (filter.type === 'eq') {
             rows = rows.filter((row) => row[filter.column] === filter.value);
           }
+
+          if (filter.type === 'in') {
+            rows = rows.filter((row) => filter.values.includes(row[filter.column]));
+          }
         }
 
         return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
@@ -469,6 +482,10 @@ function createLearningDb(overrides = {}) {
         for (const filter of this.filters) {
           if (filter.type === 'eq') {
             rows = rows.filter((row) => row[filter.column] === filter.value);
+          }
+
+          if (filter.type === 'in') {
+            rows = rows.filter((row) => filter.values.includes(row[filter.column]));
           }
         }
 
@@ -590,6 +607,10 @@ function createBoundaryLearningDb() {
     for (const filter of filters) {
       if (filter.type === 'eq') {
         rows = rows.filter((row) => row[filter.column] === filter.value);
+      }
+
+      if (filter.type === 'in') {
+        rows = rows.filter((row) => filter.values.includes(row[filter.column]));
       }
     }
 
@@ -913,6 +934,11 @@ function createBoundaryLearningDb() {
       return this;
     }
 
+    in(column, values) {
+      this.filters.push({ type: 'in', column, values });
+      return this;
+    }
+
     lte(column, value) {
       this.filters.push({ type: 'lte', column, value });
       return this;
@@ -954,6 +980,49 @@ function createBoundaryLearningDb() {
 
   return {
     queries,
+    async rpc(name, params) {
+      queries.push({
+        table: `rpc:${name}`,
+        params,
+      });
+
+      if (name !== 'create_learning_artifact_content_version') {
+        throw new Error(`Unhandled rpc: ${name}`);
+      }
+
+      const current = listArtifactContentVersions([
+        { type: 'eq', column: 'artifact_id', value: params.p_artifact_id },
+        { type: 'eq', column: 'is_current', value: true },
+      ])[0] ?? null;
+
+      if (params.p_is_current ?? true) {
+        if (current) {
+          state.artifactContentVersions.set(current.artifact_content_version_id, {
+            ...current,
+            is_current: false,
+          });
+        }
+      }
+
+      const row = {
+        artifact_content_version_id:
+          `artifact-content-version-${state.nextArtifactContentVersionId++}`,
+        artifact_id: params.p_artifact_id,
+        version_number: params.p_version_number,
+        lineage_parent_version_id: params.p_lineage_parent_version_id,
+        is_current: params.p_is_current,
+        title: params.p_title,
+        summary: params.p_summary,
+        body_markdown: params.p_body_markdown,
+        content_format: params.p_content_format,
+        render_payload: params.p_render_payload,
+        materialization_kind: params.p_materialization_kind,
+        source_refs: params.p_source_refs,
+        created_at: params.p_created_at ?? '2026-03-22T09:00:00.000Z',
+      };
+      state.artifactContentVersions.set(row.artifact_content_version_id, row);
+      return { data: row, error: null };
+    },
     from(table) {
       return new QueryBuilder(table);
     },

--- a/api/learning/__tests__/workspace-read-service.test.js
+++ b/api/learning/__tests__/workspace-read-service.test.js
@@ -248,6 +248,8 @@ function createLearningDb(overrides = {}) {
     },
   ];
 
+  const artifactContentVersionRows = overrides.artifactContentVersionRows ?? [];
+
   const sessionRows = overrides.sessionRows ?? [
     {
       session_id: 'session-topic-2-later',
@@ -388,6 +390,32 @@ function createLearningDb(overrides = {}) {
         single: true,
       });
 
+      if (this.table === 'learning_artifact_content_versions') {
+        let rows = [...artifactContentVersionRows];
+
+        for (const filter of this.filters) {
+          if (filter.type === 'eq') {
+            rows = rows.filter((row) => row[filter.column] === filter.value);
+          }
+        }
+
+        for (const order of this.orders) {
+          rows = rows.sort((left, right) => {
+            const leftValue = left[order.column];
+            const rightValue = right[order.column];
+            const direction = order.options?.ascending === false ? -1 : 1;
+
+            if (leftValue === rightValue) {
+              return 0;
+            }
+
+            return leftValue > rightValue ? direction : -direction;
+          });
+        }
+
+        return { data: rows[0] ?? null, error: null };
+      }
+
       if (this.table !== 'learning_workspace_projection') {
         throw new Error(`Unexpected maybeSingle table: ${this.table}`);
       }
@@ -435,6 +463,32 @@ function createLearningDb(overrides = {}) {
         return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
       }
 
+      if (this.table === 'learning_artifact_content_versions') {
+        let rows = [...artifactContentVersionRows];
+
+        for (const filter of this.filters) {
+          if (filter.type === 'eq') {
+            rows = rows.filter((row) => row[filter.column] === filter.value);
+          }
+        }
+
+        for (const order of this.orders) {
+          rows = rows.sort((left, right) => {
+            const leftValue = left[order.column];
+            const rightValue = right[order.column];
+            const direction = order.options?.ascending === false ? -1 : 1;
+
+            if (leftValue === rightValue) {
+              return 0;
+            }
+
+            return leftValue > rightValue ? direction : -direction;
+          });
+        }
+
+        return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+      }
+
       if (this.table !== 'learning_review_queue_projection') {
         return Promise.reject(new Error(`Unexpected list table: ${this.table}`)).then(resolve, reject);
       }
@@ -468,6 +522,7 @@ function createBoundaryLearningDb() {
   const state = {
     nextReviewTaskId: 1,
     nextArtifactId: 1,
+    nextArtifactContentVersionId: 1,
     nextWorkspaceId: 1,
     nextWorkspaceSlotId: 1,
     nextReconciliationId: 1,
@@ -482,6 +537,7 @@ function createBoundaryLearningDb() {
     ]),
     reviewTasks: new Map(),
     artifacts: new Map(),
+    artifactContentVersions: new Map(),
     workspaces: new Map(),
     workspaceByUserTopic: new Map(),
     workspaceSlots: new Map(),
@@ -526,6 +582,18 @@ function createBoundaryLearningDb() {
 
       return String(left.created_at ?? '').localeCompare(String(right.created_at ?? ''));
     });
+  }
+
+  function listArtifactContentVersions(filters = []) {
+    let rows = [...state.artifactContentVersions.values()];
+
+    for (const filter of filters) {
+      if (filter.type === 'eq') {
+        rows = rows.filter((row) => row[filter.column] === filter.value);
+      }
+    }
+
+    return rows.sort((left, right) => Number(right.version_number ?? 0) - Number(left.version_number ?? 0));
   }
 
   function deriveWorkspaceProjection(userId, topicId) {
@@ -644,8 +712,33 @@ function createBoundaryLearningDb() {
     }
 
     if (query.table === 'learning_artifacts' && query.operation === 'select') {
-      const artifactId = findFilter(query.filters, 'artifact_id');
-      return { data: state.artifacts.get(artifactId) || null, error: null };
+      let rows = [...state.artifacts.values()];
+
+      for (const filter of query.filters) {
+        if (filter.type === 'eq') {
+          rows = rows.filter((row) => row[filter.column] === filter.value);
+        }
+      }
+
+      for (const order of query.orders ?? []) {
+        rows = rows.sort((left, right) => {
+          const leftValue = left[order.column];
+          const rightValue = right[order.column];
+          const direction = order.options?.ascending === false ? -1 : 1;
+
+          if (leftValue === rightValue) {
+            return 0;
+          }
+
+          return leftValue > rightValue ? direction : -direction;
+        });
+      }
+
+      if (query.options?.single || query.options?.maybeSingle) {
+        return { data: rows[0] || null, error: null };
+      }
+
+      return { data: rows, error: null };
     }
 
     if (query.table === 'learning_artifacts' && query.operation === 'update') {
@@ -655,6 +748,44 @@ function createBoundaryLearningDb() {
 
       if (next) {
         state.artifacts.set(artifactId, next);
+      }
+
+      return { data: next, error: null };
+    }
+
+    if (query.table === 'learning_artifact_content_versions' && query.operation === 'insert') {
+      const artifactId = query.payload.artifact_id;
+      const existing = listArtifactContentVersions([
+        { type: 'eq', column: 'artifact_id', value: artifactId },
+      ]);
+      const row = {
+        artifact_content_version_id:
+          `artifact-content-version-${state.nextArtifactContentVersionId++}`,
+        created_at: query.payload.created_at ?? '2026-03-22T09:00:00.000Z',
+        ...query.payload,
+      };
+      if (row.version_number == null) {
+        row.version_number = (existing[0]?.version_number ?? 0) + 1;
+      }
+      state.artifactContentVersions.set(row.artifact_content_version_id, row);
+      return { data: row, error: null };
+    }
+
+    if (query.table === 'learning_artifact_content_versions' && query.operation === 'select') {
+      const rows = listArtifactContentVersions(query.filters);
+      if (query.options?.single || query.options?.maybeSingle) {
+        return { data: rows[0] || null, error: null };
+      }
+      return { data: rows, error: null };
+    }
+
+    if (query.table === 'learning_artifact_content_versions' && query.operation === 'update') {
+      const versionId = findFilter(query.filters, 'artifact_content_version_id');
+      const current = state.artifactContentVersions.get(versionId) || null;
+      const next = current ? { ...current, ...query.payload } : null;
+
+      if (next) {
+        state.artifactContentVersions.set(versionId, next);
       }
 
       return { data: next, error: null };
@@ -885,6 +1016,7 @@ describe('workspace read service', () => {
     expect(payload.workspace.slots.overview_map).toEqual({
       workspace_slot_id: null,
       primary_artifact_ref: null,
+      primary_artifact: null,
       linked_references: [],
       updated_at: null,
     });
@@ -894,6 +1026,7 @@ describe('workspace read service', () => {
         kind: 'artifact',
         artifact_id: 'artifact-primary',
       },
+      primary_artifact: null,
       linked_references: [
         { kind: 'artifact', artifact_id: 'artifact-linked-1' },
       ],
@@ -964,9 +1097,139 @@ describe('workspace read service', () => {
           updated_at: '2026-03-22T08:04:00.000Z',
         },
       ],
+      artifactContentVersionRows: [
+        {
+          artifact_content_version_id: 'artifact-content-verified-primary',
+          artifact_id: 'artifact-primary',
+          version_number: 1,
+          is_current: true,
+          title: 'Common trap: interval sign slip',
+          summary: 'The verified resident stays renderable while the successor remains unverified.',
+          body_markdown: 'Keep the verified resident visible until the successor is verified.',
+          content_format: 'markdown',
+        },
+      ],
       expectedPrimaryArtifactId: 'artifact-primary',
+      expectedPrimaryArtifact: {
+        title: 'Common trap: interval sign slip',
+        summary: 'The verified resident stays renderable while the successor remains unverified.',
+        current_content_version_number: 1,
+      },
       expectedSlotState: 'active',
       expectedInboxArtifactId: 'artifact-successor-unverified',
+    },
+    {
+      label: 'verified resident without current content stays pinned but surfaces missing_artifact_content',
+      workspaceProjection: {
+        workspace_id: 'workspace-1',
+        user_id: 'student-1',
+        topic_id: 'topic-1',
+        topic_path: '9709/trigonometry/equations',
+        slot_state: {
+          common_traps: 'active',
+        },
+        linked_reference_summary: {
+          total_linked_references: 0,
+        },
+        updated_at: '2026-03-22T08:00:00.000Z',
+        slots: [
+          {
+            workspace_slot_id: 'slot-common-traps',
+            slot_key: 'common_traps',
+            primary_artifact_ref: {
+              kind: 'artifact',
+              artifact_id: 'artifact-primary',
+            },
+            linked_reference_refs: [],
+            updated_at: '2026-03-22T08:00:00.000Z',
+          },
+        ],
+      },
+      artifactRows: [
+        {
+          artifact_id: 'artifact-primary',
+          artifact_kind: 'misconception_card',
+          canonical_home_topic_id: 'topic-1',
+          slot_key: 'common_traps',
+          trust_status: 'grounded',
+          placement_status: 'pinned',
+          lifecycle_status: 'active',
+          artifact_state: 'verified',
+          verified_by: 'operator-1',
+          verified_at: '2026-03-22T07:40:00.000Z',
+          verification_evidence_ref: { kind: 'review_run', review_run_id: 'review-1' },
+          updated_at: '2026-03-22T08:00:00.000Z',
+        },
+      ],
+      artifactContentVersionRows: [],
+      expectedPrimaryArtifactId: 'artifact-primary',
+      expectedPrimaryArtifact: null,
+      expectedSlotState: 'missing_artifact_content',
+      expectedInboxArtifactId: null,
+    },
+    {
+      label: 'verified resident with current content stays active and exposes renderable resident fields',
+      workspaceProjection: {
+        workspace_id: 'workspace-1',
+        user_id: 'student-1',
+        topic_id: 'topic-1',
+        topic_path: '9709/trigonometry/equations',
+        slot_state: {
+          common_traps: 'active',
+        },
+        linked_reference_summary: {
+          total_linked_references: 0,
+        },
+        updated_at: '2026-03-22T08:00:00.000Z',
+        slots: [
+          {
+            workspace_slot_id: 'slot-common-traps',
+            slot_key: 'common_traps',
+            primary_artifact_ref: {
+              kind: 'artifact',
+              artifact_id: 'artifact-primary',
+            },
+            linked_reference_refs: [],
+            updated_at: '2026-03-22T08:00:00.000Z',
+          },
+        ],
+      },
+      artifactRows: [
+        {
+          artifact_id: 'artifact-primary',
+          artifact_kind: 'misconception_card',
+          canonical_home_topic_id: 'topic-1',
+          slot_key: 'common_traps',
+          trust_status: 'grounded',
+          placement_status: 'pinned',
+          lifecycle_status: 'active',
+          artifact_state: 'verified',
+          verified_by: 'operator-1',
+          verified_at: '2026-03-22T07:40:00.000Z',
+          verification_evidence_ref: { kind: 'review_run', review_run_id: 'review-1' },
+          updated_at: '2026-03-22T08:00:00.000Z',
+        },
+      ],
+      artifactContentVersionRows: [
+        {
+          artifact_content_version_id: 'artifact-content-1',
+          artifact_id: 'artifact-primary',
+          version_number: 1,
+          is_current: true,
+          title: 'Common trap: sign error',
+          summary: 'Watch for sign changes before applying the interval restriction.',
+          body_markdown: 'Check the sign before you solve for the interval.',
+          content_format: 'markdown',
+        },
+      ],
+      expectedPrimaryArtifactId: 'artifact-primary',
+      expectedPrimaryArtifact: {
+        title: 'Common trap: sign error',
+        summary: 'Watch for sign changes before applying the interval restriction.',
+        current_content_version_number: 1,
+      },
+      expectedSlotState: 'active',
+      expectedInboxArtifactId: null,
     },
     {
       label: 'resident projection preserves stale warning state',
@@ -1011,7 +1274,24 @@ describe('workspace read service', () => {
           updated_at: '2026-03-22T08:03:00.000Z',
         },
       ],
+      artifactContentVersionRows: [
+        {
+          artifact_content_version_id: 'artifact-content-stale-primary',
+          artifact_id: 'artifact-primary',
+          version_number: 1,
+          is_current: true,
+          title: 'Common trap: stale but renderable',
+          summary: 'Resident content stays available even when the projection warning remains stale.',
+          body_markdown: 'Preserve the stale warning while keeping the resident renderable.',
+          content_format: 'markdown',
+        },
+      ],
       expectedPrimaryArtifactId: 'artifact-primary',
+      expectedPrimaryArtifact: {
+        title: 'Common trap: stale but renderable',
+        summary: 'Resident content stays available even when the projection warning remains stale.',
+        current_content_version_number: 1,
+      },
       expectedSlotState: 'stale',
       expectedInboxArtifactId: null,
     },
@@ -1065,13 +1345,16 @@ describe('workspace read service', () => {
   ])('workspace residency matrix: $label', async ({
     workspaceProjection,
     artifactRows,
+    artifactContentVersionRows,
     expectedPrimaryArtifactId,
+    expectedPrimaryArtifact,
     expectedSlotState,
     expectedInboxArtifactId,
   }) => {
     const db = createLearningDb({
       workspaceProjection,
       artifactRows,
+      artifactContentVersionRows,
     });
 
     const payload = await getWorkspaceView(db, {
@@ -1087,6 +1370,11 @@ describe('workspace read service', () => {
           kind: 'artifact',
           artifact_id: expectedPrimaryArtifactId,
         }
+        : null,
+    );
+    expect(payload.workspace.slots.common_traps.primary_artifact ?? null).toEqual(
+      expectedPrimaryArtifact
+        ? expect.objectContaining(expectedPrimaryArtifact)
         : null,
     );
     if (expectedInboxArtifactId) {
@@ -1419,6 +1707,12 @@ describe('workspace read service', () => {
     expect(outcome.release_scope_status).toBe('non_released_fallback');
     expect(outcome.review_tasks).toHaveLength(1);
     expect(outcome.artifact_candidates).toHaveLength(1);
+    expect(outcome.artifact_candidates[0]).toMatchObject({
+      title: expect.any(String),
+      summary: expect.any(String),
+      current_content_version_number: 1,
+      body_markdown: expect.stringContaining('domain interval'),
+    });
 
     await expect(
       getWorkspaceView(db, {
@@ -1443,12 +1737,32 @@ describe('workspace read service', () => {
       status: 'open',
     });
 
+    const verifyResult = await patchLearningArtifact({
+      client: db,
+      userId: 'student-1',
+      artifactId: outcome.artifact_candidates[0].artifact_id,
+      intent: 'mark_verified',
+      verificationEvidenceRef: {
+        kind: 'review_run',
+        review_run_id: 'review-verified-1',
+      },
+    }, {
+      lifecycleFlagEnabled: true,
+    });
+
+    expect(verifyResult.artifact).toMatchObject({
+      artifact_id: outcome.artifact_candidates[0].artifact_id,
+      artifact_state: 'verified',
+    });
+
     const patchResult = await patchLearningArtifact({
       client: db,
       userId: 'student-1',
       artifactId: outcome.artifact_candidates[0].artifact_id,
       intent: 'set_placement_status',
       placementStatus: 'pinned',
+    }, {
+      lifecycleFlagEnabled: true,
     });
 
     expect(patchResult.artifact).toMatchObject({
@@ -1465,6 +1779,7 @@ describe('workspace read service', () => {
     const workspaceAfterPatch = await getWorkspaceView(db, {
       userId: 'student-1',
       topicId: 'repair-target-topic',
+      residencyFlagEnabled: true,
     });
 
     expect(workspaceAfterPatch.review_queue.items[0].review_task_id)
@@ -1475,9 +1790,16 @@ describe('workspace read service', () => {
         kind: 'artifact',
         artifact_id: outcome.artifact_candidates[0].artifact_id,
       },
+      primary_artifact: expect.objectContaining({
+        artifact_id: outcome.artifact_candidates[0].artifact_id,
+        title: expect.any(String),
+        summary: expect.any(String),
+        current_content_version_number: 1,
+      }),
       linked_references: [],
       updated_at: '2026-03-22T09:00:00.000Z',
     });
+    expect(workspaceAfterPatch.workspace.slot_state.common_traps).toBe('active');
   });
 
   test('review-task writes update topic projections and active review-queue references', async () => {
@@ -1524,8 +1846,8 @@ describe('workspace read service', () => {
       },
     );
 
-    expect(outcome.release_scope_status).toBe('released_scoring');
-    expect(outcome.authoritative_scoring_allowed).toBe(true);
+    expect(outcome.release_scope_status).toBe('non_released_fallback');
+    expect(outcome.authoritative_scoring_allowed).toBe(false);
 
     await patchLearningArtifact({
       client: db,

--- a/api/learning/lib/artifacts/artifact-service.js
+++ b/api/learning/lib/artifacts/artifact-service.js
@@ -8,6 +8,10 @@ import {
   hasNonAuthoritativeAttemptGrounding,
 } from '../contracts/runtime-authority-posture.js';
 import { createArtifactRepository } from '../repositories/artifact-repository.js';
+import {
+  createArtifactContentRepository,
+  mergeArtifactWithCurrentContent,
+} from '../repositories/artifact-content-repository.js';
 
 const LEGACY_ARTIFACT_INTENTS = new Set([
   'set_placement_status',
@@ -72,6 +76,15 @@ export function isArtifactLifecycleEnabled(env = process.env) {
 
 function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
+}
+
+function normalizeString(value, fallback = null) {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  return trimmed || fallback;
 }
 
 function isPlainObject(value) {
@@ -160,9 +173,142 @@ export function buildArtifactCandidate(input = {}, timestamp) {
   };
 }
 
+function humanizeArtifactToken(value, fallback = 'artifact') {
+  return normalizeString(value, fallback)
+    .replace(/[:_]/g, ' ')
+    .replace(/\s+/g, ' ');
+}
+
+function buildArtifactContentTitle(candidate = {}) {
+  if (candidate.artifact_kind === 'misconception_card') {
+    const firstTag = normalizeArray(candidate.misconception_tags)[0];
+    return `Common trap: ${humanizeArtifactToken(firstTag, 'repair target')}`;
+  }
+
+  if (candidate.artifact_kind === 'derivation_card') {
+    return `Core derivation: ${humanizeArtifactToken(candidate.target_question_type_id, 'method')}`;
+  }
+
+  if (candidate.artifact_kind === 'worked_example_card') {
+    return `Worked example: ${humanizeArtifactToken(candidate.target_question_type_id, 'topic')}`;
+  }
+
+  if (candidate.artifact_kind === 'summary_card') {
+    return `Topic summary: ${humanizeArtifactToken(candidate.canonical_home_topic_path, 'topic')}`;
+  }
+
+  if (candidate.artifact_kind === 'formula_card') {
+    return `Formula card: ${humanizeArtifactToken(candidate.target_question_type_id, 'formula')}`;
+  }
+
+  if (candidate.artifact_kind === 'free_note') {
+    return `Runtime note: ${humanizeArtifactToken(candidate.canonical_home_topic_path, 'workspace')}`;
+  }
+
+  return humanizeArtifactToken(candidate.artifact_kind, 'artifact');
+}
+
+function buildArtifactContentSummary(candidate = {}) {
+  const parts = [];
+  const tags = normalizeArray(candidate.misconception_tags).map((tag) => humanizeArtifactToken(tag));
+
+  if (candidate.target_question_type_id) {
+    parts.push(`Question type: ${candidate.target_question_type_id}.`);
+  }
+
+  if (tags.length > 0) {
+    parts.push(`Focus: ${tags.join(', ')}.`);
+  }
+
+  if (candidate.canonical_home_topic_path) {
+    parts.push(`Topic: ${candidate.canonical_home_topic_path}.`);
+  }
+
+  return parts.join(' ');
+}
+
+function buildArtifactContentBody(candidate = {}) {
+  const tags = normalizeArray(candidate.misconception_tags).map((tag) => humanizeArtifactToken(tag));
+  const lines = [
+    `## ${buildArtifactContentTitle(candidate)}`,
+    '',
+    '### Focus',
+  ];
+
+  if (tags.length > 0) {
+    for (const tag of tags) {
+      lines.push(`- ${tag}`);
+    }
+  } else {
+    lines.push('- Review the runtime candidate details for this artifact.');
+  }
+
+  lines.push('', '### Applies to');
+  if (candidate.target_question_type_id) {
+    lines.push(`- Question type: ${candidate.target_question_type_id}`);
+  }
+  if (candidate.canonical_home_topic_path) {
+    lines.push(`- Topic: ${candidate.canonical_home_topic_path}`);
+  }
+
+  lines.push('', '### Runtime provenance');
+  if (candidate.source_attempt_id) {
+    lines.push(`- Attempt: ${candidate.source_attempt_id}`);
+  }
+  if (candidate.source_mark_run_id) {
+    lines.push(`- Mark run: ${candidate.source_mark_run_id}`);
+  }
+  if (candidate.source_session_id) {
+    lines.push(`- Session: ${candidate.source_session_id}`);
+  }
+
+  return lines.join('\n');
+}
+
+function buildArtifactContentSourceRefs(candidate = {}) {
+  const refs = [];
+
+  if (candidate.source_attempt_id) {
+    refs.push({ kind: 'attempt', attempt_id: candidate.source_attempt_id });
+  }
+
+  if (candidate.source_mark_run_id) {
+    refs.push({ kind: 'mark_run', mark_run_id: candidate.source_mark_run_id });
+  }
+
+  if (candidate.source_session_id) {
+    refs.push({ kind: 'session', session_id: candidate.source_session_id });
+  }
+
+  return refs;
+}
+
+function buildArtifactContentDraft(candidate = {}, storedArtifact = {}) {
+  const title = buildArtifactContentTitle(candidate);
+  const summary = buildArtifactContentSummary(candidate);
+  const bodyMarkdown = buildArtifactContentBody(candidate);
+
+  return {
+    artifact_id: storedArtifact.artifact_id,
+    title,
+    summary,
+    body_markdown: bodyMarkdown,
+    content_format: 'markdown',
+    render_payload: {
+      schema_version: 'learning_artifact_render.v1',
+      title,
+      summary,
+    },
+    materialization_kind: 'runtime_candidate',
+    source_refs: buildArtifactContentSourceRefs(candidate),
+    created_at: storedArtifact.created_at ?? candidate.created_at ?? null,
+  };
+}
+
 async function materializeArtifactCandidate({
   candidate,
   artifactRepository,
+  artifactContentRepository,
   lifecycleFlagEnabled,
 } = {}) {
   if (!candidate || !candidate.canonical_home_topic_id) {
@@ -174,12 +320,21 @@ async function materializeArtifactCandidate({
   }
 
   const stored = await artifactRepository.insertArtifact(candidate);
+  const currentContent = artifactContentRepository?.createArtifactContentVersion
+    ? await artifactContentRepository.createArtifactContentVersion(
+      buildArtifactContentDraft(candidate, stored),
+    )
+    : null;
+
   return [
-    normalizeArtifactResult({
-      ...stored,
-      canonical_home_topic_path: candidate.canonical_home_topic_path,
-      misconception_tags: candidate.misconception_tags,
-    }, lifecycleFlagEnabled),
+    normalizeArtifactResult(
+      mergeArtifactWithCurrentContent({
+        ...stored,
+        canonical_home_topic_path: candidate.canonical_home_topic_path,
+        misconception_tags: candidate.misconception_tags,
+      }, currentContent),
+      lifecycleFlagEnabled,
+    ),
   ];
 }
 
@@ -312,6 +467,7 @@ function requireContestedReason(value) {
 
 export function createArtifactService({
   artifactRepository = null,
+  artifactContentRepository = null,
   now = () => new Date(),
   lifecycleFlagEnabled = isArtifactLifecycleEnabled(),
 } = {}) {
@@ -328,6 +484,7 @@ export function createArtifactService({
       return materializeArtifactCandidate({
         candidate,
         artifactRepository,
+        artifactContentRepository,
         lifecycleFlagEnabled,
       });
     },
@@ -336,6 +493,7 @@ export function createArtifactService({
       return materializeArtifactCandidate({
         candidate,
         artifactRepository,
+        artifactContentRepository,
         lifecycleFlagEnabled,
       });
     },
@@ -822,6 +980,8 @@ export async function patchLearningArtifact({
   const artifactService = createArtifactService({
     ...options,
     artifactRepository: options.artifactRepository || createArtifactRepository(client),
+    artifactContentRepository:
+      options.artifactContentRepository || createArtifactContentRepository(client),
   });
 
   return artifactService.patchArtifact({

--- a/api/learning/lib/events/learning-effect-engine.js
+++ b/api/learning/lib/events/learning-effect-engine.js
@@ -1,6 +1,7 @@
 import { createArtifactService } from '../artifacts/artifact-service.js';
 import { createMasteryOrchestrator } from '../mastery/mastery-orchestrator.js';
 import { createArtifactRepository } from '../repositories/artifact-repository.js';
+import { createArtifactContentRepository } from '../repositories/artifact-content-repository.js';
 import { createLearningEventEffectRepository } from '../repositories/learning-event-effect-repository.js';
 import {
   createDefaultReviewTaskService,
@@ -110,6 +111,7 @@ function buildDefaultHandlers({
   const resolvedArtifactService = artifactService
     || createArtifactService({
       artifactRepository: supabase ? createArtifactRepository(supabase) : null,
+      artifactContentRepository: supabase ? createArtifactContentRepository(supabase) : null,
     });
   const resolvedMasteryOrchestrator = masteryOrchestrator
     || createMasteryOrchestrator({

--- a/api/learning/lib/mastery/mastery-orchestrator.js
+++ b/api/learning/lib/mastery/mastery-orchestrator.js
@@ -11,6 +11,7 @@ import {
 } from '../review/review-task-service.js';
 import { buildArtifactCandidate, createArtifactService } from '../artifacts/artifact-service.js';
 import { createArtifactRepository } from '../repositories/artifact-repository.js';
+import { createArtifactContentRepository } from '../repositories/artifact-content-repository.js';
 import { createReconciliationService } from '../reconciliation/reconciliation-service.js';
 import { createDefaultReconciliationService } from '../reconciliation/reconciliation-service.js';
 import { SUBJECT_ADAPTER_CAPABILITY_POSTURES } from '../subjects/subject-adapter-contract.js';
@@ -529,6 +530,9 @@ export async function applyLearningEffects(input = {}, dependencies = {}) {
       || createArtifactService({
         artifactRepository:
           dependencies.artifactRepository || (supabase ? createArtifactRepository(supabase) : null),
+        artifactContentRepository:
+          dependencies.artifactContentRepository
+          || (supabase ? createArtifactContentRepository(supabase) : null),
       }),
     reconciliationService:
       dependencies.reconciliationService

--- a/api/learning/lib/repositories/artifact-content-repository.js
+++ b/api/learning/lib/repositories/artifact-content-repository.js
@@ -1,0 +1,155 @@
+function normalizeString(value, fallback = null) {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+async function maybeSingle(promise, message) {
+  const { data, error } = await promise;
+
+  if (error) {
+    throw new Error(`${message}: ${error.message}`);
+  }
+
+  return data ?? null;
+}
+
+export function hasRenderableArtifactContent(content = {}) {
+  return Boolean(
+    normalizeString(content.title)
+    || normalizeString(content.summary)
+    || normalizeString(content.body_markdown),
+  );
+}
+
+export function mergeArtifactWithCurrentContent(artifact, currentContent) {
+  if (!artifact) {
+    return artifact;
+  }
+
+  if (!currentContent) {
+    return {
+      ...artifact,
+      current_content_version_id: null,
+      current_content_version_number: null,
+      current_content_lineage_parent_version_id: null,
+      has_renderable_content: false,
+    };
+  }
+
+  return {
+    ...artifact,
+    title: normalizeString(currentContent.title),
+    summary: normalizeString(currentContent.summary),
+    body_markdown: normalizeString(currentContent.body_markdown),
+    content_format: normalizeString(currentContent.content_format, 'markdown'),
+    render_payload: normalizeObject(currentContent.render_payload),
+    content_source_refs: normalizeArray(currentContent.source_refs),
+    current_content_version_id: currentContent.artifact_content_version_id,
+    current_content_version_number: currentContent.version_number ?? null,
+    current_content_lineage_parent_version_id: currentContent.lineage_parent_version_id ?? null,
+    has_renderable_content: hasRenderableArtifactContent(currentContent),
+  };
+}
+
+function buildInsertRow(input = {}, currentContent = null) {
+  return {
+    artifact_id: input.artifact_id,
+    version_number:
+      Number.isInteger(Number(input.version_number)) && Number(input.version_number) > 0
+        ? Number(input.version_number)
+        : Number(currentContent?.version_number ?? 0) + 1,
+    lineage_parent_version_id:
+      input.lineage_parent_version_id ?? currentContent?.artifact_content_version_id ?? null,
+    is_current: input.is_current ?? true,
+    title: normalizeString(input.title, `Artifact ${input.artifact_id ?? 'content'}`),
+    summary: normalizeString(input.summary),
+    body_markdown: normalizeString(input.body_markdown, ''),
+    content_format: normalizeString(input.content_format, 'markdown'),
+    render_payload: normalizeObject(input.render_payload),
+    materialization_kind: normalizeString(input.materialization_kind, 'runtime_candidate'),
+    source_refs: normalizeArray(input.source_refs),
+    ...(input.created_at ? { created_at: input.created_at } : {}),
+  };
+}
+
+export async function getCurrentArtifactContentByArtifactId(client, artifactId) {
+  return maybeSingle(
+    client
+      .from('learning_artifact_content_versions')
+      .select('*')
+      .eq('artifact_id', artifactId)
+      .eq('is_current', true)
+      .order('version_number', { ascending: false })
+      .maybeSingle(),
+    'Failed to load current learning artifact content',
+  );
+}
+
+export async function listArtifactContentVersionsByArtifactId(client, artifactId) {
+  const { data, error } = await client
+    .from('learning_artifact_content_versions')
+    .select('*')
+    .eq('artifact_id', artifactId)
+    .order('version_number', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to load learning artifact content versions: ${error.message}`);
+  }
+
+  return Array.isArray(data) ? data : [];
+}
+
+export async function createArtifactContentVersion(client, input = {}) {
+  const currentContent = await getCurrentArtifactContentByArtifactId(client, input.artifact_id);
+
+  if (currentContent && (input.is_current ?? true)) {
+    await maybeSingle(
+      client
+        .from('learning_artifact_content_versions')
+        .update({
+          is_current: false,
+        })
+        .eq('artifact_content_version_id', currentContent.artifact_content_version_id)
+        .select('*')
+        .single(),
+      'Failed to demote current learning artifact content version',
+    );
+  }
+
+  return maybeSingle(
+    client
+      .from('learning_artifact_content_versions')
+      .insert(buildInsertRow(input, currentContent))
+      .select('*')
+      .single(),
+    'Failed to insert learning artifact content version',
+  );
+}
+
+export function createArtifactContentRepository(client) {
+  return {
+    async getCurrentArtifactContentByArtifactId(artifactId) {
+      return getCurrentArtifactContentByArtifactId(client, artifactId);
+    },
+
+    async listArtifactContentVersionsByArtifactId(artifactId) {
+      return listArtifactContentVersionsByArtifactId(client, artifactId);
+    },
+
+    async createArtifactContentVersion(input) {
+      return createArtifactContentVersion(client, input);
+    },
+  };
+}

--- a/api/learning/lib/repositories/artifact-content-repository.js
+++ b/api/learning/lib/repositories/artifact-content-repository.js
@@ -11,6 +11,14 @@ function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
+function normalizeArtifactIds(artifactIds = []) {
+  return [...new Set(
+    normalizeArray(artifactIds)
+      .map((artifactId) => normalizeString(artifactId))
+      .filter(Boolean),
+  )];
+}
+
 function normalizeObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }
@@ -20,6 +28,20 @@ async function maybeSingle(promise, message) {
 
   if (error) {
     throw new Error(`${message}: ${error.message}`);
+  }
+
+  return data ?? null;
+}
+
+async function maybeRpcSingle(promise, message) {
+  const { data, error } = await promise;
+
+  if (error) {
+    throw new Error(`${message}: ${error.message}`);
+  }
+
+  if (Array.isArray(data)) {
+    return data[0] ?? null;
   }
 
   return data ?? null;
@@ -111,29 +133,53 @@ export async function listArtifactContentVersionsByArtifactId(client, artifactId
   return Array.isArray(data) ? data : [];
 }
 
-export async function createArtifactContentVersion(client, input = {}) {
-  const currentContent = await getCurrentArtifactContentByArtifactId(client, input.artifact_id);
-
-  if (currentContent && (input.is_current ?? true)) {
-    await maybeSingle(
-      client
-        .from('learning_artifact_content_versions')
-        .update({
-          is_current: false,
-        })
-        .eq('artifact_content_version_id', currentContent.artifact_content_version_id)
-        .select('*')
-        .single(),
-      'Failed to demote current learning artifact content version',
-    );
+export async function listCurrentArtifactContentsByArtifactIds(client, artifactIds = []) {
+  const normalizedArtifactIds = normalizeArtifactIds(artifactIds);
+  if (normalizedArtifactIds.length === 0) {
+    return new Map();
   }
 
-  return maybeSingle(
-    client
-      .from('learning_artifact_content_versions')
-      .insert(buildInsertRow(input, currentContent))
-      .select('*')
-      .single(),
+  const { data, error } = await client
+    .from('learning_artifact_content_versions')
+    .select('*')
+    .in('artifact_id', normalizedArtifactIds)
+    .eq('is_current', true)
+    .order('version_number', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to load current learning artifact content batch: ${error.message}`);
+  }
+
+  return (Array.isArray(data) ? data : []).reduce((acc, row) => {
+    const artifactId = normalizeString(row?.artifact_id);
+    if (!artifactId || acc.has(artifactId)) {
+      return acc;
+    }
+
+    acc.set(artifactId, row);
+    return acc;
+  }, new Map());
+}
+
+export async function createArtifactContentVersion(client, input = {}) {
+  const currentContent = await getCurrentArtifactContentByArtifactId(client, input.artifact_id);
+  const row = buildInsertRow(input, currentContent);
+
+  return maybeRpcSingle(
+    client.rpc('create_learning_artifact_content_version', {
+      p_artifact_id: row.artifact_id,
+      p_version_number: row.version_number,
+      p_lineage_parent_version_id: row.lineage_parent_version_id,
+      p_is_current: row.is_current,
+      p_title: row.title,
+      p_summary: row.summary,
+      p_body_markdown: row.body_markdown,
+      p_content_format: row.content_format,
+      p_render_payload: row.render_payload,
+      p_materialization_kind: row.materialization_kind,
+      p_source_refs: row.source_refs,
+      p_created_at: row.created_at ?? null,
+    }),
     'Failed to insert learning artifact content version',
   );
 }
@@ -146,6 +192,10 @@ export function createArtifactContentRepository(client) {
 
     async listArtifactContentVersionsByArtifactId(artifactId) {
       return listArtifactContentVersionsByArtifactId(client, artifactId);
+    },
+
+    async listCurrentArtifactContentsByArtifactIds(artifactIds) {
+      return listCurrentArtifactContentsByArtifactIds(client, artifactIds);
     },
 
     async createArtifactContentVersion(input) {

--- a/api/learning/lib/repositories/artifact-repository.js
+++ b/api/learning/lib/repositories/artifact-repository.js
@@ -1,5 +1,6 @@
 import {
   getCurrentArtifactContentByArtifactId,
+  listCurrentArtifactContentsByArtifactIds,
   mergeArtifactWithCurrentContent,
 } from './artifact-content-repository.js';
 
@@ -130,11 +131,16 @@ export async function listArtifactsByTopic(client, { topicId } = {}) {
   }
 
   const rows = Array.isArray(data) ? data : [];
+  const currentContentByArtifactId = await listCurrentArtifactContentsByArtifactIds(
+    client,
+    rows.map((artifact) => artifact.artifact_id),
+  );
 
-  return Promise.all(rows.map(async (artifact) => {
-    const currentContent = await getCurrentArtifactContentByArtifactId(client, artifact.artifact_id);
-    return mergeArtifactWithCurrentContent(artifact, currentContent);
-  }));
+  return rows.map((artifact) =>
+    mergeArtifactWithCurrentContent(
+      artifact,
+      currentContentByArtifactId.get(artifact.artifact_id) ?? null,
+    ));
 }
 
 export async function updateArtifact(client, artifactId, patch = {}) {

--- a/api/learning/lib/repositories/artifact-repository.js
+++ b/api/learning/lib/repositories/artifact-repository.js
@@ -1,3 +1,8 @@
+import {
+  getCurrentArtifactContentByArtifactId,
+  mergeArtifactWithCurrentContent,
+} from './artifact-content-repository.js';
+
 function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
 }
@@ -84,7 +89,7 @@ export function createArtifactRepository(client) {
 }
 
 export async function getArtifactById(client, artifactId) {
-  return maybeSingle(
+  const artifact = await maybeSingle(
     client
       .from('learning_artifacts')
       .select('*')
@@ -92,6 +97,13 @@ export async function getArtifactById(client, artifactId) {
       .maybeSingle(),
     'Failed to load learning artifact',
   );
+
+  if (!artifact) {
+    return null;
+  }
+
+  const currentContent = await getCurrentArtifactContentByArtifactId(client, artifactId);
+  return mergeArtifactWithCurrentContent(artifact, currentContent);
 }
 
 export async function insertArtifact(client, input = {}) {
@@ -117,7 +129,12 @@ export async function listArtifactsByTopic(client, { topicId } = {}) {
     throw new Error(`Failed to load learning artifacts for topic: ${error.message}`);
   }
 
-  return Array.isArray(data) ? data : [];
+  const rows = Array.isArray(data) ? data : [];
+
+  return Promise.all(rows.map(async (artifact) => {
+    const currentContent = await getCurrentArtifactContentByArtifactId(client, artifact.artifact_id);
+    return mergeArtifactWithCurrentContent(artifact, currentContent);
+  }));
 }
 
 export async function updateArtifact(client, artifactId, patch = {}) {

--- a/api/learning/lib/repositories/workspace-repository.js
+++ b/api/learning/lib/repositories/workspace-repository.js
@@ -23,6 +23,7 @@ function separateWorkspaceSlots(slotRows) {
     slots[slot.slot_key] = {
       workspace_slot_id: slot.workspace_slot_id,
       primary_artifact_ref: slot.primary_artifact_ref ?? null,
+      primary_artifact: slot.primary_artifact ?? null,
       updated_at: slot.updated_at ?? null,
     };
     linked_references[slot.slot_key] = Array.isArray(slot.linked_reference_refs)

--- a/api/learning/lib/review/review-task-service.js
+++ b/api/learning/lib/review/review-task-service.js
@@ -338,7 +338,7 @@ export function shouldGenerateReviewTaskFromOutcome(input = {}) {
   return hasRepairSignal(input);
 }
 
-function buildReviewTaskPayload(input = {}, now = new Date()) {
+export function buildReviewTaskPayload(input = {}, now = new Date()) {
   const targetQuestionTypeId =
     input.repair_target_question_type_id
     || input.question_context?.question_type_id

--- a/api/learning/lib/workspaces/workspace-read-service.js
+++ b/api/learning/lib/workspaces/workspace-read-service.js
@@ -73,6 +73,7 @@ function createEmptySlot() {
   return {
     workspace_slot_id: null,
     primary_artifact_ref: null,
+    primary_artifact: null,
     linked_references: [],
     updated_at: null,
   };
@@ -138,6 +139,7 @@ function buildStableSlots(workspaceProjection, { reviewQueueItems = [] } = {}) {
         {
           workspace_slot_id: slot.workspace_slot_id ?? null,
           primary_artifact_ref: slot.primary_artifact_ref ?? null,
+          primary_artifact: slot.primary_artifact ?? null,
           linked_references: normalizeLinkedReferences(
             linkedReferences,
             slot.primary_artifact_ref ?? null,
@@ -201,6 +203,36 @@ function isResidentArtifact(artifact = {}) {
 function isPendingVerificationArtifact(artifact = {}) {
   return isActiveArtifact(artifact)
     && artifact.artifact_state === 'unverified';
+}
+
+function hasRenderableResidentContent(artifact = {}) {
+  return Boolean(
+    artifact?.has_renderable_content
+    || normalizeString(artifact?.title)
+    || normalizeString(artifact?.summary)
+    || normalizeString(artifact?.body_markdown),
+  );
+}
+
+function buildResidentArtifactProjection(artifact = {}) {
+  return {
+    artifact_id: artifact.artifact_id ?? null,
+    artifact_kind: artifact.artifact_kind ?? null,
+    title: normalizeString(artifact.title),
+    summary: normalizeString(artifact.summary),
+    body_markdown: normalizeString(artifact.body_markdown),
+    content_format: normalizeString(artifact.content_format, 'markdown'),
+    current_content_version_id: artifact.current_content_version_id ?? null,
+    current_content_version_number: artifact.current_content_version_number ?? null,
+    capabilities: artifact.capabilities ?? null,
+    placement_status: artifact.placement_status ?? null,
+    trust_status: artifact.trust_status ?? null,
+    lifecycle_status: artifact.lifecycle_status ?? null,
+    artifact_state: artifact.artifact_state ?? null,
+    slot_key: artifact.slot_key ?? null,
+    target_question_type_id: artifact.target_question_type_id ?? null,
+    updated_at: artifact.updated_at ?? null,
+  };
 }
 
 function shouldResetSlotStateToActive(currentState) {
@@ -268,6 +300,10 @@ function projectWorkspaceResidency(workspaceProjection, topicArtifacts = []) {
       projectedSlots[slotKey] = {
         ...slot,
         primary_artifact_ref: residentArtifact ? buildArtifactRef(residentArtifact.artifact_id) : null,
+        primary_artifact:
+          residentArtifact && hasRenderableResidentContent(residentArtifact)
+            ? buildResidentArtifactProjection(residentArtifact)
+            : null,
       };
     }
 
@@ -277,6 +313,13 @@ function projectWorkspaceResidency(workspaceProjection, topicArtifacts = []) {
 
     if (!residentArtifact && slotArtifacts.some(isPendingVerificationArtifact)) {
       projectedSlotState[slotKey] = 'awaiting_verification';
+      return;
+    }
+
+    if (residentArtifact && !hasRenderableResidentContent(residentArtifact)) {
+      if (shouldResetSlotStateToActive(projectedSlotState[slotKey])) {
+        projectedSlotState[slotKey] = 'missing_artifact_content';
+      }
       return;
     }
 

--- a/src/components/learning-runtime/__tests__/view-models.test.js
+++ b/src/components/learning-runtime/__tests__/view-models.test.js
@@ -1426,6 +1426,40 @@ describe('learning runtime session view model', () => {
     });
   });
 
+  test('workspace view-model prefers renderable resident content over the missing-content placeholder when slot payload includes primary_artifact data', () => {
+    const payload = createWorkspacePayload();
+    payload.workspace.slotState.coreMethodDerivation = 'active';
+    payload.workspace.slots.coreMethodDerivation.primaryArtifact = {
+      artifactId: 'artifact-derivation-ready',
+      artifactKind: 'derivation_card',
+      title: 'Derive the tangent double-angle route',
+      summary: 'Start from the double-angle identity, then isolate the tangent substitution carefully.',
+      placementStatus: 'pinned',
+      artifactState: 'verified',
+      lifecycleStatus: 'active',
+      slotKey: 'core_method_derivation',
+      currentContentVersionNumber: 2,
+      capabilities: {
+        shellVisible: true,
+        bodyVisible: true,
+        residentEligible: true,
+        authoritativeAutomationEligible: false,
+      },
+    };
+
+    const vm = buildWorkspaceViewModel(payload, {
+      now: '2026-03-22T12:00:00.000Z',
+    });
+
+    expect(vm.slots.core_method_derivation.contentState).toBeNull();
+    expect(vm.slots.core_method_derivation.primaryArtifactCard).toMatchObject({
+      artifactId: 'artifact-derivation-ready',
+      title: 'Derive the tangent double-angle route',
+      description:
+        'Start from the double-angle identity, then isolate the tangent substitution carefully.',
+    });
+  });
+
   test('builds queue action drafts that preserve canonical launch and scheduling defaults', () => {
     const vm = buildWorkspaceViewModel(createWorkspacePayload(), {
       now: '2026-03-22T12:00:00.000Z',

--- a/src/components/learning-runtime/view-models/workspace-view-model.js
+++ b/src/components/learning-runtime/view-models/workspace-view-model.js
@@ -550,8 +550,49 @@ function buildSlotEmptyState(rawState) {
 function buildSlotViewModel(definition, slots, slotState, workspace) {
   const slot = readSlotRecord(slots, definition);
   const primaryArtifact = normalizeRef(slot.primaryArtifactRef ?? slot.primary_artifact_ref ?? null);
-  const primaryArtifactRecord = primaryArtifact
+  const primaryArtifactPayload = slot.primaryArtifact ?? slot.primary_artifact ?? null;
+  const primaryArtifactRecord = primaryArtifactPayload
     ? normalizeArtifactRecord({
+      ...primaryArtifactPayload,
+      artifactId:
+        primaryArtifactPayload.artifactId
+        ?? primaryArtifactPayload.artifact_id
+        ?? primaryArtifact?.artifactId
+        ?? primaryArtifact?.artifact_id,
+      artifactKind:
+        primaryArtifactPayload.artifactKind
+        ?? primaryArtifactPayload.artifact_kind
+        ?? defaultArtifactKindForSlot(definition.key),
+      canonicalHomeTopicId:
+        primaryArtifactPayload.canonicalHomeTopicId
+        ?? primaryArtifactPayload.canonical_home_topic_id
+        ?? workspace.topicId,
+      lifecycleStatus:
+        primaryArtifactPayload.lifecycleStatus
+        ?? primaryArtifactPayload.lifecycle_status
+        ?? 'active',
+      placementStatus:
+        primaryArtifactPayload.placementStatus
+        ?? primaryArtifactPayload.placement_status
+        ?? 'pinned',
+      slotKey:
+        primaryArtifactPayload.slotKey
+        ?? primaryArtifactPayload.slot_key
+        ?? definition.key,
+      title:
+        primaryArtifactPayload.title
+        ?? primaryArtifact?.label,
+      updatedAt:
+        primaryArtifactPayload.updatedAt
+        ?? primaryArtifactPayload.updated_at
+        ?? slot.updatedAt
+        ?? slot.updated_at
+        ?? null,
+    }, {
+      source: 'slot_primary',
+    })
+    : primaryArtifact
+      ? normalizeArtifactRecord({
       artifactId: primaryArtifact.artifactId ?? primaryArtifact.artifact_id,
       artifactKind: defaultArtifactKindForSlot(definition.key),
       canonicalHomeTopicId: workspace.topicId,
@@ -562,7 +603,7 @@ function buildSlotViewModel(definition, slots, slotState, workspace) {
     }, {
       source: 'slot_primary',
     })
-    : null;
+      : null;
   const linkedReferences = normalizeRefList(slot.linkedReferences ?? slot.linked_references);
   const rawState = readSlotState(slotState, definition);
   const surfaceState = buildSurfaceState(rawState);
@@ -577,7 +618,7 @@ function buildSlotViewModel(definition, slots, slotState, workspace) {
     primaryArtifact,
     primaryArtifactCard: buildArtifactCard(primaryArtifactRecord, {
       placementLabel: 'Canonical resident',
-      description: 'Pinned to the canonical slot for this topic.',
+      description: primaryArtifactRecord?.summary || 'Pinned to the canonical slot for this topic.',
       fallbackState: contentState,
       slotTitle: definition.title,
       workspace,

--- a/supabase/migrations/20260417123000_create_learning_artifact_content_versions.sql
+++ b/supabase/migrations/20260417123000_create_learning_artifact_content_versions.sql
@@ -22,3 +22,108 @@ CREATE INDEX IF NOT EXISTS idx_learning_artifact_content_versions_artifact
 CREATE UNIQUE INDEX IF NOT EXISTS idx_learning_artifact_content_versions_current
   ON public.learning_artifact_content_versions (artifact_id)
   WHERE is_current;
+
+DROP FUNCTION IF EXISTS public.create_learning_artifact_content_version(
+  UUID,
+  INT,
+  UUID,
+  BOOLEAN,
+  TEXT,
+  TEXT,
+  TEXT,
+  TEXT,
+  JSONB,
+  TEXT,
+  JSONB,
+  TIMESTAMPTZ
+);
+
+CREATE OR REPLACE FUNCTION public.create_learning_artifact_content_version(
+  p_artifact_id UUID,
+  p_version_number INT DEFAULT NULL,
+  p_lineage_parent_version_id UUID DEFAULT NULL,
+  p_is_current BOOLEAN DEFAULT true,
+  p_title TEXT DEFAULT NULL,
+  p_summary TEXT DEFAULT NULL,
+  p_body_markdown TEXT DEFAULT '',
+  p_content_format TEXT DEFAULT 'markdown',
+  p_render_payload JSONB DEFAULT '{}'::jsonb,
+  p_materialization_kind TEXT DEFAULT 'runtime_candidate',
+  p_source_refs JSONB DEFAULT '[]'::jsonb,
+  p_created_at TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS public.learning_artifact_content_versions
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $fn$
+DECLARE
+  v_current public.learning_artifact_content_versions%ROWTYPE;
+  v_inserted public.learning_artifact_content_versions%ROWTYPE;
+BEGIN
+  SELECT *
+  INTO v_current
+  FROM public.learning_artifact_content_versions
+  WHERE artifact_id = p_artifact_id
+    AND is_current = true
+  ORDER BY version_number DESC
+  LIMIT 1
+  FOR UPDATE;
+
+  IF COALESCE(p_is_current, true) AND v_current.artifact_content_version_id IS NOT NULL THEN
+    UPDATE public.learning_artifact_content_versions
+    SET is_current = false
+    WHERE artifact_content_version_id = v_current.artifact_content_version_id;
+  END IF;
+
+  INSERT INTO public.learning_artifact_content_versions (
+    artifact_id,
+    version_number,
+    lineage_parent_version_id,
+    is_current,
+    title,
+    summary,
+    body_markdown,
+    content_format,
+    render_payload,
+    materialization_kind,
+    source_refs,
+    created_at
+  )
+  VALUES (
+    p_artifact_id,
+    CASE
+      WHEN p_version_number IS NOT NULL AND p_version_number > 0 THEN p_version_number
+      ELSE COALESCE(v_current.version_number, 0) + 1
+    END,
+    COALESCE(p_lineage_parent_version_id, v_current.artifact_content_version_id),
+    COALESCE(p_is_current, true),
+    COALESCE(NULLIF(BTRIM(p_title), ''), FORMAT('Artifact %s', p_artifact_id)),
+    NULLIF(BTRIM(p_summary), ''),
+    COALESCE(p_body_markdown, ''),
+    COALESCE(NULLIF(BTRIM(p_content_format), ''), 'markdown'),
+    COALESCE(p_render_payload, '{}'::jsonb),
+    COALESCE(NULLIF(BTRIM(p_materialization_kind), ''), 'runtime_candidate'),
+    COALESCE(p_source_refs, '[]'::jsonb),
+    COALESCE(p_created_at, now())
+  )
+  RETURNING *
+  INTO v_inserted;
+
+  RETURN v_inserted;
+END;
+$fn$;
+
+GRANT EXECUTE ON FUNCTION public.create_learning_artifact_content_version(
+  UUID,
+  INT,
+  UUID,
+  BOOLEAN,
+  TEXT,
+  TEXT,
+  TEXT,
+  TEXT,
+  JSONB,
+  TEXT,
+  JSONB,
+  TIMESTAMPTZ
+) TO service_role;

--- a/supabase/migrations/20260417123000_create_learning_artifact_content_versions.sql
+++ b/supabase/migrations/20260417123000_create_learning_artifact_content_versions.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS public.learning_artifact_content_versions (
+  artifact_content_version_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  artifact_id UUID NOT NULL REFERENCES public.learning_artifacts(artifact_id) ON DELETE CASCADE,
+  version_number INT NOT NULL CHECK (version_number > 0),
+  lineage_parent_version_id UUID REFERENCES public.learning_artifact_content_versions(artifact_content_version_id) ON DELETE SET NULL,
+  is_current BOOLEAN NOT NULL DEFAULT false,
+  title TEXT NOT NULL,
+  summary TEXT,
+  body_markdown TEXT NOT NULL DEFAULT '',
+  content_format TEXT NOT NULL DEFAULT 'markdown',
+  render_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  materialization_kind TEXT NOT NULL DEFAULT 'runtime_candidate',
+  source_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (artifact_id, version_number),
+  CHECK (lineage_parent_version_id IS NULL OR lineage_parent_version_id <> artifact_content_version_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_learning_artifact_content_versions_artifact
+  ON public.learning_artifact_content_versions (artifact_id, version_number DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_learning_artifact_content_versions_current
+  ON public.learning_artifact_content_versions (artifact_id)
+  WHERE is_current;

--- a/supabase/migrations/20260417123000_create_learning_artifact_content_versions.sql
+++ b/supabase/migrations/20260417123000_create_learning_artifact_content_versions.sql
@@ -113,6 +113,21 @@ BEGIN
 END;
 $fn$;
 
+REVOKE ALL ON FUNCTION public.create_learning_artifact_content_version(
+  UUID,
+  INT,
+  UUID,
+  BOOLEAN,
+  TEXT,
+  TEXT,
+  TEXT,
+  TEXT,
+  JSONB,
+  TEXT,
+  JSONB,
+  TIMESTAMPTZ
+) FROM PUBLIC;
+
 GRANT EXECUTE ON FUNCTION public.create_learning_artifact_content_version(
   UUID,
   INT,


### PR DESCRIPTION
Closes #231

## Summary
This PR activates artifact content for the pilot learning-runtime slice so verified and released residents can render real content instead of living indefinitely in a `missing_artifact_content` metadata-only posture.

It adds a dedicated content-version store alongside `learning_artifacts`, writes an initial renderable content version when runtime artifact candidates are materialized, and projects renderable resident content back into workspace slots through a new `primary_artifact` payload while preserving `primary_artifact_ref` compatibility.

## What Changed
- added `learning_artifact_content_versions` with version lineage, one-current-version enforcement, and migration coverage
- added `artifact-content-repository` helpers for current-version reads, historical listing, version creation, and artifact/content merging
- updated artifact reads and materialization so runtime candidates persist deterministic title, summary, body, render payload, and source refs as content versions
- updated workspace residency projection to distinguish resident pointers from renderable resident content, keeping `missing_artifact_content` only when the resident lacks current content
- updated the workspace view-model to prefer slot-level `primary_artifact` data when renderable content exists
- added focused repository, service, workspace projection, and view-model tests for the resident-content activation matrix
- corrected one stale workspace test assertion that previously expected `released_scoring` despite `classification_confidence: 0.77`, which is below the current authoritative threshold

## Verification
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/artifact-content-repository.test.js api/learning/__tests__/artifact-service.test.js api/learning/__tests__/workspace-read-service.test.js src/components/learning-runtime/__tests__/view-models.test.js`
