### PR TITLE
[codex] Add 9709 release preflight gate

### DIFF
--- a/docs/superpowers/plans/2026-04-24-9709-release-preflight.md
+++ b/docs/superpowers/plans/2026-04-24-9709-release-preflight.md
@@ -1,0 +1,55 @@
+# 9709 Release Preflight Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a 9709-specific release preflight that blocks publication when the authority-ready batch regresses into the failure modes found during the 300-question audit.
+
+**Architecture:** Implement a pure validator library plus a thin CLI. Wire the library into `run_9709_authority_ready_batch.js` before write-side backfill steps, while keeping JSON and Markdown reports available for standalone operator use.
+
+**Tech Stack:** Node.js ES modules, Jest, existing 9709 manifest/sidecar/curriculum JSON artifacts.
+
+---
+
+## File Map
+
+- Create: `scripts/learning/lib/9709-release-preflight.js`
+- Create: `scripts/learning/run_9709_release_preflight.js`
+- Create: `scripts/learning/__tests__/9709-release-preflight.test.js`
+- Create: `scripts/learning/__tests__/run-9709-release-preflight.test.js`
+- Modify: `scripts/learning/run_9709_authority_ready_batch.js`
+- Add docs: `docs/superpowers/specs/2026-04-24-9709-release-preflight-design.md`
+
+## Task 1: Validator Red Tests
+
+- [ ] Write tests for a passing 300-row fixture with warnings allowed.
+- [ ] Write tests for `diagram_present=null` as a blocker.
+- [ ] Write tests for missing sidecar join entries as blockers.
+- [ ] Write tests for missing canonical topic and unseeded topic blockers.
+- [ ] Write tests for legacy P1 vector rows that are not canonicalized to `p3.vectors`.
+- [ ] Write tests for OCR-empty and unresolved-image blockers.
+- [ ] Run the focused Jest file and confirm it fails because the validator does not exist.
+
+## Task 2: Validator Implementation
+
+- [ ] Implement manifest, sidecar, seed, and optional bundle normalization.
+- [ ] Implement blocker/warning accumulation with reason codes and examples.
+- [ ] Implement `status`, `counts`, and Markdown rendering.
+- [ ] Run focused tests and make them pass.
+
+## Task 3: CLI
+
+- [ ] Add argument parsing for manifest, sidecar, seed, bundles, expected count, JSON output, Markdown output, and fail-on-warning.
+- [ ] Add tests for CLI report writing and exit-code behavior through exported `main`.
+- [ ] Run focused CLI tests and make them pass.
+
+## Task 4: Batch Runner Integration
+
+- [ ] Add preflight options to `run_9709_authority_ready_batch.js`.
+- [ ] Run preflight after artifact build and before backfill steps.
+- [ ] Add a runner test proving blockers stop execution before write steps.
+
+## Task 5: Verification
+
+- [ ] Run the focused preflight tests.
+- [ ] Run the existing `run-9709-authority-ready-batch.test.js`.
+- [ ] Run the preflight CLI against the published 300-row artifacts and confirm no blockers.

--- a/docs/superpowers/specs/2026-04-24-9709-release-preflight-design.md
+++ b/docs/superpowers/specs/2026-04-24-9709-release-preflight-design.md
@@ -1,0 +1,65 @@
+# 9709 Release Preflight Design
+
+## Purpose
+
+The 9709 authority-ready batch can now publish 300 audited questions, but the path that produced it required manual repair. This design adds a 9709-specific release preflight so future runs fail before publish when the same classes of defects recur.
+
+The preflight does not replace VLM extraction, authority review, or registry backfill. It validates the artifacts those steps produce and writes a release-quality report that is both machine-readable and reviewable by an operator.
+
+## Scope
+
+This design is intentionally 9709-specific. It validates the `9709_authority_ready_batch_300_v1` manifest, authority sidecar, curriculum seed, and optional evidence bundles or lane output summaries. It does not generalize subject ingest for every syllabus.
+
+## Blocking Checks
+
+The preflight fails when any of these conditions is present:
+
+- Manifest item count differs from the expected count, defaulting to 300.
+- Any manifest item has `diagram_present` missing, `null`, or non-boolean.
+- Manifest and authority sidecar cannot join 1:1 by `storage_key`.
+- Any sidecar item is missing `authority_input_pack.canonical_primary_topic_path`.
+- Any canonical topic path cannot be resolved by the configured 9709 curriculum seed.
+- A historical paper-1 vector item is not canonicalized to `9709.p3.vectors` with legacy metadata.
+- An OCR-empty item lacks an explicit acceptable status such as out-of-scope, asset failed, or manual review required.
+- An image path is unresolved without an acceptable `WM_` fallback or explicit review reason.
+- A ready-to-write artifact contains an item whose `overall_alignment_verdict` is not `ready`.
+
+## Warning Checks
+
+The preflight passes with warnings for these conditions:
+
+- `diagram_present=true` but `diagram_elements` is empty.
+- `diagram_present=true` but `spatial_evidence` is empty.
+- Crop quality is suspicious but OCR is present.
+- Paper 5 or Paper 6 content is present in the batch but the authority sidecar explicitly resolves it.
+- Manifest `primary_topic_path` is missing while the sidecar provides canonical authority.
+
+## Outputs
+
+The CLI writes a JSON report with:
+
+- `status`: `pass` or `fail`
+- `blockers`: blocking findings with storage keys and reason codes
+- `warnings`: non-blocking findings with storage keys and reason codes
+- `counts`: manifest, sidecar, diagram, topic, and evidence summary counts
+
+When requested, it also writes a Markdown report summarizing the same information for review.
+
+Exit behavior:
+
+- Non-zero when blockers exist.
+- Zero when only warnings exist.
+- Zero when no findings exist.
+
+## Integration
+
+The preflight is exposed as a reusable library and a CLI:
+
+- `scripts/learning/lib/9709-release-preflight.js`
+- `scripts/learning/run_9709_release_preflight.js`
+
+`run_9709_authority_ready_batch.js` should call the library after building artifacts and before executing registry or analysis backfill steps. The first implementation may keep this behind a CLI flag if needed, but the release path should treat blockers as hard failures.
+
+## Validation Strategy
+
+Tests use small fixtures for failure modes and the published 300-row manifest as a passing fixture. The passing fixture is allowed to contain warnings for known partial `diagram_elements` coverage, but it must have no blockers.

