### PR TITLE
feat: add 9709 boundary annotations draft

### DIFF
--- a/data/syllabus/9709/boundary_annotations_draft_v1.json
+++ b/data/syllabus/9709/boundary_annotations_draft_v1.json
@@ -523,6 +523,228 @@
           "locator": "Knowledge of the content of Paper 5: Probability & Statistics 1 is assumed, and candidates may be required\nto demonstrate such knowledge in answering questions. Knowledge of calculus within the content for\nPaper 3: Pure Mathematics 3 will also be assumed."
         }
       ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:route.as.valid_combinations",
+      "boundary_kind": "route_constraint",
+      "claim": "AS Mathematics candidates take two components in the same series using one of three valid combinations: P1/P2, P1/P4, or P1/P5.",
+      "component_scope": [
+        {
+          "component_code": "P1",
+          "paper": "Paper 1",
+          "role": "required_as_route_component"
+        },
+        {
+          "component_code": "P2",
+          "paper": "Paper 2",
+          "role": "eligible_as_route_component"
+        },
+        {
+          "component_code": "P4",
+          "paper": "Paper 4",
+          "role": "eligible_as_route_component"
+        },
+        {
+          "component_code": "P5",
+          "paper": "Paper 5",
+          "role": "eligible_as_route_component"
+        }
+      ],
+      "route_scope": [
+        {
+          "route": "AS Mathematics (AS Level only)",
+          "eligibility": "eligible",
+          "valid_component_combinations": [
+            [
+              "P1",
+              "P2"
+            ],
+            [
+              "P1",
+              "P4"
+            ],
+            [
+              "P1",
+              "P5"
+            ]
+          ],
+          "progression": "P1/P2 is separately constrained as AS-only with no carry-forward to A Level."
+        }
+      ],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p1",
+        "9709:2026-2027_v4:component:p2",
+        "9709:2026-2027_v4:component:p4",
+        "9709:2026-2027_v4:component:p5"
+      ],
+      "cross_component_claim": true,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 8-17",
+          "section_ref": "2 Syllabus overview",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+          "locator": "AS Mathematics (AS Level only)\nCandidates take two components in the same series.\nPaper 1 and Paper 2\nPure Mathematics 1 Pure Mathematics 2\n(Please note, this route cannot count towards A Level)\nOR\nPaper 1 and Paper 4\nPure Mathematics 1 Mechanics\nOR\nPaper 1 and Paper 5\nPure Mathematics 1 Probability & Statistics 1"
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:route.a_level.staged_valid_combinations",
+      "boundary_kind": "route_constraint",
+      "claim": "A Level Mathematics staged routes carry forward AS components and then add two more components using one of three valid combinations: P1/P4 then P3/P5; P1/P5 then P3/P4; or P1/P5 then P3/P6.",
+      "component_scope": [
+        {
+          "component_code": "P1",
+          "paper": "Paper 1",
+          "role": "required_staged_route_component"
+        },
+        {
+          "component_code": "P3",
+          "paper": "Paper 3",
+          "role": "required_staged_route_component"
+        },
+        {
+          "component_code": "P4",
+          "paper": "Paper 4",
+          "role": "eligible_staged_route_component"
+        },
+        {
+          "component_code": "P5",
+          "paper": "Paper 5",
+          "role": "eligible_staged_route_component"
+        },
+        {
+          "component_code": "P6",
+          "paper": "Paper 6",
+          "role": "eligible_staged_route_component"
+        }
+      ],
+      "route_scope": [
+        {
+          "route": "A Level Mathematics (Staged route)",
+          "eligibility": "eligible",
+          "valid_component_combinations": [
+            [
+              "P1",
+              "P4",
+              "P3",
+              "P5"
+            ],
+            [
+              "P1",
+              "P5",
+              "P3",
+              "P4"
+            ],
+            [
+              "P1",
+              "P5",
+              "P3",
+              "P6"
+            ]
+          ],
+          "progression": "Candidates take AS Level components first, carry forward the AS result, and complete the A Level in another series."
+        }
+      ],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p1",
+        "9709:2026-2027_v4:component:p3",
+        "9709:2026-2027_v4:component:p4",
+        "9709:2026-2027_v4:component:p5",
+        "9709:2026-2027_v4:component:p6"
+      ],
+      "cross_component_claim": true,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 8-17",
+          "section_ref": "2 Syllabus overview",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+          "locator": "A Level Mathematics (Staged route)\nCandidates take AS Level components in the first year and carry forward their AS Level result. They then take\ntwo more components in another series to complete the A Level.\nYear 1 Paper 1 and Paper 4\n(AS Level) Pure Mathematics 1 Mechanics\nthen\nYear 2 Paper 3 and Paper 5\n(A Level) Pure Mathematics 3 Probability & Statistics 1\nOR\nYear 1 Paper 1 and Paper 5\n(AS Level) Pure Mathematics 1 Probability & Statistics 1\nthen\nYear 2 Paper 3 and Paper 4\n(A Level) Pure Mathematics 3 Mechanics\nOR\nYear 1 Paper 1 and Paper 5\n(AS Level) Pure Mathematics 1 Probability & Statistics 1\nthen\nYear 2 Paper 3 and Paper 6\n(A Level) Pure Mathematics 3 Probability & Statistics 2"
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:route.a_level.linear_valid_combinations",
+      "boundary_kind": "route_constraint",
+      "claim": "A Level Mathematics linear routes take all A Level components in the same series using either P1/P3/P4/P5 or P1/P3/P5/P6.",
+      "component_scope": [
+        {
+          "component_code": "P1",
+          "paper": "Paper 1",
+          "role": "required_linear_route_component"
+        },
+        {
+          "component_code": "P3",
+          "paper": "Paper 3",
+          "role": "required_linear_route_component"
+        },
+        {
+          "component_code": "P4",
+          "paper": "Paper 4",
+          "role": "eligible_linear_route_component"
+        },
+        {
+          "component_code": "P5",
+          "paper": "Paper 5",
+          "role": "eligible_linear_route_component"
+        },
+        {
+          "component_code": "P6",
+          "paper": "Paper 6",
+          "role": "eligible_linear_route_component"
+        }
+      ],
+      "route_scope": [
+        {
+          "route": "A Level Mathematics (Linear route)",
+          "eligibility": "eligible",
+          "valid_component_combinations": [
+            [
+              "P1",
+              "P3",
+              "P4",
+              "P5"
+            ],
+            [
+              "P1",
+              "P3",
+              "P5",
+              "P6"
+            ]
+          ],
+          "progression": "Candidates take the A Level components in the same series."
+        }
+      ],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p1",
+        "9709:2026-2027_v4:component:p3",
+        "9709:2026-2027_v4:component:p4",
+        "9709:2026-2027_v4:component:p5",
+        "9709:2026-2027_v4:component:p6"
+      ],
+      "cross_component_claim": true,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 8-17",
+          "section_ref": "2 Syllabus overview",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+          "locator": "A Level Mathematics (Linear route)\nCandidates take the A Level components in the same series.\nPaper 1 Paper 4\nPure Mathematics 1 Mechanics\nPaper 3 Paper 5\nPure Mathematics 3 Probability & Statistics 1\nOR\nPaper 1 Paper 5\nPure Mathematics 1 Probability & Statistics 1\nPaper 3 Paper 6\nPure Mathematics 3 Probability & Statistics 2"
+        }
+      ]
     }
   ]
 }

