### PR TITLE
fix: calibrate Wave A q02 diagram routing

### DIFF
--- a/docs/reports/2026-04-20-issue-253-wave-a-review-lane-remediation.md
+++ b/docs/reports/2026-04-20-issue-253-wave-a-review-lane-remediation.md
@@ -1,0 +1,125 @@
+# Issue 253: Wave A Bounded Review-Lane Remediation
+
+Date: 2026-04-20
+Issue: `#253`
+Status: code fix landed, targeted verification pass, local baseline gate rerun blocked by current branch data state
+
+## Scope
+
+Bound the change to the single Wave A shard-3 follow-up case:
+
+- `9709/s22_qp_13/questions/q02.png`
+
+No prompt changes, schema changes, or general threshold softening were introduced.
+
+## Source Evidence
+
+Authoritative Wave A evidence remains the closeout line recorded in commit `4427c35` / `origin/feat/242`.
+
+- `git show 4427c35:docs/reports/2026-04-19-9709-wave-a-closeout-summary.json`
+  - `shard3_follow_up_cases = ["9709/s22_qp_13/questions/q02.png"]`
+  - `baseline_gate_result.pass = true`
+  - `baseline_gate_result.metrics = {"exact_structured_match_rate":1,"subject_leakage_rate":0,"metadata_completeness_rate":1,"null_summary_rate":0}`
+- `git show 4427c35:docs/reports/2026-04-19-9709-wave-a-shard3-full-review.json`
+  - the row was routed as `review_lane`
+  - deterministic review marked `route_verdict = "over_conservative"`
+- `git show 4427c35:data/manifests/9709_question_search_expansion_wave_a_v1.json`
+  - the manifest row already carried:
+    - `route_hint = "diagram_lane"`
+    - `diagram_present = true`
+    - `formula_dense = false`
+    - `table_heavy = false`
+    - `surface_evidence_status = "verified_primary_asset"`
+    - `gate_critical = true`
+    - `requires_review` absent / false in the repaired execution line
+
+That combination shows the row was gate-critical, but not unknown-surface and not review-flagged. The remaining over-conservative behavior came from the blanket `gate_critical -> review_lane` override.
+
+## Remediation
+
+Added a narrow routing exception in both runtime copies of the router:
+
+- `scripts/vlm/qwen_router_v1.py`
+- `scripts/learning/lib/question-evidence-bundle-v1.js`
+
+The exception applies only when all of the following are true:
+
+- `gate_critical === true`
+- `requires_review === false`
+- `route_hint === "diagram_lane"`
+- `diagram_present === true`
+- `formula_dense === false`
+- `table_heavy === false`
+- `surface_evidence_status === "verified_primary_asset"`
+
+When that predicate holds, the row uses `diagram_lane` instead of the generic `review_lane` override.
+
+Guard behavior remains unchanged for:
+
+- gate-critical unknown-surface rows
+- non-gate rows that still need extraction-first OCR before any review posture
+
+## Regression Coverage
+
+Added targeted regressions for the exact Wave A posture:
+
+- `tests/test_qwen_router_v1.py`
+- `scripts/learning/__tests__/question-evidence-bundle-v1.test.js`
+
+The new tests assert that the `9709/s22_qp_13/questions/q02.png` posture resolves to `diagram_lane`, while existing review-lane guard cases stay unchanged.
+
+## Verification
+
+Fresh commands run in this worktree:
+
+```bash
+python3 -m venv .venv-issue253
+.venv-issue253/bin/pip install pytest
+.venv-issue253/bin/pytest tests/test_qwen_router_v1.py -q
+```
+
+Result:
+
+- pass
+- `6 passed in 0.05s`
+
+```bash
+npm install
+npm test -- --runInBand scripts/learning/__tests__/question-evidence-bundle-v1.test.js
+```
+
+Result:
+
+- pass
+- `7 passed, 7 total`
+
+Direct behavior checks also passed for:
+
+- fixed case -> `diagram_lane`
+- gate-critical unknown-surface guard -> `review_lane`
+- non-gate extraction-first guard -> `ocr_lane`
+
+Baseline gate rerun attempted:
+
+```bash
+node scripts/evaluation/run_question_search_gate.js \
+  --fixture data/eval/question_search_gold_9709_v1.json \
+  --report /tmp/issue-253-baseline-gate-report.md \
+  --json-out /tmp/issue-253-baseline-gate.json \
+  --psql-mode docker
+```
+
+Result:
+
+- fail in the current `main`-based branch state
+- reported metrics:
+  - `exact_structured_match_rate = 0.8`
+  - `subject_leakage_rate = 0`
+  - `metadata_completeness_rate = 0.8421`
+  - `null_summary_rate = 0.3333`
+
+Interpretation:
+
+- this fix does not widen the baseline gate and does not touch the question-search runtime or DB content used by that gate
+- the authoritative Wave A closeout evidence in `4427c35` still records the intended green baseline gate for the repaired shard line
+- the fresh local rerun shows the current branch/data surface is not at that historical baseline, so this issue closes the bounded router regression but does not claim a fresh full Wave A re-closeout from `main`

