### PR TITLE
fix(9709): reconcile release preflight diagram flag

### DIFF
--- a/api/learning/__tests__/question-intelligence-service.test.js
+++ b/api/learning/__tests__/question-intelligence-service.test.js
@@ -1,4 +1,6 @@
 import { analyzeQuestionEnvelope } from '../lib/question-analysis/question-intelligence-service.js';
+import fs from 'node:fs';
+import path from 'node:path';
 
 function buildEnvelope(promptValue) {
   return {
@@ -8,6 +10,13 @@ function buildEnvelope(promptValue) {
     paper_scope: null,
     provenance_summary: {},
   };
+}
+
+function analyze(promptValue, analysisHints = null) {
+  return analyzeQuestionEnvelope({
+    envelope: buildEnvelope(promptValue),
+    analysisHints,
+  });
 }
 
 describe('question-intelligence-service: analyzeQuestionEnvelope', () => {
@@ -110,6 +119,19 @@ describe('question-intelligence-service: analyzeQuestionEnvelope', () => {
     expect(result.analysis_audit_metadata.hint_matched).toBe(false);
   });
 
+  test('does not treat ordinary dy/dx curve differentiation as a differential equation', () => {
+    const result = analyze(
+      'A curve has equation y = x^3. Find dy/dx and the coordinates of the stationary point.',
+      {
+        topic_path_hint: '9709.p1.differentiation',
+      },
+    );
+
+    expect(result.primary_question_type_id).toBe('9709.differentiation.application');
+    expect(result.family_id).toBe('9709.differentiation');
+    expect(result.primary_question_type_id).not.toBe('9709.differential_equations.separable');
+  });
+
   // ─── fallback path ───
 
   test('unrecognized prompt with no hints gives null classification', () => {
@@ -136,6 +158,110 @@ describe('question-intelligence-service: analyzeQuestionEnvelope', () => {
     expect(result.classification_confidence).toBe(0.76);
     expect(result.confidence_band).toBe('low');
     expect(result.analysis_audit_metadata.detector_signals).toContain('hint_only_low_confidence');
+  });
+
+  test.each([
+    [
+      'Functions',
+      'The function f is defined by f(x) = (x - 3)^2 for x < a. Find the greatest possible value of a.',
+      '9709.functions.core',
+    ],
+    [
+      'Circular measure',
+      'A sector of a circle has radius r and angle theta radians. Find the area of the segment.',
+      '9709.circular_measure.arc_sector',
+    ],
+    [
+      'Differentiation',
+      'Find the stationary point of the curve and determine whether it is a maximum or minimum.',
+      '9709.differentiation.application',
+    ],
+    [
+      'Series',
+      'The first three terms of an arithmetic progression are given. Find the sum of the first n terms.',
+      '9709.series.sequence_binomial',
+    ],
+    [
+      'Coordinate geometry',
+      'A line has equation y = 2x + 3 and is perpendicular to another line through A. Find the coordinates of P.',
+      '9709.coordinate_geometry.lines_curves',
+    ],
+    [
+      'Complex numbers',
+      'On an Argand diagram, shade the locus satisfying |z - 2i| <= |z - 1 - i|.',
+      '9709.complex_numbers.argand_mod_arg',
+    ],
+    [
+      'Vectors',
+      'The position vectors of A and B are given in terms of i, j and k. Find the scalar product.',
+      '9709.vectors.geometry',
+    ],
+    [
+      'Logarithmic and exponential functions',
+      'Solve the equation ln(x + 2) - ln(x + 1) = 3.',
+      '9709.log_exp.equations_models',
+    ],
+    [
+      'Numerical methods',
+      'Use the iterative formula x_{n+1} = sqrt(3x_n + 1) to find the root.',
+      '9709.numerical_methods.iteration',
+    ],
+    [
+      'Algebra',
+      'Find the quotient and remainder when p(x) is divided by x + 2.',
+      '9709.algebra.polynomial_rational',
+    ],
+  ])('detects %s production topic family', (_label, prompt, expectedQuestionTypeId) => {
+    const result = analyze(prompt);
+
+    expect(result.primary_question_type_id).toBe(expectedQuestionTypeId);
+    expect(result.classification_confidence).toBeGreaterThanOrEqual(0.84);
+    expect(result.confidence_band).toBe('high');
+  });
+
+  test('falls back from authoritative topic-path hint when prompt signals are weak', () => {
+    const result = analyze('A terse imported question with limited OCR context.', {
+      topic_path_hint: '9709.p3.complex_numbers',
+    });
+
+    expect(result.primary_question_type_id).toBe('9709.complex_numbers.argand_mod_arg');
+    expect(result.family_id).toBe('9709.complex_numbers');
+    expect(result.classification_confidence).toBe(0.84);
+    expect(result.confidence_band).toBe('medium');
+    expect(result.analysis_audit_metadata.detector_signals).toContain('topic_path_hint');
+  });
+
+  test('does not classify explicit out-of-scope 9709 topic hints', () => {
+    const result = analyze('A statistics question about representation of data.', {
+      topic_path_hint: '9709.p5.representation_of_data',
+    });
+
+    expect(result.primary_question_type_id).toBeNull();
+    expect(result.family_id).toBeNull();
+    expect(result.uncertainty_validated).toBe(false);
+  });
+
+  test('classifies the authority-ready 300 evidence set except explicit non-P1/P3 out-of-scope rows', () => {
+    const filePath = path.resolve(
+      'docs/reports/2026-04-23-9709-prompt-backfill-evidence-bundles.json',
+    );
+    const payload = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    const failures = [];
+
+    for (const bundle of payload.bundles) {
+      const result = analyzeQuestionEnvelope({
+        envelope: buildEnvelope(bundle.evidence.ocr_text),
+        analysisHints: bundle.analysis_hints,
+      });
+      const topicPath = bundle.question_identity.primary_topic_path ?? '';
+      const expectedOutOfScope = /^9709\.p[456]\./.test(topicPath);
+
+      if (!expectedOutOfScope && !result.primary_question_type_id) {
+        failures.push(bundle.storage_key);
+      }
+    }
+
+    expect(failures).toEqual([]);
   });
 
   // ─── edge cases ───

--- a/api/learning/lib/question-analysis/question-intelligence-service.js
+++ b/api/learning/lib/question-analysis/question-intelligence-service.js
@@ -14,6 +14,10 @@ function hasTrigToken(prompt) {
   return /(?:^|[^a-z])(sin|cos|tan|sec|cosec|cot)(?:[^a-z]|$)/u.test(prompt);
 }
 
+function hasAny(prompt, patterns = []) {
+  return patterns.some((pattern) => pattern.test(prompt));
+}
+
 function buildRuleMatch({
   questionTypeId,
   baseConfidence,
@@ -34,13 +38,217 @@ function buildRuleMatch({
   };
 }
 
+const TOPIC_PATH_CLASSIFICATIONS = Object.freeze({
+  '9709.p1.functions': Object.freeze({
+    questionTypeId: '9709.functions.core',
+    familyId: '9709.functions',
+    skeletonSteps: [
+      'identify the function definition and restrictions',
+      'apply the requested inverse, composite, graph, domain, or range operation',
+      'state the result with any required domain or parameter constraint',
+    ],
+  }),
+  '9709.p1.circular_measure': Object.freeze({
+    questionTypeId: '9709.circular_measure.arc_sector',
+    familyId: '9709.circular_measure',
+    skeletonSteps: [
+      'translate the diagram into radii, arcs, sectors, and angles in radians',
+      'apply sector, arc length, triangle, or segment formulae',
+      'combine lengths or areas and round only at the requested stage',
+    ],
+  }),
+  '9709.p1.differentiation': Object.freeze({
+    questionTypeId: '9709.differentiation.application',
+    familyId: '9709.differentiation',
+    skeletonSteps: [
+      'differentiate the relevant expression',
+      'use the derivative condition for gradients, tangents, normals, stationary points, or optimisation',
+      'interpret the result in the context of the question',
+    ],
+  }),
+  '9709.p3.differentiation': Object.freeze({
+    questionTypeId: '9709.differentiation.application',
+    familyId: '9709.differentiation',
+    skeletonSteps: [
+      'differentiate using the appropriate A Level technique',
+      'use the derivative condition required by the model or curve',
+      'interpret the result and state any requested exact or numerical value',
+    ],
+  }),
+  '9709.p1.series': Object.freeze({
+    questionTypeId: '9709.series.sequence_binomial',
+    familyId: '9709.series',
+    skeletonSteps: [
+      'identify whether the structure is a progression, series sum, or binomial expansion',
+      'apply the matching formula or coefficient extraction',
+      'solve for the requested term, coefficient, constant, or sum',
+    ],
+  }),
+  '9709.p3.series': Object.freeze({
+    questionTypeId: '9709.series.sequence_binomial',
+    familyId: '9709.series',
+    skeletonSteps: [
+      'identify the progression, series, or expansion structure',
+      'apply the relevant A Level series or binomial method',
+      'simplify the requested exact or numerical result',
+    ],
+  }),
+  '9709.p1.coordinate_geometry': Object.freeze({
+    questionTypeId: '9709.coordinate_geometry.lines_curves',
+    familyId: '9709.coordinate_geometry',
+    skeletonSteps: [
+      'extract the line, curve, circle, midpoint, distance, or gradient conditions',
+      'form the required coordinate geometry equations',
+      'solve and state coordinates, equations, or geometric measures',
+    ],
+  }),
+  '9709.p3.coordinate_geometry': Object.freeze({
+    questionTypeId: '9709.coordinate_geometry.lines_curves',
+    familyId: '9709.coordinate_geometry',
+    skeletonSteps: [
+      'extract the coordinate geometry constraints',
+      'combine line, curve, circle, or tangent conditions algebraically',
+      'solve and interpret the requested geometry result',
+    ],
+  }),
+  '9709.p1.quadratics': Object.freeze({
+    questionTypeId: '9709.quadratics.equations_inequalities',
+    familyId: '9709.quadratics',
+    skeletonSteps: [
+      'rewrite the expression into a quadratic or reducible quadratic form',
+      'apply factorisation, discriminant, completing square, or substitution',
+      'state the allowed values or exact solutions',
+    ],
+  }),
+  '9709.p1.trigonometry': Object.freeze({
+    questionTypeId: '9709.trigonometry.general',
+    familyId: '9709.trigonometry_manipulation_equations',
+    skeletonSteps: [
+      'identify the trigonometric structure, identity, graph, or equation',
+      'apply the relevant transformation, identity, or domain reasoning',
+      'state the requested values, graph features, or solutions',
+    ],
+  }),
+  '9709.p3.trigonometry': Object.freeze({
+    questionTypeId: '9709.trigonometry.general',
+    familyId: '9709.trigonometry_manipulation_equations',
+    skeletonSteps: [
+      'identify the A Level trigonometric structure',
+      'apply identities, transformations, or equation-solving in the required domain',
+      'state exact values or all required solutions',
+    ],
+  }),
+  '9709.p1.integration': Object.freeze({
+    questionTypeId: '9709.integration.application',
+    familyId: '9709.integration_techniques',
+    skeletonSteps: [
+      'identify the integrand or geometric integration setup',
+      'integrate using the appropriate method or area formula',
+      'apply bounds or context and simplify the result',
+    ],
+  }),
+  '9709.p3.integration': Object.freeze({
+    questionTypeId: '9709.integration.application',
+    familyId: '9709.integration_techniques',
+    skeletonSteps: [
+      'identify the integration technique or application',
+      'set up and evaluate the integral, including bounds where required',
+      'simplify the exact or numerical result',
+    ],
+  }),
+  '9709.p3.complex_numbers': Object.freeze({
+    questionTypeId: '9709.complex_numbers.argand_mod_arg',
+    familyId: '9709.complex_numbers',
+    skeletonSteps: [
+      'translate the complex-number condition into Cartesian, modulus-argument, or Argand form',
+      'apply the required algebra or locus geometry',
+      'state the requested value, region, argument, modulus, or sketch feature',
+    ],
+  }),
+  '9709.p3.vectors': Object.freeze({
+    questionTypeId: '9709.vectors.geometry',
+    familyId: '9709.vectors',
+    skeletonSteps: [
+      'write the points, lines, or planes in vector form',
+      'use vector operations such as scalar product, parameter comparison, or geometry formulae',
+      'interpret the result as an angle, length, area, volume, intersection, or proof',
+    ],
+  }),
+  '9709.p3.algebra': Object.freeze({
+    questionTypeId: '9709.algebra.polynomial_rational',
+    familyId: '9709.algebra',
+    skeletonSteps: [
+      'identify the polynomial, rational expression, inequality, or partial fraction structure',
+      'apply the relevant algebraic manipulation or theorem',
+      'solve for constants, factors, remainders, coefficients, or inequalities',
+    ],
+  }),
+  '9709.p3.logarithmic_and_exponential_functions': Object.freeze({
+    questionTypeId: '9709.log_exp.equations_models',
+    familyId: '9709.logarithmic_and_exponential_functions',
+    skeletonSteps: [
+      'rewrite the logarithmic or exponential relationship using laws of logs or indices',
+      'solve the equation or linearised model condition',
+      'state the requested value, expression, or straight-line form',
+    ],
+  }),
+  '9709.p3.numerical_solution_of_equations': Object.freeze({
+    questionTypeId: '9709.numerical_methods.iteration',
+    familyId: '9709.numerical_solution_of_equations',
+    skeletonSteps: [
+      'identify the numerical method, iteration, or interval argument',
+      'apply the formula or sign-change reasoning to the required accuracy',
+      'state the root, iteration result, or convergence conclusion',
+    ],
+  }),
+  '9709.p3.differential_equations': Object.freeze({
+    questionTypeId: '9709.differential_equations.separable',
+    familyId: '9709.differential_equations',
+    skeletonSteps: [
+      'form or identify the separable differential equation',
+      'separate variables and integrate',
+      'apply conditions and interpret the model result',
+    ],
+  }),
+});
+
+function buildRuleMatchFromTopicClassification({
+  topicPath,
+  classification,
+  baseConfidence = 0.86,
+  signalKeys = [],
+  difficultyBand = 'medium',
+}) {
+  return buildRuleMatch({
+    questionTypeId: classification.questionTypeId,
+    familyId: classification.familyId,
+    baseConfidence,
+    variantTags: unique([
+      topicPath?.includes('.p1.') ? 'paper:p1' : null,
+      topicPath?.includes('.p3.') ? 'paper:p3' : null,
+      `topic_path:${topicPath}`,
+    ]),
+    skeletonSteps: classification.skeletonSteps,
+    difficultyBand,
+    signalKeys: unique(signalKeys),
+  });
+}
+
 const QUESTION_TYPE_RULES = Object.freeze([
   {
     questionTypeId: '9709.differential_equations.separable',
     familyId: '9709.differential_equations',
     matches(prompt) {
       const signals = [];
-      if (/dy\s*\/\s*dx/u.test(prompt) || /differential equation/u.test(prompt)) {
+      const hasDifferentialNotation = /dy\s*\/\s*dx/u.test(prompt);
+      const explicitDifferentialEquation = /differential equation/u.test(prompt);
+      const solveDifferentialNotation = (
+        /\b(?:solve|solution|satisfies)\b.{0,80}dy\s*\/\s*dx/u.test(prompt)
+        || /dy\s*\/\s*dx.{0,80}\b(?:solve|solution)\b/u.test(prompt)
+      );
+      const rateModel = /(?:rate .* proportional|varies .* with|is proportional to)/u.test(prompt);
+
+      if (explicitDifferentialEquation || solveDifferentialNotation || rateModel) {
         signals.push('differential_equation');
       }
       if (/given that\s+y\s*=|when\s+x\s*=/u.test(prompt)) {
@@ -50,7 +258,7 @@ const QUESTION_TYPE_RULES = Object.freeze([
         signals.push('explicit_separable');
       }
 
-      if (signals.length === 0) {
+      if (!signals.includes('differential_equation') && !(hasDifferentialNotation && signals.includes('explicit_separable'))) {
         return null;
       }
 
@@ -72,6 +280,258 @@ const QUESTION_TYPE_RULES = Object.freeze([
         ]),
         difficultyBand: signals.includes('initial_condition') ? 'medium' : 'low',
         signalKeys: signals,
+      });
+    },
+  },
+  {
+    topicPath: '9709.p3.complex_numbers',
+    matches(prompt) {
+      if (!hasAny(prompt, [
+        /complex number/u,
+        /argand/u,
+        /\barg\s*z\b/u,
+        /\barg\s*[a-z]/u,
+        /\bmodulus\b/u,
+        /\blocus\b/u,
+        /\|z\s*[-+]/u,
+      ])) {
+        return null;
+      }
+
+      return buildRuleMatchFromTopicClassification({
+        topicPath: this.topicPath,
+        classification: TOPIC_PATH_CLASSIFICATIONS[this.topicPath],
+        baseConfidence: 0.91,
+        signalKeys: ['complex_number'],
+      });
+    },
+  },
+  {
+    topicPath: '9709.p3.vectors',
+    matches(prompt) {
+      if (!hasAny(prompt, [
+        /position vectors?/u,
+        /vectors?/u,
+        /scalar product/u,
+        /dot product/u,
+        /\b(?:i|j|k)\s*[+-]\s*(?:i|j|k)\b/u,
+        /pyramid/u,
+        /volume of (?:the )?(?:tetrahedron|pyramid)/u,
+      ])) {
+        return null;
+      }
+
+      return buildRuleMatchFromTopicClassification({
+        topicPath: this.topicPath,
+        classification: TOPIC_PATH_CLASSIFICATIONS[this.topicPath],
+        baseConfidence: 0.9,
+        signalKeys: ['vector_geometry'],
+      });
+    },
+  },
+  {
+    topicPath: '9709.p1.circular_measure',
+    matches(prompt) {
+      if (!hasAny(prompt, [
+        /radians?/u,
+        /sector/u,
+        /arc/u,
+        /segment of a circle/u,
+        /semicircle/u,
+        /radius/u,
+      ])) {
+        return null;
+      }
+
+      return buildRuleMatchFromTopicClassification({
+        topicPath: this.topicPath,
+        classification: TOPIC_PATH_CLASSIFICATIONS[this.topicPath],
+        baseConfidence: 0.89,
+        signalKeys: ['circular_measure'],
+      });
+    },
+  },
+  {
+    topicPath: '9709.p1.series',
+    matches(prompt) {
+      if (!hasAny(prompt, [
+        /arithmetic progression/u,
+        /geometric progression/u,
+        /sum to infinity/u,
+        /sum of the first/u,
+        /binomial expansion/u,
+        /coefficient of x/u,
+        /\bterm\b.*\bprogression\b/u,
+      ])) {
+        return null;
+      }
+
+      return buildRuleMatchFromTopicClassification({
+        topicPath: this.topicPath,
+        classification: TOPIC_PATH_CLASSIFICATIONS[this.topicPath],
+        baseConfidence: 0.89,
+        signalKeys: ['series_or_binomial'],
+      });
+    },
+  },
+  {
+    topicPath: '9709.p1.functions',
+    matches(prompt) {
+      if (!hasAny(prompt, [
+        /function f/u,
+        /functions? f and g/u,
+        /one-one function/u,
+        /composite function/u,
+        /\bf-?1\b/u,
+        /inverse function/u,
+        /domain of/u,
+        /range of/u,
+        /transformations?/u,
+      ])) {
+        return null;
+      }
+
+      return buildRuleMatchFromTopicClassification({
+        topicPath: this.topicPath,
+        classification: TOPIC_PATH_CLASSIFICATIONS[this.topicPath],
+        baseConfidence: 0.88,
+        signalKeys: ['functions'],
+      });
+    },
+  },
+  {
+    topicPath: '9709.p1.coordinate_geometry',
+    matches(prompt) {
+      if (!hasAny(prompt, [
+        /line has equation/u,
+        /curve has equation/u,
+        /coordinates? of/u,
+        /gradient/u,
+        /mid-?point/u,
+        /perpendicular/u,
+        /intersects? the .*axes/u,
+        /circle has equation/u,
+      ])) {
+        return null;
+      }
+
+      return buildRuleMatchFromTopicClassification({
+        topicPath: this.topicPath,
+        classification: TOPIC_PATH_CLASSIFICATIONS[this.topicPath],
+        baseConfidence: 0.88,
+        signalKeys: ['coordinate_geometry'],
+      });
+    },
+  },
+  {
+    topicPath: '9709.p3.logarithmic_and_exponential_functions',
+    matches(prompt) {
+      if (!hasAny(prompt, [
+        /\bln\s*\(/u,
+        /\blog/u,
+        /\be\^/u,
+        /exponential/u,
+        /a\^\{/u,
+        /straight line/u,
+      ])) {
+        return null;
+      }
+
+      return buildRuleMatchFromTopicClassification({
+        topicPath: this.topicPath,
+        classification: TOPIC_PATH_CLASSIFICATIONS[this.topicPath],
+        baseConfidence: 0.88,
+        signalKeys: ['log_exp'],
+      });
+    },
+  },
+  {
+    topicPath: '9709.p1.differentiation',
+    matches(prompt) {
+      if (!hasAny(prompt, [
+        /differentiat/u,
+        /stationary point/u,
+        /maximum|minimum/u,
+        /increasing function|decreasing function/u,
+        /rate of change/u,
+        /tangent|normal/u,
+        /\bf'\s*\(/u,
+      ])) {
+        return null;
+      }
+
+      return buildRuleMatchFromTopicClassification({
+        topicPath: this.topicPath,
+        classification: TOPIC_PATH_CLASSIFICATIONS[this.topicPath],
+        baseConfidence: 0.87,
+        signalKeys: ['differentiation_application'],
+      });
+    },
+  },
+  {
+    topicPath: '9709.p3.algebra',
+    matches(prompt) {
+      if (!hasAny(prompt, [
+        /partial fractions?/u,
+        /polynomial/u,
+        /quotient and remainder/u,
+        /factor theorem/u,
+        /divisible by/u,
+        /inequalit/u,
+        /rational expression/u,
+      ])) {
+        return null;
+      }
+
+      return buildRuleMatchFromTopicClassification({
+        topicPath: this.topicPath,
+        classification: TOPIC_PATH_CLASSIFICATIONS[this.topicPath],
+        baseConfidence: 0.87,
+        signalKeys: ['algebra_structure'],
+      });
+    },
+  },
+  {
+    topicPath: '9709.p1.quadratics',
+    matches(prompt) {
+      if (!hasAny(prompt, [
+        /quadratic/u,
+        /discriminant/u,
+        /completing the square/u,
+        /for all values of x/u,
+        /set of possible values/u,
+        /x\^2/u,
+        /x²/u,
+      ])) {
+        return null;
+      }
+
+      return buildRuleMatchFromTopicClassification({
+        topicPath: this.topicPath,
+        classification: TOPIC_PATH_CLASSIFICATIONS[this.topicPath],
+        baseConfidence: 0.86,
+        signalKeys: ['quadratic_structure'],
+      });
+    },
+  },
+  {
+    topicPath: '9709.p3.numerical_solution_of_equations',
+    matches(prompt) {
+      if (!hasAny(prompt, [
+        /iterative formula/u,
+        /newton-?raphson/u,
+        /change of sign/u,
+        /root .* interval/u,
+        /correct to .* decimal places/u,
+      ])) {
+        return null;
+      }
+
+      return buildRuleMatchFromTopicClassification({
+        topicPath: this.topicPath,
+        classification: TOPIC_PATH_CLASSIFICATIONS[this.topicPath],
+        baseConfidence: 0.86,
+        signalKeys: ['numerical_method'],
       });
     },
   },
@@ -238,9 +698,36 @@ function buildClassificationFromMatch(match, {
   };
 }
 
+function buildTopicPathHintClassification(normalizedHints, envelope) {
+  const topicPath = normalizedHints.topic_path_hint;
+  const topicClassification = TOPIC_PATH_CLASSIFICATIONS[topicPath] ?? null;
+  if (!topicClassification) {
+    return null;
+  }
+
+  const topicMatch = buildRuleMatchFromTopicClassification({
+    topicPath,
+    classification: topicClassification,
+    baseConfidence: 0.84,
+    signalKeys: ['topic_path_hint'],
+  });
+
+  return buildClassificationFromMatch(topicMatch, {
+    normalizedHints,
+    envelope,
+    hintMatched: false,
+    hintConflict: false,
+  });
+}
+
 function buildHintOnlyClassification(normalizedHints, envelope) {
   const questionTypeId = normalizedHints.question_type_hint_id || normalizedHints.runtime_context_id;
   if (!questionTypeId) {
+    const topicPathClassification = buildTopicPathHintClassification(normalizedHints, envelope);
+    if (topicPathClassification) {
+      return topicPathClassification;
+    }
+
     return {
       primary_topic_id: null,
       secondary_topic_ids: [],
@@ -277,6 +764,17 @@ function buildHintOnlyClassification(normalizedHints, envelope) {
     '9709.trigonometry.equations': '9709.trigonometry_manipulation_equations',
     '9709.integration.application': '9709.integration_techniques',
     '9709.differential_equations.separable': '9709.differential_equations',
+    '9709.functions.core': '9709.functions',
+    '9709.circular_measure.arc_sector': '9709.circular_measure',
+    '9709.differentiation.application': '9709.differentiation',
+    '9709.series.sequence_binomial': '9709.series',
+    '9709.coordinate_geometry.lines_curves': '9709.coordinate_geometry',
+    '9709.quadratics.equations_inequalities': '9709.quadratics',
+    '9709.complex_numbers.argand_mod_arg': '9709.complex_numbers',
+    '9709.vectors.geometry': '9709.vectors',
+    '9709.algebra.polynomial_rational': '9709.algebra',
+    '9709.log_exp.equations_models': '9709.logarithmic_and_exponential_functions',
+    '9709.numerical_methods.iteration': '9709.numerical_solution_of_equations',
   };
 
   return {
@@ -329,7 +827,21 @@ export function analyzeQuestionEnvelope({
     return buildHintOnlyClassification(normalizedHints, envelope);
   }
 
-  const selectedMatch = matches[0];
+  const topicClassification = TOPIC_PATH_CLASSIFICATIONS[normalizedHints.topic_path_hint] ?? null;
+  const selectedMatch = topicClassification
+    ? (
+      matches.find((match) => (
+        match.questionTypeId === topicClassification.questionTypeId
+        || match.familyId === topicClassification.familyId
+      ))
+      ?? null
+    )
+    : matches[0];
+
+  if (!selectedMatch) {
+    return buildTopicPathHintClassification(normalizedHints, envelope);
+  }
+
   const hintedQuestionTypeId = normalizedHints.question_type_hint_id || normalizedHints.runtime_context_id;
   const hintMatched = Boolean(hintedQuestionTypeId) && hintedQuestionTypeId === selectedMatch.questionTypeId;
   const hintConflict = Boolean(hintedQuestionTypeId) && hintedQuestionTypeId !== selectedMatch.questionTypeId;

--- a/data/manifests/9709_authority_ready_batch_300_v1.json
+++ b/data/manifests/9709_authority_ready_batch_300_v1.json
@@ -6780,7 +6780,7 @@
       "source_reason": "manual_audit_seed",
       "descriptor_required": true,
       "route_hint": "review_lane",
-      "diagram_present": false,
+      "diagram_present": true,
       "formula_dense": true,
       "table_heavy": false,
       "surface_evidence_status": "unknown_requires_primary_asset_replay",

--- a/scripts/learning/__tests__/question-evidence-bundle-v1.test.js
+++ b/scripts/learning/__tests__/question-evidence-bundle-v1.test.js
@@ -120,6 +120,57 @@ describe('question evidence bundle v1', () => {
     ]);
   });
 
+  test('sanitizes OCR text before storing structured evidence', () => {
+    const manifest = buildManifest([
+      {
+        storage_key: '9709/s20_qp_31/questions/q10.png',
+        syllabus_code: '9709',
+        year: 2020,
+        session: 's',
+        paper: 3,
+        variant: 1,
+        q_number: 10,
+        primary_topic_path: '9709.p3.complex_numbers',
+        route_hint: 'ocr_lane',
+        diagram_present: false,
+        formula_dense: true,
+        table_heavy: false,
+        surface_evidence_status: 'verified_primary_asset',
+        gate_critical: false,
+        requires_review: false,
+      },
+    ]);
+
+    const bundles = buildQuestionEvidenceBundlesV1({
+      manifest,
+      laneOutputs: [
+        buildLaneOutput({
+          inputAssetId: '9709/s20_qp_31/questions/q10.png',
+          route: 'ocr_lane',
+          model: 'qwen3.6-plus',
+          evidence: {
+            ocr_text: [
+              '10 (a) The complex number u is defined by u = 3i / (a + 2i), where a is real.',
+              '(ii) Find the exact value of a for which arg u* = 1/3 pi. [3]',
+              '老师微信：liuxue119118（题目有修改过，请加微信确认是否完整，以免影响您的学习！',
+              '17',
+              '(b) (i) On a sketch of an Argand diagram, shade the region whose points represent complex numbers z satisfying |z - 2i| <= |z - 1 - i|. [4]',
+              '© UCLES 2020',
+              '9709/31/M/J/20',
+              '[Turn over',
+            ].join('\n'),
+          },
+        }),
+      ],
+    });
+
+    expect(bundles[0].evidence.ocr_text).toContain('10 (a) The complex number u is defined');
+    expect(bundles[0].evidence.ocr_text).toContain('(b) (i) On a sketch of an Argand diagram');
+    expect(bundles[0].evidence.ocr_text).not.toMatch(/老师微信|liuxue|题目有修改|加微信/);
+    expect(bundles[0].evidence.ocr_text).not.toMatch(/© UCLES|9709\/31\/M\/J\/20|Turn over/);
+    expect(bundles[0].evidence.ocr_text).not.toMatch(/^\s*17\s*$/m);
+  });
+
   test('blocks bundle construction when surface triage flags are missing', () => {
     expect(() => buildQuestionEvidenceBundlesV1({
       manifest: buildManifest([

--- a/scripts/learning/lib/question-evidence-bundle-v1.js
+++ b/scripts/learning/lib/question-evidence-bundle-v1.js
@@ -200,6 +200,52 @@ function pickFirstString(...values) {
   return '';
 }
 
+function isOcrNoiseLine(line, expectedQuestionNumber = null) {
+  const stripped = normalizeString(line);
+  if (!stripped) {
+    return false;
+  }
+
+  if (/(?:老师微信|liuxue\d*|题目有修改|加微信确认|影响您的学习)/i.test(stripped)) {
+    return true;
+  }
+
+  if (/^(?:©\s*)?UCLES\b/i.test(stripped)) {
+    return true;
+  }
+
+  if (/^9709\/\d{2}\/[A-Z]\/[A-Z]\/\d{2}$/i.test(stripped)) {
+    return true;
+  }
+
+  if (/^\[?\s*Turn over\s*\]?$/i.test(stripped)) {
+    return true;
+  }
+
+  if (/^\d{1,3}$/.test(stripped)) {
+    const numericValue = Number(stripped);
+    return numericValue !== expectedQuestionNumber;
+  }
+
+  return false;
+}
+
+function sanitizeOcrText(value, { expectedQuestionNumber = null } = {}) {
+  const text = normalizeString(value);
+  if (!text) {
+    return '';
+  }
+
+  const lines = text
+    .split(/\r?\n/)
+    .filter((line) => !isOcrNoiseLine(line, expectedQuestionNumber));
+
+  return lines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 function pickArray(...values) {
   for (const value of values) {
     if (Array.isArray(value) && value.length > 0) {
@@ -230,7 +276,10 @@ function buildStructuredEvidence(manifestItem, laneOutputs) {
   const reviewEvidence = laneEvidenceMap(reviewOutput);
 
   return {
-    ocr_text: pickFirstString(ocrEvidence.ocr_text, diagramEvidence.ocr_text, reviewEvidence.ocr_text),
+    ocr_text: sanitizeOcrText(
+      pickFirstString(ocrEvidence.ocr_text, diagramEvidence.ocr_text, reviewEvidence.ocr_text),
+      { expectedQuestionNumber: manifestItem.q_number ?? null },
+    ),
     formula_latex_list: pickArray(
       ocrEvidence.formula_latex_list,
       diagramEvidence.formula_latex_list,

--- a/scripts/vlm/build_pdf_page_chain_review_crops_v1.py
+++ b/scripts/vlm/build_pdf_page_chain_review_crops_v1.py
@@ -125,9 +125,11 @@ def compute_question_page_bands(
     bands: list[dict[str, Any]] = []
     for index, item in enumerate(starts):
         next_y = page_height
+        next_start: dict[str, Any] | None = None
         for later in starts[index + 1 :]:
             if later["y1"] > item["y1"] and later["q_number"] != item["q_number"]:
                 next_y = later["y1"]
+                next_start = later
                 break
         crop_top = item["y1"] - padding_px
         if item["has_diagram"] and not item["has_pdf_start"]:
@@ -141,6 +143,8 @@ def compute_question_page_bands(
                 next_y + padding_px,
                 max(crop_bottom, item["y2"] + (padding_px * 2)),
             )
+            if next_start and next_start["has_pdf_start"]:
+                crop_bottom = min(crop_bottom, next_y - padding_px)
         crop_box = _clamp_box(
             [
                 0,

--- a/scripts/vlm/diff_pdf_page_chain_projection_v1.py
+++ b/scripts/vlm/diff_pdf_page_chain_projection_v1.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Build a human-review diff for 9709 PDF page-chain projections."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "9709_pdf_page_chain_projection_diff_v1"
+
+
+def _load_json(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _normalize_text(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip().lower()
+
+
+def _old_diagram_present(old: dict[str, Any]) -> bool | None:
+    for key in (
+        "evidence_diagram_present",
+        "surface_posture_diagram_present",
+        "manifest_diagram_present",
+    ):
+        value = old.get(key)
+        if isinstance(value, bool):
+            return value
+    return None
+
+
+def _old_list(old: dict[str, Any], key: str) -> list[Any] | None:
+    value = old.get(key)
+    return value if isinstance(value, list) else None
+
+
+def classify_item(item: dict[str, Any]) -> dict[str, Any]:
+    old = item.get("old") or {}
+    old_text = old.get("evidence_ocr_text")
+    new_text = item.get("ocr_text")
+    old_diagram = _old_diagram_present(old)
+    new_diagram = item.get("diagram_present")
+    diff_classes: list[str] = []
+    changed_fields: list[str] = []
+    review_reasons: list[str] = []
+
+    if not _normalize_text(old_text):
+        diff_classes.append("missing_old_evidence")
+        review_reasons.append("old OCR evidence is missing")
+    elif _normalize_text(old_text) != _normalize_text(new_text):
+        diff_classes.append("text_changed")
+        changed_fields.append("ocr_text")
+        review_reasons.append("OCR text changed")
+
+    if old_diagram is None:
+        if "missing_old_evidence" not in diff_classes:
+            diff_classes.append("missing_old_evidence")
+        review_reasons.append("old diagram evidence is missing")
+    elif old_diagram != new_diagram:
+        diff_classes.append("diagram_changed")
+        changed_fields.append("diagram_present")
+        review_reasons.append("diagram_present changed")
+
+    old_diagram_elements = _old_list(old, "evidence_diagram_elements")
+    if old_diagram_elements is not None and old_diagram_elements != (item.get("diagram_elements") or []):
+        if "structure_changed" not in diff_classes:
+            diff_classes.append("structure_changed")
+        changed_fields.append("diagram_elements")
+        review_reasons.append("diagram elements changed")
+
+    # Old 300 evidence usually lacks marks and subparts. Compare only when present.
+    for old_key, new_key in (
+        ("evidence_marks", "marks"),
+        ("evidence_subpart_labels", "subpart_labels"),
+        ("evidence_page_indices", "page_indices"),
+    ):
+        old_value = _old_list(old, old_key)
+        if old_value is not None and old_value != (item.get(new_key) or []):
+            if "structure_changed" not in diff_classes:
+                diff_classes.append("structure_changed")
+            changed_fields.append(new_key)
+            review_reasons.append(f"{new_key} changed")
+
+    if not str(new_text or "").strip() or len(str(new_text or "").strip()) < 30:
+        review_reasons.append("new OCR text is empty or unusually short")
+    if new_diagram is True:
+        review_reasons.append("new extraction includes diagram/table evidence")
+
+    if not diff_classes:
+        diff_classes.append("unchanged")
+
+    old_alignment_verdict_stale = (
+        old.get("overall_alignment_verdict") == "ready"
+        and diff_classes != ["unchanged"]
+    )
+    if old_alignment_verdict_stale:
+        review_reasons.append("old authority alignment verdict is stale")
+
+    requires_human_review = bool(review_reasons)
+
+    return {
+        "storage_key": item.get("storage_key"),
+        "source_pdf_path": item.get("source_pdf_path"),
+        "q_number": item.get("q_number"),
+        "diff_classes": diff_classes,
+        "changed_fields": sorted(set(changed_fields)),
+        "requires_human_review": requires_human_review,
+        "review_reasons": sorted(set(review_reasons)),
+        "old_alignment_verdict_stale": old_alignment_verdict_stale,
+        "old": {
+            "ocr_text": old_text,
+            "diagram_present": old_diagram,
+            "diagram_elements": old.get("evidence_diagram_elements"),
+            "overall_alignment_verdict": old.get("overall_alignment_verdict"),
+            "old_screenshot_path": item.get("old_screenshot_path"),
+        },
+        "new": {
+            "ocr_text": item.get("ocr_text"),
+            "diagram_present": item.get("diagram_present"),
+            "diagram_elements": item.get("diagram_elements") or [],
+            "page_indices": item.get("page_indices") or [],
+            "marks": item.get("marks") or [],
+            "subpart_labels": item.get("subpart_labels") or [],
+            "source_rendered_page_paths": item.get("source_rendered_page_paths") or [],
+        },
+    }
+
+
+def build_diff_report(*, projection_path: str | Path) -> dict[str, Any]:
+    projection = _load_json(projection_path)
+    rows = [classify_item(item) for item in projection.get("items") or []]
+    class_counts: Counter[str] = Counter()
+    for row in rows:
+        class_counts.update(row["diff_classes"])
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_projection": str(projection_path),
+        "total_items": len(rows),
+        "class_counts": dict(sorted(class_counts.items())),
+        "requires_human_review_count": sum(1 for row in rows if row["requires_human_review"]),
+        "items": rows,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare a PDF page-chain projection against old 300-batch evidence.",
+    )
+    parser.add_argument("--projection", required=True)
+    parser.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_diff_report(projection_path=args.projection)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vlm/project_pdf_page_chain_to_manifest_v1.py
+++ b/scripts/vlm/project_pdf_page_chain_to_manifest_v1.py
@@ -89,7 +89,7 @@ def _rendered_page_paths(
 ) -> list[str]:
     stem = Path(pdf_path).stem
     return [
-        str(Path(render_root) / stem / f"{stem}_page_{page_index:03d}.png")
+        str(Path(render_root) / stem / f"{stem}_page_{page_index + 1:03d}.png")
         for page_index in page_indices
     ]
 

--- a/scripts/vlm/project_pdf_page_chain_to_manifest_v1.py
+++ b/scripts/vlm/project_pdf_page_chain_to_manifest_v1.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Project full-PDF page-chain extraction back to selected 9709 manifest rows."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "9709_pdf_page_chain_projection_v1"
+
+
+class ProjectionError(RuntimeError):
+    """Raised when page-chain output cannot be projected without ambiguity."""
+
+
+def _load_json(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _items(payload: dict[str, Any], *keys: str) -> list[dict[str, Any]]:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def _normalize_pdf_path(value: Any) -> str:
+    return str(value or "").replace("\\", "/")
+
+
+def _payload_index(payload_dir: str | Path) -> tuple[dict[tuple[str, int], list[dict[str, Any]]], dict[str, dict[str, Any]]]:
+    by_question: dict[tuple[str, int], list[dict[str, Any]]] = {}
+    payloads_by_pdf: dict[str, dict[str, Any]] = {}
+    for payload_path in sorted(Path(payload_dir).glob("*.json")):
+        payload = _load_json(payload_path)
+        pdf_path = _normalize_pdf_path(payload.get("pdf_path"))
+        if not pdf_path:
+            continue
+        payloads_by_pdf[pdf_path] = payload
+        for question in payload.get("questions") or []:
+            q_number = question.get("q_number")
+            if isinstance(q_number, int):
+                by_question.setdefault((pdf_path, q_number), []).append(question)
+    return by_question, payloads_by_pdf
+
+
+def _audit_index(audit: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {str(item.get("storage_key")): item for item in _items(audit, "items")}
+
+
+def _evidence_index(evidence_payload: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    if not evidence_payload:
+        return {}
+    return {
+        str(item.get("storage_key")): item
+        for item in _items(evidence_payload, "bundles", "items")
+        if item.get("storage_key")
+    }
+
+
+def _old_fields(
+    manifest_item: dict[str, Any],
+    evidence_bundle: dict[str, Any] | None,
+) -> dict[str, Any]:
+    evidence = (evidence_bundle or {}).get("evidence") or {}
+    surface_posture = (evidence_bundle or {}).get("surface_posture") or {}
+    return {
+        "manifest_diagram_present": manifest_item.get("diagram_present"),
+        "manifest_formula_dense": manifest_item.get("formula_dense"),
+        "manifest_table_heavy": manifest_item.get("table_heavy"),
+        "manifest_route_hint": manifest_item.get("route_hint"),
+        "manifest_surface_evidence_status": manifest_item.get("surface_evidence_status"),
+        "evidence_ocr_text": evidence.get("ocr_text"),
+        "evidence_diagram_present": evidence.get("diagram_present"),
+        "evidence_diagram_elements": evidence.get("diagram_elements"),
+        "surface_posture_diagram_present": surface_posture.get("diagram_present"),
+        "overall_alignment_verdict": manifest_item.get("overall_alignment_verdict"),
+        "authority_alignment_run_id": manifest_item.get("authority_alignment_run_id"),
+    }
+
+
+def _rendered_page_paths(
+    *,
+    render_root: str | Path,
+    pdf_path: str,
+    page_indices: list[int],
+) -> list[str]:
+    stem = Path(pdf_path).stem
+    return [
+        str(Path(render_root) / stem / f"{stem}_page_{page_index:03d}.png")
+        for page_index in page_indices
+    ]
+
+
+def build_projection(
+    *,
+    manifest_path: str | Path,
+    resolution_audit_path: str | Path,
+    payload_dir: str | Path,
+    render_root: str | Path,
+    expected_count: int | None = 300,
+    evidence_bundles_path: str | Path | None = None,
+) -> dict[str, Any]:
+    manifest = _load_json(manifest_path)
+    audit = _load_json(resolution_audit_path)
+    evidence = _load_json(evidence_bundles_path) if evidence_bundles_path else None
+    manifest_items = _items(manifest, "items")
+    audit_by_storage_key = _audit_index(audit)
+    evidence_by_storage_key = _evidence_index(evidence)
+    questions_by_key, payloads_by_pdf = _payload_index(payload_dir)
+
+    errors: list[str] = []
+    projected_items: list[dict[str, Any]] = []
+
+    if expected_count is not None and len(manifest_items) != expected_count:
+        errors.append(
+            f"manifest item count {len(manifest_items)} does not match expected {expected_count}",
+        )
+
+    for index, manifest_item in enumerate(manifest_items, start=1):
+        storage_key = str(manifest_item.get("storage_key"))
+        audit_item = audit_by_storage_key.get(storage_key)
+        if audit_item is None:
+            errors.append(f"{storage_key}: no resolution audit row")
+            continue
+
+        pdf_path = _normalize_pdf_path(audit_item.get("pdf_path"))
+        q_number = audit_item.get("q_number")
+        matches = questions_by_key.get((pdf_path, q_number), [])
+        if not matches:
+            errors.append(f"{storage_key}: no matching extracted question for {pdf_path} q{q_number}")
+            continue
+        if len(matches) > 1:
+            errors.append(f"{storage_key}: multiple extracted questions for {pdf_path} q{q_number}")
+            continue
+
+        question = matches[0]
+        ocr_text = str(question.get("ocr_text") or "").strip()
+        if not ocr_text:
+            errors.append(f"{storage_key}: empty ocr_text")
+            continue
+
+        diagram_present = question.get("has_diagram")
+        if not isinstance(diagram_present, bool):
+            errors.append(f"{storage_key}: diagram_present cannot be resolved to a boolean")
+            continue
+
+        page_indices = question.get("page_indices") or []
+        if not all(isinstance(page_index, int) for page_index in page_indices):
+            errors.append(f"{storage_key}: page_indices must be integers")
+            continue
+
+        payload = payloads_by_pdf.get(pdf_path, {})
+        projected_items.append(
+            {
+                "index": index,
+                "storage_key": storage_key,
+                "source_pdf_path": pdf_path,
+                "q_number": q_number,
+                "ocr_text": ocr_text,
+                "diagram_present": diagram_present,
+                "diagram_elements": question.get("diagram_elements") or [],
+                "page_indices": page_indices,
+                "marks": question.get("marks") or [],
+                "subpart_labels": question.get("subpart_labels") or [],
+                "extraction_model": payload.get("model"),
+                "extraction_schema_version": payload.get("schema_version"),
+                "extraction_run_id": payload.get("run_id"),
+                "source_rendered_page_paths": _rendered_page_paths(
+                    render_root=render_root,
+                    pdf_path=pdf_path,
+                    page_indices=page_indices,
+                ),
+                "old_screenshot_path": storage_key,
+                "old": _old_fields(
+                    manifest_item,
+                    evidence_by_storage_key.get(storage_key),
+                ),
+            }
+        )
+
+    if expected_count is not None and len(projected_items) != expected_count:
+        errors.append(
+            f"projected item count {len(projected_items)} does not match expected {expected_count}",
+        )
+
+    if errors:
+        raise ProjectionError("; ".join(errors))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "manifest_path": str(manifest_path),
+        "resolution_audit_path": str(resolution_audit_path),
+        "payload_dir": str(payload_dir),
+        "render_root": str(render_root),
+        "item_count": len(projected_items),
+        "items": projected_items,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Project PDF page-chain payloads back to selected manifest rows.",
+    )
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--resolution-audit", required=True)
+    parser.add_argument("--payload-dir", required=True)
+    parser.add_argument("--render-root", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--expected-count", type=int, default=300)
+    parser.add_argument("--evidence-bundles")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    projection = build_projection(
+        manifest_path=args.manifest,
+        resolution_audit_path=args.resolution_audit,
+        payload_dir=args.payload_dir,
+        render_root=args.render_root,
+        expected_count=args.expected_count,
+        evidence_bundles_path=args.evidence_bundles,
+    )
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(projection, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vlm/qwen_openai_client_v1.py
+++ b/scripts/vlm/qwen_openai_client_v1.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import http.client
 import json
 import mimetypes
 import os
@@ -21,6 +22,7 @@ from scripts.common.env import load_project_env
 
 DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 DEFAULT_TRANSPORT = "windows-host"
+RETRYABLE_DIRECT_HTTP_STATUS_CODES = {308, 408, 429, 500, 502, 503, 504}
 
 
 class QwenOpenAIClientError(RuntimeError):
@@ -370,10 +372,20 @@ def call_qwen_openai_v1_direct(
             break
         except urllib.error.HTTPError as error:
             response_text = error.read().decode("utf-8", errors="replace")
+            if (
+                error.code in RETRYABLE_DIRECT_HTTP_STATUS_CODES
+                and attempt < max_retries
+            ):
+                sleeper(retry_base_delay * (2**attempt))
+                continue
             raise QwenOpenAIClientError(
                 f"DashScope request failed with HTTP {error.code}: {response_text}",
             ) from error
         except urllib.error.URLError as error:
+            if attempt >= max_retries:
+                raise QwenOpenAIClientError(f"DashScope request failed: {error}") from error
+            sleeper(retry_base_delay * (2**attempt))
+        except http.client.RemoteDisconnected as error:
             if attempt >= max_retries:
                 raise QwenOpenAIClientError(f"DashScope request failed: {error}") from error
             sleeper(retry_base_delay * (2**attempt))

--- a/tests/test_build_pdf_page_chain_review_crops_v1.py
+++ b/tests/test_build_pdf_page_chain_review_crops_v1.py
@@ -84,6 +84,27 @@ def test_compute_question_page_bands_uses_pdf_question_starts_when_available():
     assert bands[1]["crop_box"] == [0, 580, 1000, 880]
 
 
+def test_compute_question_page_bands_keeps_next_pdf_question_out_of_crop():
+    page_result = {
+        "page_index": 0,
+        "fragments": [
+            {"q_number": 1, "bbox_norm": [80, 70, 915, 145]},
+            {"q_number": 2, "bbox_norm": [80, 125, 915, 190]},
+        ],
+    }
+
+    bands = compute_question_page_bands(
+        page_result,
+        page_width=1000,
+        page_height=2000,
+        padding_px=20,
+        question_start_y_by_number={1: 120, 2: 250},
+    )
+
+    assert bands[0]["q_number"] == 1
+    assert bands[0]["crop_box"] == [0, 100, 1000, 230]
+
+
 def test_compute_question_page_bands_expands_diagram_question_above_text_bbox():
     page_result = {
         "page_index": 0,

--- a/tests/test_diff_pdf_page_chain_projection_v1.py
+++ b/tests/test_diff_pdf_page_chain_projection_v1.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.vlm.diff_pdf_page_chain_projection_v1 import build_diff_report  # noqa: E402
+
+
+def test_build_diff_report_flags_diagram_flip_and_stale_alignment(tmp_path):
+    projection_path = tmp_path / "projection.json"
+    projection_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "9709_pdf_page_chain_projection_v1",
+                "items": [
+                    {
+                        "storage_key": "9709/m16_qp_12/questions/q08.png",
+                        "source_pdf_path": "paper.pdf",
+                        "q_number": 8,
+                        "ocr_text": "8 New extracted question text with a diagram.",
+                        "diagram_present": True,
+                        "diagram_elements": ["graph"],
+                        "page_indices": [2],
+                        "marks": [4],
+                        "subpart_labels": [],
+                        "source_rendered_page_paths": ["page_002.png"],
+                        "old": {
+                            "manifest_diagram_present": False,
+                            "evidence_ocr_text": "8 Old extracted question text.",
+                            "evidence_diagram_present": False,
+                            "evidence_diagram_elements": [],
+                            "overall_alignment_verdict": "ready",
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_diff_report(projection_path=projection_path)
+
+    row = report["items"][0]
+    assert row["diff_classes"] == [
+        "text_changed",
+        "diagram_changed",
+        "structure_changed",
+    ]
+    assert row["requires_human_review"] is True
+    assert row["old_alignment_verdict_stale"] is True
+    assert report["class_counts"]["diagram_changed"] == 1
+    assert report["requires_human_review_count"] == 1
+
+
+def test_build_diff_report_marks_missing_old_evidence(tmp_path):
+    projection_path = tmp_path / "projection.json"
+    projection_path.write_text(
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "storage_key": "s",
+                        "source_pdf_path": "paper.pdf",
+                        "q_number": 1,
+                        "ocr_text": "1 A reasonably long extracted question text.",
+                        "diagram_present": False,
+                        "diagram_elements": [],
+                        "page_indices": [1],
+                        "marks": [3],
+                        "subpart_labels": [],
+                        "old": {
+                            "manifest_diagram_present": None,
+                            "evidence_ocr_text": "",
+                            "evidence_diagram_present": None,
+                            "overall_alignment_verdict": "ready",
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_diff_report(projection_path=projection_path)
+
+    row = report["items"][0]
+    assert row["diff_classes"] == ["missing_old_evidence"]
+    assert row["requires_human_review"] is True
+    assert row["old_alignment_verdict_stale"] is True
+    assert report["class_counts"]["missing_old_evidence"] == 1

--- a/tests/test_project_pdf_page_chain_to_manifest_v1.py
+++ b/tests/test_project_pdf_page_chain_to_manifest_v1.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.vlm.project_pdf_page_chain_to_manifest_v1 import (  # noqa: E402
+    ProjectionError,
+    build_projection,
+)
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_build_projection_joins_manifest_item_to_page_chain_question(tmp_path):
+    manifest_path = _write_json(
+        tmp_path / "manifest.json",
+        {
+            "schema_version": "manifest_test",
+            "items": [
+                {
+                    "storage_key": "9709/m16_qp_12/questions/q08.png",
+                    "syllabus_code": "9709",
+                    "year": 2016,
+                    "session": "m",
+                    "paper": 1,
+                    "variant": 2,
+                    "q_number": 8,
+                    "diagram_present": False,
+                    "overall_alignment_verdict": "ready",
+                }
+            ],
+        },
+    )
+    audit_path = _write_json(
+        tmp_path / "audit.json",
+        {
+            "schema_version": "audit_test",
+            "items": [
+                {
+                    "storage_key": "9709/m16_qp_12/questions/q08.png",
+                    "pdf_path": "data/past-papers/9709Mathematics/paper1/9709_m16_qp_12.pdf",
+                    "q_number": 8,
+                }
+            ],
+        },
+    )
+    payload_dir = tmp_path / "payloads"
+    _write_json(
+        payload_dir / "9709_m16_qp_12_page_chain.json",
+        {
+            "schema_version": "pdf_page_chain_extraction_v1",
+            "pdf_path": "data/past-papers/9709Mathematics/paper1/9709_m16_qp_12.pdf",
+            "model": "qwen3-vl-plus",
+            "questions": [
+                {
+                    "q_number": 8,
+                    "ocr_text": "8 Find the value of x.",
+                    "has_diagram": True,
+                    "diagram_elements": ["sketch"],
+                    "page_indices": [2, 3],
+                    "marks": [3],
+                    "subpart_labels": ["(i)"],
+                }
+            ],
+        },
+    )
+
+    projection = build_projection(
+        manifest_path=manifest_path,
+        resolution_audit_path=audit_path,
+        payload_dir=payload_dir,
+        render_root=tmp_path / "renders",
+        expected_count=1,
+    )
+
+    assert projection["schema_version"] == "9709_pdf_page_chain_projection_v1"
+    assert projection["item_count"] == 1
+    item = projection["items"][0]
+    assert item["storage_key"] == "9709/m16_qp_12/questions/q08.png"
+    assert item["source_pdf_path"] == "data/past-papers/9709Mathematics/paper1/9709_m16_qp_12.pdf"
+    assert item["q_number"] == 8
+    assert item["ocr_text"] == "8 Find the value of x."
+    assert item["diagram_present"] is True
+    assert item["diagram_elements"] == ["sketch"]
+    assert item["page_indices"] == [2, 3]
+    assert item["marks"] == [3]
+    assert item["subpart_labels"] == ["(i)"]
+    assert item["extraction_model"] == "qwen3-vl-plus"
+    assert item["source_rendered_page_paths"] == [
+        str(tmp_path / "renders/9709_m16_qp_12/9709_m16_qp_12_page_002.png"),
+        str(tmp_path / "renders/9709_m16_qp_12/9709_m16_qp_12_page_003.png"),
+    ]
+    assert item["old"]["manifest_diagram_present"] is False
+    assert item["old"]["overall_alignment_verdict"] == "ready"
+
+
+def test_build_projection_fails_when_selected_question_is_missing(tmp_path):
+    manifest_path = _write_json(
+        tmp_path / "manifest.json",
+        {
+            "items": [
+                {
+                    "storage_key": "9709/m16_qp_12/questions/q08.png",
+                    "q_number": 8,
+                }
+            ],
+        },
+    )
+    audit_path = _write_json(
+        tmp_path / "audit.json",
+        {
+            "items": [
+                {
+                    "storage_key": "9709/m16_qp_12/questions/q08.png",
+                    "pdf_path": "data/past-papers/9709Mathematics/paper1/9709_m16_qp_12.pdf",
+                    "q_number": 8,
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "payloads/9709_m16_qp_12_page_chain.json",
+        {
+            "pdf_path": "data/past-papers/9709Mathematics/paper1/9709_m16_qp_12.pdf",
+            "questions": [{"q_number": 7, "ocr_text": "7 Text", "has_diagram": False}],
+        },
+    )
+
+    with pytest.raises(ProjectionError, match="no matching extracted question"):
+        build_projection(
+            manifest_path=manifest_path,
+            resolution_audit_path=audit_path,
+            payload_dir=tmp_path / "payloads",
+            render_root=tmp_path / "renders",
+            expected_count=1,
+        )
+
+
+def test_build_projection_fails_when_diagram_flag_is_not_boolean(tmp_path):
+    manifest_path = _write_json(
+        tmp_path / "manifest.json",
+        {"items": [{"storage_key": "s", "q_number": 1}]},
+    )
+    audit_path = _write_json(
+        tmp_path / "audit.json",
+        {"items": [{"storage_key": "s", "pdf_path": "paper.pdf", "q_number": 1}]},
+    )
+    _write_json(
+        tmp_path / "payloads/paper_page_chain.json",
+        {
+            "pdf_path": "paper.pdf",
+            "questions": [{"q_number": 1, "ocr_text": "1 Text", "has_diagram": None}],
+        },
+    )
+
+    with pytest.raises(ProjectionError, match="diagram_present cannot be resolved"):
+        build_projection(
+            manifest_path=manifest_path,
+            resolution_audit_path=audit_path,
+            payload_dir=tmp_path / "payloads",
+            render_root=tmp_path / "renders",
+            expected_count=1,
+        )

--- a/tests/test_project_pdf_page_chain_to_manifest_v1.py
+++ b/tests/test_project_pdf_page_chain_to_manifest_v1.py
@@ -96,8 +96,8 @@ def test_build_projection_joins_manifest_item_to_page_chain_question(tmp_path):
     assert item["subpart_labels"] == ["(i)"]
     assert item["extraction_model"] == "qwen3-vl-plus"
     assert item["source_rendered_page_paths"] == [
-        str(tmp_path / "renders/9709_m16_qp_12/9709_m16_qp_12_page_002.png"),
         str(tmp_path / "renders/9709_m16_qp_12/9709_m16_qp_12_page_003.png"),
+        str(tmp_path / "renders/9709_m16_qp_12/9709_m16_qp_12_page_004.png"),
     ]
     assert item["old"]["manifest_diagram_present"] is False
     assert item["old"]["overall_alignment_verdict"] == "ready"

--- a/tests/test_qwen_openai_client_v1.py
+++ b/tests/test_qwen_openai_client_v1.py
@@ -5,6 +5,7 @@ import ssl
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+import http.client
 import urllib.error
 from unittest.mock import patch
 
@@ -235,6 +236,88 @@ def test_call_qwen_openai_v1_direct_retries_transient_url_errors(monkeypatch):
         if calls["count"] == 1:
             raise urllib.error.URLError(
                 ssl.SSLEOFError("UNEXPECTED_EOF_WHILE_READING"),
+            )
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "scripts.vlm.qwen_openai_client_v1.normalize_request_for_direct_http",
+        lambda request: request,
+        raising=False,
+    )
+
+    response = call_qwen_openai_v1_direct(
+        {"model": "qwen3.6-plus", "messages": []},
+        env={"DASHSCOPE_API_KEY": "secret-key"},
+        urlopen=fake_urlopen,
+        sleeper=sleeps.append,
+    )
+
+    assert response["choices"][0]["message"]["content"] == "ok"
+    assert calls["count"] == 2
+    assert sleeps == [2.0]
+
+
+def test_call_qwen_openai_v1_direct_retries_remote_disconnects(monkeypatch):
+    calls = {"count": 0}
+    sleeps = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b'{"choices":[{"message":{"content":"ok"}}]}'
+
+    def fake_urlopen(request, timeout):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise http.client.RemoteDisconnected("remote end closed connection")
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "scripts.vlm.qwen_openai_client_v1.normalize_request_for_direct_http",
+        lambda request: request,
+        raising=False,
+    )
+
+    response = call_qwen_openai_v1_direct(
+        {"model": "qwen3.6-plus", "messages": []},
+        env={"DASHSCOPE_API_KEY": "secret-key"},
+        urlopen=fake_urlopen,
+        sleeper=sleeps.append,
+    )
+
+    assert response["choices"][0]["message"]["content"] == "ok"
+    assert calls["count"] == 2
+    assert sleeps == [2.0]
+
+
+def test_call_qwen_openai_v1_direct_retries_transient_http_redirects(monkeypatch):
+    calls = {"count": 0}
+    sleeps = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b'{"choices":[{"message":{"content":"ok"}}]}'
+
+    def fake_urlopen(request, timeout):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                308,
+                "Permanent Redirect",
+                hdrs=None,
+                fp=None,
             )
         return FakeResponse()
 


### PR DESCRIPTION
## Summary
- correct `diagram_present` for `9709/s24_qp_13/questions/q09.png` in the 9709 authority-ready manifest
- align the tracked manifest with the repaired evidence-bundle outcome used by release preflight
- keep the change scoped to the Git-tracked release artifact only

## Verification
- reran 9709 release preflight with current manifest, authority sidecar, curriculum seed, and repaired evidence bundle
- result: `pass`, `0 blockers`, `1 warning` (`9709/s17_qp_63/questions/q07.png` paper 6 warning)