--- a/data/syllabus/9709/boundary_annotations_draft_v1.json
+++ b/data/syllabus/9709/boundary_annotations_draft_v1.json
@@ -1,0 +1,528 @@
+{
+  "schema_version": "9709_boundary_annotations_draft_v1",
+  "issue": 290,
+  "parent_tracker": 286,
+  "subject_code": "9709",
+  "syllabus_version": "2026-2027_v4",
+  "generated_at": "2026-04-27T14:35:00Z",
+  "canonical_topic_tree_mutation": false,
+  "source_lock": {
+    "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+    "source_type": "official_syllabus",
+    "official_pdf_url": "https://www.cambridgeinternational.org/Images/697427-2026-2027-syllabus.pdf",
+    "raw_sections_path": "data/syllabus/9709/raw_sections_v1.json",
+    "source_inventory_path": "data/syllabus/9709/source_inventory.json"
+  },
+  "draft_scope": {
+    "official_syllabus_only": true,
+    "canonical_topic_tree_mutation": false,
+    "approved_baseline": false,
+    "notes": [
+      "Boundary annotations are a separate draft overlay.",
+      "Ambiguous, indirect, and conflict-bearing statements remain marked for human review."
+    ]
+  },
+  "boundary_annotations": [
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:component.p1.assessment_scope",
+      "boundary_kind": "assessment_scope",
+      "claim": "Paper 1 assesses Pure Mathematics 1 topics 1.1 through 1.8.",
+      "component_scope": [
+        {
+          "component_code": "P1",
+          "paper": "Paper 1",
+          "role": "assessed_component"
+        }
+      ],
+      "route_scope": [],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p1",
+        "9709:2026-2027_v4:section:p1.quadratics",
+        "9709:2026-2027_v4:section:p1.functions",
+        "9709:2026-2027_v4:section:p1.coordinate_geometry",
+        "9709:2026-2027_v4:section:p1.circular_measure",
+        "9709:2026-2027_v4:section:p1.trigonometry",
+        "9709:2026-2027_v4:section:p1.series",
+        "9709:2026-2027_v4:section:p1.differentiation",
+        "9709:2026-2027_v4:section:p1.integration"
+      ],
+      "cross_component_claim": false,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 8-17",
+          "section_ref": "2 Syllabus overview",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+          "locator": "1 Pure Mathematics 1 Paper 1 1.1 Quadratics\n1.2 Functions\n1.3 Coordinate geometry\n1.4 Circular measure\n1.5 Trigonometry\n1.6 Series\n1.7 Differentiation\n1.8 Integration"
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:component.p2.assessment_scope",
+      "boundary_kind": "assessment_scope",
+      "claim": "Paper 2 assesses Pure Mathematics 2 topics 2.1 through 2.6.",
+      "component_scope": [
+        {
+          "component_code": "P2",
+          "paper": "Paper 2",
+          "role": "assessed_component"
+        }
+      ],
+      "route_scope": [],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p2",
+        "9709:2026-2027_v4:section:p2.algebra",
+        "9709:2026-2027_v4:section:p2.logarithmic_and_exponential_functions",
+        "9709:2026-2027_v4:section:p2.trigonometry",
+        "9709:2026-2027_v4:section:p2.differentiation",
+        "9709:2026-2027_v4:section:p2.integration",
+        "9709:2026-2027_v4:section:p2.numerical_solution_of_equations"
+      ],
+      "cross_component_claim": false,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 8-17",
+          "section_ref": "2 Syllabus overview",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+          "locator": "2 Pure Mathematics 2 Paper 2 2.1 Algebra\n2.2 Logarithmic and exponential functions\n2.3 Trigonometry\n2.4 Differentiation\n2.5 Integration\n2.6 Numerical solution of equations"
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:component.p3.assessment_scope",
+      "boundary_kind": "assessment_scope",
+      "claim": "Paper 3 assesses Pure Mathematics 3 topics 3.1 through 3.9.",
+      "component_scope": [
+        {
+          "component_code": "P3",
+          "paper": "Paper 3",
+          "role": "assessed_component"
+        }
+      ],
+      "route_scope": [],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p3",
+        "9709:2026-2027_v4:section:p3.algebra",
+        "9709:2026-2027_v4:section:p3.logarithmic_and_exponential_functions",
+        "9709:2026-2027_v4:section:p3.trigonometry",
+        "9709:2026-2027_v4:section:p3.differentiation",
+        "9709:2026-2027_v4:section:p3.integration",
+        "9709:2026-2027_v4:section:p3.numerical_solution_of_equations",
+        "9709:2026-2027_v4:section:p3.vectors",
+        "9709:2026-2027_v4:section:p3.differential_equations",
+        "9709:2026-2027_v4:section:p3.complex_numbers"
+      ],
+      "cross_component_claim": false,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 8-17",
+          "section_ref": "2 Syllabus overview",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+          "locator": "3 Pure Mathematics 3 Paper 3 3.1 Algebra\n3.2 Logarithmic and exponential functions\n3.3 Trigonometry\n3.4 Differentiation\n3.5 Integration\n3.6 Numerical solution of equations\n3.7 Vectors\n3.8 Differential equations\n3.9 Complex numbers"
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:component.p4.assessment_scope",
+      "boundary_kind": "assessment_scope",
+      "claim": "Paper 4 assesses Mechanics topics 4.1 through 4.5.",
+      "component_scope": [
+        {
+          "component_code": "P4",
+          "paper": "Paper 4",
+          "role": "assessed_component"
+        }
+      ],
+      "route_scope": [],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p4",
+        "9709:2026-2027_v4:section:p4.forces_and_equilibrium",
+        "9709:2026-2027_v4:section:p4.kinematics_of_motion_in_a_straight_line",
+        "9709:2026-2027_v4:section:p4.momentum",
+        "9709:2026-2027_v4:section:p4.newton_s_laws_of_motion",
+        "9709:2026-2027_v4:section:p4.energy_work_and_power"
+      ],
+      "cross_component_claim": false,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 8-17",
+          "section_ref": "2 Syllabus overview",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+          "locator": "4 Mechanics Paper 4 4.1 Forces and equilibrium\n4.2 Kinematics of motion in a straight line\n4.3 Momentum\n4.4 Newton’s laws of motion\n4.5 Energy, work and power"
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:component.p5.assessment_scope",
+      "boundary_kind": "assessment_scope",
+      "claim": "Paper 5 assesses Probability & Statistics 1 topics 5.1 through 5.5.",
+      "component_scope": [
+        {
+          "component_code": "P5",
+          "paper": "Paper 5",
+          "role": "assessed_component"
+        }
+      ],
+      "route_scope": [],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p5",
+        "9709:2026-2027_v4:section:p5.representation_of_data",
+        "9709:2026-2027_v4:section:p5.permutations_and_combinations",
+        "9709:2026-2027_v4:section:p5.probability",
+        "9709:2026-2027_v4:section:p5.discrete_random_variables",
+        "9709:2026-2027_v4:section:p5.the_normal_distribution"
+      ],
+      "cross_component_claim": false,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 8-17",
+          "section_ref": "2 Syllabus overview",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+          "locator": "5 Probability & Statistics 1 Paper 5 5.1 Representation of data\n5.2 Permutations and combinations\n5.3 Probability\n5.4 Discrete random variables\n5.5 The normal distribution"
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:component.p6.assessment_scope",
+      "boundary_kind": "assessment_scope",
+      "claim": "Paper 6 assesses Probability & Statistics 2 topics 6.1 through 6.5.",
+      "component_scope": [
+        {
+          "component_code": "P6",
+          "paper": "Paper 6",
+          "role": "assessed_component"
+        }
+      ],
+      "route_scope": [],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p6",
+        "9709:2026-2027_v4:section:p6.the_poisson_distribution",
+        "9709:2026-2027_v4:section:p6.linear_combinations_of_random_variables",
+        "9709:2026-2027_v4:section:p6.continuous_random_variables",
+        "9709:2026-2027_v4:section:p6.sampling_and_estimation",
+        "9709:2026-2027_v4:section:p6.hypothesis_tests"
+      ],
+      "cross_component_claim": false,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 8-17",
+          "section_ref": "2 Syllabus overview",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+          "locator": "6 Probability & Statistics 2 Paper 6 6.1 The Poisson distribution\n6.2 Linear combinations of random variables\n6.3 Continuous random variables\n6.4 Sampling and estimation\n6.5 Hypothesis tests"
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:route.as_p1_p2.no_a_level_progression",
+      "boundary_kind": "route_constraint",
+      "claim": "The AS Pure Mathematics only route using Paper 1 and Paper 2 is AS Level only and cannot be carried forward to complete the A Level.",
+      "component_scope": [
+        {
+          "component_code": "P1",
+          "paper": "Paper 1",
+          "role": "route_component"
+        },
+        {
+          "component_code": "P2",
+          "paper": "Paper 2",
+          "role": "route_component"
+        }
+      ],
+      "route_scope": [
+        {
+          "route": "AS Mathematics",
+          "eligibility": "AS Level only",
+          "progression": "cannot count towards A Level"
+        }
+      ],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p1",
+        "9709:2026-2027_v4:component:p2"
+      ],
+      "cross_component_claim": true,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 8-17",
+          "section_ref": "2 Syllabus overview",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+          "locator": "Please note, the Pure Mathematics only route (Paper 1 and Paper 2) is available at AS Level only. Candidates\nwho take the Pure Mathematics only route cannot then use their AS result and carry forward to complete the\nA Level."
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:route.no_p4_p6_combination",
+      "boundary_kind": "route_constraint",
+      "claim": "A Level routes cannot combine Paper 4 and Paper 6 because Paper 6 depends on Paper 5 prior knowledge.",
+      "component_scope": [
+        {
+          "component_code": "P4",
+          "paper": "Paper 4",
+          "role": "disallowed_combination_member"
+        },
+        {
+          "component_code": "P5",
+          "paper": "Paper 5",
+          "role": "required_prior_component_for_p6"
+        },
+        {
+          "component_code": "P6",
+          "paper": "Paper 6",
+          "role": "disallowed_combination_member"
+        }
+      ],
+      "route_scope": [
+        {
+          "route": "A Level Mathematics",
+          "eligibility": "P4/P6 combination unavailable",
+          "progression": "requires a valid P5-backed P6 route"
+        }
+      ],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p4",
+        "9709:2026-2027_v4:component:p5",
+        "9709:2026-2027_v4:component:p6"
+      ],
+      "cross_component_claim": true,
+      "needs_human_review": true,
+      "status": "needs_human_review",
+      "review_reasons": [
+        "component_conflict",
+        "route_table_text_extracted_from_multi-column_pdf"
+      ],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 8-17",
+          "section_ref": "2 Syllabus overview",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+          "locator": "Please note, it is not possible to combine Paper 4 and Paper 6. This is because Paper 6 depends on prior\nknowledge of the subject content for Paper 5."
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:prior.igcse_extended_or_o_level",
+      "boundary_kind": "assumed_knowledge",
+      "claim": "The syllabus assumes prior study equivalent to Cambridge IGCSE Mathematics 0580 Extended curriculum or Cambridge International O Level 4024/4029, including scientific notation for compound units.",
+      "component_scope": [
+        {
+          "component_code": "P1",
+          "paper": "Paper 1",
+          "role": "applies_to_course_entry"
+        },
+        {
+          "component_code": "P2",
+          "paper": "Paper 2",
+          "role": "applies_to_course_entry"
+        },
+        {
+          "component_code": "P3",
+          "paper": "Paper 3",
+          "role": "applies_to_course_entry"
+        },
+        {
+          "component_code": "P4",
+          "paper": "Paper 4",
+          "role": "applies_to_course_entry"
+        },
+        {
+          "component_code": "P5",
+          "paper": "Paper 5",
+          "role": "applies_to_course_entry"
+        },
+        {
+          "component_code": "P6",
+          "paper": "Paper 6",
+          "role": "applies_to_course_entry"
+        }
+      ],
+      "route_scope": [
+        {
+          "route": "All routes",
+          "eligibility": "assumed prior course knowledge",
+          "progression": "course-entry prerequisite"
+        }
+      ],
+      "linked_node_ids": [],
+      "cross_component_claim": true,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "p. 18",
+          "section_ref": "Prior knowledge",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.prior_knowledge",
+          "locator": "Knowledge of the content of the Cambridge IGCSE™ Mathematics 0580 (Extended curriculum), or Cambridge\nInternational O Level (4024/4029), is assumed. Candidates should be familiar with scientific notation for\ncompound units"
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:component.p4.no_vector_notation",
+      "boundary_kind": "excluded_knowledge",
+      "claim": "Paper 4 Mechanics question papers will not use vector notation.",
+      "component_scope": [
+        {
+          "component_code": "P4",
+          "paper": "Paper 4",
+          "role": "excluded_from_question_papers"
+        }
+      ],
+      "route_scope": [],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p4"
+      ],
+      "cross_component_claim": false,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "p. 31",
+          "section_ref": "4 Mechanics (for Paper 4)",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p4.introduction",
+          "locator": "Vector notation will not be used in the question papers."
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:relationship.p2_subset_p3",
+      "boundary_kind": "component_only_coverage",
+      "claim": "Paper 2 content is described as largely a subset of Paper 3 content, but the syllabus does not provide a one-to-one mapping in this statement.",
+      "component_scope": [
+        {
+          "component_code": "P2",
+          "paper": "Paper 2",
+          "role": "AS_only_alternative_route_component"
+        },
+        {
+          "component_code": "P3",
+          "paper": "Paper 3",
+          "role": "A_level_alternative_route_component"
+        }
+      ],
+      "route_scope": [
+        {
+          "route": "Alternative P2/P3 routes",
+          "eligibility": "P2 for AS Level only; P3 for A Level",
+          "progression": "do not silently normalize subset logic"
+        }
+      ],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p2",
+        "9709:2026-2027_v4:component:p3"
+      ],
+      "cross_component_claim": true,
+      "needs_human_review": true,
+      "status": "needs_human_review",
+      "review_reasons": [
+        "uses_largely_subset_wording",
+        "no_one_to_one_section_mapping_in_source_statement"
+      ],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 40-42",
+          "section_ref": "4 Details of the assessment",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.4.details_of_the_assessment",
+          "locator": "Paper 2: Pure Mathematics 2 and Paper 3: Pure Mathematics 3 build on the subject content for Paper 1: Pure\nMathematics 1."
+        },
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "pp. 40-42",
+          "section_ref": "4 Details of the assessment",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.4.details_of_the_assessment",
+          "locator": "Paper 2 subject content is largely a subset of the Paper 3 subject content."
+        }
+      ]
+    },
+    {
+      "boundary_id": "9709:2026-2027_v4:boundary:component.p6.assumes_p5_and_p3_calculus",
+      "boundary_kind": "assumed_knowledge",
+      "claim": "Paper 6 assumes Paper 5 Probability & Statistics 1 content and calculus within Paper 3 Pure Mathematics 3.",
+      "component_scope": [
+        {
+          "component_code": "P3",
+          "paper": "Paper 3",
+          "role": "calculus_prior_knowledge"
+        },
+        {
+          "component_code": "P5",
+          "paper": "Paper 5",
+          "role": "statistics_prior_knowledge"
+        },
+        {
+          "component_code": "P6",
+          "paper": "Paper 6",
+          "role": "dependent_component"
+        }
+      ],
+      "route_scope": [
+        {
+          "route": "A Level route using Paper 6",
+          "eligibility": "requires P5-backed route and P3 calculus knowledge",
+          "progression": "do not treat P6 as independent from P5/P3 prerequisites"
+        }
+      ],
+      "linked_node_ids": [
+        "9709:2026-2027_v4:component:p3",
+        "9709:2026-2027_v4:component:p5",
+        "9709:2026-2027_v4:component:p6"
+      ],
+      "cross_component_claim": true,
+      "needs_human_review": false,
+      "status": "draft",
+      "review_reasons": [],
+      "source_refs": [
+        {
+          "source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+          "source_type": "official_syllabus",
+          "page_ref": "p. 37",
+          "section_ref": "6 Probability & Statistics 2 (for Paper 6)",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p6.introduction",
+          "locator": "Knowledge of the content of Paper 5: Probability & Statistics 1 is assumed, and candidates may be required\nto demonstrate such knowledge in answering questions. Knowledge of calculus within the content for\nPaper 3: Pure Mathematics 3 will also be assumed."
+        }
+      ]
+    }
+  ]
+}

