### PR TITLE
fix: recover 9709 q07 authority row

### DIFF
--- a/data/curriculum/9709_authority_ready_batch_300_nodes_v2.json
+++ b/data/curriculum/9709_authority_ready_batch_300_nodes_v2.json
@@ -243,6 +243,30 @@
         "seed_reason": "issue_273_batch_seed_extension",
         "source": "manual_audit_topics"
       }
+    },
+    {
+      "topic_path": "9709.p5",
+      "title": "Probability & Statistics 1",
+      "level": "paper",
+      "paper": 5,
+      "parent_topic_path": "9709",
+      "sort_order": 500,
+      "metadata": {
+        "paper_code": "P5",
+        "seed_reason": "issue_9709_authority_missing_q07"
+      }
+    },
+    {
+      "topic_path": "9709.p5.representation_of_data",
+      "title": "Representation of Data",
+      "level": "topic",
+      "paper": 5,
+      "parent_topic_path": "9709.p5",
+      "sort_order": 510,
+      "metadata": {
+        "seed_reason": "issue_9709_authority_missing_q07",
+        "source": "historical_s1_crosswalk"
+      }
     }
   ],
   "notes": [

--- a/data/manifests/9709_authority_ready_batch_300_authority_sidecar_v2.json
+++ b/data/manifests/9709_authority_ready_batch_300_authority_sidecar_v2.json
@@ -7,7 +7,7 @@
   "notes": [
     "Full-coverage authority sidecar for issue #273 round 2 dry-run.",
     "Promotes repo-evidence rows to frozen only when supported by checked-in audit/reclassification evidence or explicit operator-review adjudication.",
-    "The paper-6 histogram row remains legal missing because the current frozen evidence set does not safely establish a canonical topic path."
+    "The former paper-6 histogram row is now frozen through a checked-in Statistics 1 crosswalk onto the current p5 Representation of Data taxonomy."
   ],
   "items": [
     {
@@ -6065,7 +6065,7 @@
     {
       "storage_key": "9709/s17_qp_63/questions/q07.png",
       "authority_input_pack": {
-        "canonical_primary_topic_path": null,
+        "canonical_primary_topic_path": "9709.p5.representation_of_data",
         "curriculum_version_tag": "2025-2027_v1",
         "topic_authority_sources": [
           "repo_evidence",
@@ -6073,17 +6073,17 @@
         ],
         "topic_authority_refs": [
           {
-            "kind": "operator_review",
-            "locator": "issue-273-batch-prep-round-2",
-            "note": "Held as legal missing after round-2 review. Available repo evidence only shows a paper-6 histogram about worm lengths; no checked-in frozen taxonomy or audited primary topic path is available for safe authority freeze."
+            "kind": "repo_evidence",
+            "locator": "data/manifests/9709_diagram_lane_live_probe_v1.json",
+            "note": "storage_key=9709/s17_qp_63/questions/q07.png; primary_topic_path=9709.p5.representation_of_data; live probe shows a grouped-data histogram with Length (cm) on the x-axis and Frequency density on the y-axis."
           },
           {
             "kind": "operator_review",
-            "locator": "docs/reports/2026-04-16-9709-diagram-lane-live-probe-results.json",
-            "note": "Probe summary=histogram; histogram evidence exists but does not safely determine canonical topic truth."
+            "locator": "docs/reports/2026-04-23-9709-authority-missing-q07-recovery.md",
+            "note": "Historical review confirms 9709/63 June 2017 is Statistics 1 and that Q7 is the histogram/frequency-density item, so the current repo taxonomy crosswalk is 9709.p5.representation_of_data."
           }
         ],
-        "cross_paper_dependency_note": null
+        "cross_paper_dependency_note": "Historical component 9709/63 (June 2017) is Statistics 1. The current repo taxonomy anchors Statistics 1 under p5, so this row freezes to 9709.p5.representation_of_data rather than a synthetic p6 topic."
       }
     },
     {

--- a/data/manifests/9709_diagram_lane_live_probe_v1.json
+++ b/data/manifests/9709_diagram_lane_live_probe_v1.json
@@ -56,7 +56,7 @@
       "paper": 6,
       "variant": 3,
       "q_number": 7,
-      "primary_topic_path": "9709.p6.statistics.data_representation",
+      "primary_topic_path": "9709.p5.representation_of_data",
       "source_reason": "diagram_lane_live_probe",
       "descriptor_required": true,
       "route_hint": "diagram_lane",

--- a/docs/reports/2026-04-23-9709-authority-missing-q07-aligned-manifest.json
+++ b/docs/reports/2026-04-23-9709-authority-missing-q07-aligned-manifest.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "v1",
+  "manifest_id": "9709_authority_missing_q07_v1",
+  "subject_code": "9709",
+  "curriculum_version_tag": "2025-2027_v1",
+  "frozen_on": "2026-04-22",
+  "wave": "authority_ready_batch_300",
+  "scope": "evidence_backed_9709_batch_dry_run",
+  "source_documents": [
+    "data/eval/a1_topic_link_manual_audit_9709_p1p3_v1.csv",
+    "data/curriculum/9709_question_search_recovery_nodes_v1.json",
+    "docs/reports/2026-04-16-9709-qwen-wave1-live-results-hotfix-rerun-v4.json"
+  ],
+  "notes": [
+    "One-row manifest for q07 authority recovery follow-up."
+  ],
+  "items": [
+    {
+      "storage_key": "9709/s17_qp_63/questions/q07.png",
+      "syllabus_code": "9709",
+      "year": 2017,
+      "session": "s",
+      "paper": 6,
+      "variant": 3,
+      "q_number": 7,
+      "primary_topic_path": "9709.p5.representation_of_data",
+      "source_reason": "repo_evidence_selection",
+      "descriptor_required": true,
+      "route_hint": "review_lane",
+      "diagram_present": null,
+      "formula_dense": null,
+      "table_heavy": null,
+      "surface_evidence_status": "unknown_requires_primary_asset_replay",
+      "gate_critical": false,
+      "requires_review": true,
+      "audit_source": "docs/reports/2026-04-16-9709-diagram-lane-live-probe-results.json",
+      "audit_verdict": null,
+      "authority_alignment_run_id": "authority-alignment-54a99331-4c35-4363-86ba-e528b4b0575d",
+      "source_manifest_digest": "7792790a706b8e94dd9f4a2c096693d3314ace0858cb5b1024a6d348dbdf18db",
+      "canonical_primary_topic_path": "9709.p5.representation_of_data",
+      "curriculum_version_tag": "2025-2027_v1",
+      "authority_truth_status": "frozen",
+      "taxonomy_resolution_status": "resolved",
+      "manual_action_required": false,
+      "provisional_alignment_verdict": "ready",
+      "topic_authority_sources": [
+        "repo_evidence",
+        "operator_review"
+      ],
+      "topic_authority_refs": [
+        {
+          "kind": "repo_evidence",
+          "locator": "data/manifests/9709_diagram_lane_live_probe_v1.json",
+          "note": "storage_key=9709/s17_qp_63/questions/q07.png; primary_topic_path=9709.p5.representation_of_data; live probe shows a grouped-data histogram with Length (cm) on the x-axis and Frequency density on the y-axis."
+        },
+        {
+          "kind": "operator_review",
+          "locator": "docs/reports/2026-04-23-9709-authority-missing-q07-recovery.md",
+          "note": "Historical review confirms 9709/63 June 2017 is Statistics 1 and that Q7 is the histogram/frequency-density item, so the current repo taxonomy crosswalk is 9709.p5.representation_of_data."
+        }
+      ],
+      "cross_paper_dependency_note": "Historical component 9709/63 (June 2017) is Statistics 1. The current repo taxonomy anchors Statistics 1 under p5, so this row freezes to 9709.p5.representation_of_data rather than a synthetic p6 topic.",
+      "visual_topic_guess": null,
+      "alignment_status": "not_compared",
+      "alignment_review_required": false,
+      "overall_alignment_verdict": "ready"
+    }
+  ],
+  "authority_alignment_run_id": "authority-alignment-54a99331-4c35-4363-86ba-e528b4b0575d"
+}

--- a/docs/reports/2026-04-23-9709-authority-missing-q07-authority-manifest.json
+++ b/docs/reports/2026-04-23-9709-authority-missing-q07-authority-manifest.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "v1",
+  "manifest_id": "9709_authority_missing_q07_v1",
+  "subject_code": "9709",
+  "curriculum_version_tag": "2025-2027_v1",
+  "frozen_on": "2026-04-22",
+  "wave": "authority_ready_batch_300",
+  "scope": "evidence_backed_9709_batch_dry_run",
+  "source_documents": [
+    "data/eval/a1_topic_link_manual_audit_9709_p1p3_v1.csv",
+    "data/curriculum/9709_question_search_recovery_nodes_v1.json",
+    "docs/reports/2026-04-16-9709-qwen-wave1-live-results-hotfix-rerun-v4.json"
+  ],
+  "notes": [
+    "One-row manifest for q07 authority recovery follow-up."
+  ],
+  "items": [
+    {
+      "storage_key": "9709/s17_qp_63/questions/q07.png",
+      "syllabus_code": "9709",
+      "year": 2017,
+      "session": "s",
+      "paper": 6,
+      "variant": 3,
+      "q_number": 7,
+      "primary_topic_path": "9709.p5.representation_of_data",
+      "source_reason": "repo_evidence_selection",
+      "descriptor_required": true,
+      "route_hint": "review_lane",
+      "diagram_present": null,
+      "formula_dense": null,
+      "table_heavy": null,
+      "surface_evidence_status": "unknown_requires_primary_asset_replay",
+      "gate_critical": false,
+      "requires_review": true,
+      "audit_source": "docs/reports/2026-04-16-9709-diagram-lane-live-probe-results.json",
+      "audit_verdict": null,
+      "authority_alignment_run_id": "authority-alignment-54a99331-4c35-4363-86ba-e528b4b0575d",
+      "source_manifest_digest": "7792790a706b8e94dd9f4a2c096693d3314ace0858cb5b1024a6d348dbdf18db",
+      "canonical_primary_topic_path": "9709.p5.representation_of_data",
+      "curriculum_version_tag": "2025-2027_v1",
+      "authority_truth_status": "frozen",
+      "taxonomy_resolution_status": "resolved",
+      "manual_action_required": false,
+      "provisional_alignment_verdict": "ready",
+      "topic_authority_sources": [
+        "repo_evidence",
+        "operator_review"
+      ],
+      "topic_authority_refs": [
+        {
+          "kind": "repo_evidence",
+          "locator": "data/manifests/9709_diagram_lane_live_probe_v1.json",
+          "note": "storage_key=9709/s17_qp_63/questions/q07.png; primary_topic_path=9709.p5.representation_of_data; live probe shows a grouped-data histogram with Length (cm) on the x-axis and Frequency density on the y-axis."
+        },
+        {
+          "kind": "operator_review",
+          "locator": "docs/reports/2026-04-23-9709-authority-missing-q07-recovery.md",
+          "note": "Historical review confirms 9709/63 June 2017 is Statistics 1 and that Q7 is the histogram/frequency-density item, so the current repo taxonomy crosswalk is 9709.p5.representation_of_data."
+        }
+      ],
+      "cross_paper_dependency_note": "Historical component 9709/63 (June 2017) is Statistics 1. The current repo taxonomy anchors Statistics 1 under p5, so this row freezes to 9709.p5.representation_of_data rather than a synthetic p6 topic."
+    }
+  ],
+  "authority_alignment_run_id": "authority-alignment-54a99331-4c35-4363-86ba-e528b4b0575d"
+}

--- a/docs/reports/2026-04-23-9709-authority-missing-q07-authority-sidecar.json
+++ b/docs/reports/2026-04-23-9709-authority-missing-q07-authority-sidecar.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "v1",
+  "sidecar_id": "9709_authority_missing_q07_authority_sidecar_v1",
+  "subject_code": "9709",
+  "curriculum_version_tag": "2025-2027_v1",
+  "generated_on": "2026-04-22",
+  "notes": [
+    "One-row sidecar for q07 authority recovery follow-up."
+  ],
+  "items": [
+    {
+      "storage_key": "9709/s17_qp_63/questions/q07.png",
+      "authority_input_pack": {
+        "canonical_primary_topic_path": "9709.p5.representation_of_data",
+        "curriculum_version_tag": "2025-2027_v1",
+        "topic_authority_sources": [
+          "repo_evidence",
+          "operator_review"
+        ],
+        "topic_authority_refs": [
+          {
+            "kind": "repo_evidence",
+            "locator": "data/manifests/9709_diagram_lane_live_probe_v1.json",
+            "note": "storage_key=9709/s17_qp_63/questions/q07.png; primary_topic_path=9709.p5.representation_of_data; live probe shows a grouped-data histogram with Length (cm) on the x-axis and Frequency density on the y-axis."
+          },
+          {
+            "kind": "operator_review",
+            "locator": "docs/reports/2026-04-23-9709-authority-missing-q07-recovery.md",
+            "note": "Historical review confirms 9709/63 June 2017 is Statistics 1 and that Q7 is the histogram/frequency-density item, so the current repo taxonomy crosswalk is 9709.p5.representation_of_data."
+          }
+        ],
+        "cross_paper_dependency_note": "Historical component 9709/63 (June 2017) is Statistics 1. The current repo taxonomy anchors Statistics 1 under p5, so this row freezes to 9709.p5.representation_of_data rather than a synthetic p6 topic."
+      }
+    }
+  ]
+}

--- a/docs/reports/2026-04-23-9709-authority-missing-q07-curriculum-seed.json
+++ b/docs/reports/2026-04-23-9709-authority-missing-q07-curriculum-seed.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "v1",
+  "seed_id": "9709_authority_missing_q07_nodes_v1",
+  "syllabus_code": "9709",
+  "version_tag": "2025-2027_v1",
+  "frozen_on": "2026-04-22",
+  "scope": "evidence_backed_9709_batch_dry_run",
+  "nodes": [
+    {
+      "topic_path": "9709",
+      "title": "Cambridge International AS and A Level Mathematics",
+      "level": "syllabus",
+      "paper": null,
+      "parent_topic_path": null,
+      "sort_order": 0,
+      "metadata": {
+        "display_name": "9709 Mathematics",
+        "scope": "question_search_recovery_wave1"
+      }
+    },
+    {
+      "topic_path": "9709.p5",
+      "title": "Probability & Statistics 1",
+      "level": "paper",
+      "paper": 5,
+      "parent_topic_path": "9709",
+      "sort_order": 500,
+      "metadata": {
+        "paper_code": "P5",
+        "seed_reason": "issue_9709_authority_missing_q07"
+      }
+    },
+    {
+      "topic_path": "9709.p5.representation_of_data",
+      "title": "Representation of Data",
+      "level": "topic",
+      "paper": 5,
+      "parent_topic_path": "9709.p5",
+      "sort_order": 510,
+      "metadata": {
+        "seed_reason": "issue_9709_authority_missing_q07",
+        "source": "historical_s1_crosswalk"
+      }
+    }
+  ],
+  "notes": [
+    "Minimal seed for the q07 authority recovery follow-up."
+  ]
+}

