### PR TITLE
feat: execute 9709 pilot adapter templates in evaluate-v1

### DIFF
--- a/api/learning/__tests__/adapter-method-dispatcher.test.js
+++ b/api/learning/__tests__/adapter-method-dispatcher.test.js
@@ -121,4 +121,76 @@ describe('adapter-method-dispatcher', () => {
       ]),
     );
   });
+
+  test('builds compat v0 alignments from remaining rubric order when later pilot steps lack direct evidence spans', async () => {
+    const { runPilotAdapterRuntime } = await import('../lib/marking/adapter-method-dispatcher.js');
+
+    const template = {
+      question_type_id: '9709.trigonometry.identities',
+      parts: [
+        {
+          part_id: 'main',
+          points: [
+            {
+              point_id: 'identity-rewrite',
+              official_mark_notation: 'M1',
+              mark_family: 'M',
+              max_score: 1,
+              verification_condition: {
+                kind: 'adapter_call',
+                adapter_method: 'proof_structure_check',
+                params: {
+                  requires_identity_rewrite: true,
+                },
+              },
+            },
+            {
+              point_id: 'identity-result',
+              official_mark_notation: 'A1',
+              mark_family: 'A',
+              max_score: 1,
+              verification_condition: {
+                kind: 'adapter_call',
+                adapter_method: 'symbolic_check',
+                params: {
+                  expects_target_identity: true,
+                },
+              },
+              dependency_chain: {
+                prerequisite_point_ids: ['identity-rewrite'],
+                prerequisite_policy: 'all',
+                strict: true,
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = runPilotAdapterRuntime({
+      rubricTemplate: template,
+      compatMode: 'v0',
+      studentSteps: [
+        { step_id: 's1', text: 'sin^2 x + cos^2 x = 1' },
+        { step_id: 's2', text: 'Hence the target identity is proved.' },
+      ],
+    });
+
+    expect(result.alignments).toEqual([
+      expect.objectContaining({
+        step_id: 's1',
+        status: 'aligned',
+        rubric_id: 'identity-rewrite',
+        mark_label: 'M1',
+        reason: 'pilot_adapter_match',
+      }),
+      expect.objectContaining({
+        step_id: 's2',
+        status: 'aligned',
+        rubric_id: 'identity-result',
+        mark_label: 'A1',
+        reason: 'pilot_adapter_match',
+      }),
+    ]);
+  });
 });

--- a/api/learning/__tests__/adapter-method-dispatcher.test.js
+++ b/api/learning/__tests__/adapter-method-dispatcher.test.js
@@ -1,0 +1,124 @@
+describe('adapter-method-dispatcher', () => {
+  test('executes the approved pilot adapter methods and preserves dependency gating', async () => {
+    const {
+      runPilotAdapterRuntime,
+      PILOT_9709_ADAPTER_METHODS,
+    } = await import('../lib/marking/adapter-method-dispatcher.js');
+
+    const template = {
+      question_type_id: '9709.integration.application',
+      parts: [
+        {
+          part_id: 'main',
+          points: [
+            {
+              point_id: 'transform',
+              official_mark_notation: 'M1',
+              mark_family: 'M',
+              max_score: 1,
+              verification_condition: {
+                kind: 'adapter_call',
+                adapter_method: 'transform_bundle_check',
+                params: {
+                  requires_substitution: true,
+                },
+              },
+            },
+            {
+              point_id: 'symbolic',
+              official_mark_notation: 'A1',
+              mark_family: 'A',
+              max_score: 1,
+              verification_condition: {
+                kind: 'adapter_call',
+                adapter_method: 'symbolic_check',
+                params: {
+                  expects_exact_integral: true,
+                },
+              },
+              dependency_chain: {
+                prerequisite_point_ids: ['transform'],
+                prerequisite_policy: 'all',
+                strict: true,
+              },
+            },
+            {
+              point_id: 'numeric',
+              official_mark_notation: 'B1',
+              mark_family: 'B',
+              max_score: 1,
+              verification_condition: {
+                kind: 'adapter_call',
+                adapter_method: 'numeric_check',
+                params: {
+                  requires_initial_condition: true,
+                },
+              },
+            },
+            {
+              point_id: 'proof',
+              official_mark_notation: 'C1',
+              mark_family: 'C',
+              max_score: 1,
+              verification_condition: {
+                kind: 'adapter_call',
+                adapter_method: 'proof_structure_check',
+                params: {
+                  requires_identity_rewrite: true,
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = runPilotAdapterRuntime({
+      rubricTemplate: template,
+      studentSteps: [
+        { step_id: 's1', text: 'Let u = x^2 + 1 so the substitution is explicit.' },
+        { step_id: 's2', text: 'Therefore the exact integral is ln(x^2 + 1) + C.' },
+        { step_id: 's3', text: 'Using x = 0 and y = 1 gives C = 1.' },
+        { step_id: 's4', text: 'sin^2 x + cos^2 x = 1 proves the rewrite.' },
+      ],
+      includeUncertainReason: true,
+    });
+
+    expect(PILOT_9709_ADAPTER_METHODS).toEqual([
+      'numeric_check',
+      'proof_structure_check',
+      'symbolic_check',
+      'transform_bundle_check',
+    ]);
+    expect(result.decisions).toEqual([
+      expect.objectContaining({
+        rubric_id: 'transform',
+        reason: 'pilot_adapter_match',
+        awarded: true,
+      }),
+      expect.objectContaining({
+        rubric_id: 'symbolic',
+        reason: 'pilot_adapter_match',
+        awarded: true,
+      }),
+      expect.objectContaining({
+        rubric_id: 'numeric',
+        reason: 'pilot_adapter_match',
+        awarded: true,
+      }),
+      expect.objectContaining({
+        rubric_id: 'proof',
+        reason: 'pilot_adapter_match',
+        awarded: true,
+      }),
+    ]);
+    expect(result.rubric_points).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rubric_id: 'symbolic',
+          depends_on: ['transform'],
+        }),
+      ]),
+    );
+  });
+});

--- a/api/learning/__tests__/subject-adapter-registry.test.js
+++ b/api/learning/__tests__/subject-adapter-registry.test.js
@@ -9,6 +9,7 @@ import {
   buildSubjectRuntimePostureOrNull,
   getSubjectAdapter,
   getSubjectCapabilityPosture,
+  resolvePilotMarkingTemplateBinding,
 } from '../lib/subjects/subject-adapter-registry.js';
 
 describe('subject adapter registry', () => {
@@ -149,5 +150,36 @@ describe('subject adapter registry', () => {
       subject_code: '9702',
       read_only: true,
     });
+  });
+
+  test('pilot template binding requires an approved released rubric version', () => {
+    expect(resolvePilotMarkingTemplateBinding({
+      subjectCode: '9709',
+      questionTypeId: '9709.trigonometry.identities',
+      candidateRubricRefs: [
+        {
+          kind: 'rubric_release',
+          rubric_set_id: '9709.trigonometry.identities',
+          rubric_version_id: 'trig-identities-v1',
+          release_state: 'released',
+        },
+      ],
+    })).toMatchObject({
+      question_type_id: '9709.trigonometry.identities',
+      rubric_set_id: '9709.trigonometry.identities',
+    });
+
+    expect(resolvePilotMarkingTemplateBinding({
+      subjectCode: '9709',
+      questionTypeId: '9709.trigonometry.identities',
+      candidateRubricRefs: [
+        {
+          kind: 'rubric_release',
+          rubric_set_id: '9709.trigonometry.identities',
+          rubric_version_id: 'trig-identities-v2',
+          release_state: 'released',
+        },
+      ],
+    })).toBeNull();
   });
 });

--- a/api/learning/lib/marking/adapter-method-dispatcher.js
+++ b/api/learning/lib/marking/adapter-method-dispatcher.js
@@ -1,0 +1,283 @@
+import { buildUncertainReason } from '../../../marking/lib/marking-semantics-v1.js';
+import { APPROVED_9709_PILOT_ADAPTER_METHODS } from '../subjects/subject-adapter-registry.js';
+
+export const PILOT_9709_ADAPTER_METHODS = Object.freeze([
+  ...APPROVED_9709_PILOT_ADAPTER_METHODS,
+]);
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeText(value) {
+  return normalizeString(value)
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+}
+
+function hasAny(text, patterns = []) {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function hasEquationSignal(text) {
+  return text.includes('=') || text.includes('=>') || text.includes('->')
+    || hasAny(text, [/\bhence\b/, /\btherefore\b/, /\bprove[sd]?\b/]);
+}
+
+function hasTrigSignal(text) {
+  return hasAny(text, [/\bsin\b/, /\bcos\b/, /\btan\b/, /\bcosec\b/, /\bsec\b/, /\bcot\b/]);
+}
+
+function hasIntegralSignal(text) {
+  return hasAny(text, [/\bintegral\b/, /∫/, /\bln\b/, /\+ c\b/, /\banti-?derivative\b/]);
+}
+
+function hasSubstitutionSignal(text) {
+  return hasAny(text, [/\blet\s+[a-z]\s*=/, /\bu\s*=/, /\bsubstitut/, /\bchange of variable/]);
+}
+
+function hasSeparationSignal(text) {
+  return hasAny(text, [
+    /\bdy\s*\/\s*dx\b/,
+    /\bdy\b.*\bdx\b/,
+    /\bseparat/,
+  ]);
+}
+
+function hasInitialConditionSignal(text) {
+  return hasAny(text, [/\binitial\b/, /\bx\s*=/, /\by\s*=/, /\bc\s*=/]);
+}
+
+function hasDomainSignal(text) {
+  return hasAny(text, [/\bdomain\b/, /\bdegree/, /<=/, /π/, /\bpi\b/, /\bnπ\b/]);
+}
+
+function hasNumericSignal(text) {
+  return /[0-9]/.test(text);
+}
+
+function scoreMethodMatch(adapterMethod, params = {}, text) {
+  switch (adapterMethod) {
+    case 'proof_structure_check':
+      return hasTrigSignal(text) && hasEquationSignal(text) ? 0.94 : 0;
+    case 'symbolic_check':
+      if (params?.expects_target_identity === true) {
+        return hasTrigSignal(text) && hasEquationSignal(text) ? 0.93 : 0;
+      }
+      if (params?.checks === 'base_trigonometric_equation') {
+        return hasTrigSignal(text) && hasEquationSignal(text) ? 0.92 : 0;
+      }
+      if (params?.expects_exact_integral === true) {
+        return hasIntegralSignal(text) && hasEquationSignal(text) ? 0.9 : 0;
+      }
+      return hasEquationSignal(text) ? 0.82 : 0;
+    case 'numeric_check':
+      if (params?.requires_domain_filter === true) {
+        return hasNumericSignal(text) && hasDomainSignal(text) ? 0.91 : 0;
+      }
+      if (params?.requires_initial_condition === true) {
+        return hasInitialConditionSignal(text) ? 0.92 : 0;
+      }
+      return hasNumericSignal(text) ? 0.8 : 0;
+    case 'transform_bundle_check':
+      if (params?.requires_substitution === true) {
+        return hasSubstitutionSignal(text) ? 0.91 : 0;
+      }
+      if (params?.requires_separation === true) {
+        return hasSeparationSignal(text) ? 0.9 : 0;
+      }
+      return hasAny(text, [/\btransform\b/, /\brewrite\b/, /\bsubstitut/, /\bseparat/]) ? 0.8 : 0;
+    default:
+      return 0;
+  }
+}
+
+function findBestMatchingStep(studentSteps = [], adapterMethod, params = {}) {
+  let bestStep = null;
+  let bestConfidence = 0;
+
+  for (const step of normalizeArray(studentSteps)) {
+    const stepText = normalizeText(step?.text);
+    const confidence = scoreMethodMatch(adapterMethod, params, stepText);
+
+    if (confidence > bestConfidence) {
+      bestConfidence = confidence;
+      bestStep = step;
+    }
+  }
+
+  return {
+    step: bestStep,
+    confidence: Number(bestConfidence.toFixed(4)),
+  };
+}
+
+function flattenTemplatePoints(parts = [], parentPartId = null) {
+  const points = [];
+
+  for (const part of normalizeArray(parts)) {
+    const partId = normalizeString(part?.part_id) || parentPartId || null;
+
+    for (const point of normalizeArray(part?.points)) {
+      const verification = point?.verification_condition ?? {};
+      const dependencyChain = point?.dependency_chain ?? {};
+
+      points.push({
+        rubric_id: normalizeString(point?.point_id),
+        mark_label: normalizeString(point?.official_mark_notation) || null,
+        kind: normalizeString(point?.mark_family) || null,
+        marks: Number(point?.max_score ?? 0),
+        description: normalizeString(point?.point_id).replace(/[-_]+/g, ' ') || null,
+        depends_on: normalizeArray(dependencyChain?.prerequisite_point_ids),
+        ft_mode: point?.follow_through?.enabled === true
+          ? (dependencyChain?.strict === true ? 'strict_ft' : 'ft')
+          : 'none',
+        part_id: partId,
+        subpart_id: null,
+        adapter_method: normalizeString(verification?.adapter_method),
+        adapter_params: verification?.params && typeof verification.params === 'object'
+          ? JSON.parse(JSON.stringify(verification.params))
+          : {},
+      });
+    }
+
+    if (Array.isArray(part?.subparts)) {
+      points.push(...flattenTemplatePoints(part.subparts, partId));
+    }
+  }
+
+  return points;
+}
+
+function buildDecision({
+  rubricPoint,
+  includeUncertainReason = false,
+  awarded = false,
+  reason = 'pilot_adapter_mismatch',
+  confidence = 0,
+  step = null,
+} = {}) {
+  const stepText = normalizeString(step?.text);
+  const decision = {
+    rubric_id: rubricPoint.rubric_id,
+    mark_label: rubricPoint.mark_label,
+    reason,
+    awarded,
+    awarded_marks: awarded ? Number(rubricPoint.marks ?? 0) : 0,
+    alignment_confidence: confidence,
+    evidence_spans: step
+      ? [
+        {
+          step_id: normalizeString(step?.step_id) || null,
+          start: 0,
+          end: stepText.length,
+        },
+      ]
+      : [],
+    part_id: rubricPoint.part_id,
+    subpart_id: rubricPoint.subpart_id,
+  };
+
+  if (includeUncertainReason) {
+    decision.uncertain_reason = buildUncertainReason(reason, { awarded });
+  }
+
+  return decision;
+}
+
+export function dispatchAdapterMethod({
+  adapterMethod,
+  studentSteps = [],
+  params = {},
+} = {}) {
+  const normalizedMethod = normalizeString(adapterMethod);
+
+  if (!PILOT_9709_ADAPTER_METHODS.includes(normalizedMethod)) {
+    return {
+      awarded: false,
+      reason: 'pilot_adapter_mismatch',
+      confidence: 0,
+      step: null,
+    };
+  }
+
+  const { step, confidence } = findBestMatchingStep(studentSteps, normalizedMethod, params);
+
+  return {
+    awarded: confidence >= 0.9,
+    reason: confidence >= 0.9 ? 'pilot_adapter_match' : 'pilot_adapter_mismatch',
+    confidence,
+    step,
+  };
+}
+
+export function buildPilotRuntimeRubricPoints(rubricTemplate = {}) {
+  return flattenTemplatePoints(rubricTemplate?.parts);
+}
+
+export function runPilotAdapterRuntime({
+  rubricTemplate = {},
+  studentSteps = [],
+  includeUncertainReason = false,
+} = {}) {
+  const rubricPoints = buildPilotRuntimeRubricPoints(rubricTemplate);
+  const decisions = [];
+  const awardedRubricIds = new Set();
+
+  for (const rubricPoint of rubricPoints) {
+    if (!rubricPoint.rubric_id) {
+      continue;
+    }
+
+    const unmetDependency = normalizeArray(rubricPoint.depends_on).find(
+      (dependencyId) => !awardedRubricIds.has(normalizeString(dependencyId)),
+    );
+
+    if (unmetDependency) {
+      decisions.push(buildDecision({
+        rubricPoint,
+        includeUncertainReason,
+        awarded: false,
+        reason: 'dependency_not_met',
+        confidence: 0,
+        step: null,
+      }));
+      continue;
+    }
+
+    const dispatched = dispatchAdapterMethod({
+      adapterMethod: rubricPoint.adapter_method,
+      studentSteps,
+      params: rubricPoint.adapter_params,
+    });
+    const decision = buildDecision({
+      rubricPoint,
+      includeUncertainReason,
+      awarded: dispatched.awarded,
+      reason: dispatched.reason,
+      confidence: dispatched.confidence,
+      step: dispatched.step,
+    });
+
+    if (decision.awarded) {
+      awardedRubricIds.add(rubricPoint.rubric_id);
+    }
+
+    decisions.push(decision);
+  }
+
+  return {
+    decisions,
+    rubric_points: rubricPoints,
+    execution_summary: {
+      execution_path: 'pilot_adapter_runtime',
+      adapter_methods: [...new Set(rubricPoints.map((point) => point.adapter_method))].sort(),
+      rubric_template_id: normalizeString(rubricTemplate?.rubric_template_id) || null,
+      question_type_id: normalizeString(rubricTemplate?.question_type_id) || null,
+    },
+  };
+}

--- a/api/learning/lib/marking/adapter-method-dispatcher.js
+++ b/api/learning/lib/marking/adapter-method-dispatcher.js
@@ -189,6 +189,85 @@ function buildDecision({
   return decision;
 }
 
+function buildPilotCompatAlignments(
+  studentSteps = [],
+  decisions = [],
+  { includeUncertainReason = false } = {},
+) {
+  const normalizedDecisions = normalizeArray(decisions);
+  const consumedDecisionIndexes = new Set();
+  const stepDecisionIndexes = normalizeArray(studentSteps).map((step, index) => {
+    const stepId = normalizeString(step?.step_id) || `s${index + 1}`;
+    const directDecisionIndex = normalizedDecisions.findIndex((decision, decisionIndex) =>
+      !consumedDecisionIndexes.has(decisionIndex)
+      && normalizeArray(decision?.evidence_spans).some((span) => normalizeString(span?.step_id) === stepId));
+
+    if (directDecisionIndex >= 0) {
+      consumedDecisionIndexes.add(directDecisionIndex);
+      return directDecisionIndex;
+    }
+
+    return null;
+  });
+
+  let nextFallbackDecisionIndex = 0;
+
+  return normalizeArray(studentSteps).map((step, index) => {
+    const stepId = normalizeString(step?.step_id) || `s${index + 1}`;
+    let matchingDecisionIndex = stepDecisionIndexes[index];
+
+    if (matchingDecisionIndex == null) {
+      while (
+        nextFallbackDecisionIndex < normalizedDecisions.length
+        && consumedDecisionIndexes.has(nextFallbackDecisionIndex)
+      ) {
+        nextFallbackDecisionIndex += 1;
+      }
+
+      if (nextFallbackDecisionIndex < normalizedDecisions.length) {
+        matchingDecisionIndex = nextFallbackDecisionIndex;
+        consumedDecisionIndexes.add(matchingDecisionIndex);
+        nextFallbackDecisionIndex += 1;
+      }
+    }
+
+    const matchingDecision = matchingDecisionIndex == null
+      ? null
+      : normalizedDecisions[matchingDecisionIndex] ?? null;
+
+    if (!matchingDecision) {
+      return {
+        step_id: stepId,
+        status: 'uncertain',
+        confidence: 0,
+        rubric_id: null,
+        mark_label: null,
+        reason: 'no_match',
+        ...(includeUncertainReason
+          ? { uncertain_reason: buildUncertainReason('no_match') }
+          : {}),
+      };
+    }
+
+    const status = matchingDecision.awarded === true ? 'aligned' : 'uncertain';
+    return {
+      step_id: stepId,
+      status,
+      confidence: Number(matchingDecision.alignment_confidence ?? 0),
+      rubric_id: matchingDecision.rubric_id ?? null,
+      mark_label: matchingDecision.mark_label ?? null,
+      reason: matchingDecision.reason ?? null,
+      ...(includeUncertainReason
+        ? {
+          uncertain_reason: buildUncertainReason(matchingDecision.reason, {
+            awarded: status === 'aligned',
+          }),
+        }
+        : {}),
+    };
+  });
+}
+
 export function dispatchAdapterMethod({
   adapterMethod,
   studentSteps = [],
@@ -223,6 +302,7 @@ export function runPilotAdapterRuntime({
   rubricTemplate = {},
   studentSteps = [],
   includeUncertainReason = false,
+  compatMode = null,
 } = {}) {
   const rubricPoints = buildPilotRuntimeRubricPoints(rubricTemplate);
   const decisions = [];
@@ -272,6 +352,13 @@ export function runPilotAdapterRuntime({
 
   return {
     decisions,
+    ...(compatMode === 'v0'
+      ? {
+        alignments: buildPilotCompatAlignments(studentSteps, decisions, {
+          includeUncertainReason,
+        }),
+      }
+      : {}),
     rubric_points: rubricPoints,
     execution_summary: {
       execution_path: 'pilot_adapter_runtime',

--- a/api/learning/lib/subjects/subject-adapter-registry.js
+++ b/api/learning/lib/subjects/subject-adapter-registry.js
@@ -19,6 +19,10 @@ function normalizeArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
 function normalizeSubjectCode(value) {
   const normalized = normalizeString(value);
   return /^\d{4}$/.test(normalized) ? normalized : null;
@@ -224,6 +228,65 @@ export const SUBJECT_ADAPTER_DECISION = Object.freeze({
   evidence_report_path: 'docs/reports/learning_runtime_second_subject_decision_2026-03-25.md',
 });
 
+const PILOT_MARKING_TEMPLATE_BINDINGS = Object.freeze({
+  '9709.trigonometry.identities': Object.freeze({
+    subject_code: '9709',
+    question_type_id: '9709.trigonometry.identities',
+    rubric_set_id: '9709.trigonometry.identities',
+    rubric_template_path: 'data/learning_runtime/pilot_rubrics/9709.trigonometry.identities.json',
+    released_rubric_version_ids: Object.freeze(['trig-identities-v1']),
+    adapter_methods: Object.freeze(['proof_structure_check', 'symbolic_check']),
+  }),
+  '9709.trigonometry.equations': Object.freeze({
+    subject_code: '9709',
+    question_type_id: '9709.trigonometry.equations',
+    rubric_set_id: '9709.trigonometry.equations',
+    rubric_template_path: 'data/learning_runtime/pilot_rubrics/9709.trigonometry.equations.json',
+    released_rubric_version_ids: Object.freeze(['trig-equations-v1']),
+    adapter_methods: Object.freeze(['numeric_check', 'symbolic_check']),
+  }),
+  '9709.integration.application': Object.freeze({
+    subject_code: '9709',
+    question_type_id: '9709.integration.application',
+    rubric_set_id: '9709.integration.application',
+    rubric_template_path: 'data/learning_runtime/pilot_rubrics/9709.integration.application.json',
+    released_rubric_version_ids: Object.freeze(['integration-application-v1']),
+    adapter_methods: Object.freeze(['symbolic_check', 'transform_bundle_check']),
+  }),
+  '9709.differential_equations.separable': Object.freeze({
+    subject_code: '9709',
+    question_type_id: '9709.differential_equations.separable',
+    rubric_set_id: '9709.differential_equations.separable',
+    rubric_template_path: 'data/learning_runtime/pilot_rubrics/9709.differential_equations.separable.json',
+    released_rubric_version_ids: Object.freeze(['differential-separable-v1', 'diff-eq-v1']),
+    adapter_methods: Object.freeze(['numeric_check', 'transform_bundle_check']),
+  }),
+});
+
+export const APPROVED_9709_PILOT_ADAPTER_METHODS = Object.freeze(
+  [...new Set(Object.values(PILOT_MARKING_TEMPLATE_BINDINGS)
+    .flatMap((binding) => binding.adapter_methods))]
+    .sort(),
+);
+
+function hasReleasedPilotRubricRef(binding, candidateRubricRefs = []) {
+  return normalizeArray(candidateRubricRefs).some((ref) => {
+    const releaseState = normalizeString(ref?.release_state).toLowerCase();
+    const rubricSetId = normalizeString(ref?.rubric_set_id);
+    const rubricVersionId = normalizeString(ref?.rubric_version_id);
+
+    if (releaseState !== 'released') {
+      return false;
+    }
+
+    if (rubricSetId && rubricSetId === binding.rubric_set_id) {
+      return true;
+    }
+
+    return binding.released_rubric_version_ids.includes(rubricVersionId);
+  });
+}
+
 const SUBJECT_ADAPTERS = new Map([
   [
     '9709',
@@ -318,6 +381,29 @@ export function getSubjectAdapter(subjectCode, { allowDisabled = false } = {}) {
   }
 
   return adapter;
+}
+
+export function resolvePilotMarkingTemplateBinding({
+  subjectCode = null,
+  questionTypeId = null,
+  candidateRubricRefs = [],
+} = {}) {
+  const normalizedQuestionTypeId = normalizeString(questionTypeId);
+  const binding = PILOT_MARKING_TEMPLATE_BINDINGS[normalizedQuestionTypeId] ?? null;
+  const normalizedSubjectCode = normalizeSubjectCode(subjectCode)
+    || deriveSubjectCodeFromStructuredId(normalizedQuestionTypeId);
+
+  if (!binding || normalizedSubjectCode !== binding.subject_code) {
+    return null;
+  }
+
+  if (!hasReleasedPilotRubricRef(binding, candidateRubricRefs)) {
+    return null;
+  }
+
+  return {
+    ...cloneJson(binding),
+  };
 }
 
 export function getSubjectCapabilityPosture(

--- a/api/learning/lib/subjects/subject-adapter-registry.js
+++ b/api/learning/lib/subjects/subject-adapter-registry.js
@@ -279,11 +279,15 @@ function hasReleasedPilotRubricRef(binding, candidateRubricRefs = []) {
       return false;
     }
 
-    if (rubricSetId && rubricSetId === binding.rubric_set_id) {
-      return true;
+    if (!binding.released_rubric_version_ids.includes(rubricVersionId)) {
+      return false;
     }
 
-    return binding.released_rubric_version_ids.includes(rubricVersionId);
+    if (rubricSetId && rubricSetId !== binding.rubric_set_id) {
+      return false;
+    }
+
+    return true;
   });
 }
 

--- a/api/marking/__tests__/evaluate-v1.test.js
+++ b/api/marking/__tests__/evaluate-v1.test.js
@@ -8,27 +8,30 @@ import { jest } from '@jest/globals';
 // The rubric resolver calls supabase.from('rubric_points').select().eq()...
 // and supabase.from('rubric_points_ready_v1').select().eq().order()...
 
-const MOCK_READY_POINT = {
-  rubric_id: 'aaaaaaaa-0000-0000-0000-000000000001',
-  storage_key: '9709/s22/qp11/q01.png',
-  q_number: 1,
-  subpart: null,
-  step_index: 1,
-  mark_label: 'M1',
-  kind: 'M',
-  description: 'Correct method',
-  marks: 1,
-  depends_on: [],
-  ft_mode: 'none',
-  confidence: 0.95,
-  source: 'vlm',
-  extractor_version: 'v1',
-  provider: 'openai',
-  model: 'gpt-4-turbo',
-  prompt_version: 'p1',
-  source_version: 'v1:openai:gpt-4-turbo:p1',
-  updated_at: '2026-02-15T10:00:00Z',
-};
+function buildReadyPoint(overrides = {}) {
+  return {
+    rubric_id: 'aaaaaaaa-0000-0000-0000-000000000001',
+    storage_key: '9709/s22/qp11/q01.png',
+    q_number: 1,
+    subpart: null,
+    step_index: 1,
+    mark_label: 'M1',
+    kind: 'M',
+    description: 'Correct method',
+    marks: 1,
+    depends_on: [],
+    ft_mode: 'none',
+    confidence: 0.95,
+    source: 'vlm',
+    extractor_version: 'v1',
+    provider: 'openai',
+    model: 'gpt-4-turbo',
+    prompt_version: 'p1',
+    source_version: 'v1:openai:gpt-4-turbo:p1',
+    updated_at: '2026-02-15T10:00:00Z',
+    ...overrides,
+  };
+}
 
 function buildLearningQuestionProjectionRow(overrides = {}) {
   return {
@@ -52,6 +55,8 @@ function buildLearningQuestionProjectionRow(overrides = {}) {
 }
 
 let learningQuestionProjectionRow = buildLearningQuestionProjectionRow();
+let mockRubricVersionRows = [buildReadyPoint()];
+let mockReadyPoints = [buildReadyPoint()];
 
 function createChainMock(data) {
   const chain = {};
@@ -69,10 +74,10 @@ function createChainMock(data) {
 
 const mockFrom = jest.fn((table) => {
   if (table === 'rubric_points') {
-    return createChainMock([MOCK_READY_POINT]);
+    return createChainMock(mockRubricVersionRows);
   }
   if (table === 'rubric_points_ready_v1') {
-    return createChainMock([MOCK_READY_POINT]);
+    return createChainMock(mockReadyPoints);
   }
   if (table === 'learning_question_registry_projection') {
     return createChainMock(learningQuestionProjectionRow);
@@ -191,6 +196,8 @@ beforeEach(() => {
   process.env.EVIDENCE_LEDGER_ENABLED = 'false';
   process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'false';
   learningQuestionProjectionRow = buildLearningQuestionProjectionRow();
+  mockRubricVersionRows = [buildReadyPoint()];
+  mockReadyPoints = [buildReadyPoint()];
   jest.clearAllMocks();
   mockApplyLearningEffects.mockResolvedValue({
     release_scope_status: 'released_scoring',
@@ -563,6 +570,149 @@ describe('learning-runtime orchestration', () => {
         }),
       }),
     );
+  });
+
+  it('executes a released 9709 pilot rubric through the adapter runtime behind the runtime flag', async () => {
+    process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'true';
+    learningQuestionProjectionRow = buildLearningQuestionProjectionRow({
+      primary_topic_id: 'topic-trig-identities',
+      primary_question_type_id: '9709.trigonometry.identities',
+      candidate_rubric_refs: [
+        {
+          kind: 'rubric_release',
+          rubric_set_id: '9709.trigonometry.identities',
+          rubric_version_id: 'trig-identities-v1',
+          release_state: 'released',
+        },
+      ],
+    });
+    mockReadyPoints = [
+      buildReadyPoint({
+        rubric_id: 'identity-rewrite',
+        mark_label: 'M1',
+        description: 'Identity rewrite',
+      }),
+      buildReadyPoint({
+        rubric_id: 'identity-result',
+        mark_label: 'A1',
+        description: 'Identity result',
+        step_index: 2,
+      }),
+    ];
+
+    const req = mockReq({
+      body: {
+        ...mockReq().body,
+        student_steps: [
+          { step_id: 's1', text: 'sin^2 x + cos^2 x = 1' },
+          { step_id: 's2', text: 'Hence the target identity is proved.' },
+        ],
+      },
+    });
+    const res = mockRes();
+
+    await handler(req, res);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.decisions).toEqual([
+      expect.objectContaining({
+        rubric_id: 'identity-rewrite',
+        mark_label: 'M1',
+        reason: 'pilot_adapter_match',
+        awarded: true,
+        awarded_marks: 1,
+      }),
+      expect.objectContaining({
+        rubric_id: 'identity-result',
+        mark_label: 'A1',
+        reason: 'pilot_adapter_match',
+        awarded: true,
+        awarded_marks: 1,
+      }),
+    ]);
+    expect(body.marking_result.marking_summary.total_awarded).toBe(2);
+    expect(mockWriteLedger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rubric_points: expect.arrayContaining([
+          expect.objectContaining({ rubric_id: 'identity-rewrite' }),
+          expect.objectContaining({ rubric_id: 'identity-result' }),
+        ]),
+      }),
+    );
+  });
+
+  it('keeps pilot adapter execution conservative when released-scope posture fails closed', async () => {
+    process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'true';
+    learningQuestionProjectionRow = buildLearningQuestionProjectionRow({
+      primary_topic_id: 'topic-trig-identities',
+      primary_question_type_id: '9709.trigonometry.identities',
+      classification_confidence: 0.42,
+      candidate_rubric_refs: [
+        {
+          kind: 'rubric_release',
+          rubric_set_id: '9709.trigonometry.identities',
+          rubric_version_id: 'trig-identities-v1',
+          release_state: 'released',
+        },
+      ],
+    });
+    mockReadyPoints = [
+      buildReadyPoint({
+        rubric_id: 'identity-rewrite',
+        mark_label: 'M1',
+        description: 'Identity rewrite',
+      }),
+      buildReadyPoint({
+        rubric_id: 'identity-result',
+        mark_label: 'A1',
+        description: 'Identity result',
+        step_index: 2,
+      }),
+    ];
+    mockApplyLearningEffects.mockResolvedValueOnce({
+      release_scope_status: 'non_released_fallback',
+      authoritative_scoring_allowed: false,
+      learning_signal_posture: 'conservative_fallback',
+      fallback_reason_code: 'low_classification_confidence',
+      mastery_updates: [],
+      review_tasks: [],
+      artifact_candidates: [],
+      reconciliation: null,
+    });
+
+    const req = mockReq({
+      body: {
+        ...mockReq().body,
+        student_steps: [
+          { step_id: 's1', text: 'sin^2 x + cos^2 x = 1' },
+          { step_id: 's2', text: 'Hence the target identity is proved.' },
+        ],
+      },
+    });
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(mockApplyLearningEffects).toHaveBeenCalledWith(
+      expect.objectContaining({
+        release_scope_posture: expect.objectContaining({
+          authoritative_scoring_allowed: false,
+          fallback_reason_code: 'low_classification_confidence',
+          learning_signal_posture: 'conservative_fallback',
+        }),
+      }),
+      expect.any(Object),
+    );
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.decisions[0]).toMatchObject({
+      reason: 'pilot_adapter_match',
+      awarded: true,
+    });
+    expect(body.learning_effects).toMatchObject({
+      authoritative_scoring_allowed: false,
+      fallback_reason_code: 'low_classification_confidence',
+    });
   });
 
   it('marks imported-question attempts as explicit non-authoritative runtime inputs across ledger, bridge, and learning effects', async () => {

--- a/api/marking/__tests__/evaluate-v1.test.js
+++ b/api/marking/__tests__/evaluate-v1.test.js
@@ -408,6 +408,67 @@ describe('v0 compat mode', () => {
     const body = res.json.mock.calls[0][0];
     expect(body.alignments).toBeUndefined();
   });
+
+  it('preserves alignments[] for pilot-bound questions in compat_mode=v0', async () => {
+    process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'true';
+    learningQuestionProjectionRow = buildLearningQuestionProjectionRow({
+      primary_topic_id: 'topic-trig-identities',
+      primary_question_type_id: '9709.trigonometry.identities',
+      candidate_rubric_refs: [
+        {
+          kind: 'rubric_release',
+          rubric_set_id: '9709.trigonometry.identities',
+          rubric_version_id: 'trig-identities-v1',
+          release_state: 'released',
+        },
+      ],
+    });
+    mockReadyPoints = [
+      buildReadyPoint({
+        rubric_id: 'identity-rewrite',
+        mark_label: 'M1',
+        description: 'Identity rewrite',
+      }),
+      buildReadyPoint({
+        rubric_id: 'identity-result',
+        mark_label: 'A1',
+        description: 'Identity result',
+        step_index: 2,
+      }),
+    ];
+
+    const req = mockReq({
+      body: {
+        ...mockReq().body,
+        compat_mode: 'v0',
+        student_steps: [
+          { step_id: 's1', text: 'sin^2 x + cos^2 x = 1' },
+          { step_id: 's2', text: 'Hence the target identity is proved.' },
+        ],
+      },
+    });
+    const res = mockRes();
+
+    await handler(req, res);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.alignments).toEqual([
+      expect.objectContaining({
+        step_id: 's1',
+        status: 'aligned',
+        rubric_id: 'identity-rewrite',
+        mark_label: 'M1',
+        reason: 'pilot_adapter_match',
+      }),
+      expect.objectContaining({
+        step_id: 's2',
+        status: 'aligned',
+        rubric_id: 'identity-result',
+        mark_label: 'A1',
+        reason: 'pilot_adapter_match',
+      }),
+    ]);
+  });
 });
 
 describe('learning-runtime orchestration', () => {

--- a/api/marking/__tests__/rubric-resolver-v1.test.js
+++ b/api/marking/__tests__/rubric-resolver-v1.test.js
@@ -362,6 +362,72 @@ describe('resolveRubric — error handling', () => {
   });
 });
 
+describe('resolveRubric — pilot template binding', () => {
+  it('binds released pilot template metadata behind the runtime flag', async () => {
+    const versionRows = [makeVersionRow()];
+    const readyPoints = [
+      makePoint({ rubric_id: 'identity-rewrite', mark_label: 'M1' }),
+      makePoint({ rubric_id: 'identity-result', mark_label: 'A1', step_index: 2 }),
+    ];
+
+    const supabase = createMockSupabase({
+      rubricPointsData: versionRows,
+      readyViewData: readyPoints,
+    });
+
+    const result = await resolveRubric({
+      supabase,
+      storage_key: '9709/s22/qp11/q01.png',
+      q_number: 1,
+      subpart: null,
+      subject_code: '9709',
+      question_type_id: '9709.trigonometry.identities',
+      candidate_rubric_refs: [
+        {
+          kind: 'rubric_release',
+          rubric_set_id: '9709.trigonometry.identities',
+          rubric_version_id: 'trig-identities-v1',
+          release_state: 'released',
+        },
+      ],
+      pilot_runtime_enabled: true,
+    });
+
+    expect(result.pilot_rubric_template).toMatchObject({
+      question_type_id: '9709.trigonometry.identities',
+      release_state: 'released',
+    });
+    expect(result.pilot_adapter_methods).toEqual([
+      'proof_structure_check',
+      'symbolic_check',
+    ]);
+  });
+
+  it('does not bind pilot template metadata without a released rubric ref', async () => {
+    const versionRows = [makeVersionRow()];
+    const readyPoints = [makePoint()];
+
+    const supabase = createMockSupabase({
+      rubricPointsData: versionRows,
+      readyViewData: readyPoints,
+    });
+
+    const result = await resolveRubric({
+      supabase,
+      storage_key: '9709/s22/qp11/q01.png',
+      q_number: 1,
+      subpart: null,
+      subject_code: '9709',
+      question_type_id: '9709.trigonometry.identities',
+      candidate_rubric_refs: [],
+      pilot_runtime_enabled: true,
+    });
+
+    expect(result.pilot_rubric_template).toBeNull();
+    expect(result.pilot_adapter_methods).toEqual([]);
+  });
+});
+
 // ── resolveRubric: audit log ────────────────────────────────────────────────
 
 describe('resolveRubric — audit log', () => {

--- a/api/marking/evaluate-v1.js
+++ b/api/marking/evaluate-v1.js
@@ -334,11 +334,17 @@ export default async function handler(req, res) {
           rubricTemplate: pilot_rubric_template,
           studentSteps: student_steps,
           includeUncertainReason: include_uncertain_reason === true,
+          compatMode: compat_mode,
         });
         rubric_points = pilotResult.rubric_points;
         decisions = pilotResult.decisions.map((decision) => serializeDecisionForResponse(decision, {
           includeUncertainReason: include_uncertain_reason === true,
         }));
+        if (pilotResult.alignments) {
+          alignments = pilotResult.alignments.map((alignment) => serializeAlignmentForResponse(alignment, {
+            includeUncertainReason: include_uncertain_reason === true,
+          }));
+        }
       } else {
         const engineResult = runDecisionEngine({
           student_steps,

--- a/api/marking/evaluate-v1.js
+++ b/api/marking/evaluate-v1.js
@@ -15,6 +15,7 @@ import { resolveReleasedScoringPosture } from '../learning/lib/contracts/release
 import { buildRuntimeAuthorityPosture } from '../learning/lib/contracts/runtime-authority-posture.js';
 import { persistAttemptEventBridge } from '../learning/lib/events/attempt-event-service.js';
 import { applyLearningEffects } from '../learning/lib/mastery/mastery-orchestrator.js';
+import { runPilotAdapterRuntime } from '../learning/lib/marking/adapter-method-dispatcher.js';
 
 // ── Feature flag (evaluated per-request so env changes take effect) ──────────
 function isV1Enabled() {
@@ -283,38 +284,78 @@ export default async function handler(req, res) {
       ts: new Date().toISOString(),
     }));
 
+    const runtimeAuthorityPosture = buildRuntimeAuthorityPosture(
+      resolveReleasedScoringPosture({
+        questionTypeId: questionContext.question_type_id,
+        questionTypeReleaseState: questionContext.question_type_release_state,
+        candidateRubricRefs: questionContext.candidate_rubric_refs,
+        classificationConfidence: questionContext.classification_confidence,
+        uncertaintyValidated: true,
+      }),
+      {
+        questionContext,
+      },
+    );
+
     // ── Rubric Resolver (Task 4) ─────────────────────────────────────────
-    const {
-      rubric_source_version,
-      rubric_points,
-      rubric_rows_used,
-    } = await resolveRubric({
+    const resolvedRubric = await resolveRubric({
       supabase,
       storage_key,
       q_number,
       subpart,
       rubric_source_version: requestedVersion,
+      subject_code: subjectCode,
+      question_type_id: questionContext.question_type_id,
+      candidate_rubric_refs: questionContext.candidate_rubric_refs,
+      pilot_runtime_enabled: isRuntimeBridgeEnabled(),
     });
+    const {
+      rubric_source_version,
+      pilot_rubric_template,
+      pilot_adapter_methods,
+      rubric_rows_used,
+    } = resolvedRubric;
+    let rubric_points = resolvedRubric.rubric_points;
 
     // ── Decision Engine (Task 5) ─────────────────────────────────────────
     let decisions = [];
     let alignments;
+    const runtimeExecution = {
+      execution_path: pilot_rubric_template ? 'pilot_adapter_runtime' : 'legacy_decision_engine',
+      authority_level: runtimeAuthorityPosture.authoritative_scoring_allowed
+        ? 'authoritative'
+        : 'conservative',
+      pilot_question_type_id: pilot_rubric_template?.question_type_id ?? null,
+      adapter_methods: pilot_rubric_template ? pilot_adapter_methods : [],
+    };
     try {
-      const engineResult = runDecisionEngine({
-        student_steps,
-        rubric_points,
-        options: {
-          compat_mode: compat_mode,
-          include_uncertain_reason: include_uncertain_reason === true,
-        },
-      });
-      decisions = engineResult.decisions.map((d) => serializeDecisionForResponse(d, {
-        includeUncertainReason: include_uncertain_reason === true,
-      }));
-      if (engineResult.alignments) {
-        alignments = engineResult.alignments.map((a) => serializeAlignmentForResponse(a, {
+      if (pilot_rubric_template) {
+        const pilotResult = runPilotAdapterRuntime({
+          rubricTemplate: pilot_rubric_template,
+          studentSteps: student_steps,
+          includeUncertainReason: include_uncertain_reason === true,
+        });
+        rubric_points = pilotResult.rubric_points;
+        decisions = pilotResult.decisions.map((decision) => serializeDecisionForResponse(decision, {
           includeUncertainReason: include_uncertain_reason === true,
         }));
+      } else {
+        const engineResult = runDecisionEngine({
+          student_steps,
+          rubric_points,
+          options: {
+            compat_mode: compat_mode,
+            include_uncertain_reason: include_uncertain_reason === true,
+          },
+        });
+        decisions = engineResult.decisions.map((d) => serializeDecisionForResponse(d, {
+          includeUncertainReason: include_uncertain_reason === true,
+        }));
+        if (engineResult.alignments) {
+          alignments = engineResult.alignments.map((a) => serializeAlignmentForResponse(a, {
+            includeUncertainReason: include_uncertain_reason === true,
+          }));
+        }
       }
     } catch (engineError) {
       console.error(JSON.stringify({
@@ -332,18 +373,6 @@ export default async function handler(req, res) {
     let markingResult = null;
     const requestScopedPartId = part_id;
     const requestScopedSubpartId = subpart_id ?? subpart ?? null;
-    const runtimeAuthorityPosture = buildRuntimeAuthorityPosture(
-      resolveReleasedScoringPosture({
-        questionTypeId: questionContext.question_type_id,
-        questionTypeReleaseState: questionContext.question_type_release_state,
-        candidateRubricRefs: questionContext.candidate_rubric_refs,
-        classificationConfidence: questionContext.classification_confidence,
-        uncertaintyValidated: true,
-      }),
-      {
-        questionContext,
-      },
-    );
 
     try {
       const baseMarkingResult = buildMarkingResult({
@@ -379,6 +408,7 @@ export default async function handler(req, res) {
           rubric_rows_used,
           marking_result: baseMarkingResult,
           authority_posture: runtimeAuthorityPosture,
+          runtime_execution: runtimeExecution,
         },
       });
 
@@ -527,6 +557,7 @@ export default async function handler(req, res) {
       decisions,
       ledger_write_status,
       marking_result: markingResult,
+      marking_runtime: runtimeExecution,
     };
 
     if (learningEffects) {

--- a/api/marking/lib/rubric-resolver-v1.js
+++ b/api/marking/lib/rubric-resolver-v1.js
@@ -2,6 +2,11 @@
 // Rubric Resolver v1 — version selection + ready data fetch.
 // Implements design §2.2 (version selection on base table) and §5.3 (SQL).
 
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolvePilotMarkingTemplateBinding } from '../../learning/lib/subjects/subject-adapter-registry.js';
+
 // ── Custom error classes ────────────────────────────────────────────────────
 
 export class RubricNotReadyError extends Error {
@@ -26,6 +31,76 @@ export class RubricContractInvalidError extends Error {
 // ── Contract validation ─────────────────────────────────────────────────────
 
 const CONTRACT_REQUIRED_FIELDS = ['rubric_id', 'mark_label', 'kind', 'depends_on', 'marks'];
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(MODULE_DIR, '../../..');
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function loadPilotRubricTemplate(templatePath) {
+  const absolutePath = path.join(PROJECT_ROOT, templatePath);
+  return JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+}
+
+function collectPilotAdapterMethods(template = {}) {
+  const methods = new Set();
+
+  function visit(parts = []) {
+    for (const part of normalizeArray(parts)) {
+      for (const point of normalizeArray(part?.points)) {
+        const adapterMethod = normalizeString(point?.verification_condition?.adapter_method);
+        if (adapterMethod) {
+          methods.add(adapterMethod);
+        }
+      }
+
+      if (Array.isArray(part?.subparts)) {
+        visit(part.subparts);
+      }
+    }
+  }
+
+  visit(template?.parts);
+  return [...methods].sort();
+}
+
+function resolvePilotTemplateMetadata({
+  subject_code = null,
+  question_type_id = null,
+  candidate_rubric_refs = [],
+  pilot_runtime_enabled = false,
+} = {}) {
+  if (!pilot_runtime_enabled) {
+    return {
+      pilot_rubric_template: null,
+      pilot_adapter_methods: [],
+    };
+  }
+
+  const binding = resolvePilotMarkingTemplateBinding({
+    subjectCode: subject_code,
+    questionTypeId: question_type_id,
+    candidateRubricRefs: candidate_rubric_refs,
+  });
+
+  if (!binding) {
+    return {
+      pilot_rubric_template: null,
+      pilot_adapter_methods: [],
+    };
+  }
+
+  const pilotRubricTemplate = loadPilotRubricTemplate(binding.rubric_template_path);
+  return {
+    pilot_rubric_template: pilotRubricTemplate,
+    pilot_adapter_methods: collectPilotAdapterMethods(pilotRubricTemplate),
+  };
+}
 
 /**
  * Validate that every rubric point has the required contract fields.
@@ -177,11 +252,25 @@ async function fetchReadyPoints(supabase, storageKey, qNumber, subpartNorm, sour
  * @param {number} params.q_number
  * @param {string|null|undefined} params.subpart
  * @param {string|null|undefined} params.rubric_source_version - optional pinned version
- * @returns {Promise<{ rubric_source_version: string, rubric_points: object[], rubric_rows_used: number }>}
+ * @param {string|null|undefined} params.subject_code
+ * @param {string|null|undefined} params.question_type_id
+ * @param {object[]} [params.candidate_rubric_refs]
+ * @param {boolean} [params.pilot_runtime_enabled]
+ * @returns {Promise<{ rubric_source_version: string, rubric_points: object[], rubric_rows_used: number, pilot_rubric_template: object|null, pilot_adapter_methods: string[] }>}
  * @throws {RubricNotReadyError} 409 — no ready rubric found
  * @throws {RubricContractInvalidError} 422 — contract fields missing
  */
-export async function resolveRubric({ supabase, storage_key, q_number, subpart, rubric_source_version }) {
+export async function resolveRubric({
+  supabase,
+  storage_key,
+  q_number,
+  subpart,
+  rubric_source_version,
+  subject_code = null,
+  question_type_id = null,
+  candidate_rubric_refs = [],
+  pilot_runtime_enabled = false,
+}) {
   const subpartNorm = subpart ?? '';
 
   let selectedVersion;
@@ -219,6 +308,16 @@ export async function resolveRubric({ supabase, storage_key, q_number, subpart, 
     );
   }
 
+  const {
+    pilot_rubric_template,
+    pilot_adapter_methods,
+  } = resolvePilotTemplateMetadata({
+    subject_code,
+    question_type_id,
+    candidate_rubric_refs,
+    pilot_runtime_enabled,
+  });
+
   // Audit log
   console.log(JSON.stringify({
     event: 'rubric_resolved',
@@ -227,6 +326,8 @@ export async function resolveRubric({ supabase, storage_key, q_number, subpart, 
     subpart: subpartNorm,
     rubric_source_version: selectedVersion,
     rubric_rows_used: points.length,
+    pilot_template_bound: Boolean(pilot_rubric_template),
+    pilot_adapter_methods,
     ts: new Date().toISOString(),
   }));
 
@@ -234,5 +335,7 @@ export async function resolveRubric({ supabase, storage_key, q_number, subpart, 
     rubric_source_version: selectedVersion,
     rubric_points: points,
     rubric_rows_used: points.length,
+    pilot_rubric_template,
+    pilot_adapter_methods,
   };
 }

--- a/docs/reports/2026-04-18-issue-230-pilot-adapter-runtime-coverage-note.md
+++ b/docs/reports/2026-04-18-issue-230-pilot-adapter-runtime-coverage-note.md
@@ -1,0 +1,28 @@
+# Issue 230 Pilot Adapter Runtime Coverage Note
+
+## Scope
+
+This slice wires the approved `9709` pilot rubric templates into the real `evaluate-v1` marking path behind the existing runtime flag surface.
+
+## Approved Runtime Coverage
+
+| Question type | Template path | Adapter methods |
+| --- | --- | --- |
+| `9709.trigonometry.identities` | `data/learning_runtime/pilot_rubrics/9709.trigonometry.identities.json` | `proof_structure_check`, `symbolic_check` |
+| `9709.trigonometry.equations` | `data/learning_runtime/pilot_rubrics/9709.trigonometry.equations.json` | `symbolic_check`, `numeric_check` |
+| `9709.integration.application` | `data/learning_runtime/pilot_rubrics/9709.integration.application.json` | `transform_bundle_check`, `symbolic_check` |
+| `9709.differential_equations.separable` | `data/learning_runtime/pilot_rubrics/9709.differential_equations.separable.json` | `transform_bundle_check`, `numeric_check` |
+
+## Guardrails
+
+- Runtime dispatch stays limited to the four adapter methods above.
+- Pilot template binding only activates when `MARKING_V1_RUNTIME_BRIDGE_ENABLED=true`.
+- Released-rubric metadata is still required before a pilot template is bound.
+- Authoritative vs conservative posture still comes from the existing released-scope and runtime-authority rules; pilot dispatch does not widen that gate.
+
+## Focused Proof
+
+- `api/learning/__tests__/adapter-method-dispatcher.test.js`
+- `api/learning/__tests__/subject-adapter-registry.test.js`
+- `api/marking/__tests__/rubric-resolver-v1.test.js`
+- `api/marking/__tests__/evaluate-v1.test.js`


### PR DESCRIPTION
## Summary
- bind released 9709 pilot rubric template metadata in `rubric-resolver-v1` behind the existing runtime flag surface
- add a narrow pilot adapter dispatcher for `proof_structure_check`, `symbolic_check`, `numeric_check`, and `transform_bundle_check`
- execute the pilot template runtime path in `evaluate-v1` while keeping released-scope and runtime-authority posture unchanged
- add focused runtime dispatch tests plus a compact pilot-family coverage note

Closes #230

## Verification
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/learning/__tests__/subject-adapter-registry.test.js api/learning/__tests__/adapter-method-dispatcher.test.js api/marking/__tests__/rubric-resolver-v1.test.js api/marking/__tests__/evaluate-v1.test.js`