--- a/docs/reports/9709-boundary-audit-v1.md
+++ b/docs/reports/9709-boundary-audit-v1.md
@@ -1,0 +1,40 @@
+# 9709 Boundary Audit v1
+
+Issue: #290
+Parent tracker: #286
+Source: Cambridge International AS & A Level Mathematics 9709 syllabus, 2026-2027 version 4.
+
+## Scope
+
+This audit creates `data/syllabus/9709/boundary_annotations_draft_v1.json` as a draft boundary overlay for the locked official syllabus source. Boundary annotations remain separate from the canonical topic tree and only link to `node_id` values from `data/syllabus/9709/canonical_topic_tree_draft_v1.json` where the official source supports that link.
+
+The draft does not approve boundary decisions, alter topic-tree nodes, add scheduler logic, or infer boundaries from legacy files, past papers, VLM outputs, or unofficial sources.
+
+## Extracted Boundary Classes
+
+- `assessment_scope`: compact P1-P6 component scope annotations from the syllabus content overview.
+- `route_constraint`: AS-only and A Level route eligibility constraints, including the P1/P2 no-progression rule and the P4/P6 combination conflict.
+- `assumed_knowledge`: course-entry prior knowledge and P6 dependencies on P5 plus P3 calculus.
+- `excluded_knowledge`: explicit exclusions such as Paper 4 question papers not using vector notation.
+- `component_only_coverage`: the P2/P3 alternative-route and subset relationship, preserved as review-needed rather than normalized.
+
+## Human Review Flags
+
+The following claims are intentionally marked `needs_human_review`:
+
+- `9709:2026-2027_v4:boundary:route.no_p4_p6_combination`: component conflict and multi-column route-table extraction risk.
+- `9709:2026-2027_v4:boundary:relationship.p2_subset_p3`: the official wording says Paper 2 is "largely a subset" of Paper 3, without a one-to-one mapping.
+
+## Source Discipline
+
+Every annotation has `source_refs` into `data/syllabus/9709/raw_sections_v1.json` and uses `source_type: official_syllabus`. The source lock points to `cambridge-9709-syllabus-2026-2027-v4` from `data/syllabus/9709/source_inventory.json`.
+
+## Verification
+
+Focused contract coverage is in `tests/contracts/9709-boundary-annotations-draft.test.js`. It checks:
+
+- the JSON artifact and report exist;
+- every annotation resolves to the locked official raw section layer;
+- linked node IDs exist in the draft canonical topic tree;
+- required boundary categories and all P1-P6 component scopes are represented;
+- cross-component and review-needed claims are marked explicitly.