--- a/docs/reports/2026-04-23-9709-authority-missing-q07-evidence-bundles.json
+++ b/docs/reports/2026-04-23-9709-authority-missing-q07-evidence-bundles.json
@@ -1,0 +1,110 @@
+{
+  "manifest_id": "9709_authority_missing_q07_v1",
+  "bundles": [
+    {
+      "schema_version": "question_evidence_bundle_v1",
+      "manifest_id": "9709_authority_missing_q07_v1",
+      "manifest_position": 0,
+      "storage_key": "9709/s17_qp_63/questions/q07.png",
+      "question_identity": {
+        "subject_code": "9709",
+        "year": 2017,
+        "session": "s",
+        "paper": 6,
+        "variant": 3,
+        "q_number": 7,
+        "primary_topic_path": "9709.p5.representation_of_data"
+      },
+      "analysis_hints": {
+        "runtime_context_id": null,
+        "question_type_hint_id": null,
+        "topic_path_hint": "9709.p5.representation_of_data"
+      },
+      "evidence": {
+        "ocr_text": "",
+        "formula_latex_list": [],
+        "subquestion_blocks": [],
+        "layout_hints": [],
+        "diagram_present": true,
+        "diagram_elements": [
+          "vertical bars (4)",
+          "x-axis labeled 'Length (cm)'",
+          "y-axis labeled 'Frequency density'",
+          "grid lines"
+        ],
+        "spatial_evidence": [
+          "bar 1 spans x=0 to 5, height ≈2",
+          "bar 2 spans x=5 to 10, height ≈8",
+          "bar 3 spans x=10 to 20, height ≈12",
+          "bar 4 spans x=20 to 25, height ≈6"
+        ]
+      },
+      "surface_posture": {
+        "descriptor_required": true,
+        "route_hint": "review_lane",
+        "diagram_present": null,
+        "formula_dense": null,
+        "table_heavy": null,
+        "surface_evidence_status": "unknown_requires_primary_asset_replay",
+        "gate_critical": false,
+        "requires_review": true
+      },
+      "review_posture": {
+        "requires_review": true,
+        "gate_critical": false,
+        "review_reasons": [],
+        "ambiguity_flags": [],
+        "review_summary": null,
+        "review_confidence": null
+      },
+      "route": {
+        "route": "ocr_lane",
+        "model": "qwen3.6-plus",
+        "region": "dashscope-cn",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "api_key_scope": "DASHSCOPE_API_KEY",
+        "prompt_template_version": "v1",
+        "response_schema_version": "v1",
+        "input_asset_id": "9709/s17_qp_63/questions/q07.png",
+        "input_asset_hash": null,
+        "confidence": null,
+        "failure_reason": null,
+        "decision_reasons": [
+          "requires_review",
+          "unknown_surface_flags",
+          "extraction_first_unknown_surface"
+        ]
+      },
+      "model_provenance": [
+        {
+          "route": "diagram_lane",
+          "model": "qwen3-vl-plus",
+          "region": "dashscope-cn",
+          "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+          "api_key_scope": null,
+          "prompt_template_version": "v1",
+          "response_schema_version": "v1",
+          "input_asset_id": "9709/s17_qp_63/questions/q07.png",
+          "input_asset_hash": "9cbe447a12a1386ab0b6c7126d97b23b5594d242199a8b1bead99c55d9ff0081",
+          "confidence": 1,
+          "failure_reason": null
+        }
+      ],
+      "lazy_attach_original_image": true,
+      "lazy_attach_reasons": [
+        "requires_review"
+      ],
+      "original_image_asset": {
+        "input_asset_id": "9709/s17_qp_63/questions/q07.png",
+        "input_asset_hash": null
+      }
+    }
+  ],
+  "summary": {
+    "bundles_planned": 1,
+    "route_counts": {
+      "ocr_lane": 1
+    },
+    "lazy_attach_original_image": 1
+  }
+}