--- a/scripts/learning/__tests__/9709-release-preflight.test.js
+++ b/scripts/learning/__tests__/9709-release-preflight.test.js
@@ -1,0 +1,340 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  render9709ReleasePreflightMarkdown,
+  validate9709ReleasePreflight,
+} from '../lib/9709-release-preflight.js';
+
+function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8'));
+}
+
+function buildManifestItem(overrides = {}) {
+  return {
+    storage_key: '9709/s24_qp_13/questions/q09.png',
+    syllabus_code: '9709',
+    year: 2024,
+    session: 's',
+    paper: 1,
+    variant: 3,
+    q_number: 9,
+    primary_topic_path: '9709.p1.integration',
+    diagram_present: true,
+    formula_dense: true,
+    table_heavy: false,
+    surface_evidence_status: 'backfilled_from_audit',
+    review_reasons: [],
+    ...overrides,
+  };
+}
+
+function buildManifest(items = [buildManifestItem()]) {
+  return {
+    schema_version: 'v1',
+    manifest_id: 'test_9709_manifest',
+    subject_code: '9709',
+    curriculum_version_tag: '2025-2027_v1',
+    items,
+  };
+}
+
+function buildAuthoritySidecarEntry(storageKey, canonicalTopicPath, overrides = {}) {
+  return {
+    storage_key: storageKey,
+    authority_input_pack: {
+      canonical_primary_topic_path: canonicalTopicPath,
+      curriculum_version_tag: '2025-2027_v1',
+      topic_authority_sources: ['manual_audit'],
+      topic_authority_refs: [
+        { kind: 'manual_audit', locator: `storage_key=${storageKey}`, note: null },
+      ],
+      cross_paper_dependency_note: null,
+      ...overrides,
+    },
+  };
+}
+
+function buildAuthoritySidecar(items = [buildAuthoritySidecarEntry(
+  '9709/s24_qp_13/questions/q09.png',
+  '9709.p1.integration',
+)]) {
+  return {
+    schema_version: 'v1',
+    sidecar_id: 'test_9709_sidecar',
+    subject_code: '9709',
+    curriculum_version_tag: '2025-2027_v1',
+    items,
+  };
+}
+
+function buildCurriculumSeed(topicPaths = ['9709.p1.integration']) {
+  return {
+    syllabus_code: '9709',
+    version_tag: '2025-2027_v1',
+    nodes: topicPaths.map((topicPath) => ({
+      syllabus_code: '9709',
+      version_tag: '2025-2027_v1',
+      topic_path: topicPath,
+    })),
+  };
+}
+
+function buildBundle(storageKey = '9709/s24_qp_13/questions/q09.png', overrides = {}) {
+  return {
+    schema_version: 'question_evidence_bundle_v1',
+    storage_key: storageKey,
+    evidence: {
+      ocr_text: 'A curve is shown in the diagram.',
+      diagram_present: true,
+      diagram_elements: ['curve'],
+      spatial_evidence: ['axes shown'],
+    },
+    surface_posture: {
+      surface_evidence_status: 'backfilled_from_audit',
+    },
+    review_posture: {
+      review_reasons: [],
+    },
+    ...overrides,
+  };
+}
+
+describe('9709 release preflight', () => {
+  test('passes the published 300-row authority-ready batch with no blockers', () => {
+    const result = validate9709ReleasePreflight({
+      manifest: readJson('data/manifests/9709_authority_ready_batch_300_v1.json'),
+      authoritySidecar: readJson('data/manifests/9709_authority_ready_batch_300_authority_sidecar_v2.json'),
+      curriculumSeed: readJson('data/curriculum/9709_authority_ready_batch_300_nodes_v2.json'),
+      expectedManifestCount: 300,
+    });
+
+    expect(result.status).toBe('pass');
+    expect(result.blockers).toHaveLength(0);
+    expect(result.counts.manifest_items).toBe(300);
+    expect(result.counts.diagram_present).toEqual({ true: 83, false: 217, invalid: 0 });
+    expect(result.counts.sidecar_items).toBe(300);
+    expect(result.counts.sidecar_canonical_missing).toBe(0);
+    expect(result.counts.sidecar_distinct_topics).toBe(18);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ reason_code: 'manifest_primary_topic_missing_sidecar_canonical_present' }),
+      ]),
+    );
+  });
+
+  test('blocks null diagram_present values', () => {
+    const result = validate9709ReleasePreflight({
+      manifest: buildManifest([buildManifestItem({ diagram_present: null })]),
+      authoritySidecar: buildAuthoritySidecar(),
+      curriculumSeed: buildCurriculumSeed(),
+      expectedManifestCount: 1,
+    });
+
+    expect(result.status).toBe('fail');
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          storage_key: '9709/s24_qp_13/questions/q09.png',
+          reason_code: 'diagram_present_not_boolean',
+        }),
+      ]),
+    );
+  });
+
+  test('blocks sidecar join and canonical topic failures', () => {
+    const storageKey = '9709/s24_qp_13/questions/q09.png';
+    const result = validate9709ReleasePreflight({
+      manifest: buildManifest([buildManifestItem({ storage_key: storageKey })]),
+      authoritySidecar: buildAuthoritySidecar([]),
+      curriculumSeed: buildCurriculumSeed(),
+      expectedManifestCount: 1,
+    });
+
+    expect(result.status).toBe('fail');
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ storage_key: storageKey, reason_code: 'missing_authority_sidecar_entry' }),
+      ]),
+    );
+
+    const missingCanonical = validate9709ReleasePreflight({
+      manifest: buildManifest([buildManifestItem({ storage_key: storageKey })]),
+      authoritySidecar: buildAuthoritySidecar([
+        buildAuthoritySidecarEntry(storageKey, null),
+      ]),
+      curriculumSeed: buildCurriculumSeed(),
+      expectedManifestCount: 1,
+    });
+
+    expect(missingCanonical.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ storage_key: storageKey, reason_code: 'missing_canonical_primary_topic_path' }),
+      ]),
+    );
+  });
+
+  test('blocks canonical topics not present in the 9709 curriculum seed', () => {
+    const storageKey = '9709/s24_qp_13/questions/q09.png';
+    const result = validate9709ReleasePreflight({
+      manifest: buildManifest([buildManifestItem({ storage_key: storageKey })]),
+      authoritySidecar: buildAuthoritySidecar([
+        buildAuthoritySidecarEntry(storageKey, '9709.p7.not_real'),
+      ]),
+      curriculumSeed: buildCurriculumSeed(['9709.p1.integration']),
+      expectedManifestCount: 1,
+    });
+
+    expect(result.status).toBe('fail');
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ storage_key: storageKey, reason_code: 'canonical_topic_not_seeded' }),
+      ]),
+    );
+  });
+
+  test('blocks historical paper-1 vector rows that are not canonicalized to p3 vectors', () => {
+    const storageKey = '9709/m18_qp_12/questions/q07.png';
+    const result = validate9709ReleasePreflight({
+      manifest: buildManifest([
+        buildManifestItem({
+          storage_key: storageKey,
+          year: 2018,
+          paper: 1,
+          primary_topic_path: '9709.p1.coordinate_geometry',
+          historical_topic_label: 'legacy_p1_vectors',
+          syllabus_version: 'pre-2020',
+        }),
+      ]),
+      authoritySidecar: buildAuthoritySidecar([
+        buildAuthoritySidecarEntry(storageKey, '9709.p1.coordinate_geometry'),
+      ]),
+      curriculumSeed: buildCurriculumSeed(['9709.p1.coordinate_geometry', '9709.p3.vectors']),
+      expectedManifestCount: 1,
+    });
+
+    expect(result.status).toBe('fail');
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ storage_key: storageKey, reason_code: 'legacy_p1_vector_not_canonical_p3_vectors' }),
+      ]),
+    );
+  });
+
+  test('blocks OCR-empty and image-unresolved rows without explicit acceptable status', () => {
+    const storageKey = '9709/s24_qp_13/questions/q09.png';
+    const result = validate9709ReleasePreflight({
+      manifest: buildManifest([
+        buildManifestItem({
+          storage_key: storageKey,
+          review_reasons: [],
+        }),
+      ]),
+      authoritySidecar: buildAuthoritySidecar([
+        buildAuthoritySidecarEntry(storageKey, '9709.p1.integration'),
+      ]),
+      curriculumSeed: buildCurriculumSeed(),
+      evidenceBundles: [
+        buildBundle(storageKey, {
+          evidence: {
+            ocr_text: '',
+            diagram_present: false,
+            diagram_elements: [],
+            spatial_evidence: [],
+          },
+          route: {
+            failure_reason: 'image_not_found',
+          },
+          review_posture: {
+            review_reasons: [],
+          },
+          surface_posture: {
+            surface_evidence_status: 'unknown_requires_primary_asset_replay',
+          },
+        }),
+      ],
+      expectedManifestCount: 1,
+    });
+
+    expect(result.status).toBe('fail');
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ storage_key: storageKey, reason_code: 'ocr_empty_without_explicit_status' }),
+        expect.objectContaining({ storage_key: storageKey, reason_code: 'image_unresolved_without_fallback_or_reason' }),
+      ]),
+    );
+  });
+
+  test('warns but does not block when diagram elements are empty for diagram-present rows', () => {
+    const storageKey = '9709/s24_qp_13/questions/q09.png';
+    const result = validate9709ReleasePreflight({
+      manifest: buildManifest([buildManifestItem({ storage_key: storageKey })]),
+      authoritySidecar: buildAuthoritySidecar([
+        buildAuthoritySidecarEntry(storageKey, '9709.p1.integration'),
+      ]),
+      curriculumSeed: buildCurriculumSeed(),
+      evidenceBundles: [
+        buildBundle(storageKey, {
+          evidence: {
+            ocr_text: 'A diagram is shown.',
+            diagram_present: true,
+            diagram_elements: [],
+            spatial_evidence: [],
+          },
+        }),
+      ],
+      expectedManifestCount: 1,
+    });
+
+    expect(result.status).toBe('pass');
+    expect(result.blockers).toHaveLength(0);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ storage_key: storageKey, reason_code: 'diagram_present_but_elements_empty' }),
+        expect.objectContaining({ storage_key: storageKey, reason_code: 'diagram_present_but_spatial_evidence_empty' }),
+      ]),
+    );
+  });
+
+  test('blocks non-ready items in ready-to-write artifacts', () => {
+    const storageKey = '9709/s24_qp_13/questions/q09.png';
+    const result = validate9709ReleasePreflight({
+      manifest: buildManifest([buildManifestItem({ storage_key: storageKey })]),
+      authoritySidecar: buildAuthoritySidecar([
+        buildAuthoritySidecarEntry(storageKey, '9709.p1.integration'),
+      ]),
+      curriculumSeed: buildCurriculumSeed(),
+      readyManifest: {
+        items: [
+          {
+            storage_key: storageKey,
+            overall_alignment_verdict: 'blocked_for_review',
+          },
+        ],
+      },
+      expectedManifestCount: 1,
+    });
+
+    expect(result.status).toBe('fail');
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ storage_key: storageKey, reason_code: 'ready_artifact_contains_non_ready_item' }),
+      ]),
+    );
+  });
+
+  test('renders a markdown summary for operator review', () => {
+    const result = validate9709ReleasePreflight({
+      manifest: buildManifest(),
+      authoritySidecar: buildAuthoritySidecar(),
+      curriculumSeed: buildCurriculumSeed(),
+      expectedManifestCount: 1,
+    });
+
+    const markdown = render9709ReleasePreflightMarkdown(result);
+
+    expect(markdown).toContain('# 9709 Release Preflight');
+    expect(markdown).toContain('status: `pass`');
+    expect(markdown).toContain('manifest_items');
+  });
+});