--- a/docs/reports/9709-boundary-audit-v1.md
+++ b/docs/reports/9709-boundary-audit-v1.md
@@ -13,7 +13,7 @@ The draft does not approve boundary decisions, alter topic-tree nodes, add sched
 ## Extracted Boundary Classes
 
 - `assessment_scope`: compact P1-P6 component scope annotations from the syllabus content overview.
-- `route_constraint`: AS-only and A Level route eligibility constraints, including the P1/P2 no-progression rule and the P4/P6 combination conflict.
+- `route_constraint`: explicit eligible AS combinations, A Level staged combinations, A Level linear combinations, plus negative constraints such as the P1/P2 no-progression rule and the P4/P6 combination conflict.
 - `assumed_knowledge`: course-entry prior knowledge and P6 dependencies on P5 plus P3 calculus.
 - `excluded_knowledge`: explicit exclusions such as Paper 4 question papers not using vector notation.
 - `component_only_coverage`: the P2/P3 alternative-route and subset relationship, preserved as review-needed rather than normalized.

--- a/docs/reports/INDEX.md
+++ b/docs/reports/INDEX.md
@@ -20,6 +20,7 @@
 - `2026-04-22-9709-syllabus-authority-vlm-dual-track-decision.md` - decision baseline for splitting `9709` topic alignment into an authoritative syllabus/paper line and a separate VLM visual-evidence line.
 - `9709-syllabus-id-contract.md` - canonical `9709` syllabus topic-tree schema and durable node ID contract for issue `#288`, scoped to schema/ID rules only with no draft tree generation.
 - `9709-canonical-topic-tree-draft-v1.md` - issue `#289` first-draft canonical `9709` topic tree report, generated only from the locked official syllabus raw sections with bullet coverage and human-review merge/split candidates.
