### PR TITLE
fix(learning): rerun 9709 provider failures

### DIFF
--- a/docs/reports/2026-04-23-9709-provider-failure-rerun-db-state.json
+++ b/docs/reports/2026-04-23-9709-provider-failure-rerun-db-state.json
@@ -1,0 +1,60 @@
+{
+    "snapshot_state": [
+        {
+            "question_id": "261c6168-3d54-4888-8b9d-803952946e61",
+            "storage_key": "9709/s24_qp_13/questions/q09.png",
+            "active_snapshot_id": "1a458e04-7e97-4237-aec5-16bf1bd61306",
+            "snapshot_primary_topic_id": null,
+            "superseded_by_snapshot_id": null,
+            "snapshot_primary_question_type_id": null
+        },
+        {
+            "question_id": "5696277e-d85d-4754-8930-199e7b4b62f3",
+            "storage_key": "9709/s24_qp_33/questions/q09.png",
+            "active_snapshot_id": "65b2dc84-1e23-4b93-a95c-4c95e015d5bd",
+            "snapshot_primary_topic_id": null,
+            "superseded_by_snapshot_id": null,
+            "snapshot_primary_question_type_id": "9709.differential_equations.separable"
+        }
+    ],
+    "question_bank_projection": [
+        {
+            "question_id": "261c6168-3d54-4888-8b9d-803952946e61",
+            "storage_key": "9709/s24_qp_13/questions/q09.png",
+            "prompt_length": 436,
+            "prompt_preview": "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]\n(b) The region shad",
+            "summary_preview": "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]\n(b) The region shad",
+            "primary_topic_id": "dfd05658-a8b8-405a-afc1-ca4f4952b358",
+            "search_text_length": 1370,
+            "search_text_preview": "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]\n(b) The region shad",
+            "release_scope_status": "non_released_fallback",
+            "primary_question_type_id": null,
+            "descriptor_summary_status": "evidence_bundle_summary",
+            "projection_summary_length": 436,
+            "classification_snapshot_id": "1a458e04-7e97-4237-aec5-16bf1bd61306",
+            "projection_summary_preview": "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]\n(b) The region shad",
+            "descriptor_search_text_status": "evidence_bundle_search_text",
+            "projection_search_text_length": 1370,
+            "projection_search_text_preview": "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]\n(b) The region shad"
+        },
+        {
+            "question_id": "5696277e-d85d-4754-8930-199e7b4b62f3",
+            "storage_key": "9709/s24_qp_33/questions/q09.png",
+            "prompt_length": 459,
+            "prompt_preview": "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10,",
+            "summary_preview": "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10,",
+            "primary_topic_id": "ded0f494-64aa-460e-be17-f0f8915a2a47",
+            "search_text_length": 1745,
+            "search_text_preview": "solve differential equation separable differential equation evaluate integral\n\n9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container dec",
+            "release_scope_status": "released_scoring",
+            "primary_question_type_id": "9709.differential_equations.separable",
+            "descriptor_summary_status": "evidence_bundle_summary",
+            "projection_summary_length": 459,
+            "classification_snapshot_id": "65b2dc84-1e23-4b93-a95c-4c95e015d5bd",
+            "projection_summary_preview": "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10,",
+            "descriptor_search_text_status": "evidence_bundle_search_text",
+            "projection_search_text_length": 1745,
+            "projection_search_text_preview": "solve differential equation separable differential equation evaluate integral\n\n9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container dec"
+        }
+    ]
+}