--- a/docs/reports/2026-04-23-9709-authority-missing-q07-lane-results.json
+++ b/docs/reports/2026-04-23-9709-authority-missing-q07-lane-results.json
@@ -1,0 +1,82 @@
+[
+  {
+    "provider": "windows-qwen",
+    "model": "qwen3-vl-plus",
+    "route": "diagram_lane",
+    "lane": "diagram",
+    "prompt_template_id": "diagram_specialist",
+    "prompt_template_version": "v1",
+    "region": "dashscope-cn",
+    "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "input_asset_id": "9709/s17_qp_63/questions/q07.png",
+    "input_asset_hash": "9cbe447a12a1386ab0b6c7126d97b23b5594d242199a8b1bead99c55d9ff0081",
+    "response_schema_version": "v1",
+    "confidence": 1,
+    "failure_reason": null,
+    "lazy_attach_original_image": true,
+    "output": {
+      "summary": "histogram",
+      "evidence": [
+        {
+          "field": "diagram_present",
+          "value": true
+        },
+        {
+          "field": "diagram_type",
+          "value": "histogram"
+        },
+        {
+          "field": "diagram_elements",
+          "value": [
+            "vertical bars (4)",
+            "x-axis labeled 'Length (cm)'",
+            "y-axis labeled 'Frequency density'",
+            "grid lines"
+          ]
+        },
+        {
+          "field": "axes_labels",
+          "value": []
+        },
+        {
+          "field": "curve_point_annotations",
+          "value": []
+        },
+        {
+          "field": "shape_relations",
+          "value": [
+            "bars are adjacent with no gaps",
+            "bar heights: ~2, ~8, ~12, ~6 (from left to right)",
+            "x-axis intervals: 0–5, 5–10, 10–20, 20–25 cm"
+          ]
+        },
+        {
+          "field": "object_grounding",
+          "value": [
+            {
+              "bars": "represent frequency density for worm length intervals",
+              "x-axis": "worm length in cm",
+              "y-axis": "frequency density (frequency per unit length)"
+            }
+          ]
+        },
+        {
+          "field": "spatial_evidence",
+          "value": [
+            "bar 1 spans x=0 to 5, height ≈2",
+            "bar 2 spans x=5 to 10, height ≈8",
+            "bar 3 spans x=10 to 20, height ≈12",
+            "bar 4 spans x=20 to 25, height ≈6"
+          ]
+        },
+        {
+          "field": "diagram_confidence",
+          "value": 1
+        }
+      ],
+      "warnings": [
+        "lazy_attach_original_image"
+      ]
+    }
+  }
+]

