### PR TITLE
feat(9709): define syllabus topic tree ID contract

### DIFF
--- a/data/contracts/9709_syllabus_topic_tree_schema_v1.json
+++ b/data/contracts/9709_syllabus_topic_tree_schema_v1.json
@@ -478,6 +478,32 @@
       "allOf": [
         {
           "if": {
+            "required": [
+              "node_type"
+            ],
+            "properties": {
+              "node_type": {
+                "const": "syllabus"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "parent_node_id": {
+                "type": "null"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "parent_node_id": {
+                "$ref": "#/definitions/node_id"
+              }
+            }
+          }
+        },
+        {
+          "if": {
             "properties": {
               "status": {
                 "const": "approved"
@@ -512,6 +538,32 @@
                     "const": "deprecated"
                   }
                 }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "review_state"
+            ],
+            "properties": {
+              "review_state": {
+                "required": [
+                  "state"
+                ],
+                "properties": {
+                  "state": {
+                    "const": "accepted"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "status": {
+                "const": "approved"
               }
             }
           }

--- a/data/contracts/9709_syllabus_topic_tree_schema_v1.json
+++ b/data/contracts/9709_syllabus_topic_tree_schema_v1.json
@@ -1,0 +1,522 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ciecopilot.local/contracts/syllabus_topic_tree_schema_v1.json",
+  "title": "Canonical syllabus topic tree schema v1",
+  "description": "Generic canonical syllabus topic tree document contract, first frozen for Cambridge 9709 syllabus canonicalization.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "contract_id",
+    "syllabus_code",
+    "syllabus_version",
+    "exam_year_range",
+    "source_lock",
+    "nodes"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "v1"
+    },
+    "contract_id": {
+      "type": "string",
+      "const": "9709_syllabus_topic_tree_schema_v1"
+    },
+    "syllabus_code": {
+      "$ref": "#/definitions/syllabus_code"
+    },
+    "syllabus_version": {
+      "$ref": "#/definitions/syllabus_version"
+    },
+    "exam_year_range": {
+      "$ref": "#/definitions/exam_year_range"
+    },
+    "source_lock": {
+      "$ref": "#/definitions/source_lock"
+    },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/node"
+      }
+    }
+  },
+  "definitions": {
+    "syllabus_code": {
+      "type": "string",
+      "pattern": "^[0-9]{4}$",
+      "description": "Cambridge syllabus code, for example 9709. The schema is intentionally not hard-coded to 9709."
+    },
+    "syllabus_version": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{4}_v[0-9]+$",
+      "description": "Normalized syllabus source version tag, for example 2026-2027_v4."
+    },
+    "exam_year_range": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{4}$"
+    },
+    "node_id": {
+      "type": "string",
+      "pattern": "^[0-9]{4}:[0-9]{4}-[0-9]{4}_v[0-9]+:(syllabus|component|section|learning_objective|note|boundary)(:[a-z0-9][a-z0-9_.-]*)?$",
+      "description": "Durable machine ID. It is never derived from display_title."
+    },
+    "nullable_node_id": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/node_id"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "component_code": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[A-Za-z0-9_-]+$"
+    },
+    "paper": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 1,
+      "maximum": 9
+    },
+    "section_code": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[A-Za-z0-9_.-]+$"
+    },
+    "source_lock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_document_id",
+        "official_pdf_url",
+        "official_qualification_page",
+        "sha256",
+        "accessed_date"
+      ],
+      "properties": {
+        "source_document_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "official_pdf_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "official_qualification_page": {
+          "type": "string",
+          "format": "uri"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "accessed_date": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    },
+    "source_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_document_id",
+        "source_type",
+        "page_ref",
+        "section_ref",
+        "raw_section_id",
+        "locator"
+      ],
+      "properties": {
+        "source_document_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_type": {
+          "type": "string",
+          "enum": [
+            "official_syllabus",
+            "official_syllabus_update",
+            "official_past_paper",
+            "official_mark_scheme",
+            "legacy_taxonomy",
+            "manual_audit"
+          ]
+        },
+        "page_ref": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "section_ref": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "raw_section_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "locator": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        }
+      }
+    },
+    "source_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/source_ref"
+      }
+    },
+    "review_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "reviewed_by",
+        "reviewed_at",
+        "notes"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "unreviewed",
+            "pending_human_review",
+            "accepted",
+            "rejected",
+            "blocked",
+            "deprecated"
+          ]
+        },
+        "reviewed_by": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "reviewed_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "component_scope_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "component_code",
+        "paper"
+      ],
+      "properties": {
+        "component_code": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_-]+$"
+        },
+        "paper": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9
+        }
+      }
+    },
+    "assumed_knowledge_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "node_id",
+        "topic_path",
+        "note",
+        "source_refs"
+      ],
+      "properties": {
+        "node_id": {
+          "$ref": "#/definitions/nullable_node_id"
+        },
+        "topic_path": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/slug"
+          }
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_refs": {
+          "$ref": "#/definitions/source_refs"
+        }
+      }
+    },
+    "alias": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "source",
+        "status",
+        "source_refs"
+      ],
+      "properties": {
+        "value": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "official_title_variant",
+            "legacy_display_title",
+            "legacy_topic_path",
+            "manual_audit"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "candidate",
+            "approved",
+            "deprecated"
+          ]
+        },
+        "source_refs": {
+          "$ref": "#/definitions/source_refs"
+        }
+      }
+    },
+    "legacy_path": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "source",
+        "status",
+        "source_refs"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "legacy_topic_path",
+            "legacy_curriculum_seed",
+            "manual_audit"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "candidate",
+            "approved",
+            "deprecated"
+          ]
+        },
+        "source_refs": {
+          "$ref": "#/definitions/source_refs"
+        }
+      }
+    },
+    "node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "node_id",
+        "parent_node_id",
+        "node_type",
+        "topic_path",
+        "canonical_title",
+        "display_title",
+        "component_code",
+        "paper",
+        "section_code",
+        "component_scope",
+        "qualification_route_scope",
+        "assumed_knowledge",
+        "status",
+        "review_state",
+        "source_refs",
+        "aliases",
+        "legacy_paths"
+      ],
+      "properties": {
+        "node_id": {
+          "$ref": "#/definitions/node_id"
+        },
+        "parent_node_id": {
+          "$ref": "#/definitions/nullable_node_id"
+        },
+        "node_type": {
+          "type": "string",
+          "enum": [
+            "syllabus",
+            "component",
+            "section",
+            "learning_objective",
+            "note",
+            "boundary"
+          ]
+        },
+        "topic_path": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/slug"
+          }
+        },
+        "canonical_title": {
+          "$ref": "#/definitions/title"
+        },
+        "display_title": {
+          "$ref": "#/definitions/title"
+        },
+        "component_code": {
+          "$ref": "#/definitions/component_code"
+        },
+        "paper": {
+          "$ref": "#/definitions/paper"
+        },
+        "section_code": {
+          "$ref": "#/definitions/section_code"
+        },
+        "component_scope": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/component_scope_item"
+          }
+        },
+        "qualification_route_scope": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "AS Level",
+              "A Level"
+            ]
+          }
+        },
+        "assumed_knowledge": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/assumed_knowledge_item"
+          }
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "approved",
+            "deprecated",
+            "needs_human_review"
+          ]
+        },
+        "review_state": {
+          "$ref": "#/definitions/review_state"
+        },
+        "source_refs": {
+          "$ref": "#/definitions/source_refs"
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/alias"
+          }
+        },
+        "legacy_paths": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/legacy_path"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "approved"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "review_state": {
+                "properties": {
+                  "state": {
+                    "const": "accepted"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "deprecated"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "review_state": {
+                "properties": {
+                  "state": {
+                    "const": "deprecated"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/reports/9709-syllabus-id-contract.md
+++ b/docs/reports/9709-syllabus-id-contract.md
@@ -1,0 +1,207 @@
+# 9709 syllabus topic tree schema and ID contract
+
+Issue: #288
+Parent tracker: #286
+Predecessor: #287
+
+## Scope
+
+This freezes the schema and ID contract for a future canonical syllabus topic tree.
+It does not generate a draft topic tree, extract boundary annotations, or approve a
+baseline tree.
+
+The machine-readable schema is:
+
+- `data/contracts/9709_syllabus_topic_tree_schema_v1.json`
+
+The contract is derived from the official-source workflow locked in issue `#287`.
+For `9709`, the only baseline source for this stage is:
+
+- Source document ID: `cambridge-9709-syllabus-2026-2027-v4`
+- Exam years: `2026-2027`
+- Syllabus version: `Version 4`, normalized as `2026-2027_v4`
+- Official PDF: `https://www.cambridgeinternational.org/Images/697427-2026-2027-syllabus.pdf`
+- SHA-256: `dd0131f3cd8d4e3c270e7936cbb909c15f4cb8053f8337b67c16e8ec0b8bc5e5`
+- Local source inventory: `data/syllabus/9709/source_inventory.json`
+- Raw extraction layer: `data/syllabus/9709/raw_sections_v1.json`
+
+## Document Contract
+
+A canonical topic tree document must carry:
+
+- `schema_version`: currently `v1`
+- `contract_id`: currently `9709_syllabus_topic_tree_schema_v1`
+- `syllabus_code`: Cambridge subject code such as `9709`
+- `syllabus_version`: normalized source version such as `2026-2027_v4`
+- `exam_year_range`: source exam-year range such as `2026-2027`
+- `source_lock`: official source identity, URL, SHA-256, and access date
+- `nodes[]`: the syllabus/component/section/objective/note/boundary records
+
+The schema is generic by subject code pattern instead of hard-coding `9709`, so the
+same v1 shape can be reused for later `9231` or `9702` work. This issue only
+authorizes the `9709` contract and source lock.
+
+## Node Contract
+
+Every node-like claim must include:
+
+- `node_id`
+- `parent_node_id`
+- `topic_path`
+- `canonical_title`
+- `display_title`
+- `component_code`
+- `paper`
+- `section_code`
+- `node_type`
+- `source_refs[]`
+- `component_scope`
+- `qualification_route_scope`
+- `assumed_knowledge`
+- `status`
+- `review_state`
+- `aliases[]`
+- `legacy_paths[]`
+
+Allowed `node_type` values are:
+
+- `syllabus`
+- `component`
+- `section`
+- `learning_objective`
+- `note`
+- `boundary`
+
+Allowed lifecycle `status` values are:
+
+- `draft`
+- `approved`
+- `deprecated`
+- `needs_human_review`
+
+An `approved` node must have `review_state.state = accepted`. A `deprecated` node
+must have `review_state.state = deprecated`. Draft and review-needed records remain
+explicitly separate from approved baseline truth.
+
+## Durable ID Contract
+
+`display_title` is not a durable ID and must not be used as a join key.
+
+Durable IDs use this normalized shape:
+
+```text
+<syllabus_code>:<syllabus_version>:<node_type>[:<stable_slug_path>]
+```
+
+Examples:
+
+```text
+9709:2026-2027_v4:syllabus
+9709:2026-2027_v4:component:p1
+9709:2026-2027_v4:section:p1.quadratics
+9709:2026-2027_v4:learning_objective:p1.quadratics.solve_equations
+```
+
+Rules:
+
+- `node_id` is the durable machine identity.
+- `display_title` is human-facing text and may change for readability.
+- `canonical_title` is the normalized title for the node, but it is still not the
+  durable join key.
+- `topic_path` is an ordered slug breadcrumb for semantic mapping and review, not a
+  substitute for `node_id`.
+- `parent_node_id` links to another `node_id`, or is `null` only for root-level
+  syllabus records.
+- Node IDs must stay stable once approved. If a concept moves, use aliases,
+  legacy paths, and deprecation records rather than silently changing the approved
+  ID.
+
+JSON Schema enforces the ID shape. Cross-record checks such as node ID uniqueness,
+parent existence, and replacement-target existence should be enforced by the later
+tree validator because draft-07 JSON Schema cannot express those graph constraints
+cleanly.
+
+## Source References
+
+Every node-like claim must have at least one `source_refs[]` entry. This includes
+nodes, aliases, legacy paths, and assumed-knowledge references.
+
+A source reference records:
+
+- `source_document_id`
+- `source_type`
+- `page_ref`
+- `section_ref`
+- `raw_section_id`
+- `locator`
+
+For canonical `9709` syllabus claims, `source_document_id` should normally point to
+`cambridge-9709-syllabus-2026-2027-v4`, and `raw_section_id` should point into
+`data/syllabus/9709/raw_sections_v1.json` when a raw section exists.
+
+The schema also permits legacy and manual-audit source types for alias and
+legacy-path records. Those records are mapping aids, not authority to promote
+unofficial taxonomy as canonical syllabus truth.
+
+## Scope Fields
+
+`component_code` and `paper` identify the primary component/paper context for a
+node when applicable. Root syllabus records can use `null`.
+
+`component_scope[]` records all component/paper contexts where the claim applies.
+This keeps cross-component syllabus concepts explicit without duplicating canonical
+home objects.
+
+`qualification_route_scope[]` records whether a claim applies to `AS Level`,
+`A Level`, or both. Route scope is part of the review contract because later
+question semantic mapping must know which syllabus route a node belongs to.
+
+`assumed_knowledge[]` records upstream knowledge dependencies with their own
+source references. It is for traceability and later mapping compatibility only; it
+does not trigger question extraction in this epic.
+
+## Legacy Alias Contract
+
+`aliases[]` and `legacy_paths[]` exist so old taxonomy labels can later be mapped,
+approved, or deprecated without changing canonical IDs.
+
+They must not be used to promote old taxonomy paths directly into canonical truth.
+Each alias or legacy path must carry `source_refs[]` and a status:
+
+- `candidate`
+- `approved`
+- `deprecated`
+
+This supports future migration from existing paths such as `9709.p1.integration`
+while preserving the ability to mark them stale or unsafe.
+
+## Question Mapping Compatibility
+
+The schema supports later question semantic mapping by preserving durable node IDs,
+topic breadcrumbs, component/paper scope, route scope, source references, assumed
+knowledge, aliases, and legacy paths.
+
+It deliberately does not include question extraction output, prompt output, VLM
+surface evidence, or boundary annotation extraction. Those belong to later stages
+and must join to the canonical tree through `node_id` or reviewed alias mapping.
+
+## Validation
+
+Focused schema tests live at:
+
+- `tests/contracts/9709-syllabus-topic-tree-schema.test.js`
+
+They cover:
+
+- valid `9709` document shape
+- required node fields
+- rejection of display-title-shaped durable IDs
+- invalid `status` and `review_state` values
+- approved-node review gating
+- future-compatible subject-code reuse
+
+Run them with:
+
+```bash
+NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand tests/contracts/9709-syllabus-topic-tree-schema.test.js
+```

--- a/docs/reports/9709-syllabus-id-contract.md
+++ b/docs/reports/9709-syllabus-id-contract.md
@@ -81,7 +81,8 @@ Allowed lifecycle `status` values are:
 
 An `approved` node must have `review_state.state = accepted`. A `deprecated` node
 must have `review_state.state = deprecated`. Draft and review-needed records remain
-explicitly separate from approved baseline truth.
+explicitly separate from approved baseline truth. Conversely,
+`review_state.state = accepted` is only valid when `status = approved`.
 
 ## Durable ID Contract
 

--- a/docs/reports/INDEX.md
+++ b/docs/reports/INDEX.md
@@ -18,6 +18,7 @@
 - `2026-04-20-issue-252-remediation-report.md` - bounded remediation report for the remaining Wave A `9709.p3.trigonometry` aggregate-probe misses and their host-backfill verification posture.
 - `2026-04-20-issue-253-wave-a-review-lane-remediation.md` - bounded fix report for the remaining Wave A shard-3 over-conservative review-lane case on `9709/s22_qp_13/questions/q02.png`.
 - `2026-04-22-9709-syllabus-authority-vlm-dual-track-decision.md` - decision baseline for splitting `9709` topic alignment into an authoritative syllabus/paper line and a separate VLM visual-evidence line.
+- `9709-syllabus-id-contract.md` - canonical `9709` syllabus topic-tree schema and durable node ID contract for issue `#288`, scoped to schema/ID rules only with no draft tree generation.
 - `ao_codex_work_dossier_2026-03-26.md` - issue-by-issue reconstruction of prior AO and Codex work, with branch-vs-mainline divergence notes.
 - `prd_progress_report_2026-03-16.md` - PRD-aligned project progress assessment after recovery, including current stage, recovery impact, and parallel workstreams.
 - `learning_runtime_9709_integration_application_promotion_2026-03-24.md` - evidence-first justification for promoting `9709.integration.application` into released runtime scoring while keeping broader integration scope conservative.
@@ -54,5 +55,6 @@
 ## Coverage And Inventory
 
 - `9709-syllabus-source-inventory.md` - official Cambridge `9709` syllabus source lock, raw section extraction inventory, legacy/candidate file classification, and coverage summary for issue `#287`.
+- `9709-syllabus-id-contract.md` - schema, ID, source-reference, review-state, and legacy-alias contract for future canonical syllabus topic-tree generation.
 - `rag_corpus_source_coverage.md` - corpus source coverage summary for backend RAG.
 - `rag_restricted_official_source_inventory.md` - restricted-official inventory snapshot used for governance review.

--- a/tests/contracts/9709-syllabus-topic-tree-schema.test.js
+++ b/tests/contracts/9709-syllabus-topic-tree-schema.test.js
@@ -1,0 +1,271 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const Ajv = require('ajv');
+
+const schemaPath = path.join(
+  process.cwd(),
+  'data/contracts/9709_syllabus_topic_tree_schema_v1.json',
+);
+
+function readSchema() {
+  return JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+}
+
+function buildValidator() {
+  const ajv = new Ajv({ allErrors: true, jsonPointers: true });
+  const validate = ajv.compile(readSchema());
+  return validate;
+}
+
+function buildValidTopicTree(overrides = {}) {
+  const syllabusNodeRef = {
+    source_document_id: 'cambridge-9709-syllabus-2026-2027-v4',
+    source_type: 'official_syllabus',
+    page_ref: 'p. 1',
+    section_ref: 'Cover',
+    raw_section_id: 'cambridge-9709-syllabus-2026-2027-v4.front_matter.cover',
+    locator: 'Use this syllabus for exams in 2026 and 2027.',
+  };
+
+  const componentRef = {
+    source_document_id: 'cambridge-9709-syllabus-2026-2027-v4',
+    source_type: 'official_syllabus',
+    page_ref: 'pp. 8-17',
+    section_ref: '2 Syllabus overview',
+    raw_section_id: 'cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview',
+    locator: 'Paper 1 Pure Mathematics 1',
+  };
+
+  const sectionRef = {
+    source_document_id: 'cambridge-9709-syllabus-2026-2027-v4',
+    source_type: 'official_syllabus',
+    page_ref: 'p. 19',
+    section_ref: '3 Subject content > 1 Pure Mathematics 1 > 1.1 Quadratics',
+    raw_section_id: 'cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p1.1_1_quadratics',
+    locator: 'Quadratics',
+  };
+
+  return {
+    schema_version: 'v1',
+    contract_id: '9709_syllabus_topic_tree_schema_v1',
+    syllabus_code: '9709',
+    syllabus_version: '2026-2027_v4',
+    exam_year_range: '2026-2027',
+    source_lock: {
+      source_document_id: 'cambridge-9709-syllabus-2026-2027-v4',
+      official_pdf_url: 'https://www.cambridgeinternational.org/Images/697427-2026-2027-syllabus.pdf',
+      official_qualification_page: 'https://www.cambridgeinternational.org/programmes-and-qualifications/cambridge-international-as-and-a-level-mathematics-9709/',
+      sha256: 'dd0131f3cd8d4e3c270e7936cbb909c15f4cb8053f8337b67c16e8ec0b8bc5e5',
+      accessed_date: '2026-04-27',
+    },
+    nodes: [
+      {
+        node_id: '9709:2026-2027_v4:syllabus',
+        parent_node_id: null,
+        node_type: 'syllabus',
+        topic_path: ['9709'],
+        canonical_title: 'Cambridge International AS & A Level Mathematics 9709',
+        display_title: 'Mathematics 9709',
+        component_code: null,
+        paper: null,
+        section_code: null,
+        component_scope: [],
+        qualification_route_scope: ['AS Level', 'A Level'],
+        assumed_knowledge: [],
+        status: 'draft',
+        review_state: {
+          state: 'unreviewed',
+          reviewed_by: null,
+          reviewed_at: null,
+          notes: [],
+        },
+        source_refs: [syllabusNodeRef],
+        aliases: [],
+        legacy_paths: [],
+      },
+      {
+        node_id: '9709:2026-2027_v4:component:p1',
+        parent_node_id: '9709:2026-2027_v4:syllabus',
+        node_type: 'component',
+        topic_path: ['9709', 'pure_mathematics_1'],
+        canonical_title: 'Pure Mathematics 1',
+        display_title: 'Paper 1: Pure Mathematics 1',
+        component_code: 'P1',
+        paper: 1,
+        section_code: null,
+        component_scope: [
+          {
+            component_code: 'P1',
+            paper: 1,
+          },
+        ],
+        qualification_route_scope: ['AS Level', 'A Level'],
+        assumed_knowledge: [],
+        status: 'draft',
+        review_state: {
+          state: 'unreviewed',
+          reviewed_by: null,
+          reviewed_at: null,
+          notes: [],
+        },
+        source_refs: [componentRef],
+        aliases: [],
+        legacy_paths: [
+          {
+            path: '9709.p1',
+            source: 'legacy_topic_path',
+            status: 'candidate',
+            source_refs: [componentRef],
+          },
+        ],
+      },
+      {
+        node_id: '9709:2026-2027_v4:section:p1.quadratics',
+        parent_node_id: '9709:2026-2027_v4:component:p1',
+        node_type: 'section',
+        topic_path: ['9709', 'pure_mathematics_1', 'quadratics'],
+        canonical_title: 'Quadratics',
+        display_title: 'Quadratics',
+        component_code: 'P1',
+        paper: 1,
+        section_code: 'P1.1',
+        component_scope: [
+          {
+            component_code: 'P1',
+            paper: 1,
+          },
+        ],
+        qualification_route_scope: ['AS Level', 'A Level'],
+        assumed_knowledge: [
+          {
+            node_id: '9709:2026-2027_v4:section:prerequisite.algebra',
+            topic_path: ['9709', 'assumed_knowledge', 'algebra'],
+            note: 'Assumed algebraic manipulation knowledge.',
+            source_refs: [sectionRef],
+          },
+        ],
+        status: 'needs_human_review',
+        review_state: {
+          state: 'blocked',
+          reviewed_by: null,
+          reviewed_at: null,
+          notes: ['Awaiting canonical extraction from the official raw section.'],
+        },
+        source_refs: [sectionRef],
+        aliases: [
+          {
+            value: 'Quadratic equations',
+            source: 'legacy_display_title',
+            status: 'candidate',
+            source_refs: [sectionRef],
+          },
+        ],
+        legacy_paths: [
+          {
+            path: '9709.p1.quadratics',
+            source: 'legacy_topic_path',
+            status: 'candidate',
+            source_refs: [sectionRef],
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function expectInvalid(document, expectedSnippet) {
+  const validate = buildValidator();
+  const valid = validate(document);
+  expect(valid).toBe(false);
+  expect(validate.errors.map((error) => `${error.dataPath} ${error.message}`)).toEqual(
+    expect.arrayContaining([expect.stringContaining(expectedSnippet)]),
+  );
+}
+
+describe('9709 syllabus topic tree schema v1', () => {
+  test('accepts a 9709 tree that separates durable IDs from display titles and carries source refs', () => {
+    const validate = buildValidator();
+    const document = buildValidTopicTree();
+
+    expect(validate(document)).toBe(true);
+    expect(validate.errors).toBeNull();
+  });
+
+  test('requires the issue contract fields on each node-like claim', () => {
+    const document = buildValidTopicTree({
+      nodes: [
+        {
+          node_id: '9709:2026-2027_v4:section:p1.quadratics',
+          parent_node_id: '9709:2026-2027_v4:component:p1',
+          node_type: 'section',
+          topic_path: ['9709', 'pure_mathematics_1', 'quadratics'],
+          canonical_title: 'Quadratics',
+          display_title: 'Quadratics',
+        },
+      ],
+    });
+
+    expectInvalid(document, "should have required property 'source_refs'");
+  });
+
+  test('rejects display-title-shaped durable IDs', () => {
+    const document = buildValidTopicTree();
+    document.nodes[1].node_id = document.nodes[1].display_title;
+
+    expectInvalid(document, 'should match pattern');
+  });
+
+  test('rejects invalid lifecycle and review states', () => {
+    const document = buildValidTopicTree();
+    document.nodes[2].status = 'released';
+    document.nodes[2].review_state.state = 'approved_by_script';
+
+    expectInvalid(document, 'should be equal to one of the allowed values');
+  });
+
+  test('requires approved nodes to have accepted review state', () => {
+    const document = buildValidTopicTree();
+    document.nodes[2].status = 'approved';
+    document.nodes[2].review_state.state = 'unreviewed';
+
+    expectInvalid(document, 'should be equal to constant');
+  });
+
+  test('keeps the schema reusable by not hard-coding 9709 as the only syllabus code', () => {
+    const validate = buildValidator();
+    const document = buildValidTopicTree({
+      syllabus_code: '9231',
+      source_lock: {
+        source_document_id: 'cambridge-9231-syllabus-placeholder',
+        official_pdf_url: 'https://www.cambridgeinternational.org/example.pdf',
+        official_qualification_page: 'https://www.cambridgeinternational.org/example/',
+        sha256: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        accessed_date: '2026-04-27',
+      },
+      nodes: [
+        {
+          ...buildValidTopicTree().nodes[0],
+          node_id: '9231:2026-2027_v1:syllabus',
+          topic_path: ['9231'],
+          source_refs: [
+            {
+              source_document_id: 'cambridge-9231-syllabus-placeholder',
+              source_type: 'official_syllabus',
+              page_ref: 'p. 1',
+              section_ref: 'Cover',
+              raw_section_id: null,
+              locator: 'Placeholder source reference for schema reuse test.',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(validate(document)).toBe(true);
+    expect(validate.errors).toBeNull();
+  });
+});

--- a/tests/contracts/9709-syllabus-topic-tree-schema.test.js
+++ b/tests/contracts/9709-syllabus-topic-tree-schema.test.js
@@ -235,6 +235,21 @@ describe('9709 syllabus topic tree schema v1', () => {
     expectInvalid(document, 'should be equal to constant');
   });
 
+  test('rejects non-syllabus nodes without a parent node ID', () => {
+    const document = buildValidTopicTree();
+    document.nodes[1].parent_node_id = null;
+
+    expectInvalid(document, '/parent_node_id should be string');
+  });
+
+  test('rejects accepted review state unless the node status is approved', () => {
+    const document = buildValidTopicTree();
+    document.nodes[2].status = 'draft';
+    document.nodes[2].review_state.state = 'accepted';
+
+    expectInvalid(document, '/status should be equal to constant');
+  });
+
   test('keeps the schema reusable by not hard-coding 9709 as the only syllabus code', () => {
     const validate = buildValidator();
     const document = buildValidTopicTree({


### PR DESCRIPTION
## Summary
- Add `data/contracts/9709_syllabus_topic_tree_schema_v1.json` for the canonical syllabus topic-tree document and node contract.
- Document the 9709 durable node ID, source-ref, review-state, scope, alias, and non-goal boundaries in `docs/reports/9709-syllabus-id-contract.md`.
- Add focused Jest schema validation coverage for required fields, invalid states, display-title-shaped IDs, approved review gating, and future subject-code reuse.

Closes #288

## Verification
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand tests/contracts/9709-syllabus-topic-tree-schema.test.js`
- `git diff --cached --check`
- `node -e "JSON.parse(require('fs').readFileSync('data/contracts/9709_syllabus_topic_tree_schema_v1.json','utf8')); console.log('schema json ok')"`