### PR TITLE
feat: add 9709 syllabus coverage and drift gate

### DIFF
--- a/docs/reports/9709-syllabus-gate-report.json
+++ b/docs/reports/9709-syllabus-gate-report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "9709_syllabus_gate_report_v1",
-  "generated_at": "2026-04-27T14:58:56.290Z",
+  "generated_at": "2026-04-27T15:12:42.567Z",
   "subject_code": "9709",
   "syllabus_version": "2026-2027_v4",
   "status": "pass",

--- a/docs/reports/9709-syllabus-gate-report.json
+++ b/docs/reports/9709-syllabus-gate-report.json
@@ -1,0 +1,1499 @@
+{
+  "schema_version": "9709_syllabus_gate_report_v1",
+  "generated_at": "2026-04-27T14:58:56.290Z",
+  "subject_code": "9709",
+  "syllabus_version": "2026-2027_v4",
+  "status": "pass",
+  "approved_baseline_attempted": false,
+  "approved_baseline_ready": false,
+  "blocked_reasons": [],
+  "artifacts": {
+    "sourceInventory": "data/syllabus/9709/source_inventory.json",
+    "rawSections": "data/syllabus/9709/raw_sections_v1.json",
+    "canonicalTopicTree": "data/syllabus/9709/canonical_topic_tree_draft_v1.json",
+    "boundaryAnnotations": "data/syllabus/9709/boundary_annotations_draft_v1.json",
+    "topicTreeSchema": "data/contracts/9709_syllabus_topic_tree_schema_v1.json"
+  },
+  "source_lock": {
+    "locked_source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+    "source_inventory_version": "2026-2027_v4",
+    "canonical_topic_tree_source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+    "boundary_source_document_id": "cambridge-9709-syllabus-2026-2027-v4",
+    "raw_sections_source_document_id": "cambridge-9709-syllabus-2026-2027-v4"
+  },
+  "counts": {
+    "topic_nodes": 201,
+    "boundary_claims": 15,
+    "official_sources": 1,
+    "raw_sections": 54
+  },
+  "coverage": {
+    "raw_sections": {
+      "total": 54,
+      "mapped": [
+        "cambridge-9709-syllabus-2026-2027-v4.front_matter.cover",
+        "cambridge-9709-syllabus-2026-2027-v4.2.syllabus_overview",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.prior_knowledge",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p1.introduction",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p1.1_1_quadratics",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p1.1_2_functions",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p1.1_3_coordinate_geometry",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p1.1_4_circular_measure",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p1.1_5_trigonometry",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p1.1_6_series",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p1.1_7_differentiation",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p1.1_8_integration",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p2.introduction",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p2.2_1_algebra",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p2.2_2_logarithmic_and_exponential_functions",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p2.2_3_trigonometry",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p2.2_4_differentiation",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p2.2_5_integration",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p2.2_6_numerical_solution_of_equations",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p3.introduction",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p3.3_1_algebra",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p3.3_2_logarithmic_and_exponential_functions",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p3.3_3_trigonometry",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p3.3_4_differentiation",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p3.3_5_integration",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p3.3_6_numerical_solution_of_equations",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p3.3_7_vectors",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p3.3_8_differential_equations",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p3.3_9_complex_numbers",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p4.introduction",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p4.4_1_forces_and_equilibrium",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p4.4_2_kinematics_of_motion_in_a_straight_line",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p4.4_3_momentum",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p4.4_4_newtons_laws_of_motion",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p4.4_5_energy_work_and_power",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p5.introduction",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p5.5_1_representation_of_data",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p5.5_2_permutations_and_combinations",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p5.5_3_probability",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p5.5_4_discrete_random_variables",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p5.5_5_the_normal_distribution",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p6.introduction",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p6.6_1_the_poisson_distribution",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p6.6_2_linear_combinations_of_random_variables",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p6.6_3_continuous_random_variables",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p6.6_4_sampling_and_estimation",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.p6.6_5_hypothesis_tests",
+        "cambridge-9709-syllabus-2026-2027-v4.4.details_of_the_assessment"
+      ],
+      "unmapped": [
+        "cambridge-9709-syllabus-2026-2027-v4.front_matter.cambridge_international_context",
+        "cambridge-9709-syllabus-2026-2027-v4.front_matter.contents_and_version_notice",
+        "cambridge-9709-syllabus-2026-2027-v4.1.why_choose_this_syllabus",
+        "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.introduction",
+        "cambridge-9709-syllabus-2026-2027-v4.5.formulae_and_statistical_tables_mf19",
+        "cambridge-9709-syllabus-2026-2027-v4.6.what_else_you_need_to_know"
+      ],
+      "mapped_count": 48,
+      "unmapped_count": 6
+    }
+  },
+  "review": {
+    "unresolved_items": [
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:syllabus",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:component:p1",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:component:p2",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:component:p3",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:component:p4",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:component:p5",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:component:p6",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:note:prior_knowledge",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p1.quadratics",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p1.functions",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p1.coordinate_geometry",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p1.circular_measure",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p1.trigonometry",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p1.series",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p1.differentiation",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p1.integration",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p2.algebra",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p2.logarithmic_and_exponential_functions",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p2.trigonometry",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p2.differentiation",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p2.integration",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p2.numerical_solution_of_equations",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p3.algebra",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p3.logarithmic_and_exponential_functions",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p3.trigonometry",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p3.differentiation",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p3.integration",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p3.numerical_solution_of_equations",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p3.vectors",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p3.differential_equations",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p3.complex_numbers",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p4.forces_and_equilibrium",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p4.kinematics_of_motion_in_a_straight_line",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p4.momentum",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p4.newton_s_laws_of_motion",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p4.energy_work_and_power",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p5.representation_of_data",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p5.permutations_and_combinations",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p5.probability",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p5.discrete_random_variables",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p5.the_normal_distribution",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p6.the_poisson_distribution",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p6.linear_combinations_of_random_variables",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p6.continuous_random_variables",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p6.sampling_and_estimation",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:section:p6.hypothesis_tests",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:note:prior_knowledge.lo01_be_able_to_carry_out_simple_manipulation_of",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:note:prior_knowledge.lo02_know_the_shapes_of_graphs_of_the_form",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.quadratics.lo01_carry_out_the_process_of_completing_the_square",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.quadratics.lo02_find_the_discriminant_of_a_quadratic_polynomial_ax2",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.quadratics.lo03_solve_quadratic_equations_and_quadratic_inequalities_in_one",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.quadratics.lo04_solve_by_substitution_a_pair_of_simultaneous_equations",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.quadratics.lo05_recognise_and_solve_equations_in_x_which_are",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.functions.lo01_understand_the_terms_function_domain_range_one_one",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.functions.lo02_identify_the_range_of_a_given_function_in",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.functions.lo03_determine_whether_or_not_a_given_function_is",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.functions.lo04_illustrate_in_graphical_terms_the_relation_between_sketches",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.functions.lo05_understand_and_use_the_transformations_of_the_graph",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.coordinate_geometry.lo01_find_the_equation_of_a_straight_line_given",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.coordinate_geometry.lo02_interpret_and_use_any_of_the_forms_y",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.coordinate_geometry.lo03_understand_that_the_equation_x_a_2_y",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.coordinate_geometry.lo04_use_algebraic_methods_to_solve_problems_involving_lines",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.coordinate_geometry.lo05_understand_the_relationship_between_a_graph_and_its",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.circular_measure.lo01_understand_the_definition_of_a_radian_and_use",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.circular_measure.lo02_use_the_formulae_s_r_i_and_a",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.trigonometry.lo01_sketch_and_use_graphs_of_the_sine_cosine",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.trigonometry.lo02_use_the_exact_values_of_the_sine_cosine",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.trigonometry.lo03_use_the_notations_sin_1x_cos_1x_tan",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.trigonometry.lo04_use_the_identities_cos_i_tan_i_and",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.trigonometry.lo05_find_all_the_solutions_of_simple_trigonometrical_equations",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.series.lo01_use_the_expansion_of_a_b_n_where",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.series.lo02_recognise_arithmetic_and_geometric_progressions",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.series.lo03_use_the_formulae_for_the_nth_term_and",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.series.lo04_use_the_condition_for_the_convergence_of_a",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.differentiation.lo01_understand_the_gradient_of_a_curve_at_a",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.differentiation.lo02_use_the_derivative_of_xn_for_any_rational",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.differentiation.lo03_apply_differentiation_to_gradients_tangents_and_normals_increasing",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.differentiation.lo04_locate_stationary_points_and_determine_their_nature_and",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.integration.lo01_u_o_n_f_d_d_i_e",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.integration.lo02_solve_problems_involving_the_evaluation_of_a_constant",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.integration.lo03_evaluate_definite_integrals_as_1_x_1_2d",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p1.integration.lo04_use_definite_integration_to_find_the_area_of",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.algebra.lo01_understand_the_meaning_of_x_sketch_the_graph",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.algebra.lo02_divide_a_polynomial_of_degree_not_exceeding_4",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.algebra.lo03_use_the_factor_theorem_and_the_remainder_theorem",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.logarithmic_and_exponential_functions.lo01_understand_the_relationship_between_logarithms_and_indices_and",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.logarithmic_and_exponential_functions.lo02_understand_the_definition_and_properties_of_ex_and",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.logarithmic_and_exponential_functions.lo03_use_logarithms_to_solve_equations_and_inequalities_in",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.logarithmic_and_exponential_functions.lo04_use_logarithms_to_transform_a_given_relationship_to",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.trigonometry.lo01_understand_the_relationship_of_the_secant_cosecant_and",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.trigonometry.lo02_use_trigonometrical_identities_for_the_h_h_simplification",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.differentiation.lo01_use_the_derivatives_of_ex_ln_x_sin",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.differentiation.lo02_differentiate_products_and_quotients",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.differentiation.lo03_find_and_use_the_first_derivative_of_a",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.integration.lo01_extend_the_idea_of_reverse_differentiation_to_1",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.integration.lo02_use_trigonometrical_relationships_in_carrying_out_integration_or",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.integration.lo03_understand_and_use_the_trapezium_rule_to_estimate",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.numerical_solution_of_equations.lo01_locate_approximately_a_root_of_an_equation_by",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.numerical_solution_of_equations.lo02_understand_the_idea_of_and_use_the_notation",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p2.numerical_solution_of_equations.lo03_understand_how_a_given_simple_iterative_formula_of",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.algebra.lo01_understand_the_meaning_of_x_sketch_the_graph",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.algebra.lo02_divide_a_polynomial_of_degree_not_exceeding_4",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.algebra.lo03_use_the_factor_theorem_and_the_remainder_theorem",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.algebra.lo04_recall_an_appropriate_form_for_expressing_excluding_cases",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.algebra.lo05_use_the_expansion_of_1_x_n_where",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.logarithmic_and_exponential_functions.lo01_understand_the_relationship_between_logarithms_and_indices_and",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.logarithmic_and_exponential_functions.lo02_understand_the_definition_and_properties_of_ex_and",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.logarithmic_and_exponential_functions.lo03_use_logarithms_to_solve_equations_and_inequalities_in",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.logarithmic_and_exponential_functions.lo04_use_logarithms_to_transform_a_given_relationship_to",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.trigonometry.lo01_understand_the_relationship_of_the_secant_cosecant_and",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.trigonometry.lo02_use_trigonometrical_identities_for_the_simplification_and_exact",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.differentiation.lo01_use_the_derivatives_of_ex_ln_x_sin",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.differentiation.lo02_differentiate_products_and_quotients",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.differentiation.lo03_find_and_use_the_first_derivative_of_a",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.integration.lo01_extend_the_idea_of_reverse_differentiation_to_2",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.integration.lo02_use_trigonometrical_relationships_in_carrying_out_integration_or",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.integration.lo03_integrate_rational_functions_by_means_of_decomposition_into",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.integration.lo04_recognise_an_integrand_of_the_form_h_and",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.integration.lo05_recognise_when_an_integrand_can_usefully_be_regarded",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.integration.lo06_use_a_given_substitution_to_simplify_and_evaluate",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.numerical_solution_of_equations.lo01_locate_approximately_a_root_of_an_equation_by",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.numerical_solution_of_equations.lo02_understand_the_idea_of_and_use_the_notation",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.numerical_solution_of_equations.lo03_understand_how_a_given_simple_iterative_formula_of",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.vectors.lo01_use_standard_notations_for_vectors_i_e_x",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.vectors.lo02_carry_out_addition_and_subtraction_of_vectors_and",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.vectors.lo03_calculate_the_magnitude_of_a_vector_and_use",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.vectors.lo04_understand_the_significance_of_all_the_symbols_used",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.vectors.lo05_determine_whether_two_lines_are_parallel_calculation_of",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.vectors.lo06_use_formulae_to_calculate_the_scalar_product_of",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.differential_equations.lo01_formulate_a_simple_statement_involving_a_rate_of",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.differential_equations.lo02_find_by_integration_a_general_form_of_solution",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.differential_equations.lo03_use_an_initial_condition_to_find_a_particular",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.differential_equations.lo04_interpret_the_solution_of_a_differential_equation_in",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.complex_numbers.lo01_understand_the_idea_of_a_complex_number_notations",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.complex_numbers.lo02_carry_out_operations_of_addition_subtraction_multiplication_and",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.complex_numbers.lo03_use_the_result_that_for_a_polynomial_equation",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.complex_numbers.lo04_represent_complex_numbers_geometrically_by_means_of_an",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.complex_numbers.lo05_carry_out_operations_of_multiplication_and_1_2",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.complex_numbers.lo06_find_the_two_square_roots_of_a_complex",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.complex_numbers.lo07_understand_in_simple_terms_the_geometrical_effects_of",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p3.complex_numbers.lo08_illustrate_simple_equations_and_inequalities_involving_complex_numbers",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.forces_and_equilibrium.lo01_identify_the_forces_acting_in_a_given_situation",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.forces_and_equilibrium.lo02_understand_the_vector_nature_of_force_and_find",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.forces_and_equilibrium.lo03_use_the_principle_that_when_a_particle_is",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.forces_and_equilibrium.lo04_understand_that_a_contact_force_between_two_surfaces",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.forces_and_equilibrium.lo05_use_the_model_of_a_smooth_contact_and",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.forces_and_equilibrium.lo06_understand_the_concepts_of_limiting_friction_and_limiting",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.forces_and_equilibrium.lo07_use_newton_s_third_law_ground_on_the",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.kinematics_of_motion_in_a_straight_line.lo01_understand_the_concepts_of_distance_and_speed_as",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.kinematics_of_motion_in_a_straight_line.lo02_sketch_and_interpret_displacement_time_graphs_and_velocity",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.kinematics_of_motion_in_a_straight_line.lo03_use_differentiation_and_integration_with_respect_to_time",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.kinematics_of_motion_in_a_straight_line.lo04_use_appropriate_formulae_for_motion_with_constant_acceleration",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.momentum.lo01_use_the_definition_of_linear_momentum_and_for",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.momentum.lo02_use_conservation_of_linear_momentum_to_solve_problems",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.newton_s_laws_of_motion.lo01_apply_newton_s_laws_of_motion_to_the",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.newton_s_laws_of_motion.lo02_use_the_relationship_between_mass_and_weight",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.newton_s_laws_of_motion.lo03_solve_simple_problems_which_may_be_modelled_as",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.newton_s_laws_of_motion.lo04_solve_simple_problems_which_may_be_modelled_as",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.energy_work_and_power.lo01_understand_the_concept_of_the_work_done_by",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.energy_work_and_power.lo02_understand_the_concepts_of_gravitational_potential_energy_and",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.energy_work_and_power.lo03_understand_and_use_the_relationship_between_the_change",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.energy_work_and_power.lo04_use_the_definition_of_power_as_the_rate",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p4.energy_work_and_power.lo05_solve_problems_involving_for_example_the_instantaneous_acceleration",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.representation_of_data.lo01_select_a_suitable_way_of_presenting_raw_statistical",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.representation_of_data.lo02_draw_and_interpret_stem_and_leaf_diagrams_box",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.representation_of_data.lo03_understand_and_use_different_measures_of_central_tendency",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.representation_of_data.lo04_use_a_cumulative_frequency_graph_proportion_of_a",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.representation_of_data.lo05_calculate_and_use_the_mean_and_standard_deviation",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.permutations_and_combinations.lo01_understand_the_terms_permutation_and_combination_and_solve",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.permutations_and_combinations.lo02_solve_problems_about_arrangements_of_objects_in_a",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.probability.lo01_evaluate_probabilities_in_simple_cases_by_means_of",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.probability.lo02_use_addition_and_multiplication_of_probabilities_explicit_use",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.probability.lo03_understand_the_meaning_of_exclusive_and_independent_events",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.probability.lo04_calculate_and_use_conditional_probabilities_in_simple_cases",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.discrete_random_variables.lo01_draw_up_a_probability_distribution_table_relating_to",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.discrete_random_variables.lo02_use_formulae_for_probabilities_for_the_binomial_and",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.discrete_random_variables.lo03_use_formulae_for_the_expectation_and_variance_proofs",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.the_normal_distribution.lo01_understand_the_use_of_a_normal_distribution_to",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.the_normal_distribution.lo02_solve_problems_concerning_a_variable_x_where_x",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p5.the_normal_distribution.lo03_recall_conditions_under_which_the_normal_n_sufficiently",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.the_poisson_distribution.lo01_use_formulae_to_calculate_probabilities_for_the_po",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.the_poisson_distribution.lo02_use_the_fact_that_if_x_po_m",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.the_poisson_distribution.lo03_understand_the_relevance_of_the_poisson_distribution_to",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.the_poisson_distribution.lo04_use_the_poisson_distribution_as_an_approximation_to",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.the_poisson_distribution.lo05_use_the_normal_distribution_with_continuity_15_correction",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.linear_combinations_of_random_variables.lo01_use_when_solving_problems_the_results_that_proofs",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.continuous_random_variables.lo01_understand_the_concept_of_a_continuous_random_variable",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.continuous_random_variables.lo02_use_a_probability_density_function_to_solve_problems",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.sampling_and_estimation.lo01_understand_the_distinction_between_a_sample_and_a",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.sampling_and_estimation.lo02_explain_in_simple_terms_why_a_given_sampling",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.sampling_and_estimation.lo03_recognise_that_a_sample_mean_can_be_regarded",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.sampling_and_estimation.lo04_use_the_fact_that_x_has_a_normal",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.sampling_and_estimation.lo05_use_the_central_limit_appropriate_the_distribution_of",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.sampling_and_estimation.lo06_calculate_unbiased_estimates_of_the_population_mean_and",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.sampling_and_estimation.lo07_determine_and_interpret_a_confidence_interval_for_a",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.sampling_and_estimation.lo08_determine_from_a_large_sample_an_approximate_confidence",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.hypothesis_tests.lo01_understand_the_nature_of_a_hypothesis_test_the",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.hypothesis_tests.lo02_formulate_hypotheses_and_carry_out_a_hypothesis_test",
+        "status": "needs_human_review",
+        "review_state": "pending_human_review"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.hypothesis_tests.lo03_formulate_hypotheses_and_carry_out_a_hypothesis_test",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.hypothesis_tests.lo04_understand_the_terms_type_i_error_and_type",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "topic_node",
+        "item_id": "9709:2026-2027_v4:learning_objective:p6.hypothesis_tests.lo05_calculate_the_probabilities_of_making_type_i_and",
+        "status": "draft",
+        "review_state": "unreviewed"
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:component.p1.assessment_scope",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:component.p2.assessment_scope",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:component.p3.assessment_scope",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:component.p4.assessment_scope",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:component.p5.assessment_scope",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:component.p6.assessment_scope",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:route.as_p1_p2.no_a_level_progression",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:route.no_p4_p6_combination",
+        "status": "needs_human_review",
+        "needs_human_review": true,
+        "review_reasons": [
+          "component_conflict",
+          "route_table_text_extracted_from_multi-column_pdf"
+        ]
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:prior.igcse_extended_or_o_level",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:component.p4.no_vector_notation",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:relationship.p2_subset_p3",
+        "status": "needs_human_review",
+        "needs_human_review": true,
+        "review_reasons": [
+          "uses_largely_subset_wording",
+          "no_one_to_one_section_mapping_in_source_statement"
+        ]
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:component.p6.assumes_p5_and_p3_calculus",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:route.as.valid_combinations",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:route.a_level.staged_valid_combinations",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      },
+      {
+        "item_type": "boundary_claim",
+        "item_id": "9709:2026-2027_v4:boundary:route.a_level.linear_valid_combinations",
+        "status": "draft",
+        "needs_human_review": false,
+        "review_reasons": []
+      }
+    ],
+    "unresolved_count": 216,
+    "needs_human_review_count": 81
+  },
+  "gates": [
+    {
+      "name": "schema_validation",
+      "status": "pass",
+      "errors": [],
+      "warnings": []
+    },
+    {
+      "name": "source_lock",
+      "status": "pass",
+      "errors": [],
+      "warnings": []
+    },
+    {
+      "name": "status_contract",
+      "status": "pass",
+      "errors": [],
+      "warnings": []
+    },
+    {
+      "name": "identity_uniqueness",
+      "status": "pass",
+      "errors": [],
+      "warnings": []
+    },
+    {
+      "name": "graph_integrity",
+      "status": "pass",
+      "errors": [],
+      "warnings": []
+    },
+    {
+      "name": "source_refs",
+      "status": "pass",
+      "errors": [],
+      "warnings": []
+    },
+    {
+      "name": "legacy_file_leakage",
+      "status": "pass",
+      "errors": [],
+      "warnings": []
+    },
+    {
+      "name": "raw_section_mapping",
+      "status": "warn",
+      "errors": [],
+      "warnings": [
+        {
+          "code": "unmapped_raw_section",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.1.why_choose_this_syllabus"
+        },
+        {
+          "code": "unmapped_raw_section",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.3.subject_content.introduction"
+        },
+        {
+          "code": "unmapped_raw_section",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.5.formulae_and_statistical_tables_mf19"
+        },
+        {
+          "code": "unmapped_raw_section",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.6.what_else_you_need_to_know"
+        },
+        {
+          "code": "unmapped_raw_section",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.front_matter.cambridge_international_context"
+        },
+        {
+          "code": "unmapped_raw_section",
+          "raw_section_id": "cambridge-9709-syllabus-2026-2027-v4.front_matter.contents_and_version_notice"
+        }
+      ]
+    },
+    {
+      "name": "approved_baseline_freeze",
+      "status": "pass",
+      "errors": [],
+      "warnings": []
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:community": "node scripts/test-community-api.js",
     "test:community:dev": "npm run dev & sleep 5 && npm run test:community",
     "learning:release-gate": "node scripts/learning/run_released_family_gate.js",
+    "syllabus:9709:gate": "node scripts/syllabus/run_9709_syllabus_gate.js",
     "ao:start:clean": "bash scripts/ao/start-clean.sh",
     "ao:start:clean:dry": "bash scripts/ao/start-clean.sh --dry-run",
     "ao:reconcile": "node scripts/ao-reconcile.js",

--- a/scripts/syllabus/__tests__/9709-syllabus-gate.test.js
+++ b/scripts/syllabus/__tests__/9709-syllabus-gate.test.js
@@ -161,6 +161,49 @@ describe('9709 syllabus gate', () => {
     );
   });
 
+  test('allows official syllabus update refs when the update document is in source inventory metadata', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+    const fixture = buildFixture();
+    const updateDocument = fixture.sourceInventory.observed_official_non_baseline_documents.find(
+      (source) => source.id === 'cambridge-9709-syllabus-update-2026-2027-december-2025',
+    );
+    expect(updateDocument).toBeDefined();
+    fixture.canonicalTopicTree.nodes[0].source_refs[0] = {
+      ...fixture.canonicalTopicTree.nodes[0].source_refs[0],
+      source_document_id: updateDocument.id,
+      source_type: 'official_syllabus_update',
+    };
+
+    const report = build9709SyllabusGateReport({ artifacts: fixture });
+
+    expect(report.status).toBe('pass');
+    expect(gateByName(report, 'source_refs').status).toBe('pass');
+    expect(gateByName(report, 'legacy_file_leakage').status).toBe('pass');
+  });
+
+  test('rejects candidate comparison files even when a ref claims official update source type', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+    const fixture = buildFixture();
+    fixture.canonicalTopicTree.nodes[0].source_refs[0] = {
+      ...fixture.canonicalTopicTree.nodes[0].source_refs[0],
+      source_document_id: 'data/curriculum/9709_authority_ready_batch_300_nodes_v2.json',
+      source_type: 'official_syllabus_update',
+    };
+
+    const report = build9709SyllabusGateReport({ artifacts: fixture });
+
+    expectBlocked(report, 'legacy_file_leakage');
+    expectBlocked(report, 'missing_source_inventory_ref');
+    expect(gateByName(report, 'legacy_file_leakage').errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'legacy_file_leakage',
+          source_document_id: 'data/curriculum/9709_authority_ready_batch_300_nodes_v2.json',
+        }),
+      ]),
+    );
+  });
+
   test('reports unmapped raw syllabus sections without failing the draft gate', async () => {
     const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
     const fixture = buildFixture();
@@ -244,12 +287,38 @@ describe('9709 syllabus gate', () => {
     );
   });
 
+  test.each(['false', '0'])(
+    'CLI treats --attempt-approved-baseline=%s as normal non-freeze gate mode',
+    async (flagValue) => {
+      const outJson = `tmp/9709-syllabus-gate-report-${flagValue}-test.json`;
+      const previousExitCode = process.exitCode;
+      const { main } = await import('../run_9709_syllabus_gate.js');
+
+      try {
+        process.exitCode = undefined;
+        await main([`--attempt-approved-baseline=${flagValue}`, '--out-json', outJson]);
+
+        expect(process.exitCode).toBeUndefined();
+        const report = readJson(outJson);
+        expect(report).toMatchObject({
+          status: 'pass',
+          approved_baseline_attempted: false,
+          blocked_reasons: [],
+        });
+      } finally {
+        process.exitCode = previousExitCode;
+        fs.rmSync(path.join(process.cwd(), outJson), { force: true });
+      }
+    },
+  );
+
   test('CLI writes the deterministic gate report JSON', async () => {
     const outJson = 'tmp/9709-syllabus-gate-report-test.json';
     const previousExitCode = process.exitCode;
     const { main } = await import('../run_9709_syllabus_gate.js');
 
     try {
+      process.exitCode = undefined;
       await main(['--out-json', outJson]);
 
       expect(process.exitCode).toBeUndefined();

--- a/scripts/syllabus/__tests__/9709-syllabus-gate.test.js
+++ b/scripts/syllabus/__tests__/9709-syllabus-gate.test.js
@@ -1,0 +1,270 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const realPaths = {
+  sourceInventory: 'data/syllabus/9709/source_inventory.json',
+  rawSections: 'data/syllabus/9709/raw_sections_v1.json',
+  canonicalTopicTree: 'data/syllabus/9709/canonical_topic_tree_draft_v1.json',
+  boundaryAnnotations: 'data/syllabus/9709/boundary_annotations_draft_v1.json',
+  topicTreeSchema: 'data/contracts/9709_syllabus_topic_tree_schema_v1.json',
+};
+
+function readJson(relPath) {
+  return JSON.parse(fs.readFileSync(path.join(process.cwd(), relPath), 'utf8'));
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function buildFixture() {
+  return {
+    sourceInventory: readJson(realPaths.sourceInventory),
+    rawSections: readJson(realPaths.rawSections),
+    canonicalTopicTree: readJson(realPaths.canonicalTopicTree),
+    boundaryAnnotations: readJson(realPaths.boundaryAnnotations),
+    topicTreeSchema: readJson(realPaths.topicTreeSchema),
+  };
+}
+
+function gateByName(report, gateName) {
+  return report.gates.find((gate) => gate.name === gateName);
+}
+
+function expectBlocked(report, reason) {
+  expect(report.status).toBe('fail');
+  expect(report.blocked_reasons).toEqual(expect.arrayContaining([reason]));
+}
+
+describe('9709 syllabus gate', () => {
+  test('passes the merged official draft artifacts while reporting review and coverage state', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+
+    const report = build9709SyllabusGateReport({
+      artifacts: buildFixture(),
+    });
+
+    expect(report).toMatchObject({
+      schema_version: '9709_syllabus_gate_report_v1',
+      subject_code: '9709',
+      status: 'pass',
+      approved_baseline_attempted: false,
+      approved_baseline_ready: false,
+      blocked_reasons: [],
+    });
+    expect(gateByName(report, 'schema_validation').status).toBe('pass');
+    expect(gateByName(report, 'identity_uniqueness').status).toBe('pass');
+    expect(gateByName(report, 'source_refs').status).toBe('pass');
+    expect(report.review.unresolved_items.length).toBeGreaterThan(0);
+    expect(report.coverage.raw_sections.total).toBeGreaterThan(0);
+    expect(report.coverage.raw_sections.unmapped).toEqual(expect.any(Array));
+  });
+
+  test('fails schema validation for malformed canonical topic trees', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+    const fixture = buildFixture();
+    delete fixture.canonicalTopicTree.nodes[0].canonical_title;
+
+    const report = build9709SyllabusGateReport({ artifacts: fixture });
+
+    expectBlocked(report, 'schema_validation_failed');
+    expect(gateByName(report, 'schema_validation').errors[0].message).toContain(
+      "should have required property 'canonical_title'",
+    );
+  });
+
+  test('fails duplicate node IDs and duplicate canonical topic paths', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+    const fixture = buildFixture();
+    fixture.canonicalTopicTree.nodes[1].node_id = fixture.canonicalTopicTree.nodes[0].node_id;
+    fixture.canonicalTopicTree.nodes[2].topic_path = cloneJson(
+      fixture.canonicalTopicTree.nodes[0].topic_path,
+    );
+
+    const report = build9709SyllabusGateReport({ artifacts: fixture });
+
+    expectBlocked(report, 'duplicate_node_id');
+    expectBlocked(report, 'duplicate_topic_path');
+    expect(gateByName(report, 'identity_uniqueness').errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'duplicate_node_id' }),
+        expect.objectContaining({ code: 'duplicate_topic_path' }),
+      ]),
+    );
+  });
+
+  test('fails missing source refs on topic nodes and boundary claims', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+    const fixture = buildFixture();
+    fixture.canonicalTopicTree.nodes[0].source_refs = [];
+    fixture.boundaryAnnotations.boundary_annotations[0].source_refs = [];
+
+    const report = build9709SyllabusGateReport({ artifacts: fixture });
+
+    expectBlocked(report, 'missing_source_refs');
+    expect(gateByName(report, 'source_refs').errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'missing_source_refs', owner_type: 'topic_node' }),
+        expect.objectContaining({ code: 'missing_source_refs', owner_type: 'boundary_claim' }),
+      ]),
+    );
+  });
+
+  test('fails invalid topic-node or boundary status values', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+    const fixture = buildFixture();
+    fixture.canonicalTopicTree.nodes[0].status = 'ready_to_freeze';
+    fixture.boundaryAnnotations.boundary_annotations[0].status = 'ready_to_freeze';
+
+    const report = build9709SyllabusGateReport({ artifacts: fixture });
+
+    expectBlocked(report, 'invalid_status');
+    expect(gateByName(report, 'status_contract').errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'invalid_status', owner_type: 'topic_node' }),
+        expect.objectContaining({ code: 'invalid_status', owner_type: 'boundary_claim' }),
+      ]),
+    );
+  });
+
+  test('fails orphan nodes', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+    const fixture = buildFixture();
+    fixture.canonicalTopicTree.nodes[1].parent_node_id =
+      '9709:2026-2027_v4:section:missing_parent';
+
+    const report = build9709SyllabusGateReport({ artifacts: fixture });
+
+    expectBlocked(report, 'orphan_node');
+    expect(gateByName(report, 'graph_integrity').errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: 'orphan_node' })]),
+    );
+  });
+
+  test('fails source refs pointing outside source inventory or raw sections', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+    const fixture = buildFixture();
+    fixture.canonicalTopicTree.nodes[0].source_refs[0].raw_section_id =
+      'cambridge-9709-syllabus-2026-2027-v4.3.subject_content.missing';
+    fixture.boundaryAnnotations.boundary_annotations[0].source_refs[0].source_document_id =
+      'cambridge-9709-syllabus-2023-2025-v1';
+
+    const report = build9709SyllabusGateReport({ artifacts: fixture });
+
+    expectBlocked(report, 'missing_raw_section_ref');
+    expectBlocked(report, 'missing_source_inventory_ref');
+    expect(gateByName(report, 'source_refs').errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'missing_raw_section_ref' }),
+        expect.objectContaining({ code: 'missing_source_inventory_ref' }),
+      ]),
+    );
+  });
+
+  test('reports unmapped raw syllabus sections without failing the draft gate', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+    const fixture = buildFixture();
+    const unmappedSection = {
+      ...cloneJson(fixture.rawSections.sections[0]),
+      section_id: 'cambridge-9709-syllabus-2026-2027-v4.synthetic.unmapped_section',
+      section_ref: 'Synthetic unmapped section',
+      raw_text: 'Synthetic unmapped section',
+    };
+    fixture.rawSections.sections.push(unmappedSection);
+
+    const report = build9709SyllabusGateReport({ artifacts: fixture });
+
+    expect(report.status).toBe('pass');
+    const rawSectionMappingGate = gateByName(report, 'raw_section_mapping');
+    expect(rawSectionMappingGate.status).toBe('warn');
+    expect(rawSectionMappingGate.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'unmapped_raw_section',
+          raw_section_id: unmappedSection.section_id,
+        }),
+      ]),
+    );
+    expect(report.coverage.raw_sections.unmapped).toEqual(
+      expect.arrayContaining([unmappedSection.section_id]),
+    );
+  });
+
+  test('fails stale source version or source-lock drift', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+    const fixture = buildFixture();
+    fixture.sourceInventory.source_lock.syllabus_version_tag = '2028-2030_v1';
+
+    const report = build9709SyllabusGateReport({ artifacts: fixture });
+
+    expectBlocked(report, 'stale_source_lock');
+    expect(gateByName(report, 'source_lock').errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: 'stale_source_lock' })]),
+    );
+  });
+
+  test('fails approved baseline attempts while human review items remain unresolved', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+
+    const report = build9709SyllabusGateReport({
+      artifacts: buildFixture(),
+      approvedBaselineAttempted: true,
+    });
+
+    expectBlocked(report, 'unresolved_review_items');
+    expect(report.approved_baseline_attempted).toBe(true);
+    expect(report.approved_baseline_ready).toBe(false);
+    expect(gateByName(report, 'approved_baseline_freeze').errors[0]).toMatchObject({
+      code: 'unresolved_review_items',
+    });
+  });
+
+  test('fails legacy-file leakage without rejecting candidate legacy-path metadata', async () => {
+    const { build9709SyllabusGateReport } = await import('../lib/9709-syllabus-gate.js');
+    const fixture = buildFixture();
+    fixture.canonicalTopicTree.nodes[0].source_refs[0] = {
+      source_document_id: 'data/syllabus/9709syllabus.txt',
+      source_type: 'legacy_taxonomy',
+      page_ref: null,
+      section_ref: null,
+      raw_section_id: null,
+      locator: 'legacy syllabus text',
+    };
+
+    const report = build9709SyllabusGateReport({ artifacts: fixture });
+
+    expectBlocked(report, 'legacy_file_leakage');
+    expect(gateByName(report, 'legacy_file_leakage').errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'legacy_file_leakage',
+          source_document_id: 'data/syllabus/9709syllabus.txt',
+        }),
+      ]),
+    );
+  });
+
+  test('CLI writes the deterministic gate report JSON', async () => {
+    const outJson = 'tmp/9709-syllabus-gate-report-test.json';
+    const previousExitCode = process.exitCode;
+    const { main } = await import('../run_9709_syllabus_gate.js');
+
+    try {
+      await main(['--out-json', outJson]);
+
+      expect(process.exitCode).toBeUndefined();
+      expect(fs.existsSync(path.join(process.cwd(), outJson))).toBe(true);
+      const report = readJson(outJson);
+      expect(report).toMatchObject({
+        schema_version: '9709_syllabus_gate_report_v1',
+        status: 'pass',
+        blocked_reasons: [],
+        subject_code: '9709',
+      });
+      expect(report.artifacts).toMatchObject(realPaths);
+    } finally {
+      process.exitCode = previousExitCode;
+      fs.rmSync(path.join(process.cwd(), outJson), { force: true });
+    }
+  });
+});