--- a/docs/reports/2026-04-23-9709-provider-failure-rerun-evidence-bundles.json
+++ b/docs/reports/2026-04-23-9709-provider-failure-rerun-evidence-bundles.json
@@ -1,0 +1,200 @@
+{
+  "manifest_id": "9709_provider_failure_rerun_v1",
+  "bundles": [
+    {
+      "schema_version": "question_evidence_bundle_v1",
+      "manifest_id": "9709_provider_failure_rerun_v1",
+      "manifest_position": 0,
+      "storage_key": "9709/s24_qp_13/questions/q09.png",
+      "question_identity": {
+        "subject_code": "9709",
+        "year": 2024,
+        "session": "s",
+        "paper": 1,
+        "variant": 3,
+        "q_number": 9,
+        "primary_topic_path": "9709.p1.integration"
+      },
+      "analysis_hints": {
+        "runtime_context_id": null,
+        "question_type_hint_id": null,
+        "topic_path_hint": "9709.p1.integration"
+      },
+      "evidence": {
+        "ocr_text": "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]\n(b) The region shaded in the diagram is enclosed by the curve and the straight lines x = 1, x = 3 and y = 0.\nFind the volume of the solid obtained when the shaded region is rotated through 360° about the x-axis. [3]",
+        "formula_latex_list": [],
+        "subquestion_blocks": [
+          "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]",
+          "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(b) The region shaded in the diagram is enclosed by the curve and the straight lines x = 1, x = 3 and y = 0.\nFind the volume of the solid obtained when the shaded region is rotated through 360° about the x-axis. [3]"
+        ],
+        "layout_hints": [
+          "Question 9 includes a diagram of a curve y=sqrt(2x^3+10) with a shaded region between x=1 and x=3.",
+          "Vertical text 'DO NOT WRITE IN THIS MARGIN' appears on both left and right margins.",
+          "Barcodes are present at the top of each question block and page bottom."
+        ],
+        "diagram_present": null,
+        "diagram_elements": [],
+        "spatial_evidence": []
+      },
+      "surface_posture": {
+        "descriptor_required": true,
+        "route_hint": "review_lane",
+        "diagram_present": null,
+        "formula_dense": null,
+        "table_heavy": null,
+        "surface_evidence_status": "unknown_requires_primary_asset_replay",
+        "gate_critical": false,
+        "requires_review": true
+      },
+      "review_posture": {
+        "requires_review": true,
+        "gate_critical": false,
+        "review_reasons": [],
+        "ambiguity_flags": [],
+        "review_summary": null,
+        "review_confidence": null
+      },
+      "route": {
+        "route": "ocr_lane",
+        "model": "qwen3.6-plus",
+        "region": "dashscope-cn",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "api_key_scope": "DASHSCOPE_API_KEY",
+        "prompt_template_version": "v1",
+        "response_schema_version": "v1",
+        "input_asset_id": "9709/s24_qp_13/questions/q09.png",
+        "input_asset_hash": "da3e874e8dc900407e764acd877da5a587fb02c9696da194d0ae5440a09ab76b",
+        "confidence": 0.98,
+        "failure_reason": null,
+        "decision_reasons": [
+          "requires_review",
+          "unknown_surface_flags",
+          "extraction_first_unknown_surface"
+        ]
+      },
+      "model_provenance": [
+        {
+          "route": "ocr_lane",
+          "model": "qwen3.6-plus",
+          "region": "dashscope-cn",
+          "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+          "api_key_scope": null,
+          "prompt_template_version": "v1",
+          "response_schema_version": "v1",
+          "input_asset_id": "9709/s24_qp_13/questions/q09.png",
+          "input_asset_hash": "da3e874e8dc900407e764acd877da5a587fb02c9696da194d0ae5440a09ab76b",
+          "confidence": 0.98,
+          "failure_reason": null
+        }
+      ],
+      "lazy_attach_original_image": true,
+      "lazy_attach_reasons": [
+        "requires_review"
+      ],
+      "original_image_asset": {
+        "input_asset_id": "9709/s24_qp_13/questions/q09.png",
+        "input_asset_hash": "da3e874e8dc900407e764acd877da5a587fb02c9696da194d0ae5440a09ab76b"
+      }
+    },
+    {
+      "schema_version": "question_evidence_bundle_v1",
+      "manifest_id": "9709_provider_failure_rerun_v1",
+      "manifest_position": 1,
+      "storage_key": "9709/s24_qp_33/questions/q09.png",
+      "question_identity": {
+        "subject_code": "9709",
+        "year": 2024,
+        "session": "s",
+        "paper": 3,
+        "variant": 3,
+        "q_number": 9,
+        "primary_topic_path": null
+      },
+      "analysis_hints": {
+        "runtime_context_id": null,
+        "question_type_hint_id": null,
+        "topic_path_hint": null
+      },
+      "evidence": {
+        "ocr_text": "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10, x = 1/2 and the rate of decrease of x is 20/37.\n(a) Show that x and t satisfy the differential equation\n   dx/dt = -1 / (2t(20x - 3x^2))\n(b) Solve the differential equation, obtaining an expression for t in terms of x.",
+        "formula_latex_list": [],
+        "subquestion_blocks": [
+          "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10, x = 1/2 and the rate of decrease of x is 20/37.\n(a) Show that x and t satisfy the differential equation\n dx/dt = -1 / (2t(20x - 3x^2))",
+          "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10, x = 1/2 and the rate of decrease of x is 20/37.\n(b) Solve the differential equation, obtaining an expression for t in terms of x."
+        ],
+        "layout_hints": [
+          "Question 9 includes a diagram of a cuboid with dimensions labeled x, x, and 10-x."
+        ],
+        "diagram_present": null,
+        "diagram_elements": [],
+        "spatial_evidence": []
+      },
+      "surface_posture": {
+        "descriptor_required": true,
+        "route_hint": "review_lane",
+        "diagram_present": null,
+        "formula_dense": null,
+        "table_heavy": null,
+        "surface_evidence_status": "unknown_requires_primary_asset_replay",
+        "gate_critical": false,
+        "requires_review": true
+      },
+      "review_posture": {
+        "requires_review": true,
+        "gate_critical": false,
+        "review_reasons": [],
+        "ambiguity_flags": [],
+        "review_summary": null,
+        "review_confidence": null
+      },
+      "route": {
+        "route": "ocr_lane",
+        "model": "qwen3.6-plus",
+        "region": "dashscope-cn",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "api_key_scope": "DASHSCOPE_API_KEY",
+        "prompt_template_version": "v1",
+        "response_schema_version": "v1",
+        "input_asset_id": "9709/s24_qp_33/questions/q09.png",
+        "input_asset_hash": "52ef4b0b258cb3ed4482c8032baff02b037a763009aa41ee940064566fed6275",
+        "confidence": 0.98,
+        "failure_reason": null,
+        "decision_reasons": [
+          "requires_review",
+          "unknown_surface_flags",
+          "extraction_first_unknown_surface"
+        ]
+      },
+      "model_provenance": [
+        {
+          "route": "ocr_lane",
+          "model": "qwen3.6-plus",
+          "region": "dashscope-cn",
+          "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+          "api_key_scope": null,
+          "prompt_template_version": "v1",
+          "response_schema_version": "v1",
+          "input_asset_id": "9709/s24_qp_33/questions/q09.png",
+          "input_asset_hash": "52ef4b0b258cb3ed4482c8032baff02b037a763009aa41ee940064566fed6275",
+          "confidence": 0.98,
+          "failure_reason": null
+        }
+      ],
+      "lazy_attach_original_image": true,
+      "lazy_attach_reasons": [
+        "requires_review"
+      ],
+      "original_image_asset": {
+        "input_asset_id": "9709/s24_qp_33/questions/q09.png",
+        "input_asset_hash": "52ef4b0b258cb3ed4482c8032baff02b037a763009aa41ee940064566fed6275"
+      }
+    }
+  ],
+  "summary": {
+    "bundles_planned": 2,
+    "route_counts": {
+      "ocr_lane": 2
+    },
+    "lazy_attach_original_image": 2
+  }
+}