+- `9709-boundary-audit-v1.md` - issue `#290` draft boundary annotation audit, keeping assessment scope, route constraints, assumed knowledge, exclusions, and component-only coverage separate from the canonical topic tree.
 - `ao_codex_work_dossier_2026-03-26.md` - issue-by-issue reconstruction of prior AO and Codex work, with branch-vs-mainline divergence notes.
 - `prd_progress_report_2026-03-16.md` - PRD-aligned project progress assessment after recovery, including current stage, recovery impact, and parallel workstreams.
 - `learning_runtime_9709_integration_application_promotion_2026-03-24.md` - evidence-first justification for promoting `9709.integration.application` into released runtime scoring while keeping broader integration scope conservative.
@@ -58,5 +59,6 @@
 - `9709-syllabus-source-inventory.md` - official Cambridge `9709` syllabus source lock, raw section extraction inventory, legacy/candidate file classification, and coverage summary for issue `#287`.
 - `9709-syllabus-id-contract.md` - schema, ID, source-reference, review-state, and legacy-alias contract for future canonical syllabus topic-tree generation.
 - `9709-canonical-topic-tree-draft-v1.md` - first-draft canonical `9709` topic tree coverage report for issue `#289`, including mapped/unmapped official subject-content bullets and review candidates.
+- `9709-boundary-audit-v1.md` - draft `9709` boundary overlay report for issue `#290`, covering P1-P6 assessment scope, route eligibility, assumed knowledge, excluded knowledge, component-only coverage, and review flags.
 - `rag_corpus_source_coverage.md` - corpus source coverage summary for backend RAG.
 - `rag_restricted_official_source_inventory.md` - restricted-official inventory snapshot used for governance review.