--- a/docs/reports/2026-04-23-9709-authority-missing-q07-manifest.json
+++ b/docs/reports/2026-04-23-9709-authority-missing-q07-manifest.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "v1",
+  "manifest_id": "9709_authority_missing_q07_v1",
+  "subject_code": "9709",
+  "curriculum_version_tag": "2025-2027_v1",
+  "frozen_on": "2026-04-22",
+  "wave": "authority_ready_batch_300",
+  "scope": "evidence_backed_9709_batch_dry_run",
+  "source_documents": [
+    "data/eval/a1_topic_link_manual_audit_9709_p1p3_v1.csv",
+    "data/curriculum/9709_question_search_recovery_nodes_v1.json",
+    "docs/reports/2026-04-16-9709-qwen-wave1-live-results-hotfix-rerun-v4.json"
+  ],
+  "notes": [
+    "One-row manifest for q07 authority recovery follow-up."
+  ],
+  "items": [
+    {
+      "storage_key": "9709/s17_qp_63/questions/q07.png",
+      "syllabus_code": "9709",
+      "year": 2017,
+      "session": "s",
+      "paper": 6,
+      "variant": 3,
+      "q_number": 7,
+      "primary_topic_path": null,
+      "source_reason": "repo_evidence_selection",
+      "descriptor_required": true,
+      "route_hint": "review_lane",
+      "diagram_present": null,
+      "formula_dense": null,
+      "table_heavy": null,
+      "surface_evidence_status": "unknown_requires_primary_asset_replay",
+      "gate_critical": false,
+      "requires_review": true,
+      "audit_source": "docs/reports/2026-04-16-9709-diagram-lane-live-probe-results.json",
+      "audit_verdict": null
+    }
+  ]
+}