--- a/docs/reports/2026-04-23-9709-provider-failure-rerun-lane-results-clean.json
+++ b/docs/reports/2026-04-23-9709-provider-failure-rerun-lane-results-clean.json
@@ -1,0 +1,128 @@
+[
+  {
+    "provider": "windows-qwen",
+    "model": "qwen3.6-plus",
+    "route": "ocr_lane",
+    "lane": "ocr",
+    "prompt_template_id": "ocr_specialist",
+    "prompt_template_version": "v1",
+    "region": "dashscope-cn",
+    "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "input_asset_id": "9709/s24_qp_13/questions/q09.png",
+    "input_asset_hash": "da3e874e8dc900407e764acd877da5a587fb02c9696da194d0ae5440a09ab76b",
+    "response_schema_version": "v1",
+    "confidence": 0.98,
+    "failure_reason": null,
+    "lazy_attach_original_image": false,
+    "output": {
+      "summary": "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]\n(b) The region shaded in the diagram is enclosed by the curve and the straight lines x = 1, x = 3 and y = 0.\nFind the volume of the solid obtained when the shaded region is rotated through 360° about the x-axis. [3]",
+      "evidence": [
+        {
+          "field": "ocr_text",
+          "value": "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]\n(b) The region shaded in the diagram is enclosed by the curve and the straight lines x = 1, x = 3 and y = 0.\nFind the volume of the solid obtained when the shaded region is rotated through 360° about the x-axis. [3]"
+        },
+        {
+          "field": "formula_latex_list",
+          "value": []
+        },
+        {
+          "field": "subquestion_blocks",
+          "value": [
+            "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]",
+            "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(b) The region shaded in the diagram is enclosed by the curve and the straight lines x = 1, x = 3 and y = 0.\nFind the volume of the solid obtained when the shaded region is rotated through 360° about the x-axis. [3]"
+          ]
+        },
+        {
+          "field": "layout_hints",
+          "value": [
+            "Question 9 includes a diagram of a curve y=sqrt(2x^3+10) with a shaded region between x=1 and x=3.",
+            "Vertical text 'DO NOT WRITE IN THIS MARGIN' appears on both left and right margins.",
+            "Barcodes are present at the top of each question block and page bottom."
+          ]
+        },
+        {
+          "field": "symbol_inventory",
+          "value": []
+        },
+        {
+          "field": "table_blocks",
+          "value": []
+        },
+        {
+          "field": "line_boxes",
+          "value": []
+        },
+        {
+          "field": "ocr_confidence",
+          "value": 0.98
+        }
+      ],
+      "warnings": [
+        "requires_review",
+        "unknown_surface_flags"
+      ]
+    }
+  },
+  {
+    "provider": "windows-qwen",
+    "model": "qwen3.6-plus",
+    "route": "ocr_lane",
+    "lane": "ocr",
+    "prompt_template_id": "ocr_specialist",
+    "prompt_template_version": "v1",
+    "region": "dashscope-cn",
+    "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "input_asset_id": "9709/s24_qp_33/questions/q09.png",
+    "input_asset_hash": "52ef4b0b258cb3ed4482c8032baff02b037a763009aa41ee940064566fed6275",
+    "response_schema_version": "v1",
+    "confidence": 0.98,
+    "failure_reason": null,
+    "lazy_attach_original_image": false,
+    "output": {
+      "summary": "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10, x = 1/2 and the rate of decrease of x is 20/37.\n(a) Show that x and t satisfy the differential equation\n   dx/dt = -1 / (2t(20x - 3x^2))\n(b) Solve the differential equation, obtaining an expression for t in terms of x.",
+      "evidence": [
+        {
+          "field": "ocr_text",
+          "value": "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10, x = 1/2 and the rate of decrease of x is 20/37.\n(a) Show that x and t satisfy the differential equation\n   dx/dt = -1 / (2t(20x - 3x^2))\n(b) Solve the differential equation, obtaining an expression for t in terms of x."
+        },
+        {
+          "field": "formula_latex_list",
+          "value": []
+        },
+        {
+          "field": "subquestion_blocks",
+          "value": [
+            "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10, x = 1/2 and the rate of decrease of x is 20/37.\n(a) Show that x and t satisfy the differential equation\n dx/dt = -1 / (2t(20x - 3x^2))",
+            "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10, x = 1/2 and the rate of decrease of x is 20/37.\n(b) Solve the differential equation, obtaining an expression for t in terms of x."
+          ]
+        },
+        {
+          "field": "layout_hints",
+          "value": [
+            "Question 9 includes a diagram of a cuboid with dimensions labeled x, x, and 10-x."
+          ]
+        },
+        {
+          "field": "symbol_inventory",
+          "value": []
+        },
+        {
+          "field": "table_blocks",
+          "value": []
+        },
+        {
+          "field": "line_boxes",
+          "value": []
+        },
+        {
+          "field": "ocr_confidence",
+          "value": 0.98
+        }
+      ],
+      "warnings": [
+        "requires_review",
+        "unknown_surface_flags"
+      ]
+    }
+  }
+]