--- a/tests/contracts/9709-boundary-annotations-draft.test.js
+++ b/tests/contracts/9709-boundary-annotations-draft.test.js
@@ -126,7 +126,48 @@ describe('9709 boundary annotations draft v1', () => {
     ).toBe(true);
     expect(
       byId.get('9709:2026-2027_v4:boundary:component.p4.no_vector_notation')
-        .boundary_kind,
+      .boundary_kind,
     ).toBe('excluded_knowledge');
+  });
+
+  test('represents explicit eligible AS and A Level route options', () => {
+    const artifact = readJson(artifactPath);
+    const byId = new Map(
+      artifact.boundary_annotations.map((annotation) => [annotation.boundary_id, annotation]),
+    );
+    const requiredRouteIds = [
+      '9709:2026-2027_v4:boundary:route.as.valid_combinations',
+      '9709:2026-2027_v4:boundary:route.a_level.staged_valid_combinations',
+      '9709:2026-2027_v4:boundary:route.a_level.linear_valid_combinations',
+    ];
+
+    for (const routeId of requiredRouteIds) {
+      const annotation = byId.get(routeId);
+      expect(annotation).toBeDefined();
+      expect(annotation.boundary_kind).toBe('route_constraint');
+      expect(annotation.route_scope.some((route) => route.eligibility === 'eligible')).toBe(true);
+      expect(annotation.source_refs.length).toBeGreaterThan(0);
+    }
+
+    expect(byId.get(requiredRouteIds[0]).route_scope[0].valid_component_combinations).toEqual(
+      expect.arrayContaining([
+        ['P1', 'P2'],
+        ['P1', 'P4'],
+        ['P1', 'P5'],
+      ]),
+    );
+    expect(byId.get(requiredRouteIds[1]).route_scope[0].valid_component_combinations).toEqual(
+      expect.arrayContaining([
+        ['P1', 'P4', 'P3', 'P5'],
+        ['P1', 'P5', 'P3', 'P4'],
+        ['P1', 'P5', 'P3', 'P6'],
+      ]),
+    );
+    expect(byId.get(requiredRouteIds[2]).route_scope[0].valid_component_combinations).toEqual(
+      expect.arrayContaining([
+        ['P1', 'P3', 'P4', 'P5'],
+        ['P1', 'P3', 'P5', 'P6'],
+      ]),
+    );
   });
 });