--- a/scripts/syllabus/lib/9709-syllabus-gate.js
+++ b/scripts/syllabus/lib/9709-syllabus-gate.js
@@ -1,0 +1,672 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const Ajv = require('ajv');
+
+const PROJECT_ROOT = path.resolve(fileURLToPath(new URL('../../../', import.meta.url)));
+
+export const SYLLABUS_GATE_SCHEMA_VERSION = '9709_syllabus_gate_report_v1';
+export const DEFAULT_9709_SYLLABUS_GATE_REPORT_PATH =
+  'docs/reports/9709-syllabus-gate-report.json';
+
+export const DEFAULT_9709_SYLLABUS_GATE_PATHS = {
+  sourceInventory: 'data/syllabus/9709/source_inventory.json',
+  rawSections: 'data/syllabus/9709/raw_sections_v1.json',
+  canonicalTopicTree: 'data/syllabus/9709/canonical_topic_tree_draft_v1.json',
+  boundaryAnnotations: 'data/syllabus/9709/boundary_annotations_draft_v1.json',
+  topicTreeSchema: 'data/contracts/9709_syllabus_topic_tree_schema_v1.json',
+};
+
+const ALLOWED_TOPIC_NODE_STATUSES = new Set([
+  'draft',
+  'approved',
+  'deprecated',
+  'needs_human_review',
+]);
+const ALLOWED_BOUNDARY_STATUSES = new Set([
+  'draft',
+  'approved',
+  'deprecated',
+  'needs_human_review',
+]);
+const OFFICIAL_SOURCE_TYPES = new Set(['official_syllabus', 'official_syllabus_update']);
+
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function normalizeRootDir(rootDir) {
+  return typeof rootDir === 'string' && rootDir.trim() ? rootDir : PROJECT_ROOT;
+}
+
+function resolveFromRoot(rootDir, relPath) {
+  return path.join(normalizeRootDir(rootDir), relPath);
+}
+
+function ensureParentDir(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function readJson(rootDir, relPath) {
+  return JSON.parse(fs.readFileSync(resolveFromRoot(rootDir, relPath), 'utf8'));
+}
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function sortByStableJson(values) {
+  return [...values].sort((left, right) =>
+    JSON.stringify(left).localeCompare(JSON.stringify(right)),
+  );
+}
+
+function buildGate(name, errors = [], warnings = []) {
+  return {
+    name,
+    status: errors.length > 0 ? 'fail' : warnings.length > 0 ? 'warn' : 'pass',
+    errors: sortByStableJson(errors),
+    warnings: sortByStableJson(warnings),
+  };
+}
+
+function formatAjvError(error = {}) {
+  return {
+    code: 'schema_validation_failed',
+    path: error.dataPath || error.instancePath || '',
+    message: error.message || 'schema validation failed',
+    params: cloneJson(error.params ?? {}),
+  };
+}
+
+function officialSourceIds(sourceInventory = {}) {
+  return new Set(normalizeArray(sourceInventory.official_sources).map((source) => source.id));
+}
+
+function rawSectionIds(rawSections = {}) {
+  return new Set(normalizeArray(rawSections.sections).map((section) => section.section_id));
+}
+
+function legacyInventoryPaths(sourceInventory = {}) {
+  return new Set(
+    normalizeArray(sourceInventory.existing_repo_syllabus_or_curriculum_files)
+      .map((entry) => entry.path)
+      .filter(Boolean),
+  );
+}
+
+function canonicalTopicPath(topicPath) {
+  return normalizeArray(topicPath)
+    .map((segment) => String(segment).trim().toLowerCase())
+    .join('/');
+}
+
+function collectTopicSourceRefOwners(canonicalTopicTree = {}) {
+  const owners = [];
+
+  for (const node of normalizeArray(canonicalTopicTree.nodes)) {
+    owners.push({
+      owner_type: 'topic_node',
+      owner_id: node.node_id ?? null,
+      source_refs: node.source_refs,
+    });
+
+    for (const item of normalizeArray(node.assumed_knowledge)) {
+      owners.push({
+        owner_type: 'assumed_knowledge',
+        owner_id: `${node.node_id ?? 'unknown'}#${item.node_id ?? item.note ?? 'unknown'}`,
+        source_refs: item.source_refs,
+      });
+    }
+
+    for (const item of normalizeArray(node.aliases)) {
+      owners.push({
+        owner_type: 'alias',
+        owner_id: `${node.node_id ?? 'unknown'}#${item.value ?? 'unknown'}`,
+        source_refs: item.source_refs,
+      });
+    }
+
+    for (const item of normalizeArray(node.legacy_paths)) {
+      owners.push({
+        owner_type: 'legacy_path',
+        owner_id: `${node.node_id ?? 'unknown'}#${item.path ?? 'unknown'}`,
+        source_refs: item.source_refs,
+      });
+    }
+  }
+
+  return owners;
+}
+
+function collectBoundarySourceRefOwners(boundaryAnnotations = {}) {
+  return normalizeArray(boundaryAnnotations.boundary_annotations).map((annotation) => ({
+    owner_type: 'boundary_claim',
+    owner_id: annotation.boundary_id ?? null,
+    source_refs: annotation.source_refs,
+  }));
+}
+
+function collectAllSourceRefOwners({ canonicalTopicTree = {}, boundaryAnnotations = {} } = {}) {
+  return [
+    ...collectTopicSourceRefOwners(canonicalTopicTree),
+    ...collectBoundarySourceRefOwners(boundaryAnnotations),
+  ];
+}
+
+function validateSchema({ canonicalTopicTree = {}, topicTreeSchema = {} } = {}) {
+  const ajv = new Ajv({ allErrors: true, jsonPointers: true });
+  const validate = ajv.compile(topicTreeSchema);
+  const valid = validate(canonicalTopicTree);
+
+  return buildGate(
+    'schema_validation',
+    valid ? [] : normalizeArray(validate.errors).map(formatAjvError),
+  );
+}
+
+function validateSourceLock({
+  sourceInventory = {},
+  rawSections = {},
+  canonicalTopicTree = {},
+  boundaryAnnotations = {},
+} = {}) {
+  const errors = [];
+  const lockedSourceDocumentId = sourceInventory.source_lock?.locked_source_document_id;
+  const lockedVersion = sourceInventory.source_lock?.syllabus_version_tag;
+  const lockedExamYears = sourceInventory.source_lock?.exam_years;
+  const officialSource = normalizeArray(sourceInventory.official_sources).find(
+    (source) => source.id === lockedSourceDocumentId,
+  );
+
+  function stale(field, expected, actual, artifact) {
+    if (expected !== undefined && actual !== expected) {
+      errors.push({
+        code: 'stale_source_lock',
+        artifact,
+        field,
+        expected,
+        actual: actual ?? null,
+      });
+    }
+  }
+
+  if (!lockedSourceDocumentId || !officialSource) {
+    errors.push({
+      code: 'stale_source_lock',
+      artifact: 'source_inventory',
+      field: 'source_lock.locked_source_document_id',
+      expected: 'official source id',
+      actual: lockedSourceDocumentId ?? null,
+    });
+  }
+
+  stale('syllabus_code', sourceInventory.subject_code, canonicalTopicTree.syllabus_code, 'canonical_topic_tree');
+  stale('syllabus_version', lockedVersion, canonicalTopicTree.syllabus_version, 'canonical_topic_tree');
+  stale('exam_year_range', lockedExamYears, canonicalTopicTree.exam_year_range, 'canonical_topic_tree');
+  stale(
+    'source_lock.source_document_id',
+    lockedSourceDocumentId,
+    canonicalTopicTree.source_lock?.source_document_id,
+    'canonical_topic_tree',
+  );
+  stale(
+    'source_lock.source_document_id',
+    lockedSourceDocumentId,
+    boundaryAnnotations.source_lock?.source_document_id,
+    'boundary_annotations',
+  );
+  stale('source_document.id', lockedSourceDocumentId, rawSections.source_document?.id, 'raw_sections');
+  stale('source_document.id', lockedSourceDocumentId, officialSource?.id, 'source_inventory');
+  stale('source_document.sha256', officialSource?.sha256, canonicalTopicTree.source_lock?.sha256, 'canonical_topic_tree');
+  stale('source_document.sha256', officialSource?.sha256, rawSections.source_document?.sha256, 'raw_sections');
+  stale(
+    'official_pdf_url',
+    officialSource?.official_pdf_url,
+    canonicalTopicTree.source_lock?.official_pdf_url,
+    'canonical_topic_tree',
+  );
+  stale(
+    'official_pdf_url',
+    officialSource?.official_pdf_url,
+    boundaryAnnotations.source_lock?.official_pdf_url,
+    'boundary_annotations',
+  );
+
+  return buildGate('source_lock', errors);
+}
+
+function validateStatuses({ canonicalTopicTree = {}, boundaryAnnotations = {} } = {}) {
+  const errors = [];
+
+  for (const node of normalizeArray(canonicalTopicTree.nodes)) {
+    if (!ALLOWED_TOPIC_NODE_STATUSES.has(node.status)) {
+      errors.push({
+        code: 'invalid_status',
+        owner_type: 'topic_node',
+        owner_id: node.node_id ?? null,
+        status: node.status ?? null,
+      });
+    }
+    if (node.status === 'approved' && node.review_state?.state !== 'accepted') {
+      errors.push({
+        code: 'invalid_status',
+        owner_type: 'topic_node',
+        owner_id: node.node_id ?? null,
+        status: node.status,
+        review_state: node.review_state?.state ?? null,
+      });
+    }
+  }
+
+  for (const annotation of normalizeArray(boundaryAnnotations.boundary_annotations)) {
+    if (!ALLOWED_BOUNDARY_STATUSES.has(annotation.status)) {
+      errors.push({
+        code: 'invalid_status',
+        owner_type: 'boundary_claim',
+        owner_id: annotation.boundary_id ?? null,
+        status: annotation.status ?? null,
+      });
+    }
+    if (annotation.status === 'approved' && annotation.needs_human_review) {
+      errors.push({
+        code: 'invalid_status',
+        owner_type: 'boundary_claim',
+        owner_id: annotation.boundary_id ?? null,
+        status: annotation.status,
+        needs_human_review: annotation.needs_human_review,
+      });
+    }
+  }
+
+  return buildGate('status_contract', errors);
+}
+
+function validateIdentityUniqueness({ canonicalTopicTree = {} } = {}) {
+  const errors = [];
+  const nodeIds = new Map();
+  const topicPaths = new Map();
+
+  for (const node of normalizeArray(canonicalTopicTree.nodes)) {
+    if (node.node_id) {
+      if (nodeIds.has(node.node_id)) {
+        errors.push({
+          code: 'duplicate_node_id',
+          node_id: node.node_id,
+          first_owner_id: nodeIds.get(node.node_id),
+          duplicate_owner_id: node.node_id,
+        });
+      } else {
+        nodeIds.set(node.node_id, node.node_id);
+      }
+    }
+
+    const pathKey = canonicalTopicPath(node.topic_path);
+    if (pathKey) {
+      if (topicPaths.has(pathKey)) {
+        errors.push({
+          code: 'duplicate_topic_path',
+          topic_path: pathKey,
+          first_owner_id: topicPaths.get(pathKey),
+          duplicate_owner_id: node.node_id ?? null,
+        });
+      } else {
+        topicPaths.set(pathKey, node.node_id ?? null);
+      }
+    }
+  }
+
+  return buildGate('identity_uniqueness', errors);
+}
+
+function validateGraphIntegrity({ canonicalTopicTree = {} } = {}) {
+  const nodeIds = new Set(normalizeArray(canonicalTopicTree.nodes).map((node) => node.node_id));
+  const errors = [];
+
+  for (const node of normalizeArray(canonicalTopicTree.nodes)) {
+    if (node.parent_node_id && !nodeIds.has(node.parent_node_id)) {
+      errors.push({
+        code: 'orphan_node',
+        owner_id: node.node_id ?? null,
+        missing_parent_node_id: node.parent_node_id,
+      });
+    }
+  }
+
+  return buildGate('graph_integrity', errors);
+}
+
+function validateSourceRefs({
+  sourceInventory = {},
+  rawSections = {},
+  canonicalTopicTree = {},
+  boundaryAnnotations = {},
+} = {}) {
+  const officialIds = officialSourceIds(sourceInventory);
+  const rawIds = rawSectionIds(rawSections);
+  const errors = [];
+
+  for (const owner of collectAllSourceRefOwners({ canonicalTopicTree, boundaryAnnotations })) {
+    const refs = normalizeArray(owner.source_refs);
+    if (refs.length === 0) {
+      errors.push({
+        code: 'missing_source_refs',
+        owner_type: owner.owner_type,
+        owner_id: owner.owner_id,
+      });
+      continue;
+    }
+
+    for (const sourceRef of refs) {
+      if (!officialIds.has(sourceRef.source_document_id)) {
+        errors.push({
+          code: 'missing_source_inventory_ref',
+          owner_type: owner.owner_type,
+          owner_id: owner.owner_id,
+          source_document_id: sourceRef.source_document_id ?? null,
+        });
+      }
+      if (!sourceRef.raw_section_id || !rawIds.has(sourceRef.raw_section_id)) {
+        errors.push({
+          code: 'missing_raw_section_ref',
+          owner_type: owner.owner_type,
+          owner_id: owner.owner_id,
+          raw_section_id: sourceRef.raw_section_id ?? null,
+        });
+      }
+    }
+  }
+
+  return buildGate('source_refs', errors);
+}
+
+function validateLegacyFileLeakage({
+  sourceInventory = {},
+  canonicalTopicTree = {},
+  boundaryAnnotations = {},
+  paths = DEFAULT_9709_SYLLABUS_GATE_PATHS,
+} = {}) {
+  const errors = [];
+  const legacyPaths = legacyInventoryPaths(sourceInventory);
+
+  for (const [pathKind, relPath] of Object.entries(paths ?? {})) {
+    if (legacyPaths.has(relPath)) {
+      errors.push({
+        code: 'legacy_file_leakage',
+        path_kind: pathKind,
+        path: relPath,
+      });
+    }
+  }
+
+  for (const entry of normalizeArray(sourceInventory.existing_repo_syllabus_or_curriculum_files)) {
+    if (entry.canonical_authority === true) {
+      errors.push({
+        code: 'legacy_file_leakage',
+        path: entry.path ?? null,
+        reason: 'legacy inventory entry marked canonical_authority=true',
+      });
+    }
+  }
+
+  for (const owner of collectAllSourceRefOwners({ canonicalTopicTree, boundaryAnnotations })) {
+    for (const sourceRef of normalizeArray(owner.source_refs)) {
+      const sourceType = sourceRef.source_type ?? null;
+      const sourceDocumentId = sourceRef.source_document_id ?? null;
+      const sourceLooksLegacy =
+        sourceType === 'legacy_taxonomy'
+        || legacyPaths.has(sourceDocumentId)
+        || normalizeArray([...legacyPaths]).some((legacyPath) =>
+          sourceDocumentId === path.basename(legacyPath),
+        )
+        || !OFFICIAL_SOURCE_TYPES.has(sourceType);
+
+      if (sourceLooksLegacy) {
+        errors.push({
+          code: 'legacy_file_leakage',
+          owner_type: owner.owner_type,
+          owner_id: owner.owner_id,
+          source_document_id: sourceDocumentId,
+          source_type: sourceType,
+        });
+      }
+    }
+  }
+
+  for (const node of normalizeArray(canonicalTopicTree.nodes)) {
+    for (const legacyPath of normalizeArray(node.legacy_paths)) {
+      if (legacyPath.status === 'approved') {
+        errors.push({
+          code: 'legacy_file_leakage',
+          owner_type: 'legacy_path',
+          owner_id: node.node_id ?? null,
+          path: legacyPath.path ?? null,
+          status: legacyPath.status,
+        });
+      }
+    }
+    for (const alias of normalizeArray(node.aliases)) {
+      if (String(alias.source ?? '').startsWith('legacy_') && alias.status === 'approved') {
+        errors.push({
+          code: 'legacy_file_leakage',
+          owner_type: 'alias',
+          owner_id: node.node_id ?? null,
+          value: alias.value ?? null,
+          status: alias.status,
+        });
+      }
+    }
+  }
+
+  return buildGate('legacy_file_leakage', errors);
+}
+
+function buildRawSectionMapping({ rawSections = {}, canonicalTopicTree = {}, boundaryAnnotations = {} } = {}) {
+  const mappedIds = new Set();
+  for (const owner of collectAllSourceRefOwners({ canonicalTopicTree, boundaryAnnotations })) {
+    for (const sourceRef of normalizeArray(owner.source_refs)) {
+      if (sourceRef.raw_section_id) {
+        mappedIds.add(sourceRef.raw_section_id);
+      }
+    }
+  }
+
+  const rawIds = normalizeArray(rawSections.sections).map((section) => section.section_id);
+  const unmapped = rawIds.filter((sectionId) => !mappedIds.has(sectionId));
+  const warnings = unmapped.map((sectionId) => ({
+    code: 'unmapped_raw_section',
+    raw_section_id: sectionId,
+  }));
+
+  return {
+    gate: buildGate('raw_section_mapping', [], warnings),
+    mapped: rawIds.filter((sectionId) => mappedIds.has(sectionId)),
+    unmapped,
+  };
+}
+
+function buildReviewSummary({ canonicalTopicTree = {}, boundaryAnnotations = {} } = {}) {
+  const unresolvedItems = [];
+
+  for (const node of normalizeArray(canonicalTopicTree.nodes)) {
+    if (node.status !== 'approved' || node.review_state?.state !== 'accepted') {
+      unresolvedItems.push({
+        item_type: 'topic_node',
+        item_id: node.node_id ?? null,
+        status: node.status ?? null,
+        review_state: node.review_state?.state ?? null,
+      });
+    }
+  }
+
+  for (const annotation of normalizeArray(boundaryAnnotations.boundary_annotations)) {
+    if (annotation.status !== 'approved' || annotation.needs_human_review) {
+      unresolvedItems.push({
+        item_type: 'boundary_claim',
+        item_id: annotation.boundary_id ?? null,
+        status: annotation.status ?? null,
+        needs_human_review: Boolean(annotation.needs_human_review),
+        review_reasons: cloneJson(annotation.review_reasons ?? []),
+      });
+    }
+  }
+
+  return {
+    unresolved_items: unresolvedItems,
+    unresolved_count: unresolvedItems.length,
+    needs_human_review_count: unresolvedItems.filter(
+      (item) => item.status === 'needs_human_review' || item.needs_human_review,
+    ).length,
+  };
+}
+
+function buildApprovedBaselineFreezeGate({ approvedBaselineAttempted, reviewSummary }) {
+  if (!approvedBaselineAttempted) {
+    return buildGate('approved_baseline_freeze');
+  }
+
+  if (reviewSummary.unresolved_items.length === 0) {
+    return buildGate('approved_baseline_freeze');
+  }
+
+  return buildGate('approved_baseline_freeze', [
+    {
+      code: 'unresolved_review_items',
+      unresolved_count: reviewSummary.unresolved_items.length,
+    },
+  ]);
+}
+
+function collectBlockedReasons(gates) {
+  return unique(
+    gates.flatMap((gate) =>
+      gate.status === 'fail'
+        ? normalizeArray(gate.errors).map((error) => error.code || `${gate.name}_failed`)
+        : [],
+    ),
+  ).sort();
+}
+
+export function load9709SyllabusGateArtifacts({
+  rootDir = PROJECT_ROOT,
+  paths = DEFAULT_9709_SYLLABUS_GATE_PATHS,
+} = {}) {
+  return {
+    sourceInventory: readJson(rootDir, paths.sourceInventory),
+    rawSections: readJson(rootDir, paths.rawSections),
+    canonicalTopicTree: readJson(rootDir, paths.canonicalTopicTree),
+    boundaryAnnotations: readJson(rootDir, paths.boundaryAnnotations),
+    topicTreeSchema: readJson(rootDir, paths.topicTreeSchema),
+  };
+}
+
+export function build9709SyllabusGateReport({
+  rootDir = PROJECT_ROOT,
+  paths = DEFAULT_9709_SYLLABUS_GATE_PATHS,
+  artifacts = null,
+  approvedBaselineAttempted = false,
+  generatedAt = new Date().toISOString(),
+} = {}) {
+  const resolvedArtifacts = artifacts || load9709SyllabusGateArtifacts({ rootDir, paths });
+  const {
+    sourceInventory = {},
+    rawSections = {},
+    canonicalTopicTree = {},
+    boundaryAnnotations = {},
+    topicTreeSchema = {},
+  } = resolvedArtifacts;
+
+  const review = buildReviewSummary({ canonicalTopicTree, boundaryAnnotations });
+  const rawSectionMapping = buildRawSectionMapping({
+    rawSections,
+    canonicalTopicTree,
+    boundaryAnnotations,
+  });
+  const gates = [
+    validateSchema({ canonicalTopicTree, topicTreeSchema }),
+    validateSourceLock({ sourceInventory, rawSections, canonicalTopicTree, boundaryAnnotations }),
+    validateStatuses({ canonicalTopicTree, boundaryAnnotations }),
+    validateIdentityUniqueness({ canonicalTopicTree }),
+    validateGraphIntegrity({ canonicalTopicTree }),
+    validateSourceRefs({ sourceInventory, rawSections, canonicalTopicTree, boundaryAnnotations }),
+    validateLegacyFileLeakage({ sourceInventory, canonicalTopicTree, boundaryAnnotations, paths }),
+    rawSectionMapping.gate,
+    buildApprovedBaselineFreezeGate({ approvedBaselineAttempted, reviewSummary: review }),
+  ];
+  const blockedReasons = collectBlockedReasons(gates);
+  const approvedBaselineReady = review.unresolved_items.length === 0 && blockedReasons.length === 0;
+
+  return {
+    schema_version: SYLLABUS_GATE_SCHEMA_VERSION,
+    generated_at: generatedAt,
+    subject_code:
+      canonicalTopicTree.syllabus_code
+      ?? sourceInventory.subject_code
+      ?? rawSections.source_document?.syllabus_code
+      ?? '9709',
+    syllabus_version:
+      canonicalTopicTree.syllabus_version
+      ?? sourceInventory.source_lock?.syllabus_version_tag
+      ?? null,
+    status: blockedReasons.length === 0 ? 'pass' : 'fail',
+    approved_baseline_attempted: Boolean(approvedBaselineAttempted),
+    approved_baseline_ready: approvedBaselineReady,
+    blocked_reasons: blockedReasons,
+    artifacts: cloneJson(paths),
+    source_lock: {
+      locked_source_document_id: sourceInventory.source_lock?.locked_source_document_id ?? null,
+      source_inventory_version: sourceInventory.source_lock?.syllabus_version_tag ?? null,
+      canonical_topic_tree_source_document_id:
+        canonicalTopicTree.source_lock?.source_document_id ?? null,
+      boundary_source_document_id: boundaryAnnotations.source_lock?.source_document_id ?? null,
+      raw_sections_source_document_id: rawSections.source_document?.id ?? null,
+    },
+    counts: {
+      topic_nodes: normalizeArray(canonicalTopicTree.nodes).length,
+      boundary_claims: normalizeArray(boundaryAnnotations.boundary_annotations).length,
+      official_sources: normalizeArray(sourceInventory.official_sources).length,
+      raw_sections: normalizeArray(rawSections.sections).length,
+    },
+    coverage: {
+      raw_sections: {
+        total: normalizeArray(rawSections.sections).length,
+        mapped: rawSectionMapping.mapped,
+        unmapped: rawSectionMapping.unmapped,
+        mapped_count: rawSectionMapping.mapped.length,
+        unmapped_count: rawSectionMapping.unmapped.length,
+      },
+    },
+    review,
+    gates,
+  };
+}
+
+export function write9709SyllabusGateReport({
+  rootDir = PROJECT_ROOT,
+  paths = DEFAULT_9709_SYLLABUS_GATE_PATHS,
+  outJsonPath = DEFAULT_9709_SYLLABUS_GATE_REPORT_PATH,
+  approvedBaselineAttempted = false,
+  generatedAt,
+} = {}) {
+  const report = build9709SyllabusGateReport({
+    rootDir,
+    paths,
+    approvedBaselineAttempted,
+    generatedAt,
+  });
+  const absoluteJsonPath = resolveFromRoot(rootDir, outJsonPath);
+  ensureParentDir(absoluteJsonPath);
+  fs.writeFileSync(absoluteJsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+  return {
+    report,
+    absoluteJsonPath,
+  };
+}

--- a/scripts/syllabus/lib/9709-syllabus-gate.js
+++ b/scripts/syllabus/lib/9709-syllabus-gate.js
@@ -86,8 +86,39 @@ function formatAjvError(error = {}) {
   };
 }
 
-function officialSourceIds(sourceInventory = {}) {
-  return new Set(normalizeArray(sourceInventory.official_sources).map((source) => source.id));
+function isAllowedSyllabusUpdateDocument(sourceInventory = {}, source = {}) {
+  const id = String(source.id ?? '').toLowerCase();
+  const title = String(source.title ?? '').toLowerCase();
+  const lockedExamYears = sourceInventory.source_lock?.exam_years ?? null;
+  const embeddedExamYears = `${id} ${title}`.match(/[0-9]{4}-[0-9]{4}/)?.[0] ?? null;
+  const examYears = source.exam_years ?? embeddedExamYears;
+  const sameExamYears = Boolean(lockedExamYears) && examYears === lockedExamYears;
+  const updateLike = id.includes('update') || title.includes('update');
+
+  return Boolean(source.id) && updateLike && sameExamYears;
+}
+
+function observedOfficialDocuments(sourceInventory = {}) {
+  return [
+    ...normalizeArray(sourceInventory.observed_official_documents),
+    ...normalizeArray(sourceInventory.observed_official_non_baseline_documents),
+    ...normalizeArray(sourceInventory.official_syllabus_updates),
+    ...normalizeArray(sourceInventory.observed_official_syllabus_updates),
+  ];
+}
+
+function officialSourceIds(sourceInventory = {}, sourceType = 'official_syllabus') {
+  const sourceIds = normalizeArray(sourceInventory.official_sources).map((source) => source.id);
+
+  if (sourceType === 'official_syllabus_update') {
+    sourceIds.push(
+      ...observedOfficialDocuments(sourceInventory)
+        .filter((source) => isAllowedSyllabusUpdateDocument(sourceInventory, source))
+        .map((source) => source.id),
+    );
+  }
+
+  return new Set(sourceIds.filter(Boolean));
 }
 
 function rawSectionIds(rawSections = {}) {
@@ -349,7 +380,6 @@ function validateSourceRefs({
   canonicalTopicTree = {},
   boundaryAnnotations = {},
 } = {}) {
-  const officialIds = officialSourceIds(sourceInventory);
   const rawIds = rawSectionIds(rawSections);
   const errors = [];
 
@@ -365,7 +395,8 @@ function validateSourceRefs({
     }
 
     for (const sourceRef of refs) {
-      if (!officialIds.has(sourceRef.source_document_id)) {
+      const recognizedSourceIds = officialSourceIds(sourceInventory, sourceRef.source_type);
+      if (!recognizedSourceIds.has(sourceRef.source_document_id)) {
         errors.push({
           code: 'missing_source_inventory_ref',
           owner_type: owner.owner_type,

--- a/scripts/syllabus/run_9709_syllabus_gate.js
+++ b/scripts/syllabus/run_9709_syllabus_gate.js
@@ -51,14 +51,47 @@ function pathsFromCli(cli) {
   };
 }
 
+function parseBooleanFlag(value, flagName) {
+  if (value === undefined) {
+    return { ok: true, value: false };
+  }
+  if (value === true) {
+    return { ok: true, value: true };
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(normalized)) {
+    return { ok: true, value: true };
+  }
+  if (['false', '0', 'no', 'off'].includes(normalized)) {
+    return { ok: true, value: false };
+  }
+
+  return {
+    ok: false,
+    value: false,
+    error: `Invalid boolean value for --${flagName}: ${value}`,
+  };
+}
+
 export async function main(argv = process.argv.slice(2)) {
   const cli = parseCliArgs(argv);
   const outJsonPath = cli['out-json'] || DEFAULT_9709_SYLLABUS_GATE_REPORT_PATH;
+  const approvedBaselineFlag = parseBooleanFlag(
+    cli['attempt-approved-baseline'],
+    'attempt-approved-baseline',
+  );
+  if (!approvedBaselineFlag.ok) {
+    process.stderr.write(`${approvedBaselineFlag.error}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
   const { report } = write9709SyllabusGateReport({
     rootDir: ROOT,
     paths: pathsFromCli(cli),
     outJsonPath,
-    approvedBaselineAttempted: Boolean(cli['attempt-approved-baseline']),
+    approvedBaselineAttempted: approvedBaselineFlag.value,
   });
 
   process.stdout.write(`${outJsonPath}\n`);

--- a/scripts/syllabus/run_9709_syllabus_gate.js
+++ b/scripts/syllabus/run_9709_syllabus_gate.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_9709_SYLLABUS_GATE_PATHS,
+  DEFAULT_9709_SYLLABUS_GATE_REPORT_PATH,
+  write9709SyllabusGateReport,
+} from './lib/9709-syllabus-gate.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(fileURLToPath(new URL('../../', import.meta.url)));
+
+function parseCliArgs(args) {
+  const output = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (!token.startsWith('-')) {
+      continue;
+    }
+
+    const equalIndex = token.indexOf('=');
+    if (equalIndex !== -1) {
+      output[token.slice(token.startsWith('--') ? 2 : 1, equalIndex)] = token.slice(equalIndex + 1);
+      continue;
+    }
+
+    const key = token.slice(token.startsWith('--') ? 2 : 1);
+    const next = args[index + 1];
+    if (next && !next.startsWith('-')) {
+      output[key] = next;
+      index += 1;
+    } else {
+      output[key] = true;
+    }
+  }
+
+  return output;
+}
+
+function pathsFromCli(cli) {
+  return {
+    sourceInventory: cli['source-inventory'] || DEFAULT_9709_SYLLABUS_GATE_PATHS.sourceInventory,
+    rawSections: cli['raw-sections'] || DEFAULT_9709_SYLLABUS_GATE_PATHS.rawSections,
+    canonicalTopicTree:
+      cli['canonical-topic-tree'] || DEFAULT_9709_SYLLABUS_GATE_PATHS.canonicalTopicTree,
+    boundaryAnnotations:
+      cli['boundary-annotations'] || DEFAULT_9709_SYLLABUS_GATE_PATHS.boundaryAnnotations,
+    topicTreeSchema: cli['topic-tree-schema'] || DEFAULT_9709_SYLLABUS_GATE_PATHS.topicTreeSchema,
+  };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const cli = parseCliArgs(argv);
+  const outJsonPath = cli['out-json'] || DEFAULT_9709_SYLLABUS_GATE_REPORT_PATH;
+  const { report } = write9709SyllabusGateReport({
+    rootDir: ROOT,
+    paths: pathsFromCli(cli),
+    outJsonPath,
+    approvedBaselineAttempted: Boolean(cli['attempt-approved-baseline']),
+  });
+
+  process.stdout.write(`${outJsonPath}\n`);
+  if (report.status !== 'pass') {
+    process.exitCode = 1;
+  } else if (process.exitCode === 1) {
+    process.exitCode = undefined;
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  await main();
+}


### PR DESCRIPTION
## Summary
- Add a 9709 syllabus gate CLI and reusable JS gate library for the official source inventory, raw sections, canonical topic tree draft, and boundary annotations draft.
- Cover schema validation, duplicate IDs/topic paths, missing refs, invalid statuses, orphan nodes, missing raw/source refs, stale source locks, unresolved approved-baseline attempts, unmapped raw section reporting, and legacy-file leakage.
- Generate `docs/reports/9709-syllabus-gate-report.json` and add `npm run syllabus:9709:gate`.

Closes #291

## Verification
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules node --experimental-vm-modules /home/samsen/code/ciecopilot-home/node_modules/jest/bin/jest.js --runInBand scripts/syllabus/__tests__/9709-syllabus-gate.test.js tests/contracts/9709-syllabus-topic-tree-schema.test.js tests/contracts/9709-canonical-topic-tree-draft.test.js tests/contracts/9709-boundary-annotations-draft.test.js` (34 passed)
- `NODE_PATH=/home/samsen/code/ciecopilot-home/node_modules npm run syllabus:9709:gate` (pass; wrote `docs/reports/9709-syllabus-gate-report.json`)