--- a/docs/reports/2026-04-23-9709-provider-failure-rerun-lane-results.json
+++ b/docs/reports/2026-04-23-9709-provider-failure-rerun-lane-results.json
@@ -1,0 +1,161 @@
+[
+  {
+    "provider": "windows-qwen",
+    "model": "qwen3.6-plus",
+    "route": "ocr_lane",
+    "lane": "ocr",
+    "prompt_template_id": "ocr_specialist",
+    "prompt_template_version": "v1",
+    "region": "dashscope-cn",
+    "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "input_asset_id": "9709/s24_qp_13/questions/q09.png",
+    "input_asset_hash": "da3e874e8dc900407e764acd877da5a587fb02c9696da194d0ae5440a09ab76b",
+    "response_schema_version": "v1",
+    "confidence": 0.98,
+    "failure_reason": null,
+    "lazy_attach_original_image": false,
+    "output": {
+      "summary": "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]\n(b) The region shaded in the diagram is enclosed by the curve and the straight lines x = 1, x = 3 and y = 0.\nFind the volume of the solid obtained when the shaded region is rotated through 360° about the x-axis. [3]\n\n10 The geometric progression a1, a2, a3, ... has first term 2 and common ratio r where r > 0.\nIt is given that (5/2)a2 + 7a3 = 8.\n(a) Find the value of r. [3]\n(b) Find the sum of the first 20 terms of the geometric progression. Give your answer correct to 4 significant figures. [2]\n(c) Find the sum to infinity of the progression a2, a5, a8, ... . [3]\n\n11 The function f is defined by f(x) = 10 + 6x - x^2 for x ∈ R.\n(a) By completing the square, find the range of f. [3]\nThe function g is defined by g(x) = 4x + k for x ∈ R where k is a constant.\n(b) It is given that the graph of y = g^-1(x) meets the graph of y = g(x) at a single point P.\nDetermine the coordinates of P. [6]\n\nAdditional page\nIf you use the following page to complete the answer to any question, the question number must be clearly shown.\nBLANK PAGE\nBLANK PAGE",
+      "evidence": [
+        {
+          "field": "ocr_text",
+          "value": "9\nThe diagram shows the curve with equation y = sqrt(2x^3 + 10).\n(a) Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers. [5]\n(b) The region shaded in the diagram is enclosed by the curve and the straight lines x = 1, x = 3 and y = 0.\nFind the volume of the solid obtained when the shaded region is rotated through 360° about the x-axis. [3]\n\n10 The geometric progression a1, a2, a3, ... has first term 2 and common ratio r where r > 0.\nIt is given that (5/2)a2 + 7a3 = 8.\n(a) Find the value of r. [3]\n(b) Find the sum of the first 20 terms of the geometric progression. Give your answer correct to 4 significant figures. [2]\n(c) Find the sum to infinity of the progression a2, a5, a8, ... . [3]\n\n11 The function f is defined by f(x) = 10 + 6x - x^2 for x ∈ R.\n(a) By completing the square, find the range of f. [3]\nThe function g is defined by g(x) = 4x + k for x ∈ R where k is a constant.\n(b) It is given that the graph of y = g^-1(x) meets the graph of y = g(x) at a single point P.\nDetermine the coordinates of P. [6]\n\nAdditional page\nIf you use the following page to complete the answer to any question, the question number must be clearly shown.\nBLANK PAGE\nBLANK PAGE"
+        },
+        {
+          "field": "formula_latex_list",
+          "value": [
+            "y = \\sqrt{2x^3 + 10}",
+            "ax + by + c = 0",
+            "x = 1",
+            "x = 3",
+            "y = 0",
+            "360^{\\circ}",
+            "a_1, a_2, a_3, \\dots",
+            "r > 0",
+            "\\frac{5}{2}a_2 + 7a_3 = 8",
+            "a_2, a_5, a_8, \\dots",
+            "f(x) = 10 + 6x - x^2",
+            "x \\in \\mathbb{R}",
+            "g(x) = 4x + k",
+            "y = g^{-1}(x)",
+            "y = g(x)"
+          ]
+        },
+        {
+          "field": "subquestion_blocks",
+          "value": [
+            "{'id': '9(a)', 'text': 'Find the equation of the tangent to the curve at the point where x = 3. Give your answer in the form ax + by + c = 0 where a, b and c are integers.', 'marks': '[5]'}",
+            "{'id': '9(b)', 'text': 'The region shaded in the diagram is enclosed by the curve and the straight lines x = 1, x = 3 and y = 0. Find the volume of the solid obtained when the shaded region is rotated through 360° about the x-axis.', 'marks': '[3]'}",
+            "{'id': '10(a)', 'text': 'Find the value of r.', 'marks': '[3]'}",
+            "{'id': '10(b)', 'text': 'Find the sum of the first 20 terms of the geometric progression. Give your answer correct to 4 significant figures.', 'marks': '[2]'}",
+            "{'id': '10(c)', 'text': 'Find the sum to infinity of the progression a2, a5, a8, ... .', 'marks': '[3]'}",
+            "{'id': '11(a)', 'text': 'By completing the square, find the range of f.', 'marks': '[3]'}",
+            "{'id': '11(b)', 'text': 'It is given that the graph of y = g^-1(x) meets the graph of y = g(x) at a single point P. Determine the coordinates of P.', 'marks': '[6]'}"
+          ]
+        },
+        {
+          "field": "layout_hints",
+          "value": [
+            "Question 9 includes a diagram of a curve y=sqrt(2x^3+10) with a shaded region between x=1 and x=3.",
+            "Question 10 deals with a geometric progression.",
+            "Question 11 involves functions f(x) and g(x), including inverse functions and completing the square.",
+            "Vertical text 'DO NOT WRITE IN THIS MARGIN' appears on both left and right margins.",
+            "Barcodes are present at the top of each question block and page bottom.",
+            "Pages labeled 'Additional page' and 'BLANK PAGE' are included at the end."
+          ]
+        },
+        {
+          "field": "symbol_inventory",
+          "value": []
+        },
+        {
+          "field": "table_blocks",
+          "value": []
+        },
+        {
+          "field": "line_boxes",
+          "value": []
+        },
+        {
+          "field": "ocr_confidence",
+          "value": 0.98
+        }
+      ],
+      "warnings": [
+        "requires_review",
+        "unknown_surface_flags"
+      ]
+    }
+  },
+  {
+    "provider": "windows-qwen",
+    "model": "qwen3.6-plus",
+    "route": "ocr_lane",
+    "lane": "ocr",
+    "prompt_template_id": "ocr_specialist",
+    "prompt_template_version": "v1",
+    "region": "dashscope-cn",
+    "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "input_asset_id": "9709/s24_qp_33/questions/q09.png",
+    "input_asset_hash": "52ef4b0b258cb3ed4482c8032baff02b037a763009aa41ee940064566fed6275",
+    "response_schema_version": "v1",
+    "confidence": 0.98,
+    "failure_reason": null,
+    "lazy_attach_original_image": false,
+    "output": {
+      "summary": "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10, x = 1/2 and the rate of decrease of x is 20/37.\n(a) Show that x and t satisfy the differential equation\n   dx/dt = -1 / (2t(20x - 3x^2))\n(b) Solve the differential equation, obtaining an expression for t in terms of x.\n\n10 The equations of two straight lines are\n   r = i + j + 2ak + λ(3i + 4j + ak)  and  r = -3i - j + 4k + μ(-i + 2j + 2k),\nwhere a is a constant.\n(a) Given that the acute angle between the directions of these lines is 1/4 π, find the possible values of a.\n(b) Given instead that the lines intersect, find the value of a and the position vector of the point of intersection.\n\n11 Use the substitution 2x = tan θ to find the exact value of\n   ∫[0 to 1/4] 12 / (1 + 4x^2)^2 dx.\nGive your answer in the form a + bπ, where a and b are rational numbers.",
+      "evidence": [
+        {
+          "field": "ocr_text",
+          "value": "9\nA container in the shape of a cuboid has a square base of side x and a height of (10-x). It is given that x varies with time, t, where t > 0. The container decreases in volume at a rate which is inversely proportional to t.\nWhen t = 1/10, x = 1/2 and the rate of decrease of x is 20/37.\n(a) Show that x and t satisfy the differential equation\n   dx/dt = -1 / (2t(20x - 3x^2))\n(b) Solve the differential equation, obtaining an expression for t in terms of x.\n\n10 The equations of two straight lines are\n   r = i + j + 2ak + λ(3i + 4j + ak)  and  r = -3i - j + 4k + μ(-i + 2j + 2k),\nwhere a is a constant.\n(a) Given that the acute angle between the directions of these lines is 1/4 π, find the possible values of a.\n(b) Given instead that the lines intersect, find the value of a and the position vector of the point of intersection.\n\n11 Use the substitution 2x = tan θ to find the exact value of\n   ∫[0 to 1/4] 12 / (1 + 4x^2)^2 dx.\nGive your answer in the form a + bπ, where a and b are rational numbers."
+        },
+        {
+          "field": "formula_latex_list",
+          "value": [
+            "\\frac{\\mathrm{d}x}{\\mathrm{d}t} = \\frac{-1}{2t(20x - 3x^2)}",
+            "\\mathbf{r} = \\mathbf{i} + \\mathbf{j} + 2a\\mathbf{k} + \\lambda(3\\mathbf{i} + 4\\mathbf{j} + a\\mathbf{k})",
+            "\\mathbf{r} = -3\\mathbf{i} - \\mathbf{j} + 4\\mathbf{k} + \\mu(-\\mathbf{i} + 2\\mathbf{j} + 2\\mathbf{k})",
+            "\\frac{1}{4}\\pi",
+            "\\int_{0}^{\\frac{1}{4}} \\frac{12}{(1+4x^2)^2} \\, \\mathrm{d}x"
+          ]
+        },
+        {
+          "field": "subquestion_blocks",
+          "value": [
+            "{'id': '9', 'parts': [{'label': '(a)', 'text': 'Show that x and t satisfy the differential equation dx/dt = -1 / (2t(20x - 3x^2))', 'marks': '[5]'}, {'label': '(b)', 'text': 'Solve the differential equation, obtaining an expression for t in terms of x.', 'marks': '[6]'}]}",
+            "{'id': '10', 'parts': [{'label': '(a)', 'text': 'Given that the acute angle between the directions of these lines is 1/4 π, find the possible values of a.', 'marks': '[6]'}, {'label': '(b)', 'text': 'Given instead that the lines intersect, find the value of a and the position vector of the point of intersection.', 'marks': '[5]'}]}",
+            "{'id': '11', 'parts': [{'label': '', 'text': 'Use the substitution 2x = tan θ to find the exact value of ∫[0 to 1/4] 12 / (1 + 4x^2)^2 dx. Give your answer in the form a + bπ, where a and b are rational numbers.', 'marks': '[9]'}]}"
+          ]
+        },
+        {
+          "field": "layout_hints",
+          "value": [
+            "Question 9 includes a diagram of a cuboid with dimensions labeled x, x, and 10-x.",
+            "Questions 9, 10, and 11 are followed by lined answer spaces.",
+            "An 'Additional page' and 'BLANK PAGE' are visible at the bottom."
+          ]
+        },
+        {
+          "field": "symbol_inventory",
+          "value": []
+        },
+        {
+          "field": "table_blocks",
+          "value": []
+        },
+        {
+          "field": "line_boxes",
+          "value": []
+        },
+        {
+          "field": "ocr_confidence",
+          "value": 0.98
+        }
+      ],
+      "warnings": [
+        "requires_review",
+        "unknown_surface_flags"
+      ]
+    }
+  }
+]