--- a/tests/contracts/9709-boundary-annotations-draft.test.js
+++ b/tests/contracts/9709-boundary-annotations-draft.test.js
@@ -1,0 +1,132 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const artifactPath = path.join(
+  process.cwd(),
+  'data/syllabus/9709/boundary_annotations_draft_v1.json',
+);
+const reportPath = path.join(process.cwd(), 'docs/reports/9709-boundary-audit-v1.md');
+const rawSectionsPath = path.join(process.cwd(), 'data/syllabus/9709/raw_sections_v1.json');
+const sourceInventoryPath = path.join(process.cwd(), 'data/syllabus/9709/source_inventory.json');
+const topicTreePath = path.join(
+  process.cwd(),
+  'data/syllabus/9709/canonical_topic_tree_draft_v1.json',
+);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function compact(text) {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+describe('9709 boundary annotations draft v1', () => {
+  test('publishes a separate draft artifact and audit report', () => {
+    const artifact = readJson(artifactPath);
+    const report = fs.readFileSync(reportPath, 'utf8');
+
+    expect(artifact.schema_version).toBe('9709_boundary_annotations_draft_v1');
+    expect(artifact.issue).toBe(290);
+    expect(artifact.parent_tracker).toBe(286);
+    expect(artifact.boundary_annotations.length).toBeGreaterThan(0);
+    expect(artifact.canonical_topic_tree_mutation).toBe(false);
+    expect(report).toContain('Issue: #290');
+    expect(report).toContain('Boundary annotations remain separate from the canonical topic tree');
+  });
+
+  test('keeps every boundary claim sourced to the locked official raw section layer', () => {
+    const artifact = readJson(artifactPath);
+    const rawSections = readJson(rawSectionsPath);
+    const sourceInventory = readJson(sourceInventoryPath);
+    const rawById = new Map(rawSections.sections.map((section) => [section.section_id, section]));
+    const officialSourceIds = new Set(
+      sourceInventory.official_sources.map((source) => source.id),
+    );
+
+    expect(officialSourceIds.has(artifact.source_lock.source_document_id)).toBe(true);
+
+    for (const annotation of artifact.boundary_annotations) {
+      expect(annotation.source_refs.length).toBeGreaterThan(0);
+      for (const sourceRef of annotation.source_refs) {
+        expect(sourceRef.source_type).toBe('official_syllabus');
+        expect(officialSourceIds.has(sourceRef.source_document_id)).toBe(true);
+        expect(rawById.has(sourceRef.raw_section_id)).toBe(true);
+        expect(compact(rawById.get(sourceRef.raw_section_id).raw_text)).toContain(
+          compact(sourceRef.locator),
+        );
+      }
+    }
+  });
+
+  test('links only to existing draft topic-tree nodes when node links are source-supported', () => {
+    const artifact = readJson(artifactPath);
+    const topicTree = readJson(topicTreePath);
+    const nodeIds = new Set(topicTree.nodes.map((node) => node.node_id));
+
+    for (const annotation of artifact.boundary_annotations) {
+      expect(annotation.linked_node_ids).toEqual(
+        expect.arrayContaining(annotation.linked_node_ids),
+      );
+      for (const nodeId of annotation.linked_node_ids) {
+        expect(nodeIds.has(nodeId)).toBe(true);
+      }
+    }
+  });
+
+  test('represents required boundary categories and all component scopes explicitly', () => {
+    const artifact = readJson(artifactPath);
+    const kinds = artifact.boundary_annotations.map((annotation) => annotation.boundary_kind);
+    const componentCodes =
+      artifact.boundary_annotations.flatMap((annotation) =>
+        annotation.component_scope.map((component) => component.component_code),
+      );
+
+    expect(kinds).toEqual(
+      expect.arrayContaining([
+        'assessment_scope',
+        'component_only_coverage',
+        'assumed_knowledge',
+        'excluded_knowledge',
+        'route_constraint',
+      ]),
+    );
+    expect(componentCodes).toEqual(expect.arrayContaining(['P1', 'P2', 'P3', 'P4', 'P5', 'P6']));
+  });
+
+  test('marks cross-component and ambiguous boundaries for human review', () => {
+    const artifact = readJson(artifactPath);
+    const byId = new Map(
+      artifact.boundary_annotations.map((annotation) => [annotation.boundary_id, annotation]),
+    );
+
+    for (const annotation of artifact.boundary_annotations) {
+      if (annotation.cross_component_claim) {
+        expect(
+          annotation.component_scope.length + annotation.linked_node_ids.length,
+        ).toBeGreaterThan(1);
+      }
+      if (annotation.review_reasons.length > 0) {
+        expect(annotation.needs_human_review).toBe(true);
+        expect(annotation.status).toBe('needs_human_review');
+      }
+    }
+
+    expect(
+      byId.get('9709:2026-2027_v4:boundary:route.as_p1_p2.no_a_level_progression')
+        .needs_human_review,
+    ).toBe(false);
+    expect(
+      byId.get('9709:2026-2027_v4:boundary:route.no_p4_p6_combination')
+        .cross_component_claim,
+    ).toBe(true);
+    expect(
+      byId.get('9709:2026-2027_v4:boundary:relationship.p2_subset_p3')
+        .needs_human_review,
+    ).toBe(true);
+    expect(
+      byId.get('9709:2026-2027_v4:boundary:component.p4.no_vector_notation')
+        .boundary_kind,
+    ).toBe('excluded_knowledge');
+  });
+});


### PR DESCRIPTION
## Summary
- add `data/syllabus/9709/boundary_annotations_draft_v1.json` as a separate draft boundary overlay for the locked official 9709 syllabus
- cover P1-P6 assessment scope, route eligibility, assumed knowledge, excluded knowledge, component-only coverage, cross-component claims, and review-needed ambiguous/conflict cases
- add the boundary audit report and focused contract test coverage

Closes #290
Parent tracker: #286

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('data/syllabus/9709/boundary_annotations_draft_v1.json','utf8')); console.log('boundary_annotations_draft_v1.json parses')"`
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand tests/contracts/9709-boundary-annotations-draft.test.js`
- `git diff --cached --check`