### PR TITLE
feat: extract runtime scheduler state machine

### DIFF
--- a/api/learning/__tests__/learning-runtime-state-machine.test.js
+++ b/api/learning/__tests__/learning-runtime-state-machine.test.js
@@ -1,0 +1,101 @@
+import {
+  buildLearningRuntimeBlockedState,
+  buildLearningRuntimeReviewTaskState,
+} from '../lib/orchestration/learning-runtime-state-machine.js';
+
+function buildTask(overrides = {}) {
+  return {
+    review_task_id: 'review-task-1',
+    status: 'open',
+    trigger_type: 'short_delay',
+    due_at: '2026-03-26T08:00:00.000Z',
+    success_criteria: {
+      scheduler_policy: {
+        route: 'short_delay',
+        freshness_bucket: 'cooling',
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('learning runtime state machine', () => {
+  test('immediate repair due now escalates into the repair-critical state', () => {
+    expect(buildLearningRuntimeReviewTaskState(
+      buildTask({
+        trigger_type: 'immediate_repair',
+        due_at: '2026-03-25T10:00:00.000Z',
+        success_criteria: {
+          scheduler_policy: {
+            route: 'immediate_repair',
+            freshness_bucket: 'fresh',
+          },
+        },
+      }),
+      { now: '2026-03-25T10:00:00.000Z' },
+    )).toEqual({
+      value: 'escalated',
+      label: 'Escalated',
+      tone: 'danger',
+      reason_code: 'fresh_immediate_repair',
+      reason_summary: 'Fresh repair evidence should be retried before it is spaced.',
+    });
+  });
+
+  test('overdue spaced work becomes due instead of escalating', () => {
+    expect(buildLearningRuntimeReviewTaskState(
+      buildTask({
+        due_at: '2026-03-25T09:00:00.000Z',
+      }),
+      { now: '2026-03-25T10:00:00.000Z' },
+    )).toEqual({
+      value: 'due',
+      label: 'Due',
+      tone: 'warning',
+      reason_code: 'due_window_open',
+      reason_summary: 'Due because the current review window has opened.',
+    });
+  });
+
+  test('future review work stays deferred until its window opens', () => {
+    expect(buildLearningRuntimeReviewTaskState(
+      buildTask({
+        due_at: '2026-03-25T12:00:00.000Z',
+      }),
+      { now: '2026-03-25T10:00:00.000Z' },
+    )).toEqual({
+      value: 'deferred',
+      label: 'Deferred',
+      tone: 'neutral',
+      reason_code: 'freshness_window',
+      reason_summary: 'Deferred until the next spaced-review freshness window opens.',
+    });
+  });
+
+  test('completed lifecycle status stays completed for projection reads', () => {
+    expect(buildLearningRuntimeReviewTaskState(
+      buildTask({
+        status: 'completed',
+        due_at: null,
+      }),
+      { now: '2026-03-25T10:00:00.000Z' },
+    )).toEqual({
+      value: 'completed',
+      label: 'Completed',
+      tone: 'success',
+      reason_code: null,
+      reason_summary: null,
+    });
+  });
+
+  test('projection overload reasons can block an otherwise active task', () => {
+    expect(buildLearningRuntimeBlockedState('daily_recommendation_cap')).toEqual({
+      value: 'blocked',
+      label: 'Blocked',
+      tone: 'danger',
+      reason_code: 'daily_recommendation_cap',
+      reason_summary:
+        'Blocked by overload control because the canonical queue already has 3 higher-priority tasks.',
+    });
+  });
+});

--- a/api/learning/lib/orchestration/learning-runtime-state-machine.js
+++ b/api/learning/lib/orchestration/learning-runtime-state-machine.js
@@ -1,0 +1,155 @@
+const ACTIVE_REVIEW_TASK_STATUSES = new Set(['open', 'partial']);
+const VALID_TRIGGER_TYPES = new Set([
+  'immediate_repair',
+  'short_delay',
+  'spaced_review',
+  'regression_recovery',
+  'exam_polish',
+]);
+
+const BLOCKED_REASON_SUMMARIES = Object.freeze({
+  daily_recommendation_cap:
+    'Blocked by overload control because the canonical queue already has 3 higher-priority tasks.',
+  high_priority_type_limit:
+    'Blocked because this question type already has a stronger high-priority repair task.',
+});
+
+function normalizeString(value, fallback = null) {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  const normalized = String(value).trim();
+  return normalized || fallback;
+}
+
+function parseTimestamp(value) {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function normalizeRoute(task = {}) {
+  const storedRoute = normalizeString(task?.success_criteria?.scheduler_policy?.route);
+  if (storedRoute && VALID_TRIGGER_TYPES.has(storedRoute)) {
+    return storedRoute;
+  }
+
+  const triggerType = normalizeString(task?.trigger_type);
+  if (triggerType && VALID_TRIGGER_TYPES.has(triggerType)) {
+    return triggerType;
+  }
+
+  return 'short_delay';
+}
+
+function buildStateReason(state, route) {
+  if (state === 'escalated' && route === 'regression_recovery') {
+    return {
+      code: 'regression_recovery_due',
+      summary: 'Escalated because repeated regression needs immediate recovery work.',
+    };
+  }
+
+  if (state === 'escalated') {
+    return {
+      code: 'fresh_immediate_repair',
+      summary: 'Fresh repair evidence should be retried before it is spaced.',
+    };
+  }
+
+  if (state === 'due') {
+    return {
+      code: 'due_window_open',
+      summary: 'Due because the current review window has opened.',
+    };
+  }
+
+  if (state === 'deferred') {
+    return {
+      code: 'freshness_window',
+      summary: 'Deferred until the next spaced-review freshness window opens.',
+    };
+  }
+
+  return null;
+}
+
+export function buildLearningRuntimeBlockedState(reasonCode = null) {
+  const normalizedReasonCode = normalizeString(reasonCode);
+  return {
+    value: 'blocked',
+    label: 'Blocked',
+    tone: 'danger',
+    reason_code: normalizedReasonCode,
+    reason_summary:
+      normalizedReasonCode && BLOCKED_REASON_SUMMARIES[normalizedReasonCode]
+        ? BLOCKED_REASON_SUMMARIES[normalizedReasonCode]
+        : null,
+  };
+}
+
+export function buildLearningRuntimeReviewTaskState(task = {}, options = {}) {
+  const nowDate = parseTimestamp(options.now) || new Date();
+  const route = normalizeRoute(task);
+  const dueAtDate = parseTimestamp(task?.due_at);
+
+  if (!ACTIVE_REVIEW_TASK_STATUSES.has(task?.status)) {
+    return {
+      value: task?.status === 'completed' ? 'completed' : 'open',
+      label: task?.status === 'completed' ? 'Completed' : 'Open',
+      tone: task?.status === 'completed' ? 'success' : 'neutral',
+      reason_code: null,
+      reason_summary: null,
+    };
+  }
+
+  if (
+    (route === 'immediate_repair' || route === 'regression_recovery')
+    && dueAtDate
+    && dueAtDate.getTime() <= nowDate.getTime()
+  ) {
+    const reason = buildStateReason('escalated', route);
+    return {
+      value: 'escalated',
+      label: 'Escalated',
+      tone: 'danger',
+      reason_code: reason.code,
+      reason_summary: reason.summary,
+    };
+  }
+
+  if (dueAtDate && dueAtDate.getTime() <= nowDate.getTime()) {
+    const reason = buildStateReason('due', route);
+    return {
+      value: 'due',
+      label: 'Due',
+      tone: 'warning',
+      reason_code: reason.code,
+      reason_summary: reason.summary,
+    };
+  }
+
+  if (dueAtDate) {
+    const reason = buildStateReason('deferred', route);
+    return {
+      value: 'deferred',
+      label: 'Deferred',
+      tone: 'neutral',
+      reason_code: reason.code,
+      reason_summary: reason.summary,
+    };
+  }
+
+  return {
+    value: 'open',
+    label: 'Open',
+    tone: 'neutral',
+    reason_code: null,
+    reason_summary: null,
+  };
+}

--- a/api/learning/lib/review/review-scheduler-policy.js
+++ b/api/learning/lib/review/review-scheduler-policy.js
@@ -2,6 +2,10 @@ import {
   deriveConfidenceBand,
   normalizeConfidenceBand,
 } from '../question-analysis/low-confidence-posture.js';
+import {
+  buildLearningRuntimeBlockedState,
+  buildLearningRuntimeReviewTaskState,
+} from '../orchestration/learning-runtime-state-machine.js';
 
 const ACTIVE_REVIEW_TASK_STATUSES = new Set(['open', 'partial']);
 const HIGH_PRIORITY_VALUES = new Set(['high', 'urgent']);
@@ -310,38 +314,6 @@ function compareTaskRank(left, right) {
   }
 
   return String(left?.created_at ?? '').localeCompare(String(right?.created_at ?? ''));
-}
-
-function summarizeReasonForState(state, route) {
-  if (state === 'escalated' && route === 'regression_recovery') {
-    return buildReason(
-      'regression_recovery_due',
-      'Escalated because repeated regression needs immediate recovery work.',
-    );
-  }
-
-  if (state === 'escalated') {
-    return buildReason(
-      'fresh_immediate_repair',
-      'Fresh repair evidence should be retried before it is spaced.',
-    );
-  }
-
-  if (state === 'due') {
-    return buildReason(
-      'due_window_open',
-      'Due because the current review window has opened.',
-    );
-  }
-
-  if (state === 'deferred') {
-    return buildReason(
-      'freshness_window',
-      'Deferred until the next spaced-review freshness window opens.',
-    );
-  }
-
-  return null;
 }
 
 function buildStoredPolicy(policy = {}, fallbackReasonCode = null) {
@@ -731,64 +703,7 @@ export function buildReviewTaskSchedulerSeed({
 }
 
 export function buildSchedulerStateFromTask(task = {}, options = {}) {
-  const nowDate = parseTimestamp(options.now) || new Date();
-  const route = normalizeRoute(task);
-  const dueAtDate = parseTimestamp(task?.due_at);
-
-  if (!ACTIVE_REVIEW_TASK_STATUSES.has(task?.status)) {
-    return {
-      value: task?.status === 'completed' ? 'completed' : 'open',
-      label: task?.status === 'completed' ? 'Completed' : 'Open',
-      tone: task?.status === 'completed' ? 'success' : 'neutral',
-      reason_code: null,
-      reason_summary: null,
-    };
-  }
-
-  if (
-    (route === 'immediate_repair' || route === 'regression_recovery')
-    && dueAtDate
-    && dueAtDate.getTime() <= nowDate.getTime()
-  ) {
-    const reason = summarizeReasonForState('escalated', route);
-    return {
-      value: 'escalated',
-      label: 'Escalated',
-      tone: 'danger',
-      reason_code: reason.code,
-      reason_summary: reason.summary,
-    };
-  }
-
-  if (dueAtDate && dueAtDate.getTime() <= nowDate.getTime()) {
-    const reason = summarizeReasonForState('due', route);
-    return {
-      value: 'due',
-      label: 'Due',
-      tone: 'warning',
-      reason_code: reason.code,
-      reason_summary: reason.summary,
-    };
-  }
-
-  if (dueAtDate) {
-    const reason = summarizeReasonForState('deferred', route);
-    return {
-      value: 'deferred',
-      label: 'Deferred',
-      tone: 'neutral',
-      reason_code: reason.code,
-      reason_summary: reason.summary,
-    };
-  }
-
-  return {
-    value: 'open',
-    label: 'Open',
-    tone: 'neutral',
-    reason_code: null,
-    reason_summary: null,
-  };
+  return buildLearningRuntimeReviewTaskState(task, options);
 }
 
 export function summarizeReviewQueueItems(items = []) {
@@ -856,18 +771,11 @@ export function deriveReviewQueueProjection(tasks = [], options = {}) {
       && primaryHighPriorityTaskId
       && primaryHighPriorityTaskId !== task.review_task_id
     ) {
-      task.scheduler_state = {
-        value: 'blocked',
-        label: 'Blocked',
-        tone: 'danger',
-        reason_code: 'high_priority_type_limit',
-        reason_summary:
-          'Blocked because this question type already has a stronger high-priority repair task.',
-      };
+      task.scheduler_state = buildLearningRuntimeBlockedState('high_priority_type_limit');
       task.scheduler_reasons = [
         buildReason(
-          'high_priority_type_limit',
-          'Blocked because this question type already has a stronger high-priority repair task.',
+          task.scheduler_state.reason_code,
+          task.scheduler_state.reason_summary,
         ),
       ];
       continue;
@@ -892,18 +800,11 @@ export function deriveReviewQueueProjection(tasks = [], options = {}) {
     }
 
     if (!recommendedIds.has(task.review_task_id)) {
-      task.scheduler_state = {
-        value: 'blocked',
-        label: 'Blocked',
-        tone: 'danger',
-        reason_code: 'daily_recommendation_cap',
-        reason_summary:
-          'Blocked by overload control because the canonical queue already has 3 higher-priority tasks.',
-      };
+      task.scheduler_state = buildLearningRuntimeBlockedState('daily_recommendation_cap');
       task.scheduler_reasons = [
         buildReason(
-          'daily_recommendation_cap',
-          'Blocked by overload control because the canonical queue already has 3 higher-priority tasks.',
+          task.scheduler_state.reason_code,
+          task.scheduler_state.reason_summary,
         ),
       ];
       continue;

--- a/docs/reports/2026-04-21-issue-263-scheduler-convergence-reentry-report.md
+++ b/docs/reports/2026-04-21-issue-263-scheduler-convergence-reentry-report.md
@@ -1,0 +1,119 @@
+# Issue #263 Scheduler Convergence Re-entry Report
+
+## Scope shipped
+
+This re-entry was reconciled against the current `main` line, the `#259-#262`
+audit baseline, and the already-landed `#232` scheduler-core work before any
+code changes.
+
+Truthful remaining delta for `#263` on this branch:
+
+- keep the already-landed bounded factor model intact on the real `9709`
+  scheduler path
+- keep stable-target active-task dedupe behavior intact
+- land the missing explicit runtime state-machine seam that the audit still
+  reported as absent
+- add focused direct state-transition coverage without widening into unrelated
+  released-scope orchestration fixes
+
+Shipped changes:
+
+- extracted runtime review-task state derivation into
+  `api/learning/lib/orchestration/learning-runtime-state-machine.js`
+- wired `api/learning/lib/review/review-scheduler-policy.js` through that seam
+  for both active-state derivation and blocked-state construction
+- added focused direct coverage in
+  `api/learning/__tests__/learning-runtime-state-machine.test.js`
+- re-verified the existing bounded-factor ranking and stable-target dedupe paths
+  with focused scheduler and generation tests
+
+Changed files:
+
+- `api/learning/lib/orchestration/learning-runtime-state-machine.js`
+- `api/learning/lib/review/review-scheduler-policy.js`
+- `api/learning/__tests__/learning-runtime-state-machine.test.js`
+
+## Verification
+
+1. `npm run workflow:baseline:sync`
+
+Outcome:
+
+```text
+> cie-copilot@0.0.1 workflow:baseline:sync
+> bash scripts/workflow/baseline-sync.sh
+
++ (cd /home/samsen/code/ciecopilot-home && git -C /home/samsen/code/ciecopilot-home fetch origin --prune)
++ (cd /home/samsen/code/ciecopilot-home && git -C /home/samsen/code/ciecopilot-home pull --ff-only)
+hint: Diverging branches can't be fast-forwarded, you need to either:
+hint:
+hint:   git merge --no-ff
+hint:
+hint: or:
+hint:
+hint:   git rebase
+hint:
+hint: Disable this message with "git config advice.diverging false"
+fatal: Not possible to fast-forward, aborting.
+git failed with exit code 128
+```
+
+This was recorded as environment truth only. No repair was attempted from this
+task worktree.
+
+2. `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand --runTestsByPath api/learning/__tests__/learning-runtime-state-machine.test.js --verbose`
+
+Outcome:
+
+```text
+PASS api/learning/__tests__/learning-runtime-state-machine.test.js
+  learning runtime state machine
+    ✓ immediate repair due now escalates into the repair-critical state
+    ✓ overdue spaced work becomes due instead of escalating
+    ✓ future review work stays deferred until its window opens
+    ✓ completed lifecycle status stays completed for projection reads
+    ✓ projection overload reasons can block an otherwise active task
+
+Test Suites: 1 passed, 1 total
+Tests:       5 passed, 5 total
+```
+
+3. `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand --runTestsByPath api/learning/__tests__/review-scheduler-policy.test.js api/learning/__tests__/learning-runtime-state-machine.test.js --verbose`
+
+Outcome:
+
+```text
+PASS api/learning/__tests__/learning-runtime-state-machine.test.js
+PASS api/learning/__tests__/review-scheduler-policy.test.js
+
+Test Suites: 2 passed, 2 total
+Tests:       10 passed, 10 total
+```
+
+4. `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand --runTestsByPath api/learning/__tests__/review-task-service.test.js --testNamePattern "review task service generation" --verbose`
+
+Outcome:
+
+```text
+PASS api/learning/__tests__/review-task-service.test.js
+  review task service generation
+    ✓ fallback review tasks now route through immediate repair with explicit scheduler policy
+    ✓ generated review tasks carry low-band vulnerability into the bounded factor profile
+    ✓ fallback review tasks fold into an existing active repair task instead of growing the queue
+    ✓ stable-target dedupe keeps the stronger bounded factor profile after merge
+    ✓ fallback review tasks keep explicit part/subpart scope in success criteria
+
+Test Suites: 1 passed, 1 total
+Tests:       5 passed, 5 total
+```
+
+## Residual risks / follow-up debt
+
+- The full `api/learning/__tests__/review-task-service.test.js` file still has
+  unrelated released-scope orchestration failures on the current repo line. I
+  did not claim those were fixed here because `#263` owns scheduler convergence,
+  not the released-scope posture regression already recorded in the `#259`
+  audit.
+- `#261` / PR `#268` is still open on GitHub. It did not block this narrow
+  scheduler-state extraction because its write scope is the runtime bridge
+  retry path, not the review scheduler files changed here.


### PR DESCRIPTION
## Summary

This PR completes the honest remaining scheduler-convergence delta for issue #263 after reconciling the issue against current `main` and the #259-#262 re-entry audit baseline. The bounded factor model and stable-target dedupe behavior were already present on the runtime line from the earlier #232 work. The missing piece the audit still called out was an explicit runtime state-machine seam for review-task projection plus focused direct coverage.

The practical user-facing effect is narrow but important for the closed loop: the runtime review queue now derives active and blocked scheduler states through a dedicated state-machine module instead of leaving that logic embedded only inside `review-scheduler-policy.js`. That keeps the real ranking path intact while making the closed-loop state transitions directly testable and reportable.

## Root Cause

The original scheduler-core upgrade landed the bounded factor profile, queue ranking changes, and stable-target dedupe coverage, but the minimal runtime state-machine support described in the issue acceptance remained implicit in inline scheduler-policy code. The #259 audit recorded that gap explicitly by noting the missing `api/learning/lib/orchestration/learning-runtime-state-machine.js` surface and its missing focused test coverage.

## Fix

This change extracts the runtime review-task state derivation into `api/learning/lib/orchestration/learning-runtime-state-machine.js`, including direct support for escalated, due, deferred, completed, and blocked projection states. `api/learning/lib/review/review-scheduler-policy.js` now delegates to that seam for scheduler-state derivation and blocked-state construction, preserving the existing bounded-factor ranking semantics and stable-target queue behavior.

I also added `api/learning/__tests__/learning-runtime-state-machine.test.js` for direct state-transition coverage and checked in `docs/reports/2026-04-21-issue-263-scheduler-convergence-reentry-report.md` with the exact command evidence, including the truthful `workflow:baseline:sync` failure from the preserved root workspace.

## Testing

- `npm run workflow:baseline:sync` *(fails in the preserved root workspace because `git pull --ff-only` cannot fast-forward; recorded truthfully in the report and not repaired from this task worktree)*
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand --runTestsByPath api/learning/__tests__/learning-runtime-state-machine.test.js --verbose`
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand --runTestsByPath api/learning/__tests__/review-scheduler-policy.test.js api/learning/__tests__/learning-runtime-state-machine.test.js --verbose`
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand --runTestsByPath api/learning/__tests__/review-task-service.test.js --testNamePattern "review task service generation" --verbose`

Closes #263