--- a/docs/reports/2026-04-23-9709-provider-failure-rerun-manifest.json
+++ b/docs/reports/2026-04-23-9709-provider-failure-rerun-manifest.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "v1",
+  "manifest_id": "9709_provider_failure_rerun_v1",
+  "subject_code": "9709",
+  "frozen_on": "2026-04-23",
+  "scope": "targeted_provider_failure_rerun",
+  "notes": [
+    "Two-row follow-up manifest for the unresolved prompt-backfill provider failures from 2026-04-23.",
+    "Rows remain in the same frozen authority-ready cohort; only the unresolved storage_keys are included here."
+  ],
+  "items": [
+    {
+      "storage_key": "9709/s24_qp_13/questions/q09.png",
+      "syllabus_code": "9709",
+      "year": 2024,
+      "session": "s",
+      "paper": 1,
+      "variant": 3,
+      "q_number": 9,
+      "primary_topic_path": "9709.p1.integration",
+      "source_reason": "manual_audit_seed",
+      "descriptor_required": true,
+      "route_hint": "review_lane",
+      "diagram_present": null,
+      "formula_dense": null,
+      "table_heavy": null,
+      "surface_evidence_status": "unknown_requires_primary_asset_replay",
+      "gate_critical": false,
+      "requires_review": true,
+      "audit_source": "data/eval/a1_topic_link_manual_audit_9709_p1p3_v1.csv",
+      "audit_verdict": "wrong"
+    },
+    {
+      "storage_key": "9709/s24_qp_33/questions/q09.png",
+      "syllabus_code": "9709",
+      "year": 2024,
+      "session": "s",
+      "paper": 3,
+      "variant": 3,
+      "q_number": 9,
+      "primary_topic_path": null,
+      "source_reason": "repo_evidence_selection",
+      "descriptor_required": true,
+      "route_hint": "review_lane",
+      "diagram_present": null,
+      "formula_dense": null,
+      "table_heavy": null,
+      "surface_evidence_status": "unknown_requires_primary_asset_replay",
+      "gate_critical": false,
+      "requires_review": true,
+      "audit_source": "data/eval/a1_fallback_questions_for_reclassification.json",
+      "audit_verdict": null
+    }
+  ]
+}