--- a/docs/reports/INDEX.md
+++ b/docs/reports/INDEX.md
@@ -10,6 +10,7 @@
 - `2026-04-03-ao-reviewer-gate-rehearsal.md` - repo-local independent reviewer gate rehearsal showing request, claim, verdict, and durable freeze/release posture.
 - `2026-04-12-phase-a-question-intelligence-slice-1-report.md` - takeover closeout report for the first Phase A question-intelligence slice, including scope, touched modules, focused verification, and residual risks.
 - `2026-04-18-issue-232-scheduler-factor-coverage-report.md` - compact factor-coverage and verification report for the bounded `9709` scheduler-core upgrade on issue `#232`.
+- `2026-04-20-issue-253-wave-a-review-lane-remediation.md` - bounded fix report for the remaining Wave A shard-3 over-conservative review-lane case on `9709/s22_qp_13/questions/q02.png`.
 - `ao_codex_work_dossier_2026-03-26.md` - issue-by-issue reconstruction of prior AO and Codex work, with branch-vs-mainline divergence notes.
 - `prd_progress_report_2026-03-16.md` - PRD-aligned project progress assessment after recovery, including current stage, recovery impact, and parallel workstreams.
 - `learning_runtime_9709_integration_application_promotion_2026-03-24.md` - evidence-first justification for promoting `9709.integration.application` into released runtime scoring while keeping broader integration scope conservative.

--- a/scripts/learning/__tests__/question-evidence-bundle-v1.test.js
+++ b/scripts/learning/__tests__/question-evidence-bundle-v1.test.js
@@ -365,6 +365,43 @@ describe('question evidence bundle v1', () => {
     });
   });
 
