### PR TITLE
fix: address ao quality regressions

### DIFF
--- a/api/learning/__tests__/adapter-method-dispatcher.test.js
+++ b/api/learning/__tests__/adapter-method-dispatcher.test.js
@@ -193,4 +193,72 @@ describe('adapter-method-dispatcher', () => {
       }),
     ]);
   });
+
+  test('keeps trivial trig equations conservative for the released identities pilot template', async () => {
+    const { runPilotAdapterRuntime } = await import('../lib/marking/adapter-method-dispatcher.js');
+
+    const template = {
+      question_type_id: '9709.trigonometry.identities',
+      parts: [
+        {
+          part_id: 'main',
+          points: [
+            {
+              point_id: 'identity-rewrite',
+              official_mark_notation: 'M1',
+              mark_family: 'M',
+              max_score: 1,
+              verification_condition: {
+                kind: 'adapter_call',
+                adapter_method: 'proof_structure_check',
+                params: {
+                  requires_identity_rewrite: true,
+                },
+              },
+            },
+            {
+              point_id: 'identity-result',
+              official_mark_notation: 'A1',
+              mark_family: 'A',
+              max_score: 1,
+              verification_condition: {
+                kind: 'adapter_call',
+                adapter_method: 'symbolic_check',
+                params: {
+                  expects_target_identity: true,
+                },
+              },
+              dependency_chain: {
+                prerequisite_point_ids: ['identity-rewrite'],
+                prerequisite_policy: 'all',
+                strict: true,
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = runPilotAdapterRuntime({
+      rubricTemplate: template,
+      studentSteps: [
+        { step_id: 's1', text: 'sin x = 0' },
+      ],
+    });
+
+    expect(result.decisions).toEqual([
+      expect.objectContaining({
+        rubric_id: 'identity-rewrite',
+        reason: 'pilot_adapter_mismatch',
+        awarded: false,
+        awarded_marks: 0,
+      }),
+      expect.objectContaining({
+        rubric_id: 'identity-result',
+        reason: 'dependency_not_met',
+        awarded: false,
+        awarded_marks: 0,
+      }),
+    ]);
+  });
 });

--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -878,6 +878,17 @@ describe('attempt-event-service', () => {
       debt_pending: true,
     });
 
+    records.deliveryRow = {
+      ...records.deliveryRow,
+      delivery_state: 'retrying',
+      last_attempted_at: '2026-04-17T09:59:00.000Z',
+      last_error: {
+        code: 'effect_execution_failed',
+        message: 'review task write failed',
+      },
+      reconciliation_id: null,
+    };
+
     const retried = await reconcileAttemptEventBridgeEffects(
       client,
       {
@@ -945,6 +956,13 @@ describe('attempt-event-service', () => {
         persisted_receipt_count: 3,
       },
     });
+    expect(records.deliveryRow).toMatchObject({
+      delivery_state: 'reconciled',
+      last_error: null,
+      reconciliation_id: 'recon-1',
+      last_attempted_at: expect.any(String),
+    });
+    expect(records.deliveryRow.last_attempted_at).not.toBe('2026-04-17T09:59:00.000Z');
   });
 
   test('downstream-effect read failures after persisted event writes do not downgrade the delivery row', async () => {

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -1210,6 +1210,18 @@ export async function reconcileAttemptEventBridgeEffects(client, {
     completed_at: timestamp,
   });
 
+  if (learningEffects.effect_execution.ok) {
+    await updateAttemptEventBridgeDelivery(client, {
+      stableIdempotencyKey,
+      patch: {
+        delivery_state: 'reconciled',
+        last_attempted_at: timestamp,
+        last_error: null,
+        reconciliation_id: run?.reconciliation_run_id ?? null,
+      },
+    });
+  }
+
   return {
     reconciliation_run_id: run?.reconciliation_run_id ?? null,
     status: run?.status ?? (learningEffects.effect_execution.ok ? 'completed' : 'failed'),

--- a/api/learning/lib/marking/adapter-method-dispatcher.js
+++ b/api/learning/lib/marking/adapter-method-dispatcher.js
@@ -36,6 +36,45 @@ function hasIntegralSignal(text) {
   return hasAny(text, [/\bintegral\b/, /∫/, /\bln\b/, /\+ c\b/, /\banti-?derivative\b/]);
 }
 
+function hasIdentityRewriteVocabulary(text) {
+  return hasAny(text, [
+    /\bidentity\b/,
+    /\brewrite\b/,
+    /\blhs\b/,
+    /\brhs\b/,
+    /\bsimplif/,
+    /\bexpand/,
+    /\bfactor/,
+    /\bsubstitut/,
+    /\bequivalent\b/,
+  ]);
+}
+
+function hasTrigIdentityStructure(text) {
+  return hasAny(text, [
+    /\bsin\^?2\b.*\bcos\^?2\b/,
+    /\bcos\^?2\b.*\bsin\^?2\b/,
+    /\btan\^?2\b/,
+    /\bsec\^?2\b/,
+    /\bcosec\^?2\b/,
+    /\bcot\^?2\b/,
+    /\b1\s*\+\s*tan\b/,
+    /\b1\s*\+\s*cot\b/,
+    /\b2\s*sin\b.*\bcos\b/,
+  ]);
+}
+
+function hasTargetIdentityResultSignal(text) {
+  return hasAny(text, [
+    /\btarget identity\b/,
+    /\bidentity\b.*\b(proved|shown|verified|holds)\b/,
+    /\b(proved|shown|verified)\b.*\bidentity\b/,
+    /\bas required\b/,
+    /\bhence\b.*\b(identity|result)\b/,
+    /\btherefore\b.*\b(identity|result)\b/,
+  ]);
+}
+
 function hasSubstitutionSignal(text) {
   return hasAny(text, [/\blet\s+[a-z]\s*=/, /\bu\s*=/, /\bsubstitut/, /\bchange of variable/]);
 }
@@ -63,10 +102,20 @@ function hasNumericSignal(text) {
 function scoreMethodMatch(adapterMethod, params = {}, text) {
   switch (adapterMethod) {
     case 'proof_structure_check':
-      return hasTrigSignal(text) && hasEquationSignal(text) ? 0.94 : 0;
+      return hasTrigSignal(text)
+        && hasEquationSignal(text)
+        && (hasTrigIdentityStructure(text) || hasIdentityRewriteVocabulary(text))
+        ? 0.94
+        : 0;
     case 'symbolic_check':
       if (params?.expects_target_identity === true) {
-        return hasTrigSignal(text) && hasEquationSignal(text) ? 0.93 : 0;
+        return hasTrigSignal(text)
+          && (
+            hasTargetIdentityResultSignal(text)
+            || (hasEquationSignal(text) && hasTrigIdentityStructure(text))
+          )
+          ? 0.93
+          : 0;
       }
       if (params?.checks === 'base_trigonometric_equation') {
         return hasTrigSignal(text) && hasEquationSignal(text) ? 0.92 : 0;

--- a/api/lib/supabase/__tests__/pg-compat-client.test.js
+++ b/api/lib/supabase/__tests__/pg-compat-client.test.js
@@ -56,6 +56,50 @@ describe('pg-compat-client', () => {
     );
   });
 
+  test('supports select.in(...).eq(...) chains for batched current-content filters', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          artifact_content_version_id: 'content-1',
+          artifact_id: 'artifact-1',
+          is_current: true,
+        },
+        {
+          artifact_content_version_id: 'content-2',
+          artifact_id: 'artifact-2',
+          is_current: true,
+        },
+      ],
+    });
+
+    const client = getPgCompatClient();
+    const result = await client
+      .from('learning_artifact_content_versions')
+      .select('*')
+      .in('artifact_id', ['artifact-1', 'artifact-2'])
+      .eq('is_current', true);
+
+    expect(result).toEqual({
+      data: [
+        {
+          artifact_content_version_id: 'content-1',
+          artifact_id: 'artifact-1',
+          is_current: true,
+        },
+        {
+          artifact_content_version_id: 'content-2',
+          artifact_id: 'artifact-2',
+          is_current: true,
+        },
+      ],
+      error: null,
+    });
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('t."artifact_id" IN ($1, $2) AND t."is_current" = $3'),
+      ['artifact-1', 'artifact-2', true],
+    );
+  });
+
   test('casts learning snapshot, question event, and question bank JSONB fields explicitly', async () => {
     mockQuery
       .mockResolvedValueOnce({

--- a/api/lib/supabase/pg-compat-client.js
+++ b/api/lib/supabase/pg-compat-client.js
@@ -135,13 +135,34 @@ function buildWhereClause(tableAlias, filters, table, startingIndex = 1) {
 
   for (const filter of filters) {
     const columnSql = `${tableAlias}.${quoteIdent(filter.column)}`;
+    const filterType = filter.type || 'eq';
+
+    if (filterType === 'in') {
+      const normalizedValues = Array.isArray(filter.values)
+        ? filter.values.map((value) => normalizeParameterValue(table, filter.column, value))
+        : [];
+
+      if (normalizedValues.length === 0) {
+        clauses.push('FALSE');
+        continue;
+      }
+
+      const placeholders = normalizedValues.map((value) => {
+        values.push(value);
+        return buildPlaceholder(table, filter.column, startingIndex + values.length - 1);
+      });
+
+      clauses.push(`${columnSql} IN (${placeholders.join(', ')})`);
+      continue;
+    }
+
     if (filter.value === null) {
       clauses.push(`${columnSql} IS NULL`);
       continue;
     }
 
     values.push(normalizeParameterValue(table, filter.column, filter.value));
-    clauses.push(`${columnSql} = $${startingIndex + values.length - 1}`);
+    clauses.push(`${columnSql} = ${buildPlaceholder(table, filter.column, startingIndex + values.length - 1)}`);
   }
 
   return {
@@ -240,12 +261,17 @@ class PgCompatQueryBuilder {
   }
 
   eq(column, value) {
-    this.filters.push({ column, value });
+    this.filters.push({ type: 'eq', column, value });
     return this;
   }
 
   is(column, value) {
-    this.filters.push({ column, value });
+    this.filters.push({ type: 'is', column, value });
+    return this;
+  }
+
+  in(column, values) {
+    this.filters.push({ type: 'in', column, values });
     return this;
   }
 

--- a/api/marking/__tests__/evaluate-v1.test.js
+++ b/api/marking/__tests__/evaluate-v1.test.js
@@ -738,6 +738,66 @@ describe('learning-runtime orchestration', () => {
     );
   });
 
+  it('keeps released 9709 pilot runtime grading conservative for a trivial trig equation', async () => {
+    process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'true';
+    learningQuestionProjectionRow = buildLearningQuestionProjectionRow({
+      primary_topic_id: 'topic-trig-identities',
+      primary_question_type_id: '9709.trigonometry.identities',
+      candidate_rubric_refs: [
+        {
+          kind: 'rubric_release',
+          rubric_set_id: '9709.trigonometry.identities',
+          rubric_version_id: 'trig-identities-v1',
+          release_state: 'released',
+        },
+      ],
+    });
+    mockReadyPoints = [
+      buildReadyPoint({
+        rubric_id: 'identity-rewrite',
+        mark_label: 'M1',
+        description: 'Identity rewrite',
+      }),
+      buildReadyPoint({
+        rubric_id: 'identity-result',
+        mark_label: 'A1',
+        description: 'Identity result',
+        step_index: 2,
+      }),
+    ];
+
+    const req = mockReq({
+      body: {
+        ...mockReq().body,
+        student_steps: [
+          { step_id: 's1', text: 'sin x = 0' },
+        ],
+      },
+    });
+    const res = mockRes();
+
+    await handler(req, res);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.decisions).toEqual([
+      expect.objectContaining({
+        rubric_id: 'identity-rewrite',
+        mark_label: 'M1',
+        reason: 'pilot_adapter_mismatch',
+        awarded: false,
+        awarded_marks: 0,
+      }),
+      expect.objectContaining({
+        rubric_id: 'identity-result',
+        mark_label: 'A1',
+        reason: 'dependency_not_met',
+        awarded: false,
+        awarded_marks: 0,
+      }),
+    ]);
+    expect(body.marking_result.marking_summary.total_awarded).toBe(0);
+  });
+
   it('keeps pilot adapter execution conservative when released-scope posture fails closed', async () => {
     process.env.MARKING_V1_RUNTIME_BRIDGE_ENABLED = 'true';
     learningQuestionProjectionRow = buildLearningQuestionProjectionRow({


### PR DESCRIPTION
## Summary
- restore `pg-compat` support for batched artifact current-content queries by implementing `.in(...)`
- persist settled delivery state and `reconciliation_id` after successful attempt-event effect reconciliation
- make the 9709 pilot trig adapter fail closed on weak evidence like `sin x = 0`

## Tests
- `node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand api/lib/supabase/__tests__/pg-compat-client.test.js api/learning/__tests__/artifact-repository.test.js api/learning/__tests__/artifact-content-repository.test.js api/learning/__tests__/attempt-event-service.test.js api/learning/__tests__/adapter-method-dispatcher.test.js api/marking/__tests__/evaluate-v1.test.js src/components/learning-runtime/__tests__/view-models.test.js`

## Validation
- 7 test suites passed
- 75 tests passed
- 0 failures