--- a/scripts/learning/__tests__/run-9709-authority-ready-batch.test.js
+++ b/scripts/learning/__tests__/run-9709-authority-ready-batch.test.js
@@ -1,7 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { buildAuthorityReadyBatchArtifacts } from '../run_9709_authority_ready_batch.js';
+import {
+  assert9709ReleasePreflightPassed,
+  buildAuthorityReadyBatchArtifacts,
+  build9709ReleasePreflightForArtifacts,
+} from '../run_9709_authority_ready_batch.js';
 
 const STORAGE_KEY = '9709/s17_qp_63/questions/q07.png';
 const EXPECTED_TOPIC_PATH = '9709.p5.representation_of_data';
@@ -80,5 +84,63 @@ describe('9709 authority-ready batch q07 recovery', () => {
         topic_path_hint: EXPECTED_TOPIC_PATH,
       },
     });
+  });
+
+  test('release preflight blocks authority-ready batch artifacts before write steps', async () => {
+    const manifest = {
+      manifest_id: 'broken-9709-release-preflight',
+      items: [
+        {
+          storage_key: '9709/s24_qp_13/questions/q09.png',
+          syllabus_code: '9709',
+          paper: 1,
+          primary_topic_path: '9709.p1.integration',
+          diagram_present: null,
+        },
+      ],
+    };
+    const authoritySidecar = {
+      items: [
+        {
+          storage_key: '9709/s24_qp_13/questions/q09.png',
+          authority_input_pack: {
+            canonical_primary_topic_path: '9709.p1.integration',
+          },
+        },
+      ],
+    };
+    const curriculumSeed = {
+      syllabus_code: '9709',
+      version_tag: '2025-2027_v1',
+      nodes: [
+        {
+          syllabus_code: '9709',
+          version_tag: '2025-2027_v1',
+          topic_path: '9709.p1.integration',
+        },
+      ],
+    };
+    const artifacts = {
+      bundles: [],
+      readyManifest: {
+        items: [
+          {
+            storage_key: '9709/s24_qp_13/questions/q09.png',
+            overall_alignment_verdict: 'ready',
+          },
+        ],
+      },
+    };
+
+    const preflight = build9709ReleasePreflightForArtifacts({
+      manifest,
+      authoritySidecarPayload: authoritySidecar,
+      curriculumSeed,
+      artifacts,
+      expectedManifestCount: 1,
+    });
+
+    expect(preflight.status).toBe('fail');
+    expect(() => assert9709ReleasePreflightPassed(preflight)).toThrow(/9709 release preflight failed/);
   });
 });