--- a/docs/reports/2026-04-23-9709-authority-missing-q07-ready-manifest.json
+++ b/docs/reports/2026-04-23-9709-authority-missing-q07-ready-manifest.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "v1",
+  "manifest_id": "9709_authority_missing_q07_v1",
+  "subject_code": "9709",
+  "curriculum_version_tag": "2025-2027_v1",
+  "frozen_on": "2026-04-22",
+  "wave": "authority_ready_batch_300",
+  "scope": "evidence_backed_9709_batch_dry_run",
+  "source_documents": [
+    "data/eval/a1_topic_link_manual_audit_9709_p1p3_v1.csv",
+    "data/curriculum/9709_question_search_recovery_nodes_v1.json",
+    "docs/reports/2026-04-16-9709-qwen-wave1-live-results-hotfix-rerun-v4.json"
+  ],
+  "notes": [
+    "One-row manifest for q07 authority recovery follow-up."
+  ],
+  "items": [
+    {
+      "storage_key": "9709/s17_qp_63/questions/q07.png",
+      "syllabus_code": "9709",
+      "year": 2017,
+      "session": "s",
+      "paper": 6,
+      "variant": 3,
+      "q_number": 7,
+      "primary_topic_path": "9709.p5.representation_of_data",
+      "source_reason": "repo_evidence_selection",
+      "descriptor_required": true,
+      "route_hint": "review_lane",
+      "diagram_present": null,
+      "formula_dense": null,
+      "table_heavy": null,
+      "surface_evidence_status": "unknown_requires_primary_asset_replay",
+      "gate_critical": false,
+      "requires_review": true,
+      "audit_source": "docs/reports/2026-04-16-9709-diagram-lane-live-probe-results.json",
+      "audit_verdict": null,
+      "authority_alignment_run_id": "authority-alignment-54a99331-4c35-4363-86ba-e528b4b0575d",
+      "source_manifest_digest": "7792790a706b8e94dd9f4a2c096693d3314ace0858cb5b1024a6d348dbdf18db",
+      "canonical_primary_topic_path": "9709.p5.representation_of_data",
+      "curriculum_version_tag": "2025-2027_v1",
+      "authority_truth_status": "frozen",
+      "taxonomy_resolution_status": "resolved",
+      "manual_action_required": false,
+      "provisional_alignment_verdict": "ready",
+      "topic_authority_sources": [
+        "repo_evidence",
+        "operator_review"
+      ],
+      "topic_authority_refs": [
+        {
+          "kind": "repo_evidence",
+          "locator": "data/manifests/9709_diagram_lane_live_probe_v1.json",
+          "note": "storage_key=9709/s17_qp_63/questions/q07.png; primary_topic_path=9709.p5.representation_of_data; live probe shows a grouped-data histogram with Length (cm) on the x-axis and Frequency density on the y-axis."
+        },
+        {
+          "kind": "operator_review",
+          "locator": "docs/reports/2026-04-23-9709-authority-missing-q07-recovery.md",
+          "note": "Historical review confirms 9709/63 June 2017 is Statistics 1 and that Q7 is the histogram/frequency-density item, so the current repo taxonomy crosswalk is 9709.p5.representation_of_data."
+        }
+      ],
+      "cross_paper_dependency_note": "Historical component 9709/63 (June 2017) is Statistics 1. The current repo taxonomy anchors Statistics 1 under p5, so this row freezes to 9709.p5.representation_of_data rather than a synthetic p6 topic.",
+      "visual_topic_guess": null,
+      "alignment_status": "not_compared",
+      "alignment_review_required": false,
+      "overall_alignment_verdict": "ready"
+    }
+  ],
+  "authority_alignment_run_id": "authority-alignment-54a99331-4c35-4363-86ba-e528b4b0575d"
+}

