### PR TITLE
fix: persist downstream effect retry state in runtime bridge

### DIFF
--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -570,6 +570,20 @@ describe('attempt-event-service', () => {
         },
       },
     });
+    expect(result.delivery).toMatchObject({
+      delivery_state: 'retrying',
+      retry_count: 1,
+      last_error: {
+        code: 'attempt_event_bridge_effect_retry_pending',
+        failed_stage: 'downstream_effect_execution',
+        receipt_summary: {
+          total: 3,
+          persisted: 2,
+          retrying: 1,
+          needs_manual_review: 0,
+        },
+      },
+    });
     expect(await effectRepository.listEffectReceiptsByEventId(records.learningEvents.at(-1).event_id)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -877,16 +891,19 @@ describe('attempt-event-service', () => {
       status: 'partial_failure',
       debt_pending: true,
     });
+    expect(records.deliveryRow).toMatchObject({
+      delivery_state: 'retrying',
+      retry_count: 1,
+      last_error: {
+        code: 'attempt_event_bridge_effect_retry_pending',
+        failed_stage: 'downstream_effect_execution',
+      },
+      reconciliation_id: null,
+    });
 
     records.deliveryRow = {
       ...records.deliveryRow,
-      delivery_state: 'retrying',
       last_attempted_at: '2026-04-17T09:59:00.000Z',
-      last_error: {
-        code: 'effect_execution_failed',
-        message: 'review task write failed',
-      },
-      reconciliation_id: null,
     };
 
     const retried = await reconcileAttemptEventBridgeEffects(
@@ -965,7 +982,7 @@ describe('attempt-event-service', () => {
     expect(records.deliveryRow.last_attempted_at).not.toBe('2026-04-17T09:59:00.000Z');
   });
 
-  test('downstream-effect read failures after persisted event writes do not downgrade the delivery row', async () => {
+  test('downstream-effect read failures after persisted event writes mark durable retry debt', async () => {
     const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
     const { client } = createMockClient({
       failLearningEventReads: true,
@@ -984,9 +1001,12 @@ describe('attempt-event-service', () => {
       warningRecorded: false,
       deduped: false,
       delivery: {
-        delivery_state: 'persisted',
-        retry_count: 0,
-        last_error: null,
+        delivery_state: 'retrying',
+        retry_count: 1,
+        last_error: {
+          code: 'attempt_event_bridge_effect_retry_pending',
+          failed_stage: 'downstream_effect_execution',
+        },
       },
       learning_effects: {
         authoritative_scoring_allowed: true,
@@ -1053,9 +1073,12 @@ describe('attempt-event-service', () => {
       warningRecorded: false,
       deduped: false,
       delivery: {
-        delivery_state: 'persisted',
-        retry_count: 0,
-        last_error: null,
+        delivery_state: 'retrying',
+        retry_count: 1,
+        last_error: {
+          code: 'attempt_event_bridge_effect_retry_pending',
+          failed_stage: 'downstream_effect_execution',
+        },
       },
       learning_effects: {
         authoritative_scoring_allowed: false,
@@ -1137,9 +1160,12 @@ describe('attempt-event-service', () => {
       warningRecorded: false,
       deduped: true,
       delivery: {
-        delivery_state: 'persisted',
-        retry_count: 0,
-        last_error: null,
+        delivery_state: 'retrying',
+        retry_count: 1,
+        last_error: {
+          code: 'attempt_event_bridge_effect_retry_pending',
+          failed_stage: 'downstream_effect_execution',
+        },
       },
       learning_effects: {
         authoritative_scoring_allowed: true,
@@ -1157,6 +1183,93 @@ describe('attempt-event-service', () => {
             message: 'learning_update_proposed_event_not_found',
           },
         },
+      },
+    });
+  });
+
+  test('failed downstream-effect reconciliation keeps retry debt visible on the delivery row', async () => {
+    const {
+      persistAttemptEventBridge,
+      reconcileAttemptEventBridgeEffects,
+    } = await import('../lib/events/attempt-event-service.js');
+    const { client, records } = createMockClient();
+    const effectRepository = createInMemoryEffectRepository();
+
+    const first = await persistAttemptEventBridge(
+      client,
+      buildBridgeInput({
+        misconceptionTags: ['sign_error'],
+      }),
+      {
+        applyDownstreamEffects: true,
+        effectRepository,
+        handlers: {
+          mastery: async () => ({
+            status: 'succeeded',
+            result_ref_type: 'family_mastery',
+            result_ref_id: 'family-mastery-1',
+          }),
+          review_tasks: async () => {
+            throw new Error('review task write failed again');
+          },
+          artifact_suggestions: async () => ({
+            status: 'succeeded',
+            result_ref_type: 'artifact',
+            result_ref_id: 'artifact-1',
+          }),
+        },
+      },
+    );
+
+    const retried = await reconcileAttemptEventBridgeEffects(
+      client,
+      {
+        stableIdempotencyKey: first.delivery.stable_idempotency_key,
+      },
+      {
+        effectRepository,
+        handlers: {
+          mastery: async () => ({
+            status: 'succeeded',
+            result_ref_type: 'family_mastery',
+            result_ref_id: 'family-mastery-1',
+          }),
+          review_tasks: async () => {
+            throw new Error('review task write failed again');
+          },
+          artifact_suggestions: async () => ({
+            status: 'succeeded',
+            result_ref_type: 'artifact',
+            result_ref_id: 'artifact-1',
+          }),
+        },
+      },
+    );
+
+    expect(retried).toMatchObject({
+      reconciliation_run_id: 'recon-1',
+      status: 'failed',
+      learning_effects: {
+        effect_execution: {
+          ok: false,
+          status: 'partial_failure',
+          debt_pending: true,
+          receipt_summary: {
+            total: 3,
+            persisted: 2,
+            retrying: 1,
+          },
+        },
+      },
+    });
+    expect(records.deliveryRow).toMatchObject({
+      delivery_state: 'retrying',
+      retry_count: 2,
+      reconciliation_id: 'recon-1',
+      last_error: {
+        code: 'attempt_event_bridge_effect_retry_pending',
+        failed_stage: 'downstream_effect_execution',
+        reconciliation_run_id: 'recon-1',
       },
     });
   });

--- a/api/learning/__tests__/attempt-event-service.test.js
+++ b/api/learning/__tests__/attempt-event-service.test.js
@@ -1274,6 +1274,77 @@ describe('attempt-event-service', () => {
     });
   });
 
+  test('failed downstream-effect reconciliation keeps needs_manual_review sticky when proposal reload fails', async () => {
+    const {
+      reconcileAttemptEventBridgeEffects,
+    } = await import('../lib/events/attempt-event-service.js');
+    const { client, records } = createMockClient({
+      failLearningEventReads: true,
+      existingDeliveryRow: {
+        delivery_id: 'delivery-manual-1',
+        stable_idempotency_key: 'attempt_event_bridge:mr-bridge-1',
+        attempt_id: 'att-bridge-1',
+        learner_id: 'user-bridge-1',
+        subject_code: '9709',
+        mark_run_id: 'mr-bridge-1',
+        truth_revision: 1,
+        delivery_state: 'needs_manual_review',
+        retry_count: 1,
+        last_attempted_at: '2026-04-17T09:59:00.000Z',
+        last_error: {
+          code: 'attempt_event_bridge_effect_retry_pending',
+          failed_stage: 'downstream_effect_execution',
+        },
+        persisted_event_types: [
+          'AttemptSubmitted',
+          'QuestionClassified',
+          'MarkingCompleted',
+          'LearningUpdateProposed',
+        ],
+        persisted_event_ids: [
+          'event-1',
+          'event-2',
+          'event-3',
+          'event-4',
+        ],
+        reconciliation_id: null,
+      },
+    });
+
+    const retried = await reconcileAttemptEventBridgeEffects(
+      client,
+      {
+        stableIdempotencyKey: 'attempt_event_bridge:mr-bridge-1',
+      },
+    );
+
+    expect(retried).toMatchObject({
+      reconciliation_run_id: 'recon-1',
+      status: 'failed',
+      learning_effects: {
+        effect_execution: {
+          ok: false,
+          status: 'failed',
+          debt_pending: true,
+          error: {
+            code: 'effect_execution_failed',
+            message: 'learning_update_proposed_event_not_found',
+          },
+        },
+      },
+    });
+    expect(records.deliveryRow).toMatchObject({
+      delivery_state: 'needs_manual_review',
+      retry_count: 2,
+      reconciliation_id: 'recon-1',
+      last_error: {
+        code: 'attempt_event_bridge_effect_retry_pending',
+        failed_stage: 'downstream_effect_execution',
+        reconciliation_run_id: 'recon-1',
+      },
+    });
+  });
+
   test('retrying a prior pipeline-state failure can recover without re-inserting already-persisted bridge events', async () => {
     const { persistAttemptEventBridge } = await import('../lib/events/attempt-event-service.js');
     const { client, records } = createMockClient({

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -744,9 +744,15 @@ function buildDownstreamEffectDeliveryError(learningEffects = {}, {
   };
 }
 
-function resolveDownstreamEffectDeliveryState(learningEffects = {}) {
+function resolveDownstreamEffectDeliveryState(learningEffects = {}, deliveryRow = {}) {
   const receiptSummary = buildLearningEffectsReceiptSummary(learningEffects?.effect_execution);
-  return receiptSummary.needs_manual_review > 0 ? 'needs_manual_review' : 'retrying';
+  if (receiptSummary.needs_manual_review > 0) {
+    return 'needs_manual_review';
+  }
+
+  return normalizeString(deliveryRow?.delivery_state) === 'needs_manual_review'
+    ? 'needs_manual_review'
+    : 'retrying';
 }
 
 function buildReconciliationSourceRef(deliveryRow = {}) {
@@ -927,7 +933,7 @@ async function settleAttemptEventBridgeDeliveryAfterEffects(client, {
   const effectExecution = learningEffects?.effect_execution ?? {};
   const hasDebt = Boolean(effectExecution?.debt_pending) || !Boolean(effectExecution?.ok);
   const nextState = hasDebt
-    ? resolveDownstreamEffectDeliveryState(learningEffects)
+    ? resolveDownstreamEffectDeliveryState(learningEffects, deliveryRow)
     : (normalizedSuccessState || normalizeString(deliveryRow?.delivery_state) || 'persisted');
   const shouldUpdateForSuccess = !hasDebt
     && (

--- a/api/learning/lib/events/attempt-event-service.js
+++ b/api/learning/lib/events/attempt-event-service.js
@@ -375,6 +375,12 @@ function canRecoverPipelineStateFromDelivery(deliveryRow = {}) {
     && Number(deliveryRow.truth_revision) >= 1;
 }
 
+function canRetryDownstreamEffectsFromDelivery(deliveryRow = {}) {
+  return deliveryRow?.delivery_state === 'retrying'
+    && normalizeString(deliveryRow?.last_error?.failed_stage) === 'downstream_effect_execution'
+    && normalizeArray(deliveryRow?.persisted_event_types).includes('LearningUpdateProposed');
+}
+
 function buildPipelineStateFromDeliveryRow(deliveryRow = {}) {
   const currentStage = getLastPersistedBridgeEventType(deliveryRow);
 
@@ -720,6 +726,29 @@ function buildFallbackLearningEffectsResponseFromDeliveryRow(
   );
 }
 
+function buildDownstreamEffectDeliveryError(learningEffects = {}, {
+  reconciliationRunId = null,
+} = {}) {
+  const effectExecution = learningEffects?.effect_execution ?? {};
+  const receiptSummary = buildLearningEffectsReceiptSummary(effectExecution);
+  const reconciliationId = normalizeString(reconciliationRunId) || null;
+
+  return {
+    code: 'attempt_event_bridge_effect_retry_pending',
+    message:
+      normalizeString(effectExecution?.error?.message)
+      || `downstream effect execution ${normalizeString(effectExecution?.status) || 'failed'}`,
+    failed_stage: 'downstream_effect_execution',
+    receipt_summary: receiptSummary,
+    reconciliation_run_id: reconciliationId,
+  };
+}
+
+function resolveDownstreamEffectDeliveryState(learningEffects = {}) {
+  const receiptSummary = buildLearningEffectsReceiptSummary(learningEffects?.effect_execution);
+  return receiptSummary.needs_manual_review > 0 ? 'needs_manual_review' : 'retrying';
+}
+
 function buildReconciliationSourceRef(deliveryRow = {}) {
   if (normalizeString(deliveryRow.mark_run_id)) {
     return {
@@ -886,6 +915,55 @@ async function executePersistedLearningUpdateEffectsSafely(client, {
   }
 }
 
+async function settleAttemptEventBridgeDeliveryAfterEffects(client, {
+  stableIdempotencyKey,
+  deliveryRow,
+  learningEffects,
+  successState = null,
+  reconciliationId = null,
+} = {}) {
+  const normalizedSuccessState = normalizeString(successState);
+  const normalizedReconciliationId = normalizeString(reconciliationId) || null;
+  const effectExecution = learningEffects?.effect_execution ?? {};
+  const hasDebt = Boolean(effectExecution?.debt_pending) || !Boolean(effectExecution?.ok);
+  const nextState = hasDebt
+    ? resolveDownstreamEffectDeliveryState(learningEffects)
+    : (normalizedSuccessState || normalizeString(deliveryRow?.delivery_state) || 'persisted');
+  const shouldUpdateForSuccess = !hasDebt
+    && (
+      nextState !== normalizeString(deliveryRow?.delivery_state)
+      || deliveryRow?.last_error
+      || (
+        normalizedReconciliationId
+        && normalizedReconciliationId !== normalizeString(deliveryRow?.reconciliation_id)
+      )
+    );
+
+  if (!hasDebt && !shouldUpdateForSuccess) {
+    return deliveryRow;
+  }
+
+  return updateAttemptEventBridgeDelivery(client, {
+    stableIdempotencyKey,
+    patch: {
+      delivery_state: nextState,
+      retry_count: hasDebt
+        ? Number(deliveryRow?.retry_count ?? 0) + 1
+        : Number(deliveryRow?.retry_count ?? 0),
+      last_attempted_at: new Date().toISOString(),
+      last_error: hasDebt
+        ? buildDownstreamEffectDeliveryError(learningEffects, {
+          reconciliationRunId: normalizedReconciliationId,
+        })
+        : null,
+      reconciliation_id:
+        normalizedReconciliationId
+        || normalizeString(deliveryRow?.reconciliation_id)
+        || null,
+    },
+  });
+}
+
 async function reserveAttemptEventBridgeDelivery(client, {
   attemptId,
   learnerId,
@@ -1010,13 +1088,21 @@ export async function persistAttemptEventBridge(client, input = {}, options = {}
             deliveryRow: deliveryReservation.row,
           }, options)
           : null;
+        const replayDelivery = replayLearningEffects
+          ? await settleAttemptEventBridgeDeliveryAfterEffects(client, {
+            stableIdempotencyKey: deliveryReservation.stableIdempotencyKey,
+            deliveryRow: deliveryReservation.row,
+            learningEffects: replayLearningEffects.learningEffects,
+            successState: deliveryReservation.row.delivery_state,
+          })
+          : deliveryReservation.row;
         return {
           ok: true,
           warningRecorded: false,
           deduped: true,
           persisted_event_types: normalizeArray(deliveryReservation.row.persisted_event_types),
           pipeline_state: null,
-          delivery: deliveryReservation.row,
+          delivery: replayDelivery,
           learning_effects: replayLearningEffects?.learningEffects ?? null,
         };
       }
@@ -1030,6 +1116,40 @@ export async function persistAttemptEventBridge(client, input = {}, options = {}
           failed_stage: 'manual_review',
           error_message: 'attempt-event delivery row already requires manual review',
           delivery: deliveryReservation.row,
+        };
+      }
+
+      if (canRetryDownstreamEffectsFromDelivery(deliveryReservation.row)) {
+        if (!options.applyDownstreamEffects) {
+          return {
+            ok: true,
+            warningRecorded: false,
+            deduped: true,
+            persisted_event_types: normalizeArray(deliveryReservation.row.persisted_event_types),
+            pipeline_state: null,
+            delivery: deliveryReservation.row,
+            learning_effects: null,
+          };
+        }
+
+        const replayLearningEffects = await executePersistedLearningUpdateEffectsSafely(client, {
+          deliveryRow: deliveryReservation.row,
+        }, options);
+        const replayDelivery = await settleAttemptEventBridgeDeliveryAfterEffects(client, {
+          stableIdempotencyKey: deliveryReservation.stableIdempotencyKey,
+          deliveryRow: deliveryReservation.row,
+          learningEffects: replayLearningEffects.learningEffects,
+          successState: 'persisted',
+        });
+
+        return {
+          ok: true,
+          warningRecorded: false,
+          deduped: false,
+          persisted_event_types: normalizeArray(deliveryReservation.row.persisted_event_types),
+          pipeline_state: null,
+          delivery: replayDelivery,
+          learning_effects: replayLearningEffects.learningEffects,
         };
       }
 
@@ -1102,6 +1222,14 @@ export async function persistAttemptEventBridge(client, input = {}, options = {}
           events.find((event) => event.event_type === 'LearningUpdateProposed') ?? null,
       }, options)
       : null;
+    const settledDelivery = downstreamLearningEffects
+      ? await settleAttemptEventBridgeDeliveryAfterEffects(client, {
+        stableIdempotencyKey: deliveryReservation.stableIdempotencyKey,
+        deliveryRow: finalizedDelivery,
+        learningEffects: downstreamLearningEffects.learningEffects,
+        successState: 'persisted',
+      })
+      : finalizedDelivery;
 
     return {
       ok: true,
@@ -1109,7 +1237,7 @@ export async function persistAttemptEventBridge(client, input = {}, options = {}
       deduped: false,
       persisted_event_types: events.map((event) => event.event_type),
       pipeline_state: pipelineState,
-      delivery: finalizedDelivery,
+      delivery: settledDelivery,
       learning_effects: downstreamLearningEffects?.learningEffects ?? null,
     };
   } catch (error) {
@@ -1209,18 +1337,13 @@ export async function reconcileAttemptEventBridgeEffects(client, {
     started_at: timestamp,
     completed_at: timestamp,
   });
-
-  if (learningEffects.effect_execution.ok) {
-    await updateAttemptEventBridgeDelivery(client, {
-      stableIdempotencyKey,
-      patch: {
-        delivery_state: 'reconciled',
-        last_attempted_at: timestamp,
-        last_error: null,
-        reconciliation_id: run?.reconciliation_run_id ?? null,
-      },
-    });
-  }
+  await settleAttemptEventBridgeDeliveryAfterEffects(client, {
+    stableIdempotencyKey,
+    deliveryRow,
+    learningEffects,
+    successState: 'reconciled',
+    reconciliationId: run?.reconciliation_run_id ?? null,
+  });
 
   return {
     reconciliation_run_id: run?.reconciliation_run_id ?? null,

--- a/docs/reports/2026-04-21-issue-261-runtime-bridge-reentry-verification.md
+++ b/docs/reports/2026-04-21-issue-261-runtime-bridge-reentry-verification.md
@@ -1,0 +1,147 @@
+# 2026-04-21 Issue 261 Runtime Bridge Re-entry Verification
+
+## Scope
+
+Issue `#261` must be reconciled against the fresh `#259` truth audit and the
+`#260` runtime-effects closeout before claiming any remaining bridge work.
+
+This report records the narrow bridge delta only:
+
+- invoke downstream effects only after attempt-event persistence succeeds
+- preserve the `evaluate-v1` best-effort success contract for student-visible
+  scoring responses
+- surface durable retry debt and reconciliation state on the bridge delivery
+  row instead of hiding it only inside effect receipts or response payloads
+- keep downstream retry deterministic from the persisted
+  `LearningUpdateProposed` event
+
+This report does not widen into scheduler redesign, adapter-runtime redesign,
+artifact rendering behavior, or the broader `#232` / `#233` surfaces.
+
+## Baseline Reconciliation
+
+The fresh `#259` audit and the `#260` closeout already prove that the
+runtime-effects core was materially landed before this branch:
+
+- durable effect receipts already exist on the repo line
+- persisted `LearningUpdateProposed` payloads already exist on the bridge path
+- the real marking/runtime path already invokes `persistAttemptEventBridge`
+  behind the runtime bridge flag
+- deterministic downstream effect replay already exists through
+  `reconcileAttemptEventBridgeEffects`
+
+Current-line proof surfaces already present before this branch:
+
+- `api/marking/evaluate-v1.js`
+- `api/learning/lib/events/attempt-event-service.js`
+- `api/learning/lib/events/learning-effect-engine.js`
+- `api/learning/lib/repositories/learning-event-effect-repository.js`
+- `api/learning/lib/repositories/reconciliation-repository.js`
+- `api/learning/__tests__/attempt-event-service.test.js`
+- `api/marking/__tests__/evaluate-v1.test.js`
+
+The honest remaining delta was narrower than the original issue body implied.
+
+Before this branch:
+
+- downstream effect failure correctly produced retryable effect receipts
+- `evaluate-v1` correctly returned `200` when scoring plus ledger persistence
+  succeeded
+- but the corresponding `learning_event_deliveries` row could remain
+  `persisted` with `last_error = null` after downstream effect execution failed
+  or after persisted proposal-event reload failed
+
+That meant retry debt was visible in effect receipts and the response payload,
+but the delivery row itself could still look clean. For this issue, that was
+the real remaining reconciliation gap.
+
+## Branch Delta
+
+The narrow branch delta is commit:
+
+- `c9f427f` `fix(learning): persist downstream effect retry state`
+
+Files changed for the real remaining delta:
+
+- `api/learning/lib/events/attempt-event-service.js`
+- `api/learning/__tests__/attempt-event-service.test.js`
+
+The branch change does three things:
+
+1. initial downstream effect failure now moves the bridge delivery row into a
+   durable retry posture instead of leaving it `persisted`
+2. replay of a retrying downstream-effect delivery can re-run from the
+   persisted `LearningUpdateProposed` event without duplicating bridge events
+3. reconciliation retries now stamp the delivery row with either:
+   - `reconciled` plus the reconciliation run id on success
+   - continued retry debt plus the reconciliation run id on failure
+
+The scoring contract remains unchanged:
+
+- if scoring and ledger persistence succeed, `evaluate-v1` still returns
+  success even when downstream effects fail
+- bridge failure or partial downstream failure is surfaced as learning-effect
+  debt, not as a student-visible scoring failure
+
+## Fresh Verification
+
+Command run from the AO task worktree:
+
+```bash
+npm test -- --runInBand \
+  api/marking/__tests__/evaluate-v1.test.js \
+  api/learning/__tests__/attempt-event-service.test.js \
+  --verbose
+```
+
+Observed result:
+
+- `PASS`
+- `2` suites passed
+- `43` tests passed
+
+Live GitHub PR state at verification time:
+
+- PR `#268` is open, non-draft, and mergeable
+- all `9` GitHub check runs are passing
+- review state is still empty, so the PR is not yet through the human review
+  gate
+
+## What The Passing Proof Covers
+
+`api/learning/__tests__/attempt-event-service.test.js` proves:
+
+- downstream effects execute only after bridge persistence succeeds
+- initial downstream failures move the delivery row into durable retry state
+- proposal-event reload failures also keep retry debt visible on the delivery
+  row
+- retrying downstream effects reuses the persisted proposal event rather than
+  duplicating bridge events
+- successful reconciliation moves the row to `reconciled`
+- failed reconciliation keeps retry debt visible and records the
+  reconciliation run id
+
+`api/marking/__tests__/evaluate-v1.test.js` proves:
+
+- the real marking/runtime bridge is still called only after successful ledger
+  persistence
+- downstream partial failure does not break the `200` scoring response
+- full attempt-event bridge failure after scoring plus ledger success still
+  does not break the student-visible scoring response
+
+## Conclusion
+
+Issue `#261` was not wholly missing on the current repo line.
+
+The truthful closeout is:
+
+- `#259` and `#260` already covered the landed runtime-effects core
+- this branch closes the remaining delivery-state visibility gap for
+  downstream effect failure and retry
+- no broader runtime, scheduler, or release-gate claim is made here
+
+The remaining honest posture after this branch is:
+
+- PR `#268` is technically green and mergeable
+- explicit human review has not yet happened, so the branch should stay parked
+  in review-hold posture rather than expand scope

--- a/docs/reports/2026-04-21-issue-261-runtime-bridge-reentry-verification.md
+++ b/docs/reports/2026-04-21-issue-261-runtime-bridge-reentry-verification.md
@@ -75,6 +75,8 @@ The branch change does three things:
 3. reconciliation retries now stamp the delivery row with either:
    - `reconciled` plus the reconciliation run id on success
    - continued retry debt plus the reconciliation run id on failure
+4. an existing `needs_manual_review` delivery stays terminal when
+   reconciliation cannot even reload the persisted proposal event
 
 The scoring contract remains unchanged:
 
@@ -98,7 +100,7 @@ Observed result:
 
 - `PASS`
 - `2` suites passed
-- `43` tests passed
+- `44` tests passed
 
 Live GitHub PR state at verification time:
 
@@ -120,6 +122,8 @@ Live GitHub PR state at verification time:
 - successful reconciliation moves the row to `reconciled`
 - failed reconciliation keeps retry debt visible and records the
   reconciliation run id
+- an already-terminal `needs_manual_review` row does not get downgraded back
+  to `retrying` when proposal-event reload fails during reconciliation
 
 `api/marking/__tests__/evaluate-v1.test.js` proves:
 


### PR DESCRIPTION
## Summary
- move downstream effect execution failures into durable `learning_event_deliveries` retry state after attempt-event persistence succeeds
- retry those downstream effect rows deterministically without duplicating bridge events and stamp reconciliation runs back onto the delivery row
- extend attempt-event bridge coverage for partial failure, proposal reload failure, and failed reconciliation retries

## Testing
- npm test -- --runInBand api/marking/__tests__/evaluate-v1.test.js api/learning/__tests__/attempt-event-service.test.js --verbose

Closes #261