--- a/docs/reports/2026-04-23-9709-provider-failure-rerun-probe.json
+++ b/docs/reports/2026-04-23-9709-provider-failure-rerun-probe.json
@@ -1,0 +1,49 @@
+{
+  "manifest_path": "docs/reports/2026-04-23-9709-provider-failure-rerun-manifest.json",
+  "rows": [
+    {
+      "storage_key": "9709/s24_qp_13/questions/q09.png",
+      "input_asset_hash": "da3e874e8dc900407e764acd877da5a587fb02c9696da194d0ae5440a09ab76b",
+      "max_tokens": 768,
+      "finish_reason": "length",
+      "completion_tokens": 768,
+      "content_length": 2186,
+      "parsed_json": false,
+      "parse_error": "JSONDecodeError: Unterminated string starting at: line 31 column 13 (char 2181)",
+      "content_tail": "the diagram is enclosed by the curve and the straight lines x = 1, x = 3 and y = 0. Find the volume of the solid obtained when the shaded region is rotated through 360° about the x-axis.\",\n      \"marks\": \"[3]\"\n    },\n    {\n      \"id\": \"10(a"
+    },
+    {
+      "storage_key": "9709/s24_qp_13/questions/q09.png",
+      "input_asset_hash": "da3e874e8dc900407e764acd877da5a587fb02c9696da194d0ae5440a09ab76b",
+      "max_tokens": 1536,
+      "finish_reason": "stop",
+      "completion_tokens": 1185,
+      "content_length": 3495,
+      "parsed_json": true,
+      "parse_error": null,
+      "content_tail": "MARGIN' appears on both left and right margins.\",\n    \"Barcodes are present at the top of each question block and page bottom.\",\n    \"Pages labeled 'Additional page' and 'BLANK PAGE' are included at the end.\"\n  ],\n  \"ocr_confidence\": 0.98\n}"
+    },
+    {
+      "storage_key": "9709/s24_qp_33/questions/q09.png",
+      "input_asset_hash": "52ef4b0b258cb3ed4482c8032baff02b037a763009aa41ee940064566fed6275",
+      "max_tokens": 768,
+      "finish_reason": "length",
+      "completion_tokens": 768,
+      "content_length": 2161,
+      "parsed_json": false,
+      "parse_error": "JSONDecodeError: Unterminated string starting at: line 19 column 19 (char 2098)",
+      "content_tail": "te which is inversely proportional to t. When t = 1/10, x = 1/2 and the rate of decrease of x is 20/27.\",\n      \"parts\": [\n        {\n          \"label\": \"(a)\",\n          \"text\": \"Show that x and t satisfy the differential equation dx/dt = -1"
+    },
+    {
+      "storage_key": "9709/s24_qp_33/questions/q09.png",
+      "input_asset_hash": "52ef4b0b258cb3ed4482c8032baff02b037a763009aa41ee940064566fed6275",
+      "max_tokens": 1536,
+      "finish_reason": "stop",
+      "completion_tokens": 1021,
+      "content_length": 2952,
+      "parsed_json": true,
+      "parse_error": null,
+      "content_tail": "ludes a diagram of a cuboid with dimensions labeled x, x, and 10-x.\",\n    \"Questions 9, 10, and 11 are followed by lined answer spaces.\",\n    \"An 'Additional page' and 'BLANK PAGE' are visible at the bottom.\"\n  ],\n  \"ocr_confidence\": 0.98\n}"
+    }
+  ]
+}