+  test('uses diagram lane for the verified gate-critical shard-3 trigonometry diagram case', () => {
+    const bundles = buildQuestionEvidenceBundlesV1({
+      manifest: buildManifest([
+        {
+          storage_key: '9709/s22_qp_13/questions/q02.png',
+          syllabus_code: '9709',
+          year: 2022,
+          session: 's',
+          paper: 1,
+          variant: 3,
+          q_number: 2,
+          primary_topic_path: '9709.p1.trigonometry',
+          route_hint: 'diagram_lane',
+          diagram_present: true,
+          formula_dense: false,
+          table_heavy: false,
+          surface_evidence_status: 'verified_primary_asset',
+          gate_critical: true,
+          requires_review: false,
+        },
+      ]),
+      laneOutputs: [],
+    });
+
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0].route).toMatchObject({
+      route: 'diagram_lane',
+      model: 'qwen3-vl-plus',
+    });
+    expect(bundles[0].route.decision_reasons).toEqual(
+      expect.arrayContaining(['gate_critical', 'diagram_present']),
+    );
+    expect(bundles[0].lazy_attach_reasons).toEqual(
+      expect.arrayContaining(['route_requires_original_image', 'gate_critical']),
+    );
+  });
+
   test('summarizes route and lazy-attach counts for a bundle set', () => {
     const bundles = buildQuestionEvidenceBundlesV1({
       manifest: buildManifest([

--- a/scripts/learning/lib/question-evidence-bundle-v1.js
+++ b/scripts/learning/lib/question-evidence-bundle-v1.js
@@ -70,6 +70,16 @@ function surfaceFlagsUnknown(item) {
   return SURFACE_FLAGS.some((field) => item?.[field] === null || typeof item?.[field] === 'undefined');
 }
 
+function shouldUseDiagramLaneForVerifiedGateCriticalRow(manifestItem) {
+  return manifestItem.gate_critical === true
+    && manifestItem.requires_review === false
+    && manifestItem.route_hint === 'diagram_lane'
+    && manifestItem.diagram_present === true
+    && manifestItem.formula_dense === false
+    && manifestItem.table_heavy === false
+    && manifestItem.surface_evidence_status === 'verified_primary_asset';
+}
+
 function buildRouteDecision(route, decisionReasons, contract) {
   const routeContract = contract.routes?.[route];
   const runtime = contract.runtime_freeze ?? {};
@@ -107,6 +117,10 @@ export function resolveQuestionEvidenceRoute(manifestItem = {}, contract = loadR
   const unknownSurface = surfaceFlagsUnknown(manifestItem);
   if (unknownSurface) {
     reasons.push('unknown_surface_flags');
+  }
+
+  if (shouldUseDiagramLaneForVerifiedGateCriticalRow(manifestItem)) {
+    return buildRouteDecision('diagram_lane', [...reasons, 'diagram_present'], contract);
   }
 
   if (manifestItem.gate_critical) {

--- a/scripts/vlm/qwen_router_v1.py
+++ b/scripts/vlm/qwen_router_v1.py
@@ -73,6 +73,18 @@ def _surface_flags_unknown(item: dict[str, Any]) -> bool:
     return any(item.get(field) is None for field in SURFACE_FLAGS)
 
 
+def _should_use_diagram_lane_for_verified_gate_critical_row(item: dict[str, Any]) -> bool:
+    return (
+        item.get("gate_critical") is True
+        and item.get("requires_review") is False
+        and item.get("route_hint") == "diagram_lane"
+        and item.get("diagram_present") is True
+        and item.get("formula_dense") is False
+        and item.get("table_heavy") is False
+        and item.get("surface_evidence_status") == "verified_primary_asset"
+    )
+
+
 def build_route_decision(
     route: str,
     decision_reasons: list[str],
@@ -123,6 +135,9 @@ def route_manifest_item(
     surface_flags_unknown = _surface_flags_unknown(item)
     if surface_flags_unknown:
         reasons.append("unknown_surface_flags")
+
+    if _should_use_diagram_lane_for_verified_gate_critical_row(item):
+        return build_route_decision("diagram_lane", [*reasons, "diagram_present"], scope)
 
     if item.get("gate_critical"):
         return build_route_decision("review_lane", reasons, scope)

--- a/tests/test_qwen_router_v1.py
+++ b/tests/test_qwen_router_v1.py
@@ -55,6 +55,30 @@ def test_route_manifest_item_prefers_review_lane_for_gate_critical_unknown_surfa
     assert "unknown_surface_flags" in decision.decision_reasons
 
 
+def test_route_manifest_item_uses_diagram_lane_for_verified_gate_critical_diagram_row():
+    decision = route_manifest_item(
+        _item(
+            storage_key="9709/s22_qp_13/questions/q02.png",
+            year=2022,
+            paper=1,
+            variant=3,
+            route_hint="diagram_lane",
+            diagram_present=True,
+            formula_dense=False,
+            table_heavy=False,
+            gate_critical=True,
+            requires_review=False,
+            surface_evidence_status="verified_primary_asset",
+        )
+    )
+
+    assert decision.route == "diagram_lane"
+    assert decision.lane == "diagram"
+    assert decision.model == "qwen3-vl-plus"
+    assert "gate_critical" in decision.decision_reasons
+    assert "diagram_present" in decision.decision_reasons
+
+
 def test_route_manifest_item_selects_diagram_lane_for_evidence_backed_diagram_rows():
     decision = route_manifest_item(
         _item(


### PR DESCRIPTION
## Summary
- calibrate the bounded Wave A router so the verified gate-critical diagram case `9709/s22_qp_13/questions/q02.png` uses `diagram_lane` instead of the blanket `review_lane` override
- add Python and JS regressions for the exact shard-3 posture plus unchanged guard cases
- check in an issue-specific remediation report with the authoritative `4427c35` evidence and exact verification commands/results

## Verification
- `.venv-issue253/bin/pytest tests/test_qwen_router_v1.py -q`
- `npm test -- --runInBand scripts/learning/__tests__/question-evidence-bundle-v1.test.js`
- `node scripts/evaluation/run_question_search_gate.js --fixture data/eval/question_search_gold_9709_v1.json --report /tmp/issue-253-baseline-gate-report.md --json-out /tmp/issue-253-baseline-gate.json --psql-mode docker` (fails on the current main-based branch data state: exact structured match 0.8, metadata completeness 0.8421, null summary rate 0.3333)

## Notes
- authoritative Wave A closeout evidence is read from `4427c35` / `origin/feat/242`; the branch intentionally does not restore those broad artifacts
- this PR keeps scope to the single bounded review-lane calibration and does not widen prompt/schema behavior

Closes #253.