--- a/scripts/learning/__tests__/run-9709-release-preflight.test.js
+++ b/scripts/learning/__tests__/run-9709-release-preflight.test.js
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const TMP_DIR = path.join(process.cwd(), 'tmp', '9709-release-preflight-test');
+
+function writeJson(relativeName, payload) {
+  const filePath = path.join(TMP_DIR, relativeName);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return filePath;
+}
+
+function buildManifest(diagramPresent = true) {
+  return {
+    items: [
+      {
+        storage_key: '9709/s24_qp_13/questions/q09.png',
+        syllabus_code: '9709',
+        paper: 1,
+        primary_topic_path: '9709.p1.integration',
+        diagram_present: diagramPresent,
+      },
+    ],
+  };
+}
+
+function buildSidecar() {
+  return {
+    items: [
+      {
+        storage_key: '9709/s24_qp_13/questions/q09.png',
+        authority_input_pack: {
+          canonical_primary_topic_path: '9709.p1.integration',
+        },
+      },
+    ],
+  };
+}
+
+function buildSeed() {
+  return {
+    syllabus_code: '9709',
+    version_tag: '2025-2027_v1',
+    nodes: [
+      {
+        syllabus_code: '9709',
+        version_tag: '2025-2027_v1',
+        topic_path: '9709.p1.integration',
+      },
+    ],
+  };
+}
+
+describe('run_9709_release_preflight cli', () => {
+  beforeEach(() => {
+    fs.rmSync(TMP_DIR, { recursive: true, force: true });
+    fs.mkdirSync(TMP_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(TMP_DIR, { recursive: true, force: true });
+  });
+
+  test('writes JSON and Markdown reports and returns zero for warnings-only or clean results', async () => {
+    const { main } = await import('../run_9709_release_preflight.js');
+    const manifestPath = writeJson('manifest.json', buildManifest());
+    const sidecarPath = writeJson('sidecar.json', buildSidecar());
+    const seedPath = writeJson('seed.json', buildSeed());
+    const jsonOut = path.join(TMP_DIR, 'report.json');
+    const markdownOut = path.join(TMP_DIR, 'report.md');
+
+    const exitCode = await main([
+      '--manifest', manifestPath,
+      '--authority-sidecar', sidecarPath,
+      '--curriculum-seed', seedPath,
+      '--expected-count', '1',
+      '--json-out', jsonOut,
+      '--markdown-out', markdownOut,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(fs.readFileSync(jsonOut, 'utf8'))).toMatchObject({
+      status: 'pass',
+      counts: {
+        manifest_items: 1,
+      },
+    });
+    expect(fs.readFileSync(markdownOut, 'utf8')).toContain('# 9709 Release Preflight');
+  });
+
+  test('returns non-zero when blockers are present', async () => {
+    const { main } = await import('../run_9709_release_preflight.js');
+    const manifestPath = writeJson('manifest.json', buildManifest(null));
+    const sidecarPath = writeJson('sidecar.json', buildSidecar());
+    const seedPath = writeJson('seed.json', buildSeed());
+    const jsonOut = path.join(TMP_DIR, 'blocked.json');
+
+    const exitCode = await main([
+      '--manifest', manifestPath,
+      '--authority-sidecar', sidecarPath,
+      '--curriculum-seed', seedPath,
+      '--expected-count', '1',
+      '--json-out', jsonOut,
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(fs.readFileSync(jsonOut, 'utf8'))).toMatchObject({
+      status: 'fail',
+      blockers: [
+        expect.objectContaining({ reason_code: 'diagram_present_not_boolean' }),
+      ],
+    });
+  });
+});

--- a/scripts/learning/lib/9709-release-preflight.js
+++ b/scripts/learning/lib/9709-release-preflight.js
@@ -1,0 +1,468 @@
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeNullableString(value) {
+  const normalized = normalizeString(value);
+  return normalized || null;
+}
+
+function normalizeItems(payload = {}, preferredKey = 'items') {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (Array.isArray(payload?.[preferredKey])) {
+    return payload[preferredKey];
+  }
+  if (Array.isArray(payload?.items)) {
+    return payload.items;
+  }
+  if (Array.isArray(payload?.bundles)) {
+    return payload.bundles;
+  }
+  return [];
+}
+
+function pushFinding(target, {
+  severity,
+  reason_code: reasonCode,
+  storage_key: storageKey = null,
+  message,
+  details = {},
+}) {
+  target.push({
+    severity,
+    reason_code: reasonCode,
+    storage_key: storageKey,
+    message,
+    details: cloneJson(details) ?? {},
+  });
+}
+
+function indexByStorageKey(items = [], label = 'items') {
+  const map = new Map();
+  const duplicates = [];
+
+  for (const item of items) {
+    const storageKey = normalizeString(item?.storage_key);
+    if (!storageKey) {
+      continue;
+    }
+    if (map.has(storageKey)) {
+      duplicates.push(storageKey);
+      continue;
+    }
+    map.set(storageKey, item);
+  }
+
+  return { map, duplicates, label };
+}
+
+function normalizeSeedNode(node = {}, defaults = {}) {
+  return {
+    syllabus_code: normalizeString(node.syllabus_code) || defaults.syllabusCode,
+    version_tag: normalizeString(node.version_tag) || defaults.versionTag,
+    topic_path: normalizeString(node.topic_path),
+  };
+}
+
+function buildSeedTopicSet(curriculumSeed = {}) {
+  const defaultSyllabusCode = normalizeString(curriculumSeed.syllabus_code);
+  const defaultVersionTag = normalizeString(curriculumSeed.version_tag);
+  const nodes = Array.isArray(curriculumSeed.nodes) ? curriculumSeed.nodes : [];
+  return new Set(nodes.map((node) => normalizeSeedNode(node, {
+    syllabusCode: defaultSyllabusCode,
+    versionTag: defaultVersionTag,
+  })).filter((node) => (
+    node.syllabus_code === '9709'
+    && node.version_tag
+    && node.topic_path
+  )).map((node) => node.topic_path));
+}
+
+function sidecarPack(entry = {}) {
+  return entry?.authority_input_pack ?? entry ?? {};
+}
+
+function isLegacyP1VectorPack(manifestItem = {}, pack = {}) {
+  return manifestItem.paper === 1
+    && (
+      pack.historical_topic_label === 'legacy_p1_vectors'
+      || pack.syllabus_version === 'pre-2020'
+      || manifestItem.historical_topic_label === 'legacy_p1_vectors'
+      || manifestItem.syllabus_version === 'pre-2020'
+    );
+}
+
+function normalizeReasonList(...values) {
+  return values.flatMap((value) => {
+    if (Array.isArray(value)) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      return [value];
+    }
+    return [];
+  }).map((value) => normalizeString(value)).filter(Boolean);
+}
+
+function hasExplicitOcrEmptyStatus({ manifestItem = {}, bundle = {} } = {}) {
+  const surfaceStatus = normalizeString(
+    bundle?.surface_posture?.surface_evidence_status
+    ?? manifestItem.surface_evidence_status,
+  );
+  const reviewReasons = normalizeReasonList(
+    manifestItem.review_reasons,
+    bundle?.review_posture?.review_reasons,
+  );
+  const disposition = normalizeString(bundle?.review_posture?.disposition);
+
+  return disposition === 'excluded'
+    || surfaceStatus.startsWith('excluded')
+    || surfaceStatus.includes('asset_failed')
+    || surfaceStatus.includes('manual_review')
+    || reviewReasons.some((reason) => (
+      reason.includes('out_of_scope')
+      || reason.includes('asset_failed')
+      || reason.includes('requires_manual_review')
+      || reason.includes('ocr_empty_accepted')
+    ));
+}
+
+function hasImageFallbackOrReason({ manifestItem = {}, bundle = {} } = {}) {
+  const reviewReasons = normalizeReasonList(
+    manifestItem.review_reasons,
+    bundle?.review_posture?.review_reasons,
+    bundle?.lazy_attach_reasons,
+  );
+  const surfaceStatus = normalizeString(
+    bundle?.surface_posture?.surface_evidence_status
+    ?? manifestItem.surface_evidence_status,
+  );
+
+  return surfaceStatus.startsWith('excluded')
+    || reviewReasons.some((reason) => (
+      reason.includes('wm')
+      || reason.includes('fallback')
+      || reason.includes('out_of_scope')
+      || reason.includes('asset_failed')
+      || reason.includes('requires_manual_review')
+      || reason.includes('image_path_accepted')
+    ));
+}
+
+function routeFailureReason(bundle = {}) {
+  return normalizeString(
+    bundle?.route?.failure_reason
+    ?? bundle?.selected_route?.failure_reason
+    ?? bundle?.failure_reason,
+  );
+}
+
+function hasExtractionSignal(bundle = {}) {
+  const evidence = bundle.evidence ?? {};
+  return routeFailureReason(bundle)
+    || (Array.isArray(bundle.model_provenance) && bundle.model_provenance.length > 0)
+    || normalizeString(bundle?.route?.input_asset_hash)
+    || typeof bundle?.route?.confidence === 'number'
+    || normalizeString(evidence.ocr_text)
+    || (Array.isArray(evidence.formula_latex_list) && evidence.formula_latex_list.length > 0)
+    || (Array.isArray(evidence.subquestion_blocks) && evidence.subquestion_blocks.length > 0)
+    || (Array.isArray(evidence.layout_hints) && evidence.layout_hints.length > 0)
+    || (Array.isArray(evidence.diagram_elements) && evidence.diagram_elements.length > 0)
+    || (Array.isArray(evidence.spatial_evidence) && evidence.spatial_evidence.length > 0);
+}
+
+function buildCounts({
+  manifestItems,
+  sidecarItems,
+  sidecarTopicSet,
+  blockers,
+  warnings,
+} = {}) {
+  const diagramPresent = {
+    true: 0,
+    false: 0,
+    invalid: 0,
+  };
+
+  for (const item of manifestItems) {
+    if (item?.diagram_present === true) {
+      diagramPresent.true += 1;
+    } else if (item?.diagram_present === false) {
+      diagramPresent.false += 1;
+    } else {
+      diagramPresent.invalid += 1;
+    }
+  }
+
+  const sidecarCanonicalMissing = sidecarItems.filter((item) => (
+    !normalizeNullableString(sidecarPack(item).canonical_primary_topic_path)
+  )).length;
+
+  return {
+    manifest_items: manifestItems.length,
+    sidecar_items: sidecarItems.length,
+    diagram_present: diagramPresent,
+    sidecar_canonical_missing: sidecarCanonicalMissing,
+    sidecar_distinct_topics: sidecarTopicSet.size,
+    blockers: blockers.length,
+    warnings: warnings.length,
+  };
+}
+
+export function validate9709ReleasePreflight({
+  manifest = {},
+  authoritySidecar = {},
+  curriculumSeed = {},
+  evidenceBundles = null,
+  readyManifest = null,
+  expectedManifestCount = 300,
+} = {}) {
+  const blockers = [];
+  const warnings = [];
+  const manifestItems = normalizeItems(manifest);
+  const sidecarItems = normalizeItems(authoritySidecar);
+  const bundleItems = evidenceBundles === null ? [] : normalizeItems(evidenceBundles, 'bundles');
+  const readyItems = readyManifest === null ? [] : normalizeItems(readyManifest);
+  const seedTopics = buildSeedTopicSet(curriculumSeed);
+  const { map: sidecarByStorageKey, duplicates: sidecarDuplicates } = indexByStorageKey(sidecarItems, 'sidecar');
+  const { map: bundleByStorageKey } = indexByStorageKey(bundleItems, 'bundles');
+  const sidecarTopicSet = new Set();
+
+  if (manifestItems.length !== expectedManifestCount) {
+    pushFinding(blockers, {
+      severity: 'blocker',
+      reason_code: 'manifest_item_count_mismatch',
+      message: `Manifest item count ${manifestItems.length} did not match expected ${expectedManifestCount}.`,
+      details: { actual: manifestItems.length, expected: expectedManifestCount },
+    });
+  }
+
+  for (const duplicate of sidecarDuplicates) {
+    pushFinding(blockers, {
+      severity: 'blocker',
+      reason_code: 'duplicate_authority_sidecar_entry',
+      storage_key: duplicate,
+      message: 'Authority sidecar contains duplicate storage_key entries.',
+    });
+  }
+
+  for (const item of manifestItems) {
+    const storageKey = normalizeString(item?.storage_key);
+    const sidecarEntry = sidecarByStorageKey.get(storageKey);
+    const pack = sidecarPack(sidecarEntry);
+    const canonicalTopicPath = normalizeNullableString(pack.canonical_primary_topic_path);
+    const bundle = bundleByStorageKey.get(storageKey);
+
+    if (item?.diagram_present !== true && item?.diagram_present !== false) {
+      pushFinding(blockers, {
+        severity: 'blocker',
+        reason_code: 'diagram_present_not_boolean',
+        storage_key: storageKey,
+        message: 'Manifest item diagram_present must be true or false.',
+        details: { value: item?.diagram_present ?? null },
+      });
+    }
+
+    if (!sidecarEntry) {
+      pushFinding(blockers, {
+        severity: 'blocker',
+        reason_code: 'missing_authority_sidecar_entry',
+        storage_key: storageKey,
+        message: 'Manifest item has no matching authority sidecar entry.',
+      });
+      continue;
+    }
+
+    if (!canonicalTopicPath) {
+      pushFinding(blockers, {
+        severity: 'blocker',
+        reason_code: 'missing_canonical_primary_topic_path',
+        storage_key: storageKey,
+        message: 'Authority sidecar entry is missing canonical_primary_topic_path.',
+      });
+    } else {
+      sidecarTopicSet.add(canonicalTopicPath);
+      if (!seedTopics.has(canonicalTopicPath)) {
+        pushFinding(blockers, {
+          severity: 'blocker',
+          reason_code: 'canonical_topic_not_seeded',
+          storage_key: storageKey,
+          message: 'Canonical authority topic is not present in the 9709 curriculum seed.',
+          details: { canonical_primary_topic_path: canonicalTopicPath },
+        });
+      }
+    }
+
+    if (isLegacyP1VectorPack(item, pack) && canonicalTopicPath !== '9709.p3.vectors') {
+      pushFinding(blockers, {
+        severity: 'blocker',
+        reason_code: 'legacy_p1_vector_not_canonical_p3_vectors',
+        storage_key: storageKey,
+        message: 'Legacy paper-1 vector item must canonicalize to 9709.p3.vectors.',
+        details: { canonical_primary_topic_path: canonicalTopicPath },
+      });
+    }
+
+    if (!normalizeNullableString(item.primary_topic_path) && canonicalTopicPath) {
+      pushFinding(warnings, {
+        severity: 'warning',
+        reason_code: 'manifest_primary_topic_missing_sidecar_canonical_present',
+        storage_key: storageKey,
+        message: 'Manifest primary_topic_path is missing, but sidecar canonical authority is present.',
+        details: { canonical_primary_topic_path: canonicalTopicPath },
+      });
+    }
+
+    if ([5, 6].includes(Number(item.paper)) && canonicalTopicPath) {
+      pushFinding(warnings, {
+        severity: 'warning',
+        reason_code: 'paper_5_or_6_in_authority_ready_batch',
+        storage_key: storageKey,
+        message: 'Paper 5 or Paper 6 item is present in the 9709 batch with explicit authority resolution.',
+        details: { paper: item.paper, canonical_primary_topic_path: canonicalTopicPath },
+      });
+    }
+
+    if (bundle) {
+      const evidence = bundle.evidence ?? {};
+      const ocrText = normalizeString(evidence.ocr_text);
+      const evidenceDiagramPresent = evidence.diagram_present === true || item.diagram_present === true;
+
+      if (hasExtractionSignal(bundle) && !ocrText && !hasExplicitOcrEmptyStatus({ manifestItem: item, bundle })) {
+        pushFinding(blockers, {
+          severity: 'blocker',
+          reason_code: 'ocr_empty_without_explicit_status',
+          storage_key: storageKey,
+          message: 'Evidence bundle has empty OCR without an explicit acceptable status.',
+        });
+      }
+
+      const failureReason = routeFailureReason(bundle);
+      if (
+        failureReason
+        && failureReason.includes('image')
+        && failureReason.includes('not')
+        && !hasImageFallbackOrReason({ manifestItem: item, bundle })
+      ) {
+        pushFinding(blockers, {
+          severity: 'blocker',
+          reason_code: 'image_unresolved_without_fallback_or_reason',
+          storage_key: storageKey,
+          message: 'Image was unresolved without a WM fallback or explicit review reason.',
+          details: { failure_reason: failureReason },
+        });
+      }
+
+      if (evidenceDiagramPresent && !Array.isArray(evidence.diagram_elements)) {
+        pushFinding(warnings, {
+          severity: 'warning',
+          reason_code: 'diagram_present_but_elements_empty',
+          storage_key: storageKey,
+          message: 'Diagram-present item has no diagram_elements array.',
+        });
+      } else if (evidenceDiagramPresent && evidence.diagram_elements.length === 0) {
+        pushFinding(warnings, {
+          severity: 'warning',
+          reason_code: 'diagram_present_but_elements_empty',
+          storage_key: storageKey,
+          message: 'Diagram-present item has empty diagram_elements.',
+        });
+      }
+
+      if (evidenceDiagramPresent && !Array.isArray(evidence.spatial_evidence)) {
+        pushFinding(warnings, {
+          severity: 'warning',
+          reason_code: 'diagram_present_but_spatial_evidence_empty',
+          storage_key: storageKey,
+          message: 'Diagram-present item has no spatial_evidence array.',
+        });
+      } else if (evidenceDiagramPresent && evidence.spatial_evidence.length === 0) {
+        pushFinding(warnings, {
+          severity: 'warning',
+          reason_code: 'diagram_present_but_spatial_evidence_empty',
+          storage_key: storageKey,
+          message: 'Diagram-present item has empty spatial_evidence.',
+        });
+      }
+    }
+  }
+
+  for (const item of readyItems) {
+    if (item?.overall_alignment_verdict && item.overall_alignment_verdict !== 'ready') {
+      pushFinding(blockers, {
+        severity: 'blocker',
+        reason_code: 'ready_artifact_contains_non_ready_item',
+        storage_key: normalizeString(item.storage_key),
+        message: 'Ready-to-write artifact contains an item whose overall alignment verdict is not ready.',
+        details: { overall_alignment_verdict: item.overall_alignment_verdict },
+      });
+    }
+  }
+
+  const counts = buildCounts({
+    manifestItems,
+    sidecarItems,
+    sidecarTopicSet,
+    blockers,
+    warnings,
+  });
+
+  return {
+    schema_version: '9709_release_preflight_v1',
+    status: blockers.length > 0 ? 'fail' : 'pass',
+    counts,
+    blockers,
+    warnings,
+  };
+}
+
+function renderFindingList(title, findings) {
+  if (findings.length === 0) {
+    return [`## ${title}`, '', 'None.', ''];
+  }
+
+  return [
+    `## ${title}`,
+    '',
+    '| Severity | Reason | Storage Key | Message |',
+    '|---|---|---|---|',
+    ...findings.map((finding) => (
+      `| ${finding.severity} | \`${finding.reason_code}\` | ${finding.storage_key ?? ''} | ${finding.message} |`
+    )),
+    '',
+  ];
+}
+
+export function render9709ReleasePreflightMarkdown(result = {}) {
+  const counts = result.counts ?? {};
+  const diagramCounts = counts.diagram_present ?? {};
+
+  return [
+    '# 9709 Release Preflight',
+    '',
+    `status: \`${result.status ?? 'unknown'}\``,
+    '',
+    '## Counts',
+    '',
+    '| Metric | Value |',
+    '|---|---:|',
+    `| manifest_items | ${counts.manifest_items ?? 0} |`,
+    `| sidecar_items | ${counts.sidecar_items ?? 0} |`,
+    `| diagram_present.true | ${diagramCounts.true ?? 0} |`,
+    `| diagram_present.false | ${diagramCounts.false ?? 0} |`,
+    `| diagram_present.invalid | ${diagramCounts.invalid ?? 0} |`,
+    `| sidecar_canonical_missing | ${counts.sidecar_canonical_missing ?? 0} |`,
+    `| sidecar_distinct_topics | ${counts.sidecar_distinct_topics ?? 0} |`,
+    `| blockers | ${counts.blockers ?? 0} |`,
+    `| warnings | ${counts.warnings ?? 0} |`,
+    '',
+    ...renderFindingList('Blockers', result.blockers ?? []),
+    ...renderFindingList('Warnings', result.warnings ?? []),
+  ].join('\n');
+}

--- a/scripts/learning/run_9709_authority_ready_batch.js
+++ b/scripts/learning/run_9709_authority_ready_batch.js
@@ -10,6 +10,10 @@ import {
   authorityFreezeManifest,
 } from './lib/authority-alignment.js';
 import {
+  render9709ReleasePreflightMarkdown,
+  validate9709ReleasePreflight,
+} from './lib/9709-release-preflight.js';
+import {
   buildQuestionEvidenceBundlesV1,
   summarizeQuestionEvidenceBundlesV1,
 } from './lib/question-evidence-bundle-v1.js';
@@ -39,6 +43,8 @@ export const DEFAULT_9709_AUTHORITY_READY_BATCH_PATHS = Object.freeze({
   fixture: 'data/eval/question_search_gold_9709_v1.json',
   gateReport: 'docs/reports/2026-04-22-9709-ready-only-search-gate-report.md',
   gateJson: 'docs/reports/2026-04-22-9709-ready-only-search-gate.json',
+  releasePreflightJson: 'docs/reports/2026-04-24-9709-release-preflight.json',
+  releasePreflightMarkdown: 'docs/reports/2026-04-24-9709-release-preflight.md',
   gatePsqlMode: 'docker',
   gatePsqlContainer: null,
 });
@@ -98,6 +104,10 @@ function parseArgs(argv = process.argv.slice(2)) {
     fixture: DEFAULT_9709_AUTHORITY_READY_BATCH_PATHS.fixture,
     gateReport: DEFAULT_9709_AUTHORITY_READY_BATCH_PATHS.gateReport,
     gateJson: DEFAULT_9709_AUTHORITY_READY_BATCH_PATHS.gateJson,
+    releasePreflightJson: DEFAULT_9709_AUTHORITY_READY_BATCH_PATHS.releasePreflightJson,
+    releasePreflightMarkdown: DEFAULT_9709_AUTHORITY_READY_BATCH_PATHS.releasePreflightMarkdown,
+    releasePreflightExpectedCount: null,
+    skipReleasePreflight: false,
     gatePsqlMode: DEFAULT_9709_AUTHORITY_READY_BATCH_PATHS.gatePsqlMode,
     gatePsqlContainer: DEFAULT_9709_AUTHORITY_READY_BATCH_PATHS.gatePsqlContainer,
     dryRun: false,
@@ -174,6 +184,29 @@ function parseArgs(argv = process.argv.slice(2)) {
     if (token === '--gate-json') {
       options.gateJson = ensureRequiredValue(argv, index, '--gate-json');
       index += 1;
+      continue;
+    }
+    if (token === '--release-preflight-json') {
+      options.releasePreflightJson = ensureRequiredValue(argv, index, '--release-preflight-json');
+      index += 1;
+      continue;
+    }
+    if (token === '--release-preflight-markdown') {
+      options.releasePreflightMarkdown = ensureRequiredValue(argv, index, '--release-preflight-markdown');
+      index += 1;
+      continue;
+    }
+    if (token === '--release-preflight-expected-count') {
+      const value = Number(ensureRequiredValue(argv, index, '--release-preflight-expected-count'));
+      if (!Number.isInteger(value) || value < 0) {
+        throw new Error('--release-preflight-expected-count must be a non-negative integer.');
+      }
+      options.releasePreflightExpectedCount = value;
+      index += 1;
+      continue;
+    }
+    if (token === '--skip-release-preflight') {
+      options.skipReleasePreflight = true;
       continue;
     }
     if (token === '--gate-psql-mode') {
@@ -539,6 +572,38 @@ function writeJson(filePath, payload) {
   fs.writeFileSync(path.resolve(filePath), `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 }
 
+function writeText(filePath, text) {
+  ensureParentDir(filePath);
+  fs.writeFileSync(path.resolve(filePath), text, 'utf8');
+}
+
+export function build9709ReleasePreflightForArtifacts({
+  manifest,
+  authoritySidecarPayload,
+  curriculumSeed,
+  artifacts,
+  expectedManifestCount = null,
+} = {}) {
+  return validate9709ReleasePreflight({
+    manifest,
+    authoritySidecar: authoritySidecarPayload,
+    curriculumSeed,
+    evidenceBundles: artifacts?.bundles ?? null,
+    readyManifest: artifacts?.readyManifest ?? null,
+    expectedManifestCount: expectedManifestCount ?? (Array.isArray(manifest?.items) ? manifest.items.length : 300),
+  });
+}
+
+export function assert9709ReleasePreflightPassed(preflight) {
+  if (preflight?.status !== 'pass') {
+    const blockerSummary = (preflight?.blockers ?? [])
+      .slice(0, 5)
+      .map((finding) => `${finding.reason_code}:${finding.storage_key ?? 'batch'}`)
+      .join(', ');
+    throw new Error(`9709 release preflight failed with ${(preflight?.blockers ?? []).length} blocker(s): ${blockerSummary}`);
+  }
+}
+
 function buildAlignmentPostureResolver(alignedManifest = {}) {
   const items = Array.isArray(alignedManifest.items) ? alignedManifest.items : [];
   const itemsByStorageKey = items.reduce((accumulator, item) => {
@@ -626,8 +691,9 @@ export async function main(argv = process.argv.slice(2), {
   }
 
   const manifest = readJson(options.manifest);
+  const authoritySidecarPayload = options.authoritySidecar ? readJson(options.authoritySidecar) : {};
   const authoritySidecar = options.authoritySidecar
-    ? normalizeAuthoritySidecarPayload(readJson(options.authoritySidecar))
+    ? normalizeAuthoritySidecarPayload(authoritySidecarPayload)
     : {};
   const curriculumSeed = readJson(options.curriculumSeed);
   const laneResultPaths = options.laneResults.filter(Boolean);
@@ -649,12 +715,29 @@ export async function main(argv = process.argv.slice(2), {
   writeStdoutLine(`total_items: ${artifacts.summary.total_items}`);
   writeStdoutLine(`ready_items: ${artifacts.summary.ready_items}`);
   writeStdoutLine(`blocked_items: ${artifacts.summary.blocked_items}`);
+  const releasePreflight = options.skipReleasePreflight
+    ? null
+    : build9709ReleasePreflightForArtifacts({
+      manifest,
+      authoritySidecarPayload,
+      curriculumSeed,
+      artifacts,
+      expectedManifestCount: options.releasePreflightExpectedCount,
+    });
+
+  if (releasePreflight) {
+    writeStdoutLine(`release_preflight_status: ${releasePreflight.status}`);
+    writeStdoutLine(`release_preflight_blockers: ${releasePreflight.blockers.length}`);
+    writeStdoutLine(`release_preflight_warnings: ${releasePreflight.warnings.length}`);
+  }
 
   if (options.dryRun) {
     writeStdoutLine(`authority_manifest_out: ${options.authorityManifestOut}`);
     writeStdoutLine(`aligned_manifest_out: ${options.alignedManifestOut}`);
     writeStdoutLine(`ready_manifest_out: ${options.readyManifestOut}`);
     writeStdoutLine(`evidence_bundles_out: ${options.evidenceBundlesOut}`);
+    writeStdoutLine(`release_preflight_json: ${options.releasePreflightJson}`);
+    writeStdoutLine(`release_preflight_markdown: ${options.releasePreflightMarkdown}`);
     writeStdoutLine(`gate_report: ${options.gateReport}`);
     writeStdoutLine(`gate_json: ${options.gateJson}`);
     for (const step of plan) {
@@ -662,8 +745,15 @@ export async function main(argv = process.argv.slice(2), {
     }
     return {
       ...artifacts,
+      releasePreflight,
       plan,
     };
+  }
+
+  if (releasePreflight) {
+    writeJson(options.releasePreflightJson, releasePreflight);
+    writeText(options.releasePreflightMarkdown, render9709ReleasePreflightMarkdown(releasePreflight));
+    assert9709ReleasePreflightPassed(releasePreflight);
   }
 
   writeJson(options.authorityManifestOut, artifacts.authorityManifest);

--- a/scripts/learning/run_9709_release_preflight.js
+++ b/scripts/learning/run_9709_release_preflight.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  render9709ReleasePreflightMarkdown,
+  validate9709ReleasePreflight,
+} from './lib/9709-release-preflight.js';
+
+const DEFAULT_PATHS = Object.freeze({
+  manifest: 'data/manifests/9709_authority_ready_batch_300_v1.json',
+  authoritySidecar: 'data/manifests/9709_authority_ready_batch_300_authority_sidecar_v2.json',
+  curriculumSeed: 'data/curriculum/9709_authority_ready_batch_300_nodes_v2.json',
+  evidenceBundles: null,
+  readyManifest: null,
+  expectedCount: 300,
+  jsonOut: null,
+  markdownOut: null,
+});
+
+function writeStdoutLine(message) {
+  fs.writeSync(1, `${message}\n`);
+}
+
+function writeStderrLine(message) {
+  fs.writeSync(2, `${message}\n`);
+}
+
+function printUsage() {
+  writeStdoutLine(
+    'Usage: node scripts/learning/run_9709_release_preflight.js [--manifest <path>] [--authority-sidecar <path>] [--curriculum-seed <path>] [--evidence-bundles <path>] [--ready-manifest <path>] [--expected-count <n>] [--json-out <path>] [--markdown-out <path>]',
+  );
+}
+
+function requiredValue(argv, index, flag) {
+  const value = argv[index + 1] ?? null;
+  if (!value || String(value).startsWith('--')) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    ...DEFAULT_PATHS,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (token === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--manifest') {
+      options.manifest = requiredValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+    if (token === '--authority-sidecar') {
+      options.authoritySidecar = requiredValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+    if (token === '--curriculum-seed') {
+      options.curriculumSeed = requiredValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+    if (token === '--evidence-bundles') {
+      options.evidenceBundles = requiredValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+    if (token === '--ready-manifest') {
+      options.readyManifest = requiredValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+    if (token === '--expected-count') {
+      const value = Number(requiredValue(argv, index, token));
+      if (!Number.isInteger(value) || value < 0) {
+        throw new Error('--expected-count must be a non-negative integer.');
+      }
+      options.expectedCount = value;
+      index += 1;
+      continue;
+    }
+    if (token === '--json-out') {
+      options.jsonOut = requiredValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+    if (token === '--markdown-out') {
+      options.markdownOut = requiredValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return options;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(path.resolve(filePath), 'utf8'));
+}
+
+function ensureParentDir(filePath) {
+  fs.mkdirSync(path.dirname(path.resolve(filePath)), { recursive: true });
+}
+
+function writeJson(filePath, payload) {
+  ensureParentDir(filePath);
+  fs.writeFileSync(path.resolve(filePath), `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function writeText(filePath, text) {
+  ensureParentDir(filePath);
+  fs.writeFileSync(path.resolve(filePath), text, 'utf8');
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+
+  if (options.help) {
+    printUsage();
+    return 0;
+  }
+
+  const result = validate9709ReleasePreflight({
+    manifest: readJson(options.manifest),
+    authoritySidecar: readJson(options.authoritySidecar),
+    curriculumSeed: readJson(options.curriculumSeed),
+    evidenceBundles: options.evidenceBundles ? readJson(options.evidenceBundles) : null,
+    readyManifest: options.readyManifest ? readJson(options.readyManifest) : null,
+    expectedManifestCount: options.expectedCount,
+  });
+
+  if (options.jsonOut) {
+    writeJson(options.jsonOut, result);
+  } else {
+    writeStdoutLine(JSON.stringify(result, null, 2));
+  }
+
+  if (options.markdownOut) {
+    writeText(options.markdownOut, render9709ReleasePreflightMarkdown(result));
+  }
+
+  writeStdoutLine(`9709_release_preflight_status=${result.status}`);
+  writeStdoutLine(`9709_release_preflight_blockers=${result.blockers.length}`);
+  writeStdoutLine(`9709_release_preflight_warnings=${result.warnings.length}`);
+
+  return result.status === 'fail' ? 1 : 0;
+}
+
+export function isEntrypoint(entryScriptPath, metaUrl = import.meta.url) {
+  if (!entryScriptPath) {
+    return false;
+  }
+  return path.resolve(entryScriptPath) === fileURLToPath(metaUrl);
+}
+
+if (isEntrypoint(process.argv[1], import.meta.url)) {
+  try {
+    process.exitCode = await main();
+  } catch (error) {
+    writeStderrLine(error.message);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- Add a 9709-specific release preflight validator for the authority-ready batch artifacts.
- Expose the preflight as a standalone CLI with JSON and Markdown report output.
- Wire the preflight into `run_9709_authority_ready_batch.js` so blockers stop the flow before registry/analysis write steps.
- Document the 9709 release preflight design and implementation plan.

## What It Blocks

- Missing or non-boolean `diagram_present` values.
- Manifest/authority sidecar join failures.
- Missing canonical authority topics or topics absent from the 9709 curriculum seed.
- Legacy P1 vector rows that are not canonicalized to `9709.p3.vectors`.
- OCR-empty/image-unresolved rows without explicit acceptable status.
- Ready-to-write artifacts containing non-ready alignment verdicts.

## Warnings Only

- `diagram_present=true` with empty `diagram_elements` or `spatial_evidence`.
- Manifest `primary_topic_path=null` when sidecar canonical authority exists.
- Paper 5/6 items that are explicitly authority-resolved.

## Validation

- `/home/samsen/.nvm/versions/node/v22.22.1/bin/node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand --cacheDirectory=/tmp/jest-cache-9709-preflight scripts/learning/__tests__/9709-release-preflight.test.js scripts/learning/__tests__/run-9709-release-preflight.test.js scripts/learning/__tests__/run-9709-authority-ready-batch.test.js`
- Standalone preflight on published 300 manifest/sidecar/seed: `pass`, blockers `0`, warnings `75`.
- Standalone preflight with prompt-backfill evidence bundles: `pass`, blockers `0`, warnings `163`.
- Authority batch dry-run with empty lane results: `release_preflight_status: pass`, blockers `0`.

## Environment Note

`npm run workflow:codex-preflight -- --json` could not run in this WSL environment because default `npm` resolves to Windows Node and fails WSL1/Node path detection. Focused Jest and CLI verification were run with the available nvm Node binary.