--- a/docs/reports/2026-04-23-9709-provider-failure-rerun-question-analysis-backfill.json
+++ b/docs/reports/2026-04-23-9709-provider-failure-rerun-question-analysis-backfill.json
@@ -1,0 +1,19 @@
+{
+  "processed": 2,
+  "backfilled": 2,
+  "skipped": 0,
+  "items": [
+    {
+      "question_id": "261c6168-3d54-4888-8b9d-803952946e61",
+      "status": "backfilled",
+      "classification_snapshot_id": "1a458e04-7e97-4237-aec5-16bf1bd61306",
+      "question_event_id": "bcefe0de-bdee-4297-ae63-b042d362631c"
+    },
+    {
+      "question_id": "5696277e-d85d-4754-8930-199e7b4b62f3",
+      "status": "backfilled",
+      "classification_snapshot_id": "65b2dc84-1e23-4b93-a95c-4c95e015d5bd",
+      "question_event_id": "b7b9b74f-3a20-41be-9904-1605186369e8"
+    }
+  ]
+}

--- a/docs/reports/2026-04-23-9709-provider-failure-rerun-summary.md
+++ b/docs/reports/2026-04-23-9709-provider-failure-rerun-summary.md
@@ -1,0 +1,111 @@
+# 2026-04-23 9709 Provider Failure Rerun Summary
+
+Issue: `9709-provider-failure-rerun`
+
+## Scope
+
+Target only the two unresolved storage keys that remained after merged PR #275:
+
+- `9709/s24_qp_13/questions/q09.png`
+- `9709/s24_qp_33/questions/q09.png`
+
+## Root Cause Investigation
+
+The original prompt-backfill failure string was too coarse. Direct OCR probes against the Windows-host Qwen lane showed that the provider was no longer returning arbitrary invalid output. The actual failure mode was truncated JSON:
+
+- at `max_tokens=768`, both rows ended with `finish_reason=length` and the JSON payload cut off mid-structure
+- at `max_tokens=1536`, both rows ended with `finish_reason=stop` and parsed cleanly
+
+The first forced backfill using the raw `1536` OCR payloads still produced a bad downstream result on `9709/s24_qp_33/questions/q09.png`: the OCR covered the full page (`q09`, `q10`, `q11`), so cross-question cues polluted the classification and temporarily produced `9709.trigonometry.identities`.
+
+The final recovery path therefore used two deterministic steps:
+
+1. rerun the upstream OCR lane at `max_tokens=1536` for the two failed rows
+2. clean the successful OCR output down to the `q09` section only before rebuilding evidence bundles and rerunning `question_analysis_backfill`
+
+No local truth was fabricated. The final prompt material comes from the live provider output, trimmed only by explicit footer stripping and `q09` boundary extraction.
+
+## Commands Run
+
+Targeted probe + recovery artifact generation:
+
+```bash
+/home/samsen/code/ciecopilot-home/.venv/bin/python - <<'PY'
+# wrote:
+# - docs/reports/2026-04-23-9709-provider-failure-rerun-manifest.json
+# - docs/reports/2026-04-23-9709-provider-failure-rerun-probe.json
+# - docs/reports/2026-04-23-9709-provider-failure-rerun-lane-results.json
+# - docs/reports/2026-04-23-9709-provider-failure-rerun-lane-results-clean.json
+PY
+```
+
+Question-specific cleanup of the recovered OCR payloads:
+
+```bash
+node --input-type=module - <<'NODE'
+# rewrote docs/reports/2026-04-23-9709-provider-failure-rerun-lane-results-clean.json
+# using q09-only section extraction plus question-aware subquestion chunking
+NODE
+```
+
+Evidence bundle rebuild:
+
+```bash
+node --input-type=module - <<'NODE'
+# wrote docs/reports/2026-04-23-9709-provider-failure-rerun-evidence-bundles.json
+NODE
+```
+
+Forced paper-question analysis backfill through local PG compat:
+
+```bash
+SUPABASE_PG_COMPAT=true DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres \
+node scripts/learning/run_question_analysis_backfill.js \
+  --force \
+  --source-kind paper_question \
+  --manifest docs/reports/2026-04-23-9709-provider-failure-rerun-manifest.json \
+  --evidence-bundles docs/reports/2026-04-23-9709-provider-failure-rerun-evidence-bundles.json \
+  > docs/reports/2026-04-23-9709-provider-failure-rerun-question-analysis-backfill.json
+```
+
+Post-backfill DB verification:
+
+```bash
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres \
+psql "$DATABASE_URL" -XtA <<'SQL' \
+  > docs/reports/2026-04-23-9709-provider-failure-rerun-db-state.json
+-- queried question_bank, learning_question_analysis_snapshots,
+-- and learning_question_search_projection for the two storage keys
+SQL
+```
+
+## Results
+
+`docs/reports/2026-04-23-9709-provider-failure-rerun-question-analysis-backfill.json` recorded:
+
+- `processed = 2`
+- `backfilled = 2`
+- `skipped = 0`
+
+`docs/reports/2026-04-23-9709-provider-failure-rerun-db-state.json` recorded:
+
+- `9709/s24_qp_13/questions/q09.png`
+  - `prompt_length = 436`
+  - `descriptor_summary_status = evidence_bundle_summary`
+  - `descriptor_search_text_status = evidence_bundle_search_text`
+  - `release_scope_status = non_released_fallback`
+  - active snapshot `1a458e04-7e97-4237-aec5-16bf1bd61306`
+- `9709/s24_qp_33/questions/q09.png`
+  - `prompt_length = 459`
+  - `descriptor_summary_status = evidence_bundle_summary`
+  - `descriptor_search_text_status = evidence_bundle_search_text`
+  - `primary_question_type_id = 9709.differential_equations.separable`
+  - `release_scope_status = released_scoring`
+  - active snapshot `65b2dc84-1e23-4b93-a95c-4c95e015d5bd`
+
+Both rows now have non-empty prompt material in `question_bank` and non-empty `summary` / `search_text` in `learning_question_search_projection`.
+
+## Residual Notes
+
+- `9709/s24_qp_13/questions/q09.png` still lands in `non_released_fallback` with `primary_question_type_id = null`. That is acceptable for the current contract posture: prompt material is recovered, but the row is not promoted into released scoring.
+- `9709/s24_qp_33/questions/q09.png` now classifies correctly as `9709.differential_equations.separable`, but its derived `search_text` still contains a generic `evaluate integral` cue. That comes from the current search-signal heuristic treating `dx/dt` as an integral-like token. The active snapshot and prompt state are correct; the remaining risk is limited to search-text noisiness for this exact storage key.


