### PR TITLE
fix(learning): persist diagram-only provenance summaries

### DIFF
--- a/scripts/learning/__tests__/question-analysis-backfill.test.js
+++ b/scripts/learning/__tests__/question-analysis-backfill.test.js
@@ -776,6 +776,12 @@ describe('question-analysis backfill', () => {
         type: 'text',
         value: expect.stringContaining('Diagram Present: true'),
       },
+      provenance_summary: expect.objectContaining({
+        summary: expect.stringContaining('Diagram Present: true'),
+        search_text: expect.stringContaining('Diagram Present: true'),
+        descriptor_summary_status: 'evidence_bundle_summary',
+        descriptor_search_text_status: 'evidence_bundle_search_text',
+      }),
     });
     expect(
       state.questions.get('question-paper-q07-diagram-only').prompt_representation.value,

--- a/scripts/learning/__tests__/question-analysis-backfill.test.js
+++ b/scripts/learning/__tests__/question-analysis-backfill.test.js
@@ -797,6 +797,83 @@ describe('question-analysis backfill', () => {
     ).toEqual(expect.stringContaining('bar 3 spans x=10 to 20, height ≈12'));
   });
 
+  test('paper_question backfill preserves curated provenance descriptors when only low-signal structured fallback is available', async () => {
+    const { client, state } = createBackfillClient();
+
+    await runQuestionAnalysisBackfill(client, {
+      questions: [
+        {
+          question_id: 'question-paper-curated-descriptor',
+          source_kind: 'paper_question',
+          subject_code: '9709',
+          storage_key: '9709/s24_qp_13/questions/q09.png',
+          q_number: 9,
+          primary_topic_id: 'topic-integration-application',
+          paper_scope: {
+            year: 2024,
+            session: 's',
+            paper: 1,
+            q_number: 9,
+          },
+          prompt_representation: null,
+          questionEvidenceBundle: {
+            schema_version: 'question_evidence_bundle_v1',
+            storage_key: '9709/s24_qp_13/questions/q09.png',
+            analysis_hints: {
+              topic_path_hint: '9709.p1.integration.application',
+            },
+            evidence: {
+              ocr_text: '',
+              formula_latex_list: [],
+              subquestion_blocks: [],
+              layout_hints: [],
+              diagram_present: false,
+              diagram_elements: [],
+              spatial_evidence: [],
+            },
+            route: {
+              route: 'ocr_lane',
+              model: 'qwen3.6-plus',
+              region: 'dashscope-cn',
+              prompt_template_version: 'v1',
+              response_schema_version: 'v1',
+            },
+            model_provenance: [],
+            lazy_attach_original_image: false,
+            lazy_attach_reasons: [],
+            original_image_asset: {
+              input_asset_id: '9709/s24_qp_13/questions/q09.png',
+              input_asset_hash: 'hash-curated-descriptor',
+            },
+            review_posture: {
+              requires_review: false,
+              gate_critical: false,
+            },
+          },
+          provenance_summary: {
+            storage_key: '9709/s24_qp_13/questions/q09.png',
+            q_number: 9,
+            primary_topic_path: '9709.p1.integration.application',
+            summary: 'Curated descriptor summary.',
+            search_text: 'curated retrieval descriptor text',
+            descriptor_summary_status: 'manual_curated_summary',
+            descriptor_search_text_status: 'manual_curated_search_text',
+          },
+          classification_snapshot_ref: null,
+        },
+      ],
+    });
+
+    expect(state.questions.get('question-paper-curated-descriptor')).toMatchObject({
+      provenance_summary: expect.objectContaining({
+        summary: 'Curated descriptor summary.',
+        search_text: 'curated retrieval descriptor text',
+        descriptor_summary_status: 'manual_curated_summary',
+        descriptor_search_text_status: 'manual_curated_search_text',
+      }),
+    });
+  });
+
   test('paper_question search text adds retrieval-oriented integral substitution cues', async () => {
     const { client, state } = createBackfillClient();
 

--- a/scripts/learning/lib/question-analysis-backfill.js
+++ b/scripts/learning/lib/question-analysis-backfill.js
@@ -359,6 +359,9 @@ function buildQuestionPromptRepresentation(
   questionEvidenceBundle = null,
   questionEvidenceBundleClassificationInput = null,
 ) {
+  const structuredBundlePrompt = normalizeString(
+    questionEvidenceBundleClassificationInput?.prompt_representation?.value,
+  );
   const derivedSummary = buildEvidenceDerivedSummary(questionEvidenceBundle);
   if (derivedSummary) {
     return {
@@ -375,17 +378,27 @@ function buildQuestionPromptRepresentation(
     return existingPromptRepresentation;
   }
 
-  return normalizeObject(questionEvidenceBundleClassificationInput?.prompt_representation);
+  return structuredBundlePrompt
+    ? {
+      type: 'text',
+      value: structuredBundlePrompt,
+    }
+    : normalizeObject(questionEvidenceBundleClassificationInput?.prompt_representation);
 }
 
 function buildQuestionProvenanceSummary(
   question = {},
   questionEvidenceBundle = null,
   classification = null,
+  questionEvidenceBundleClassificationInput = null,
 ) {
   const existing = normalizeObject(question?.provenance_summary, {}) ?? {};
-  const derivedSummary = buildEvidenceDerivedSummary(questionEvidenceBundle);
-  const derivedSearchText = buildEvidenceDerivedSearchText(questionEvidenceBundle, classification);
+  const structuredBundlePrompt = normalizeString(
+    questionEvidenceBundleClassificationInput?.prompt_representation?.value,
+  );
+  const derivedSummary = buildEvidenceDerivedSummary(questionEvidenceBundle) || structuredBundlePrompt;
+  const derivedSearchText =
+    buildEvidenceDerivedSearchText(questionEvidenceBundle, classification) || structuredBundlePrompt;
 
   return {
     ...existing,
@@ -802,6 +815,7 @@ export async function backfillQuestionAnalysisRecord(client, {
           question,
           normalizedQuestionEvidenceBundle,
           materializedClassification,
+          questionEvidenceBundleClassificationInput,
         ),
         classification_snapshot_ref: buildClassificationSnapshotRef(
           insertedSnapshotId,

--- a/scripts/learning/lib/question-analysis-backfill.js
+++ b/scripts/learning/lib/question-analysis-backfill.js
@@ -396,15 +396,22 @@ function buildQuestionProvenanceSummary(
   const structuredBundlePrompt = normalizeString(
     questionEvidenceBundleClassificationInput?.prompt_representation?.value,
   );
-  const derivedSummary = buildEvidenceDerivedSummary(questionEvidenceBundle) || structuredBundlePrompt;
-  const derivedSearchText =
-    buildEvidenceDerivedSearchText(questionEvidenceBundle, classification) || structuredBundlePrompt;
+  const evidenceDerivedSummary = buildEvidenceDerivedSummary(questionEvidenceBundle);
+  const evidenceDerivedSearchText = buildEvidenceDerivedSearchText(questionEvidenceBundle, classification);
+  const existingSummary = normalizeString(existing.summary);
+  const existingTitle = normalizeString(existing.title);
+  const existingSearchText = normalizeString(existing.search_text);
+  const useStructuredSummaryFallback = !evidenceDerivedSummary && !existingSummary && structuredBundlePrompt;
+  const useStructuredSearchTextFallback =
+    !evidenceDerivedSearchText && !existingSearchText && structuredBundlePrompt;
+  const derivedSummary = evidenceDerivedSummary || useStructuredSummaryFallback;
+  const derivedSearchText = evidenceDerivedSearchText || useStructuredSearchTextFallback;
 
   return {
     ...existing,
-    summary: derivedSummary || existing.summary || null,
-    title: derivedSummary || existing.title || null,
-    search_text: derivedSearchText || existing.search_text || null,
+    summary: derivedSummary || existingSummary || null,
+    title: derivedSummary || existingTitle || null,
+    search_text: derivedSearchText || existingSearchText || null,
     descriptor_summary_status: derivedSummary
       ? 'evidence_bundle_summary'
       : existing.descriptor_summary_status ?? 'missing',


### PR DESCRIPTION
## Summary
- reuse the structured diagram-bundle prompt as the fallback summary/search text when OCR-derived descriptor text is empty
- persist the fallback into `question_bank.provenance_summary` so diagram-only backfills no longer leave descriptor status as missing
- extend the q07-shaped regression in `question-analysis-backfill.test.js` to cover the provenance fields

## Why
The live q07 closeout for `9709/s17_qp_63/questions/q07.png` showed a partial backfill on current `main`: `prompt_representation` and `learning_question_search_projection` were populated, but `question_bank.provenance_summary.summary/search_text` stayed null because the diagram-only path only fell back for prompt persistence.

## Verification
- `npm test -- --runInBand scripts/learning/__tests__/question-analysis-backfill.test.js`
- `env DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres SUPABASE_PG_COMPAT=true node scripts/learning/run_question_analysis_backfill.js --force --source-kind paper_question --manifest /tmp/cie-217-q07-live-probe-manifest.json --evidence-bundles /home/samsen/code/ciecopilot-home/tmp/2026-04-22-9709-diagram-lane-live-probe-evidence-bundles.json`
- after rerun, q07 has non-empty `prompt_representation`, non-empty `provenance_summary.summary/search_text`, `descriptor_summary_status=evidence_bundle_summary`, `descriptor_search_text_status=evidence_bundle_search_text`, and non-empty `learning_question_search_projection.summary/search_text`