--- a/docs/reports/2026-04-23-9709-authority-missing-q07-recovery.md
+++ b/docs/reports/2026-04-23-9709-authority-missing-q07-recovery.md
@@ -1,0 +1,165 @@
+# 2026-04-23 9709 Authority-Missing q07 Recovery
+
+## Scope
+
+- issue slug: `9709-authority-missing-q07`
+- target row: `9709/s17_qp_63/questions/q07.png`
+- goal: resolve the last `blocked_authority_missing` row from the ready-only / prompt-backfill chain without inventing taxonomy truth
+
+## Authority Decision
+
+The row can now be advanced truthfully as `9709.p5.representation_of_data`.
+
+Why this crosswalk is defensible:
+
+- checked-in live probe evidence already shows this row is a histogram with `Length (cm)` on the x-axis and `Frequency density` on the y-axis:
+  - `data/manifests/9709_diagram_lane_live_probe_v1.json`
+  - `docs/reports/2026-04-16-9709-diagram-lane-live-probe-results.json`
+- the checked-in current syllabus taxonomy places histograms and frequency-density interpretation under Paper 5 Representation of Data:
+  - `data/syllabus/9709syllabus.txt`
+- historical component review confirmed that `9709/63` in June 2017 was `Paper 6: Probability & Statistics 1`, and the mark scheme’s Q7 is the histogram / frequency-density / grouped-data question:
+  - `https://bestexamhelp.com/exam/cambridge-international-a-level/mathematics-9709/2017/9709_s17_qp_63.pdf`
+  - `https://www.teachifyme.com/wp-content/uploads/2016/05/9709_s17_ms_63.pdf`
+
+The repo’s current canonical Statistics 1 taxonomy lives under `p5`, not `p6`, so the truthful freeze is a historical `paper 63 -> current p5 S1` crosswalk, not a synthetic `p6.statistics.*` branch.
+
+## Checked-In Changes
+
+- corrected the q07 live-probe topic label to `9709.p5.representation_of_data`
+  - `data/manifests/9709_diagram_lane_live_probe_v1.json`
+- froze the q07 authority sidecar entry onto `9709.p5.representation_of_data`
+  - `data/manifests/9709_authority_ready_batch_300_authority_sidecar_v2.json`
+- added the minimal seed nodes required to resolve that path in the 300-row batch seed
+  - `data/curriculum/9709_authority_ready_batch_300_nodes_v2.json`
+- added a regression that proves q07 now becomes `ready`
+  - `scripts/learning/__tests__/run-9709-authority-ready-batch.test.js`
+
+## Targeted Artifacts
+
+One-row rerun inputs and outputs were materialized under:
+
+- `docs/reports/2026-04-23-9709-authority-missing-q07-manifest.json`
+- `docs/reports/2026-04-23-9709-authority-missing-q07-authority-sidecar.json`
+- `docs/reports/2026-04-23-9709-authority-missing-q07-curriculum-seed.json`
+- `docs/reports/2026-04-23-9709-authority-missing-q07-lane-results.json`
+- `docs/reports/2026-04-23-9709-authority-missing-q07-authority-manifest.json`
+- `docs/reports/2026-04-23-9709-authority-missing-q07-aligned-manifest.json`
+- `docs/reports/2026-04-23-9709-authority-missing-q07-ready-manifest.json`
+- `docs/reports/2026-04-23-9709-authority-missing-q07-evidence-bundles.json`
+
+Key artifact result:
+
+- authority freeze verdict: `ready`
+- canonical topic path: `9709.p5.representation_of_data`
+- ready items in the one-row rerun: `1`
+
+## Commands Run
+
+Regression:
+
+```bash
+npm test -- --runInBand scripts/learning/__tests__/run-9709-authority-ready-batch.test.js
+```
+
+One-row artifact generation:
+
+```bash
+node --input-type=module - <<'NODE'
+// filtered q07 inputs from the checked-in 300-row batch sources
+// wrote the one-row manifest / sidecar / seed / lane-results and ready-batch artifacts
+NODE
+```
+
+Registry backfill:
+
+```bash
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/learning/run_paper_question_registry_backfill_host.ps1 \
+  -Manifest docs/reports/2026-04-23-9709-authority-missing-q07-ready-manifest.json \
+  -CurriculumSeed docs/reports/2026-04-23-9709-authority-missing-q07-curriculum-seed.json
+```
+
+Question-analysis backfill:
+
+```bash
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/learning/run_question_analysis_backfill_host.ps1 \
+  -Manifest docs/reports/2026-04-23-9709-authority-missing-q07-ready-manifest.json \
+  -EvidenceBundles docs/reports/2026-04-23-9709-authority-missing-q07-evidence-bundles.json
+```
+
+## Downstream Results
+
+Registry backfill output:
+
+```json
+{
+  "processed": 1,
+  "inserted": 0,
+  "updated": 1,
+  "conflicts": 0,
+  "dryRun": false,
+  "curriculumNodes": {
+    "inserted": 0,
+    "existing": 3
+  },
+  "preview": [
+    {
+      "storage_key": "9709/s17_qp_63/questions/q07.png",
+      "q_number": 7,
+      "action": "update",
+      "primary_topic_id": "9328999a-b132-4feb-95db-f0b6c4331b2c",
+      "prompt_representation_source": "missing",
+      "source_kind": "paper_question"
+    }
+  ]
+}
+```
+
+Question-analysis backfill output:
+
+```json
+{
+  "processed": 1,
+  "backfilled": 1,
+  "skipped": 0,
+  "items": [
+    {
+      "question_id": "598db135-46ec-4f79-b148-e73cc98fdfc3",
+      "status": "backfilled",
+      "classification_snapshot_id": "b1e8dba8-bb95-4c3f-b93a-67e341c3990f",
+      "question_event_id": "9c187aee-532b-4960-87dc-6ce41f6ec66d"
+    }
+  ]
+}
+```
+
+## DB State
+
+Before rerun:
+
+- `question_bank` row already existed for q07
+- `primary_topic_path = 9709.p5.representation_of_data`
+- `release_scope_status = non_released_fallback`
+- `prompt_representation = null`
+- active snapshot id: `3e72a03b-979e-48a0-b3da-b6eb74cc9e04`
+
+After rerun:
+
+- `question_bank.primary_topic_path` stayed `9709.p5.representation_of_data`
+- `question_bank.release_scope_status` stayed `non_released_fallback`
+- active snapshot id is now `b1e8dba8-bb95-4c3f-b93a-67e341c3990f`
+- prior snapshot `3e72a03b-979e-48a0-b3da-b6eb74cc9e04` is superseded by the new snapshot
+- new `QuestionClassified` event id: `9c187aee-532b-4960-87dc-6ce41f6ec66d`
+
+Residual DB posture after the rerun:
+
+- `prompt_representation` is still `null`
+- `provenance_summary.summary` is still `null`
+- `provenance_summary.search_text` is still `null`
+- `descriptor_summary_status = descriptor_missing_or_empty`
+- `descriptor_search_text_status = missing`
+
+## Conclusion
+
+This slice resolves the authority blocker and produces a clean `ready` authority/alignment posture for q07, backed by checked-in evidence plus an auditable historical crosswalk.
+
+It does not fully restore prompt material on the `question_bank` row. The rerun proves the remaining gap is downstream prompt persistence for diagram-only evidence bundles, not authority truth. That residual gap should be tracked separately from this authority-fix slice.