### PR DESCRIPTION
## Summary

This PR closes the follow-up slice for `9709-provider-failure-rerun`.

It adds a narrowly scoped evidence/report set for the two unresolved storage keys left after #275:
- `9709/s24_qp_13/questions/q09.png`
- `9709/s24_qp_33/questions/q09.png`

The recovery path was:
- prove the old failure mode was truncated JSON, not arbitrary malformed output
- rerun the upstream OCR lane at a higher token ceiling that completed cleanly
- trim the recovered OCR down to the `q09` section only so downstream analysis did not ingest `q10` / `q11` from the same page
- rebuild the two evidence bundles and force a two-row `paper_question` analysis backfill
- capture post-backfill DB state and a truthful summary report

## Verification

- probed both rows at `max_tokens=768` and `max_tokens=1536`; the probe artifact shows `length` truncation at `768` and clean `stop` completions at `1536`
- rebuilt the targeted clean lane-results and evidence-bundle artifacts for the two rows
- ran:
  - `SUPABASE_PG_COMPAT=true DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres node scripts/learning/run_question_analysis_backfill.js --force --source-kind paper_question --manifest docs/reports/2026-04-23-9709-provider-failure-rerun-manifest.json --evidence-bundles docs/reports/2026-04-23-9709-provider-failure-rerun-evidence-bundles.json`
- verified fresh DB state afterwards:
  - `9709/s24_qp_13/questions/q09.png` -> prompt length `436`, `non_released_fallback`, descriptor statuses `evidence_bundle_summary` / `evidence_bundle_search_text`
  - `9709/s24_qp_33/questions/q09.png` -> prompt length `459`, `9709.differential_equations.separable`, `released_scoring`, descriptor statuses `evidence_bundle_summary` / `evidence_bundle_search_text`

## Notes

- I could not resolve a matching GitHub issue in this repository for `9709-provider-failure-rerun`, so there is no auto-close keyword in this PR body.
- The detailed evidence is in `docs/reports/2026-04-23-9709-provider-failure-rerun-summary.md`.