--- a/scripts/learning/__tests__/run-9709-authority-ready-batch.test.js
+++ b/scripts/learning/__tests__/run-9709-authority-ready-batch.test.js
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { buildAuthorityReadyBatchArtifacts } from '../run_9709_authority_ready_batch.js';
+
+const STORAGE_KEY = '9709/s17_qp_63/questions/q07.png';
+const EXPECTED_TOPIC_PATH = '9709.p5.representation_of_data';
+
+function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8'));
+}
+
+function pickManifestRow(manifest) {
+  return {
+    ...manifest,
+    items: (manifest.items ?? []).filter((item) => item?.storage_key === STORAGE_KEY),
+  };
+}
+
+function pickAuthoritySidecarEntry(sidecar) {
+  const entry = (sidecar.items ?? []).find((item) => item?.storage_key === STORAGE_KEY);
+  if (!entry) {
+    throw new Error(`Missing authority sidecar entry for ${STORAGE_KEY}`);
+  }
+  return {
+    [STORAGE_KEY]: entry.authority_input_pack,
+  };
+}
+
+function pickLaneOutputs(payload) {
+  const outputs = Array.isArray(payload) ? payload : payload.results ?? payload.items ?? payload.outputs ?? [];
+  return outputs.filter((item) => item?.input_asset_id === STORAGE_KEY);
+}
+
+describe('9709 authority-ready batch q07 recovery', () => {
+  test('advances the remaining authority-missing histogram row through the ready batch', async () => {
+    const manifest = pickManifestRow(readJson('data/manifests/9709_authority_ready_batch_300_v1.json'));
+    const authoritySidecar = pickAuthoritySidecarEntry(
+      readJson('data/manifests/9709_authority_ready_batch_300_authority_sidecar_v2.json'),
+    );
+    const curriculumSeed = readJson('data/curriculum/9709_authority_ready_batch_300_nodes_v2.json');
+    const laneOutputs = pickLaneOutputs(
+      readJson('docs/reports/2026-04-16-9709-diagram-lane-live-probe-results.json'),
+    );
+
+    expect(manifest.items).toHaveLength(1);
+    expect(laneOutputs).toHaveLength(1);
+
+    const result = await buildAuthorityReadyBatchArtifacts({
+      manifest,
+      authoritySidecar,
+      curriculumSeed,
+      laneOutputs,
+    });
+
+    expect(result.authorityManifest.items).toHaveLength(1);
+    expect(result.authorityManifest.items[0]).toMatchObject({
+      storage_key: STORAGE_KEY,
+      primary_topic_path: EXPECTED_TOPIC_PATH,
+      canonical_primary_topic_path: EXPECTED_TOPIC_PATH,
+      authority_truth_status: 'frozen',
+      taxonomy_resolution_status: 'resolved',
+      provisional_alignment_verdict: 'ready',
+    });
+
+    expect(result.alignedManifest.items[0]).toMatchObject({
+      storage_key: STORAGE_KEY,
+      overall_alignment_verdict: 'ready',
+      manual_action_required: false,
+    });
+    expect(result.readyManifest.items).toHaveLength(1);
+    expect(result.readyManifest.items[0]).toMatchObject({
+      storage_key: STORAGE_KEY,
+      primary_topic_path: EXPECTED_TOPIC_PATH,
+    });
+    expect(result.bundles).toHaveLength(1);
+    expect(result.bundles[0]).toMatchObject({
+      storage_key: STORAGE_KEY,
+      analysis_hints: {
+        topic_path_hint: EXPECTED_TOPIC_PATH,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- freeze `9709/s17_qp_63/questions/q07.png` onto the checked-in `9709.p5.representation_of_data` crosswalk
- add the minimal `p5` seed extension and a regression that proves the one-row authority batch becomes `ready`
- check in the one-row rerun artifacts and recovery report for the downstream registry / analysis replay

## Verification
- `npm test -- --runInBand scripts/learning/__tests__/run-9709-authority-ready-batch.test.js`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/learning/run_paper_question_registry_backfill_host.ps1 -Manifest docs/reports/2026-04-23-9709-authority-missing-q07-ready-manifest.json -CurriculumSeed docs/reports/2026-04-23-9709-authority-missing-q07-curriculum-seed.json`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/learning/run_question_analysis_backfill_host.ps1 -Manifest docs/reports/2026-04-23-9709-authority-missing-q07-ready-manifest.json -EvidenceBundles docs/reports/2026-04-23-9709-authority-missing-q07-evidence-bundles.json`

## Notes
- authority/alignment for q07 now resolves to `ready`
- the rerun refreshes snapshot lineage, but `question_bank.prompt_representation` remains null for this diagram-only row; that residual is documented in `docs/reports/2026-04-23-9709-authority-missing-q07-recovery.md`
- Refs `9709-authority-missing-q07`